### PR TITLE
Convert virtualmachines service to SDKv2

### DIFF
--- a/azure/converters/diagnostics.go
+++ b/azure/converters/diagnostics.go
@@ -18,59 +18,29 @@ package converters
 
 import (
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute"
 	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 )
 
-// GetDiagnosticsProfileV2 converts a CAPZ Diagnostics option to a Azure SDK Diagnostics Profile.
-func GetDiagnosticsProfileV2(diagnostics *infrav1.Diagnostics) *armcompute.DiagnosticsProfile {
-	if diagnostics != nil && diagnostics.Boot != nil {
-		switch diagnostics.Boot.StorageAccountType {
-		case infrav1.DisabledDiagnosticsStorage:
-			return &armcompute.DiagnosticsProfile{
-				BootDiagnostics: &armcompute.BootDiagnostics{
-					Enabled: ptr.To(false),
-				},
-			}
-		case infrav1.ManagedDiagnosticsStorage:
-			return &armcompute.DiagnosticsProfile{
-				BootDiagnostics: &armcompute.BootDiagnostics{
-					Enabled: ptr.To(true),
-				},
-			}
-		case infrav1.UserManagedDiagnosticsStorage:
-			return &armcompute.DiagnosticsProfile{
-				BootDiagnostics: &armcompute.BootDiagnostics{
-					Enabled:    ptr.To(true),
-					StorageURI: &diagnostics.Boot.UserManaged.StorageAccountURI,
-				},
-			}
-		}
-	}
-
-	return nil
-}
-
 // GetDiagnosticsProfile converts a CAPZ Diagnostics option to a Azure SDK Diagnostics Profile.
-func GetDiagnosticsProfile(diagnostics *infrav1.Diagnostics) *compute.DiagnosticsProfile {
+func GetDiagnosticsProfile(diagnostics *infrav1.Diagnostics) *armcompute.DiagnosticsProfile {
 	if diagnostics != nil && diagnostics.Boot != nil {
 		switch diagnostics.Boot.StorageAccountType {
 		case infrav1.DisabledDiagnosticsStorage:
-			return &compute.DiagnosticsProfile{
-				BootDiagnostics: &compute.BootDiagnostics{
+			return &armcompute.DiagnosticsProfile{
+				BootDiagnostics: &armcompute.BootDiagnostics{
 					Enabled: ptr.To(false),
 				},
 			}
 		case infrav1.ManagedDiagnosticsStorage:
-			return &compute.DiagnosticsProfile{
-				BootDiagnostics: &compute.BootDiagnostics{
+			return &armcompute.DiagnosticsProfile{
+				BootDiagnostics: &armcompute.BootDiagnostics{
 					Enabled: ptr.To(true),
 				},
 			}
 		case infrav1.UserManagedDiagnosticsStorage:
-			return &compute.DiagnosticsProfile{
-				BootDiagnostics: &compute.BootDiagnostics{
+			return &armcompute.DiagnosticsProfile{
+				BootDiagnostics: &armcompute.BootDiagnostics{
 					Enabled:    ptr.To(true),
 					StorageURI: &diagnostics.Boot.UserManaged.StorageAccountURI,
 				},

--- a/azure/converters/diagnostics_test.go
+++ b/azure/converters/diagnostics_test.go
@@ -20,13 +20,12 @@ import (
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute"
 	"github.com/google/go-cmp/cmp"
 	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 )
 
-func TestGetDiagnosticsProfileV2(t *testing.T) {
+func TestGetDiagnosticsProfile(t *testing.T) {
 	tests := []struct {
 		name        string
 		diagnostics *infrav1.Diagnostics
@@ -71,75 +70,6 @@ func TestGetDiagnosticsProfileV2(t *testing.T) {
 			},
 			want: &armcompute.DiagnosticsProfile{
 				BootDiagnostics: &armcompute.BootDiagnostics{
-					Enabled: ptr.To(false),
-				},
-			},
-		},
-		{
-			name: "nil diagnostics boot",
-			diagnostics: &infrav1.Diagnostics{
-				Boot: nil,
-			},
-			want: nil,
-		},
-	}
-	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			got := GetDiagnosticsProfileV2(tt.diagnostics)
-			if diff := cmp.Diff(tt.want, got); diff != "" {
-				t.Errorf("GetDiagnosticsProfileV2(%s) mismatch (-want +got):\n%s", tt.name, diff)
-			}
-		})
-	}
-}
-
-func TestGetDiagnosticsProfile(t *testing.T) {
-	tests := []struct {
-		name        string
-		diagnostics *infrav1.Diagnostics
-		want        *compute.DiagnosticsProfile
-	}{
-		{
-			name: "managed diagnostics",
-			diagnostics: &infrav1.Diagnostics{
-				Boot: &infrav1.BootDiagnostics{
-					StorageAccountType: infrav1.ManagedDiagnosticsStorage,
-				},
-			},
-			want: &compute.DiagnosticsProfile{
-				BootDiagnostics: &compute.BootDiagnostics{
-					Enabled: ptr.To(true),
-				},
-			},
-		},
-		{
-			name: "user managed diagnostics",
-			diagnostics: &infrav1.Diagnostics{
-				Boot: &infrav1.BootDiagnostics{
-					StorageAccountType: infrav1.UserManagedDiagnosticsStorage,
-					UserManaged: &infrav1.UserManagedBootDiagnostics{
-						StorageAccountURI: "https://fake",
-					},
-				},
-			},
-			want: &compute.DiagnosticsProfile{
-				BootDiagnostics: &compute.BootDiagnostics{
-					Enabled:    ptr.To(true),
-					StorageURI: ptr.To("https://fake"),
-				},
-			},
-		},
-		{
-			name: "disabled diagnostics",
-			diagnostics: &infrav1.Diagnostics{
-				Boot: &infrav1.BootDiagnostics{
-					StorageAccountType: infrav1.DisabledDiagnosticsStorage,
-				},
-			},
-			want: &compute.DiagnosticsProfile{
-				BootDiagnostics: &compute.BootDiagnostics{
 					Enabled: ptr.To(false),
 				},
 			},

--- a/azure/converters/extendedlocation.go
+++ b/azure/converters/extendedlocation.go
@@ -17,8 +17,8 @@ limitations under the License.
 package converters
 
 import (
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v4"
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute"
 	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 )
@@ -34,13 +34,13 @@ func ExtendedLocationToNetworkSDK(src *infrav1.ExtendedLocationSpec) *armnetwork
 	}
 }
 
-// ExtendedLocationToComputeSDK converts infrav1.ExtendedLocationSpec to compute.ExtendedLocation.
-func ExtendedLocationToComputeSDK(src *infrav1.ExtendedLocationSpec) *compute.ExtendedLocation {
+// ExtendedLocationToComputeSDK converts an infrav1.ExtendedLocationSpec to an armcompute.ExtendedLocation.
+func ExtendedLocationToComputeSDK(src *infrav1.ExtendedLocationSpec) *armcompute.ExtendedLocation {
 	if src == nil {
 		return nil
 	}
-	return &compute.ExtendedLocation{
+	return &armcompute.ExtendedLocation{
 		Name: ptr.To(src.Name),
-		Type: compute.ExtendedLocationTypes(src.Type),
+		Type: ptr.To(armcompute.ExtendedLocationTypes(src.Type)),
 	}
 }

--- a/azure/converters/extendedlocation_test.go
+++ b/azure/converters/extendedlocation_test.go
@@ -20,13 +20,13 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v4"
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute"
 	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 )
 
-func TestExtendedLocationToNetworkSDKv2(t *testing.T) {
+func TestExtendedLocationToNetworkSDK(t *testing.T) {
 	tests := []struct {
 		name string
 		args *infrav1.ExtendedLocationSpec
@@ -62,7 +62,7 @@ func TestExtendedLocationToComputeSDK(t *testing.T) {
 	tests := []struct {
 		name string
 		args *infrav1.ExtendedLocationSpec
-		want *compute.ExtendedLocation
+		want *armcompute.ExtendedLocation
 	}{
 		{
 			name: "normal extendedLocation instance",
@@ -70,9 +70,9 @@ func TestExtendedLocationToComputeSDK(t *testing.T) {
 				Name: "value",
 				Type: "Edge",
 			},
-			want: &compute.ExtendedLocation{
+			want: &armcompute.ExtendedLocation{
 				Name: ptr.To("value"),
-				Type: compute.ExtendedLocationTypes("Edge"),
+				Type: ptr.To(armcompute.ExtendedLocationTypes("Edge")),
 			},
 		},
 		{

--- a/azure/converters/image.go
+++ b/azure/converters/image.go
@@ -20,84 +20,13 @@ import (
 	"fmt"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute"
 	"github.com/pkg/errors"
 	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 )
 
-// ImageToSDKv2 converts a CAPZ Image (as RawExtension) to a Azure SDK Image Reference.
-func ImageToSDKv2(image *infrav1.Image) (*armcompute.ImageReference, error) {
-	if image.ID != nil {
-		return specificImageToSDKv2(image)
-	}
-	if image.Marketplace != nil {
-		return mpImageToSDKv2(image)
-	}
-	if image.ComputeGallery != nil || image.SharedGallery != nil {
-		return computeImageToSDKv2(image)
-	}
-
-	return nil, errors.New("unable to convert image as no options set")
-}
-
-func mpImageToSDKv2(image *infrav1.Image) (*armcompute.ImageReference, error) {
-	return &armcompute.ImageReference{
-		Publisher: &image.Marketplace.Publisher,
-		Offer:     &image.Marketplace.Offer,
-		SKU:       &image.Marketplace.SKU,
-		Version:   &image.Marketplace.Version,
-	}, nil
-}
-
-func computeImageToSDKv2(image *infrav1.Image) (*armcompute.ImageReference, error) {
-	if image.ComputeGallery == nil && image.SharedGallery == nil {
-		return nil, errors.New("unable to convert compute image to SDK as SharedGallery or ComputeGallery fields are not set")
-	}
-
-	idTemplate := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/galleries/%s/images/%s/versions/%s"
-	if image.SharedGallery != nil {
-		return &armcompute.ImageReference{
-			ID: ptr.To(fmt.Sprintf(idTemplate,
-				image.SharedGallery.SubscriptionID,
-				image.SharedGallery.ResourceGroup,
-				image.SharedGallery.Gallery,
-				image.SharedGallery.Name,
-				image.SharedGallery.Version,
-			)),
-		}, nil
-	}
-
-	// For private Azure Compute Gallery consumption both resource group and subscription ID must be provided.
-	// If they are not, we assume use of community gallery.
-	if image.ComputeGallery.ResourceGroup != nil && image.ComputeGallery.SubscriptionID != nil {
-		return &armcompute.ImageReference{
-			ID: ptr.To(fmt.Sprintf(idTemplate,
-				ptr.Deref(image.ComputeGallery.SubscriptionID, ""),
-				ptr.Deref(image.ComputeGallery.ResourceGroup, ""),
-				image.ComputeGallery.Gallery,
-				image.ComputeGallery.Name,
-				image.ComputeGallery.Version,
-			)),
-		}, nil
-	}
-
-	return &armcompute.ImageReference{
-		CommunityGalleryImageID: ptr.To(fmt.Sprintf("/CommunityGalleries/%s/Images/%s/Versions/%s",
-			image.ComputeGallery.Gallery,
-			image.ComputeGallery.Name,
-			image.ComputeGallery.Version)),
-	}, nil
-}
-
-func specificImageToSDKv2(image *infrav1.Image) (*armcompute.ImageReference, error) {
-	return &armcompute.ImageReference{
-		ID: image.ID,
-	}, nil
-}
-
 // ImageToSDK converts a CAPZ Image (as RawExtension) to a Azure SDK Image Reference.
-func ImageToSDK(image *infrav1.Image) (*compute.ImageReference, error) {
+func ImageToSDK(image *infrav1.Image) (*armcompute.ImageReference, error) {
 	if image.ID != nil {
 		return specificImageToSDK(image)
 	}
@@ -111,23 +40,23 @@ func ImageToSDK(image *infrav1.Image) (*compute.ImageReference, error) {
 	return nil, errors.New("unable to convert image as no options set")
 }
 
-func mpImageToSDK(image *infrav1.Image) (*compute.ImageReference, error) {
-	return &compute.ImageReference{
+func mpImageToSDK(image *infrav1.Image) (*armcompute.ImageReference, error) {
+	return &armcompute.ImageReference{
 		Publisher: &image.Marketplace.Publisher,
 		Offer:     &image.Marketplace.Offer,
-		Sku:       &image.Marketplace.SKU,
+		SKU:       &image.Marketplace.SKU,
 		Version:   &image.Marketplace.Version,
 	}, nil
 }
 
-func computeImageToSDK(image *infrav1.Image) (*compute.ImageReference, error) {
+func computeImageToSDK(image *infrav1.Image) (*armcompute.ImageReference, error) {
 	if image.ComputeGallery == nil && image.SharedGallery == nil {
 		return nil, errors.New("unable to convert compute image to SDK as SharedGallery or ComputeGallery fields are not set")
 	}
 
 	idTemplate := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/galleries/%s/images/%s/versions/%s"
 	if image.SharedGallery != nil {
-		return &compute.ImageReference{
+		return &armcompute.ImageReference{
 			ID: ptr.To(fmt.Sprintf(idTemplate,
 				image.SharedGallery.SubscriptionID,
 				image.SharedGallery.ResourceGroup,
@@ -141,7 +70,7 @@ func computeImageToSDK(image *infrav1.Image) (*compute.ImageReference, error) {
 	// For private Azure Compute Gallery consumption both resource group and subscription ID must be provided.
 	// If they are not, we assume use of community gallery.
 	if image.ComputeGallery.ResourceGroup != nil && image.ComputeGallery.SubscriptionID != nil {
-		return &compute.ImageReference{
+		return &armcompute.ImageReference{
 			ID: ptr.To(fmt.Sprintf(idTemplate,
 				ptr.Deref(image.ComputeGallery.SubscriptionID, ""),
 				ptr.Deref(image.ComputeGallery.ResourceGroup, ""),
@@ -152,7 +81,7 @@ func computeImageToSDK(image *infrav1.Image) (*compute.ImageReference, error) {
 		}, nil
 	}
 
-	return &compute.ImageReference{
+	return &armcompute.ImageReference{
 		CommunityGalleryImageID: ptr.To(fmt.Sprintf("/CommunityGalleries/%s/Images/%s/Versions/%s",
 			image.ComputeGallery.Gallery,
 			image.ComputeGallery.Name,
@@ -160,17 +89,17 @@ func computeImageToSDK(image *infrav1.Image) (*compute.ImageReference, error) {
 	}, nil
 }
 
-func specificImageToSDK(image *infrav1.Image) (*compute.ImageReference, error) {
-	return &compute.ImageReference{
+func specificImageToSDK(image *infrav1.Image) (*armcompute.ImageReference, error) {
+	return &armcompute.ImageReference{
 		ID: image.ID,
 	}, nil
 }
 
 // ImageToPlan converts a CAPZ Image to an Azure Compute Plan.
-func ImageToPlan(image *infrav1.Image) *compute.Plan {
+func ImageToPlan(image *infrav1.Image) *armcompute.Plan {
 	// Plan is needed when using a Shared Gallery image with Plan details.
 	if image.SharedGallery != nil && image.SharedGallery.Publisher != nil && image.SharedGallery.SKU != nil && image.SharedGallery.Offer != nil {
-		return &compute.Plan{
+		return &armcompute.Plan{
 			Publisher: image.SharedGallery.Publisher,
 			Name:      image.SharedGallery.SKU,
 			Product:   image.SharedGallery.Offer,
@@ -179,7 +108,7 @@ func ImageToPlan(image *infrav1.Image) *compute.Plan {
 
 	// Plan is needed for third party Marketplace images.
 	if image.Marketplace != nil && image.Marketplace.ThirdPartyImage {
-		return &compute.Plan{
+		return &armcompute.Plan{
 			Publisher: ptr.To(image.Marketplace.Publisher),
 			Name:      ptr.To(image.Marketplace.SKU),
 			Product:   ptr.To(image.Marketplace.Offer),
@@ -188,7 +117,7 @@ func ImageToPlan(image *infrav1.Image) *compute.Plan {
 
 	// Plan is needed when using a Azure Compute Gallery image with Plan details.
 	if image.ComputeGallery != nil && image.ComputeGallery.Plan != nil {
-		return &compute.Plan{
+		return &armcompute.Plan{
 			Publisher: ptr.To(image.ComputeGallery.Plan.Publisher),
 			Name:      ptr.To(image.ComputeGallery.Plan.SKU),
 			Product:   ptr.To(image.ComputeGallery.Plan.Offer),

--- a/azure/converters/image_test.go
+++ b/azure/converters/image_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute"
 	. "github.com/onsi/gomega"
 	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
@@ -30,7 +29,7 @@ func Test_ImageToPlan(t *testing.T) {
 	cases := []struct {
 		name   string
 		image  *infrav1.Image
-		expect func(*GomegaWithT, *compute.Plan)
+		expect func(*GomegaWithT, *armcompute.Plan)
 	}{
 		{
 			name: "Should return a plan for a Community Gallery image with plan details",
@@ -43,8 +42,8 @@ func Test_ImageToPlan(t *testing.T) {
 					},
 				},
 			},
-			expect: func(g *GomegaWithT, result *compute.Plan) {
-				g.Expect(result).To(Equal(&compute.Plan{
+			expect: func(g *GomegaWithT, result *armcompute.Plan) {
+				g.Expect(result).To(Equal(&armcompute.Plan{
 					Name:      ptr.To("my-sku"),
 					Publisher: ptr.To("my-publisher"),
 					Product:   ptr.To("my-offer"),
@@ -65,8 +64,8 @@ func Test_ImageToPlan(t *testing.T) {
 					SKU:            ptr.To("my-sku"),
 				},
 			},
-			expect: func(g *GomegaWithT, result *compute.Plan) {
-				g.Expect(result).To(Equal(&compute.Plan{
+			expect: func(g *GomegaWithT, result *armcompute.Plan) {
+				g.Expect(result).To(Equal(&armcompute.Plan{
 					Name:      ptr.To("my-sku"),
 					Publisher: ptr.To("my-publisher"),
 					Product:   ptr.To("my-offer"),
@@ -84,7 +83,7 @@ func Test_ImageToPlan(t *testing.T) {
 					Version:        "v1.0.0",
 				},
 			},
-			expect: func(g *GomegaWithT, result *compute.Plan) {
+			expect: func(g *GomegaWithT, result *armcompute.Plan) {
 				g.Expect(result).To(BeNil())
 			},
 		},
@@ -101,7 +100,7 @@ func Test_ImageToPlan(t *testing.T) {
 					ThirdPartyImage: false,
 				},
 			},
-			expect: func(g *GomegaWithT, result *compute.Plan) {
+			expect: func(g *GomegaWithT, result *armcompute.Plan) {
 				g.Expect(result).To(BeNil())
 			},
 		},
@@ -118,8 +117,8 @@ func Test_ImageToPlan(t *testing.T) {
 					ThirdPartyImage: true,
 				},
 			},
-			expect: func(g *GomegaWithT, result *compute.Plan) {
-				g.Expect(result).To(Equal(&compute.Plan{
+			expect: func(g *GomegaWithT, result *armcompute.Plan) {
+				g.Expect(result).To(Equal(&armcompute.Plan{
 					Name:      ptr.To("my-sku"),
 					Publisher: ptr.To("my-publisher"),
 					Product:   ptr.To("my-offer"),
@@ -131,7 +130,7 @@ func Test_ImageToPlan(t *testing.T) {
 			image: &infrav1.Image{
 				ID: ptr.To("fake/image/id"),
 			},
-			expect: func(g *GomegaWithT, result *compute.Plan) {
+			expect: func(g *GomegaWithT, result *armcompute.Plan) {
 				g.Expect(result).To(BeNil())
 			},
 		},
@@ -152,7 +151,7 @@ func Test_ComputeImageToSDK(t *testing.T) {
 	cases := []struct {
 		name   string
 		image  *infrav1.Image
-		expect func(*GomegaWithT, *compute.ImageReference, error)
+		expect func(*GomegaWithT, *armcompute.ImageReference, error)
 	}{
 		{
 			name: "Should return parsed compute gallery image id",
@@ -165,9 +164,9 @@ func Test_ComputeImageToSDK(t *testing.T) {
 					Version:        "my-version",
 				},
 			},
-			expect: func(g *GomegaWithT, result *compute.ImageReference, err error) {
+			expect: func(g *GomegaWithT, result *armcompute.ImageReference, err error) {
 				g.Expect(err).Should(BeNil())
-				g.Expect(result).To(Equal(&compute.ImageReference{
+				g.Expect(result).To(Equal(&armcompute.ImageReference{
 					ID: ptr.To("/subscriptions/my-subscription-id/resourceGroups/my-resourcegroup/providers/Microsoft.Compute/galleries/my-gallery/images/my-image/versions/my-version"),
 				}))
 			},
@@ -183,9 +182,9 @@ func Test_ComputeImageToSDK(t *testing.T) {
 					Version:        "my-version",
 				},
 			},
-			expect: func(g *GomegaWithT, result *compute.ImageReference, err error) {
+			expect: func(g *GomegaWithT, result *armcompute.ImageReference, err error) {
 				g.Expect(err).Should(BeNil())
-				g.Expect(result).To(Equal(&compute.ImageReference{
+				g.Expect(result).To(Equal(&armcompute.ImageReference{
 					ID: ptr.To("/subscriptions/my-subscription-id/resourceGroups/my-resourcegroup/providers/Microsoft.Compute/galleries/my-gallery/images/my-image/versions/my-version"),
 				}))
 			},
@@ -199,9 +198,9 @@ func Test_ComputeImageToSDK(t *testing.T) {
 					Version: "my-version",
 				},
 			},
-			expect: func(g *GomegaWithT, result *compute.ImageReference, err error) {
+			expect: func(g *GomegaWithT, result *armcompute.ImageReference, err error) {
 				g.Expect(err).Should(BeNil())
-				g.Expect(result).To(Equal(&compute.ImageReference{
+				g.Expect(result).To(Equal(&armcompute.ImageReference{
 					CommunityGalleryImageID: ptr.To("/CommunityGalleries/my-gallery/Images/my-image/Versions/my-version"),
 				}))
 			},
@@ -212,7 +211,7 @@ func Test_ComputeImageToSDK(t *testing.T) {
 				ComputeGallery: nil,
 				SharedGallery:  nil,
 			},
-			expect: func(g *GomegaWithT, result *compute.ImageReference, err error) {
+			expect: func(g *GomegaWithT, result *armcompute.ImageReference, err error) {
 				g.Expect(err).ShouldNot(BeNil())
 			},
 		},
@@ -229,7 +228,7 @@ func Test_ComputeImageToSDK(t *testing.T) {
 	}
 }
 
-func Test_ImageToSDKv2(t *testing.T) {
+func Test_ImageToSDK(t *testing.T) {
 	cases := []struct {
 		name   string
 		image  *infrav1.Image
@@ -338,7 +337,7 @@ func Test_ImageToSDKv2(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			t.Parallel()
 			g := NewGomegaWithT(t)
-			result, err := ImageToSDKv2(c.image)
+			result, err := ImageToSDK(c.image)
 			c.expect(g, result, err)
 		})
 	}

--- a/azure/converters/spotinstances.go
+++ b/azure/converters/spotinstances.go
@@ -20,14 +20,13 @@ import (
 	"strconv"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute"
 	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 )
 
-// GetSpotVMOptionsV2 takes the spot vm options
+// GetSpotVMOptions takes the spot vm options
 // and returns the individual vm priority, eviction policy and billing profile.
-func GetSpotVMOptionsV2(spotVMOptions *infrav1.SpotVMOptions, diffDiskSettings *infrav1.DiffDiskSettings) (*armcompute.VirtualMachinePriorityTypes, *armcompute.VirtualMachineEvictionPolicyTypes, *armcompute.BillingProfile, error) {
+func GetSpotVMOptions(spotVMOptions *infrav1.SpotVMOptions, diffDiskSettings *infrav1.DiffDiskSettings) (*armcompute.VirtualMachinePriorityTypes, *armcompute.VirtualMachineEvictionPolicyTypes, *armcompute.BillingProfile, error) {
 	// Spot VM not requested, return zero values to apply defaults
 	if spotVMOptions == nil {
 		return nil, nil, nil, nil
@@ -50,31 +49,4 @@ func GetSpotVMOptionsV2(spotVMOptions *infrav1.SpotVMOptions, diffDiskSettings *
 	}
 
 	return ptr.To(armcompute.VirtualMachinePriorityTypesSpot), evictionPolicy, billingProfile, nil
-}
-
-// GetSpotVMOptions takes the spot vm options
-// and returns the individual vm priority, eviction policy and billing profile.
-func GetSpotVMOptions(spotVMOptions *infrav1.SpotVMOptions, diffDiskSettings *infrav1.DiffDiskSettings) (compute.VirtualMachinePriorityTypes, compute.VirtualMachineEvictionPolicyTypes, *compute.BillingProfile, error) {
-	// Spot VM not requested, return zero values to apply defaults
-	if spotVMOptions == nil {
-		return "", "", nil, nil
-	}
-	var billingProfile *compute.BillingProfile
-	if spotVMOptions.MaxPrice != nil {
-		maxPrice, err := strconv.ParseFloat(spotVMOptions.MaxPrice.AsDec().String(), 64)
-		if err != nil {
-			return "", "", nil, err
-		}
-		billingProfile = &compute.BillingProfile{
-			MaxPrice: &maxPrice,
-		}
-	}
-
-	// Set the spot vm eviction policy if provided.
-	var evictionPolicy compute.VirtualMachineEvictionPolicyTypes
-	if spotVMOptions.EvictionPolicy != nil {
-		evictionPolicy = compute.VirtualMachineEvictionPolicyTypes(*spotVMOptions.EvictionPolicy)
-	}
-
-	return compute.VirtualMachinePriorityTypesSpot, evictionPolicy, billingProfile, nil
 }

--- a/azure/converters/spotinstances_test.go
+++ b/azure/converters/spotinstances_test.go
@@ -21,14 +21,13 @@ import (
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute"
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 )
 
-func TestGetSpotVMOptionsV2(t *testing.T) {
+func TestGetSpotVMOptions(t *testing.T) {
 	deletePolicy := infrav1.SpotEvictionPolicyDelete
 	type resultParams struct {
 		vmPriorityTypes       *armcompute.VirtualMachinePriorityTypes
@@ -104,102 +103,6 @@ func TestGetSpotVMOptionsV2(t *testing.T) {
 			want: resultParams{
 				vmPriorityTypes:       ptr.To(armcompute.VirtualMachinePriorityTypesSpot),
 				vmEvictionPolicyTypes: ptr.To(armcompute.VirtualMachineEvictionPolicyTypesDelete),
-				billingProfile:        nil,
-			},
-		},
-	}
-	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			g := NewGomegaWithT(t)
-			result := resultParams{}
-			var err error
-			result.vmPriorityTypes, result.vmEvictionPolicyTypes, result.billingProfile, err = GetSpotVMOptionsV2(tt.spot, tt.diffDiskSettings)
-			g.Expect(result.vmPriorityTypes).To(Equal(tt.want.vmPriorityTypes), fmt.Sprintf("got: %v, want: %v", result.vmPriorityTypes, tt.want.vmPriorityTypes))
-			g.Expect(result.vmEvictionPolicyTypes).To(Equal(tt.want.vmEvictionPolicyTypes), fmt.Sprintf("got: %v, want: %v", result.vmEvictionPolicyTypes, tt.want.vmEvictionPolicyTypes))
-			g.Expect(result.billingProfile).To(Equal(tt.want.billingProfile), fmt.Sprintf("got: %v, want: %v", result.billingProfile, tt.want.billingProfile))
-			g.Expect(err).To(BeNil())
-		})
-	}
-}
-
-func TestGetSpotVMOptions(t *testing.T) {
-	deletePolicy := infrav1.SpotEvictionPolicyDelete
-	type resultParams struct {
-		vmPriorityTypes       compute.VirtualMachinePriorityTypes
-		vmEvictionPolicyTypes compute.VirtualMachineEvictionPolicyTypes
-		billingProfile        *compute.BillingProfile
-	}
-	tests := []struct {
-		name             string
-		spot             *infrav1.SpotVMOptions
-		diffDiskSettings *infrav1.DiffDiskSettings
-		want             resultParams
-	}{
-		{
-			name:             "nil spot",
-			spot:             nil,
-			diffDiskSettings: nil,
-			want: resultParams{
-				vmPriorityTypes:       "",
-				vmEvictionPolicyTypes: "",
-				billingProfile:        nil,
-			},
-		},
-		{
-			name: "spot with nil max price",
-			spot: &infrav1.SpotVMOptions{
-				MaxPrice: nil,
-			},
-			diffDiskSettings: nil,
-			want: resultParams{
-				vmPriorityTypes:       compute.VirtualMachinePriorityTypesSpot,
-				vmEvictionPolicyTypes: "",
-				billingProfile:        nil,
-			},
-		},
-		{
-			name: "spot with max price",
-			spot: &infrav1.SpotVMOptions{
-				MaxPrice: func(price string) *resource.Quantity {
-					p := resource.MustParse(price)
-					return &p
-				}("1000"),
-			},
-			diffDiskSettings: nil,
-			want: resultParams{
-				vmPriorityTypes:       compute.VirtualMachinePriorityTypesSpot,
-				vmEvictionPolicyTypes: "",
-				billingProfile: &compute.BillingProfile{
-					MaxPrice: ptr.To[float64](1000),
-				},
-			},
-		},
-		{
-			name: "spot with ephemeral disk",
-			spot: &infrav1.SpotVMOptions{
-				MaxPrice: nil,
-			},
-			diffDiskSettings: &infrav1.DiffDiskSettings{
-				Option: string(compute.DiffDiskOptionsLocal),
-			},
-			want: resultParams{
-				vmPriorityTypes:       compute.VirtualMachinePriorityTypesSpot,
-				vmEvictionPolicyTypes: "",
-				billingProfile:        nil,
-			},
-		},
-		{
-			name: "spot with eviction policy",
-			spot: &infrav1.SpotVMOptions{
-				MaxPrice:       nil,
-				EvictionPolicy: &deletePolicy,
-			},
-			diffDiskSettings: nil,
-			want: resultParams{
-				vmPriorityTypes:       compute.VirtualMachinePriorityTypesSpot,
-				vmEvictionPolicyTypes: compute.VirtualMachineEvictionPolicyTypesDelete,
 				billingProfile:        nil,
 			},
 		},

--- a/azure/converters/vm_test.go
+++ b/azure/converters/vm_test.go
@@ -20,7 +20,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
 	"github.com/google/go-cmp/cmp"
 	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
@@ -29,66 +29,66 @@ import (
 func TestSDKToVM(t *testing.T) {
 	tests := []struct {
 		name string
-		sdk  compute.VirtualMachine
+		sdk  armcompute.VirtualMachine
 		want *VM
 	}{
 		{
 			name: "Basic conversion with required fields",
-			sdk: compute.VirtualMachine{
+			sdk: armcompute.VirtualMachine{
 				ID:   ptr.To("test-vm-id"),
 				Name: ptr.To("test-vm-name"),
-				VirtualMachineProperties: &compute.VirtualMachineProperties{
+				Properties: &armcompute.VirtualMachineProperties{
 					ProvisioningState: ptr.To("Succeeded"),
 				},
 			},
 			want: &VM{
 				ID:    "test-vm-id",
 				Name:  "test-vm-name",
-				State: infrav1.ProvisioningState(compute.ProvisioningStateSucceeded),
+				State: infrav1.ProvisioningState("Succeeded"),
 			},
 		},
 		{
 			name: "Should convert and populate with VMSize",
-			sdk: compute.VirtualMachine{
+			sdk: armcompute.VirtualMachine{
 				ID:   ptr.To("test-vm-id"),
 				Name: ptr.To("test-vm-name"),
-				VirtualMachineProperties: &compute.VirtualMachineProperties{
+				Properties: &armcompute.VirtualMachineProperties{
 					ProvisioningState: ptr.To("Succeeded"),
-					HardwareProfile: &compute.HardwareProfile{
-						VMSize: compute.VirtualMachineSizeTypesStandardA1,
+					HardwareProfile: &armcompute.HardwareProfile{
+						VMSize: ptr.To(armcompute.VirtualMachineSizeTypesStandardA1),
 					},
 				},
 			},
 			want: &VM{
 				ID:     "test-vm-id",
 				Name:   "test-vm-name",
-				State:  infrav1.ProvisioningState(compute.ProvisioningStateSucceeded),
+				State:  infrav1.ProvisioningState("Succeeded"),
 				VMSize: "Standard_A1",
 			},
 		},
 		{
 			name: "Should convert and populate with availability zones",
-			sdk: compute.VirtualMachine{
+			sdk: armcompute.VirtualMachine{
 				ID:   ptr.To("test-vm-id"),
 				Name: ptr.To("test-vm-name"),
-				VirtualMachineProperties: &compute.VirtualMachineProperties{
+				Properties: &armcompute.VirtualMachineProperties{
 					ProvisioningState: ptr.To("Succeeded"),
 				},
-				Zones: &[]string{"1", "2"},
+				Zones: []*string{ptr.To("1"), ptr.To("2")},
 			},
 			want: &VM{
 				ID:               "test-vm-id",
 				Name:             "test-vm-name",
-				State:            infrav1.ProvisioningState(compute.ProvisioningStateSucceeded),
+				State:            infrav1.ProvisioningState("Succeeded"),
 				AvailabilityZone: "1",
 			},
 		},
 		{
 			name: "Should convert and populate with tags",
-			sdk: compute.VirtualMachine{
+			sdk: armcompute.VirtualMachine{
 				ID:   ptr.To("test-vm-id"),
 				Name: ptr.To("test-vm-name"),
-				VirtualMachineProperties: &compute.VirtualMachineProperties{
+				Properties: &armcompute.VirtualMachineProperties{
 					ProvisioningState: ptr.To("Succeeded"),
 				},
 				Tags: map[string]*string{"foo": ptr.To("bar")},
@@ -96,28 +96,28 @@ func TestSDKToVM(t *testing.T) {
 			want: &VM{
 				ID:    "test-vm-id",
 				Name:  "test-vm-name",
-				State: infrav1.ProvisioningState(compute.ProvisioningStateSucceeded),
+				State: infrav1.ProvisioningState("Succeeded"),
 				Tags:  infrav1.Tags{"foo": "bar"},
 			},
 		},
 		{
 			name: "Should convert and populate with all fields",
-			sdk: compute.VirtualMachine{
+			sdk: armcompute.VirtualMachine{
 				ID:   ptr.To("test-vm-id"),
 				Name: ptr.To("test-vm-name"),
-				VirtualMachineProperties: &compute.VirtualMachineProperties{
+				Properties: &armcompute.VirtualMachineProperties{
 					ProvisioningState: ptr.To("Succeeded"),
-					HardwareProfile: &compute.HardwareProfile{
-						VMSize: compute.VirtualMachineSizeTypesStandardA1,
+					HardwareProfile: &armcompute.HardwareProfile{
+						VMSize: ptr.To(armcompute.VirtualMachineSizeTypesStandardA1),
 					},
 				},
-				Zones: &[]string{"1"},
+				Zones: []*string{ptr.To("1")},
 				Tags:  map[string]*string{"foo": ptr.To("bar")},
 			},
 			want: &VM{
 				ID:               "test-vm-id",
 				Name:             "test-vm-name",
-				State:            infrav1.ProvisioningState(compute.ProvisioningStateSucceeded),
+				State:            infrav1.ProvisioningState("Succeeded"),
 				VMSize:           "Standard_A1",
 				AvailabilityZone: "1",
 				Tags:             infrav1.Tags{"foo": "bar"},

--- a/azure/services/roleassignments/roleassignments_test.go
+++ b/azure/services/roleassignments/roleassignments_test.go
@@ -23,7 +23,6 @@ import (
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute"
 	"github.com/Azure/go-autorest/autorest"
 	. "github.com/onsi/gomega"
 	"go.uber.org/mock/gomock"
@@ -82,8 +81,8 @@ func TestReconcileRoleAssignmentsVM(t *testing.T) {
 				s.HasSystemAssignedIdentity().Return(true)
 				s.RoleAssignmentResourceType().Return("VirtualMachine")
 				s.RoleAssignmentSpecs(&fakePrincipalID).Return(fakeRoleAssignmentSpecs[:1])
-				m.Get(gomockinternal.AContext(), &fakeVMSpec).Return(compute.VirtualMachine{
-					Identity: &compute.VirtualMachineIdentity{
+				m.Get(gomockinternal.AContext(), &fakeVMSpec).Return(armcompute.VirtualMachine{
+					Identity: &armcompute.VirtualMachineIdentity{
 						PrincipalID: &fakePrincipalID,
 					},
 				}, nil)
@@ -101,7 +100,7 @@ func TestReconcileRoleAssignmentsVM(t *testing.T) {
 				s.Name().Return(fakeRoleAssignment1.MachineName)
 				s.HasSystemAssignedIdentity().Return(true)
 				s.RoleAssignmentResourceType().Return("VirtualMachine")
-				m.Get(gomockinternal.AContext(), &fakeVMSpec).Return(compute.VirtualMachine{}, autorest.NewErrorWithResponse("", "", &http.Response{StatusCode: http.StatusInternalServerError}, "Internal Server Error"))
+				m.Get(gomockinternal.AContext(), &fakeVMSpec).Return(armcompute.VirtualMachine{}, autorest.NewErrorWithResponse("", "", &http.Response{StatusCode: http.StatusInternalServerError}, "Internal Server Error"))
 			},
 		},
 		{
@@ -116,8 +115,8 @@ func TestReconcileRoleAssignmentsVM(t *testing.T) {
 				s.RoleAssignmentResourceType().Return("VirtualMachine")
 				s.HasSystemAssignedIdentity().Return(true)
 				s.RoleAssignmentSpecs(&fakePrincipalID).Return(fakeRoleAssignmentSpecs[0:1])
-				m.Get(gomockinternal.AContext(), &fakeVMSpec).Return(compute.VirtualMachine{
-					Identity: &compute.VirtualMachineIdentity{
+				m.Get(gomockinternal.AContext(), &fakeVMSpec).Return(armcompute.VirtualMachine{
+					Identity: &armcompute.VirtualMachineIdentity{
 						PrincipalID: &fakePrincipalID,
 					},
 				}, nil)

--- a/azure/services/scalesets/spec.go
+++ b/azure/services/scalesets/spec.go
@@ -159,12 +159,12 @@ func (s *ScaleSetSpec) Parameters(ctx context.Context, existing interface{}) (pa
 		return armcompute.VirtualMachineScaleSet{}, err
 	}
 
-	priority, evictionPolicy, billingProfile, err := converters.GetSpotVMOptionsV2(s.SpotVMOptions, s.OSDisk.DiffDiskSettings)
+	priority, evictionPolicy, billingProfile, err := converters.GetSpotVMOptions(s.SpotVMOptions, s.OSDisk.DiffDiskSettings)
 	if err != nil {
 		return armcompute.VirtualMachineScaleSet{}, errors.Wrapf(err, "failed to get Spot VM options")
 	}
 
-	diagnosticsProfile := converters.GetDiagnosticsProfileV2(s.DiagnosticsProfile)
+	diagnosticsProfile := converters.GetDiagnosticsProfile(s.DiagnosticsProfile)
 
 	osProfile, err := s.generateOSProfile(ctx)
 	if err != nil {
@@ -424,7 +424,7 @@ func (s *ScaleSetSpec) generateStorageProfile(ctx context.Context) (*armcompute.
 	if s.VMImage == nil {
 		return nil, errors.Errorf("vm image is nil")
 	}
-	imageRef, err := converters.ImageToSDKv2(s.VMImage)
+	imageRef, err := converters.ImageToSDK(s.VMImage)
 	if err != nil {
 		return nil, err
 	}

--- a/azure/services/scalesets/spec_test.go
+++ b/azure/services/scalesets/spec_test.go
@@ -22,7 +22,6 @@ import (
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute"
 	"github.com/google/go-cmp/cmp"
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -223,7 +222,7 @@ func getEPHVMSSS() (ScaleSetSpec, armcompute.VirtualMachineScaleSet) {
 	}
 	spec.SpotVMOptions = &infrav1.SpotVMOptions{}
 	spec.OSDisk.DiffDiskSettings = &infrav1.DiffDiskSettings{
-		Option: string(compute.DiffDiskOptionsLocal),
+		Option: string(armcompute.DiffDiskOptionsLocal),
 	}
 	vmss := newDefaultVMSS(vmSizeEPH)
 	vmss.Properties.VirtualMachineProfile.StorageProfile.OSDisk.DiffDiskSettings = &armcompute.DiffDiskSettings{

--- a/azure/services/virtualmachines/client.go
+++ b/azure/services/virtualmachines/client.go
@@ -18,18 +18,15 @@ package virtualmachines
 
 import (
 	"context"
-	"encoding/base64"
-	"encoding/json"
 	"fmt"
-	"time"
 
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute"
-	"github.com/Azure/go-autorest/autorest"
-	azureautorest "github.com/Azure/go-autorest/autorest/azure"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
 	"github.com/pkg/errors"
 	"k8s.io/utils/ptr"
-	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
+	"sigs.k8s.io/cluster-api-provider-azure/azure/services/asyncpoller"
 	azureutil "sigs.k8s.io/cluster-api-provider-azure/util/azure"
 	"sigs.k8s.io/cluster-api-provider-azure/util/reconciler"
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
@@ -38,43 +35,31 @@ import (
 type (
 	// AzureClient contains the Azure go-sdk Client.
 	AzureClient struct {
-		virtualmachines compute.VirtualMachinesClient
+		virtualmachines *armcompute.VirtualMachinesClient
 	}
 
 	// Client provides operations on Azure virtual machine resources.
 	Client interface {
 		Get(context.Context, azure.ResourceSpecGetter) (interface{}, error)
-		GetByID(context.Context, string) (compute.VirtualMachine, error)
-		CreateOrUpdateAsync(ctx context.Context, spec azure.ResourceSpecGetter, parameters interface{}) (result interface{}, future azureautorest.FutureAPI, err error)
-		DeleteAsync(ctx context.Context, spec azure.ResourceSpecGetter) (future azureautorest.FutureAPI, err error)
-		IsDone(ctx context.Context, future azureautorest.FutureAPI) (isDone bool, err error)
-		Result(ctx context.Context, future azureautorest.FutureAPI, futureType string) (result interface{}, err error)
-		GetResultIfDone(ctx context.Context, future *infrav1.Future) (compute.VirtualMachine, error)
+		GetByID(context.Context, string) (armcompute.VirtualMachine, error)
+		CreateOrUpdateAsync(ctx context.Context, spec azure.ResourceSpecGetter, resumeToken string, parameters interface{}) (result interface{}, poller *runtime.Poller[armcompute.VirtualMachinesClientCreateOrUpdateResponse], err error)
+		DeleteAsync(ctx context.Context, spec azure.ResourceSpecGetter, resumeToken string) (poller *runtime.Poller[armcompute.VirtualMachinesClientDeleteResponse], err error)
 	}
 )
 
-type genericVMFuture interface {
-	DoneWithContext(ctx context.Context, sender autorest.Sender) (done bool, err error)
-	Result(client compute.VirtualMachinesClient) (vm compute.VirtualMachine, err error)
-}
-
-type deleteFutureAdapter struct {
-	compute.VirtualMachinesDeleteFuture
-}
-
 var _ Client = &AzureClient{}
 
-// NewClient creates a new VM client from subscription ID.
-func NewClient(auth azure.Authorizer) *AzureClient {
-	c := newVirtualMachinesClient(auth.SubscriptionID(), auth.BaseURI(), auth.Authorizer())
-	return &AzureClient{c}
-}
-
-// newVirtualMachinesClient creates a new VM client from subscription ID.
-func newVirtualMachinesClient(subscriptionID string, baseURI string, authorizer autorest.Authorizer) compute.VirtualMachinesClient {
-	vmClient := compute.NewVirtualMachinesClientWithBaseURI(baseURI, subscriptionID)
-	azure.SetAutoRestClientDefaults(&vmClient.Client, authorizer)
-	return vmClient
+// NewClient creates a VMs client from an authorizer.
+func NewClient(auth azure.Authorizer) (*AzureClient, error) {
+	opts, err := azure.ARMClientOptions(auth.CloudEnvironment())
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create virtualmachines client options")
+	}
+	factory, err := armcompute.NewClientFactory(auth.SubscriptionID(), auth.Token(), opts)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create armcompute client factory")
+	}
+	return &AzureClient{factory.NewVirtualMachinesClient()}, nil
 }
 
 // Get retrieves information about the model view or the instance view of a virtual machine.
@@ -82,37 +67,50 @@ func (ac *AzureClient) Get(ctx context.Context, spec azure.ResourceSpecGetter) (
 	ctx, _, done := tele.StartSpanWithLogger(ctx, "virtualmachines.AzureClient.Get")
 	defer done()
 
-	return ac.virtualmachines.Get(ctx, spec.ResourceGroupName(), spec.ResourceName(), "")
+	resp, err := ac.virtualmachines.Get(ctx, spec.ResourceGroupName(), spec.ResourceName(), nil)
+	if err != nil {
+		return nil, err
+	}
+	return resp.VirtualMachine, nil
 }
 
 // GetByID retrieves information about the model or instance view of a virtual machine.
-func (ac *AzureClient) GetByID(ctx context.Context, resourceID string) (compute.VirtualMachine, error) {
+func (ac *AzureClient) GetByID(ctx context.Context, resourceID string) (armcompute.VirtualMachine, error) {
 	ctx, log, done := tele.StartSpanWithLogger(ctx, "virtualmachines.AzureClient.GetByID")
 	defer done()
 
 	parsed, err := azureutil.ParseResourceID(resourceID)
 	if err != nil {
-		return compute.VirtualMachine{}, errors.Wrap(err, fmt.Sprintf("failed parsing the VM resource id %q", resourceID))
+		return armcompute.VirtualMachine{}, errors.Wrap(err, fmt.Sprintf("failed parsing the VM resource id %q", resourceID))
 	}
 
 	log.V(4).Info("parsed VM resourceID", "parsed", parsed)
 
-	return ac.virtualmachines.Get(ctx, parsed.ResourceGroupName, parsed.Name, "")
+	result, err := ac.Get(ctx, newResourceAdaptor(parsed))
+	if err != nil {
+		return armcompute.VirtualMachine{}, err
+	}
+
+	if vm, ok := result.(armcompute.VirtualMachine); ok {
+		return vm, nil
+	}
+	return armcompute.VirtualMachine{}, errors.Errorf("expected VirtualMachine but got %T", result)
 }
 
 // CreateOrUpdateAsync creates or updates a virtual machine asynchronously.
-// It sends a PUT request to Azure and if accepted without error, the func will return a Future which can be used to track the ongoing
+// It sends a PUT request to Azure and if accepted without error, the func will return a Poller which can be used to track the ongoing
 // progress of the operation.
-func (ac *AzureClient) CreateOrUpdateAsync(ctx context.Context, spec azure.ResourceSpecGetter, parameters interface{}) (result interface{}, future azureautorest.FutureAPI, err error) {
+func (ac *AzureClient) CreateOrUpdateAsync(ctx context.Context, spec azure.ResourceSpecGetter, resumeToken string, parameters interface{}) (result interface{}, poller *runtime.Poller[armcompute.VirtualMachinesClientCreateOrUpdateResponse], err error) {
 	ctx, _, done := tele.StartSpanWithLogger(ctx, "virtualmachines.AzureClient.CreateOrUpdate")
 	defer done()
 
-	vm, ok := parameters.(compute.VirtualMachine)
-	if !ok {
-		return nil, nil, errors.Errorf("%T is not a compute.VirtualMachine", parameters)
+	vm, ok := parameters.(armcompute.VirtualMachine)
+	if !ok && parameters != nil {
+		return nil, nil, errors.Errorf("%T is not an armcompute.VirtualMachine", parameters)
 	}
 
-	createFuture, err := ac.virtualmachines.CreateOrUpdate(ctx, spec.ResourceGroupName(), spec.ResourceName(), vm)
+	opts := &armcompute.VirtualMachinesClientBeginCreateOrUpdateOptions{ResumeToken: resumeToken}
+	poller, err = ac.virtualmachines.BeginCreateOrUpdate(ctx, spec.ResourceGroupName(), spec.ResourceName(), vm, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -120,26 +118,28 @@ func (ac *AzureClient) CreateOrUpdateAsync(ctx context.Context, spec azure.Resou
 	ctx, cancel := context.WithTimeout(ctx, reconciler.DefaultAzureCallTimeout)
 	defer cancel()
 
-	err = createFuture.WaitForCompletionRef(ctx, ac.virtualmachines.Client)
+	pollOpts := &runtime.PollUntilDoneOptions{Frequency: asyncpoller.DefaultPollerFrequency}
+	resp, err := poller.PollUntilDone(ctx, pollOpts)
 	if err != nil {
-		// if an error occurs, return the future.
+		// if an error occurs, return the poller.
 		// this means the long-running operation didn't finish in the specified timeout.
-		return nil, &createFuture, err
+		return nil, poller, err
 	}
-	result, err = createFuture.Result(ac.virtualmachines)
-	// if the operation completed, return a nil future
-	return result, nil, err
+
+	// if the operation completed, return a nil poller
+	return resp.VirtualMachine, nil, err
 }
 
 // DeleteAsync deletes a virtual machine asynchronously. DeleteAsync sends a DELETE
-// request to Azure and if accepted without error, the func will return a Future which can be used to track the ongoing
+// request to Azure and if accepted without error, the func will return a Poller which can be used to track the ongoing
 // progress of the operation.
-func (ac *AzureClient) DeleteAsync(ctx context.Context, spec azure.ResourceSpecGetter) (future azureautorest.FutureAPI, err error) {
+func (ac *AzureClient) DeleteAsync(ctx context.Context, spec azure.ResourceSpecGetter, resumeToken string) (poller *runtime.Poller[armcompute.VirtualMachinesClientDeleteResponse], err error) {
 	ctx, _, done := tele.StartSpanWithLogger(ctx, "virtualmachines.AzureClient.Delete")
 	defer done()
 
 	forceDelete := ptr.To(true)
-	deleteFuture, err := ac.virtualmachines.Delete(ctx, spec.ResourceGroupName(), spec.ResourceName(), forceDelete)
+	opts := &armcompute.VirtualMachinesClientBeginDeleteOptions{ResumeToken: resumeToken, ForceDeletion: forceDelete}
+	poller, err = ac.virtualmachines.BeginDelete(ctx, spec.ResourceGroupName(), spec.ResourceName(), opts)
 	if err != nil {
 		return nil, err
 	}
@@ -147,116 +147,32 @@ func (ac *AzureClient) DeleteAsync(ctx context.Context, spec azure.ResourceSpecG
 	ctx, cancel := context.WithTimeout(ctx, reconciler.DefaultAzureCallTimeout)
 	defer cancel()
 
-	err = deleteFuture.WaitForCompletionRef(ctx, ac.virtualmachines.Client)
+	pollOpts := &runtime.PollUntilDoneOptions{Frequency: asyncpoller.DefaultPollerFrequency}
+	_, err = poller.PollUntilDone(ctx, pollOpts)
 	if err != nil {
-		// if an error occurs, return the future.
+		// if an error occurs, return the Poller.
 		// this means the long-running operation didn't finish in the specified timeout.
-		return &deleteFuture, err
+		return poller, err
 	}
-	_, err = deleteFuture.Result(ac.virtualmachines)
-	// if the operation completed, return a nil future.
+
+	// if the operation completed, return a nil poller.
 	return nil, err
 }
 
-// IsDone returns true if the long-running operation has completed.
-func (ac *AzureClient) IsDone(ctx context.Context, future azureautorest.FutureAPI) (isDone bool, err error) {
-	ctx, _, done := tele.StartSpanWithLogger(ctx, "virtualmachines.AzureClient.IsDone")
-	defer done()
-
-	return future.DoneWithContext(ctx, ac.virtualmachines)
+// resourceAdaptor implements the ResourceSpecGetter interface for an arm.ResourceID.
+type resourceAdaptor struct {
+	resource *arm.ResourceID
 }
 
-// Result fetches the result of a long-running operation future.
-func (ac *AzureClient) Result(ctx context.Context, future azureautorest.FutureAPI, futureType string) (result interface{}, err error) {
-	_, _, done := tele.StartSpanWithLogger(ctx, "virtualmachines.AzureClient.Result")
-	defer done()
-
-	if future == nil {
-		return nil, errors.Errorf("cannot get result from nil future")
-	}
-
-	switch futureType {
-	case infrav1.PatchFuture:
-		// Marshal and Unmarshal the future to put it into the correct future type so we can access the Result function.
-		// Unfortunately the FutureAPI can't be casted directly to VirtualMachinesUpdateFuture because it is a azureautorest.Future, which doesn't implement the Result function. See PR #1686 for discussion on alternatives.
-		// It was converted back to a generic azureautorest.Future from the CAPZ infrav1.Future type stored in Status: https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/azure/converters/futures.go#L49.
-		var updateFuture *compute.VirtualMachinesUpdateFuture
-		jsonData, err := future.MarshalJSON()
-		if err != nil {
-			return nil, errors.Wrap(err, "failed to marshal future")
-		}
-		if err := json.Unmarshal(jsonData, &updateFuture); err != nil {
-			return nil, errors.Wrap(err, "failed to unmarshal future data")
-		}
-		return updateFuture.Result(ac.virtualmachines)
-
-	case infrav1.PutFuture:
-		// Marshal and Unmarshal the future to put it into the correct future type so we can access the Result function.
-		// Unfortunately the FutureAPI can't be casted directly to VirtualMachinesCreateOrUpdateFuture because it is a azureautorest.Future, which doesn't implement the Result function. See PR #1686 for discussion on alternatives.
-		// It was converted back to a generic azureautorest.Future from the CAPZ infrav1.Future type stored in Status: https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/azure/converters/futures.go#L49.
-		var createFuture *compute.VirtualMachinesCreateOrUpdateFuture
-		jsonData, err := future.MarshalJSON()
-		if err != nil {
-			return nil, errors.Wrap(err, "failed to marshal future")
-		}
-		if err := json.Unmarshal(jsonData, &createFuture); err != nil {
-			return nil, errors.Wrap(err, "failed to unmarshal future data")
-		}
-		return createFuture.Result(ac.virtualmachines)
-
-	case infrav1.DeleteFuture:
-		// Delete does not return a result VM.
-		return nil, nil
-
-	default:
-		return nil, errors.Errorf("unknown future type %q", futureType)
-	}
+func newResourceAdaptor(resource *arm.ResourceID) *resourceAdaptor {
+	return &resourceAdaptor{resource: resource}
 }
 
-// GetResultIfDone fetches the result of a long-running operation future if it is done.
-func (ac *AzureClient) GetResultIfDone(ctx context.Context, future *infrav1.Future) (compute.VirtualMachine, error) {
-	ctx, _, spanDone := tele.StartSpanWithLogger(ctx, "virtualmachines.AzureClient.GetResultIfDone")
-	defer spanDone()
+func (r *resourceAdaptor) OwnerResourceName() string { return r.resource.Parent.Name }
 
-	var genericFuture genericVMFuture
-	futureData, err := base64.URLEncoding.DecodeString(future.Data)
-	if err != nil {
-		return compute.VirtualMachine{}, errors.Wrapf(err, "failed to base64 decode future data")
-	}
-
-	switch future.Type {
-	case infrav1.DeleteFuture:
-		var future compute.VirtualMachinesDeleteFuture
-		if err := json.Unmarshal(futureData, &future); err != nil {
-			return compute.VirtualMachine{}, errors.Wrap(err, "failed to unmarshal future data")
-		}
-
-		genericFuture = &deleteFutureAdapter{
-			VirtualMachinesDeleteFuture: future,
-		}
-	default:
-		return compute.VirtualMachine{}, errors.Errorf("unknown future type %q", future.Type)
-	}
-
-	done, err := genericFuture.DoneWithContext(ctx, ac.virtualmachines)
-	if err != nil {
-		return compute.VirtualMachine{}, errors.Wrapf(err, "failed checking if the operation was complete")
-	}
-
-	if !done {
-		return compute.VirtualMachine{}, azure.WithTransientError(azure.NewOperationNotDoneError(future), 15*time.Second)
-	}
-
-	vm, err := genericFuture.Result(ac.virtualmachines)
-	if err != nil {
-		return vm, errors.Wrapf(err, "failed fetching the result of operation for vm")
-	}
-
-	return vm, nil
+func (r *resourceAdaptor) Parameters(ctx context.Context, existing interface{}) (interface{}, error) {
+	return nil, nil // Not implemented
 }
+func (r *resourceAdaptor) ResourceGroupName() string { return r.resource.ResourceGroupName }
 
-// Result wraps result of a delete so it can be treated generically, when only the success or error is important.
-func (da *deleteFutureAdapter) Result(client compute.VirtualMachinesClient) (compute.VirtualMachine, error) {
-	_, err := da.VirtualMachinesDeleteFuture.Result(client)
-	return compute.VirtualMachine{}, err
-}
+func (r *resourceAdaptor) ResourceName() string { return r.resource.Name }

--- a/azure/services/virtualmachines/mock_virtualmachines/client_mock.go
+++ b/azure/services/virtualmachines/mock_virtualmachines/client_mock.go
@@ -24,12 +24,10 @@ import (
 	context "context"
 	reflect "reflect"
 
-	compute "github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute"
-	autorest "github.com/Azure/go-autorest/autorest"
-	azure "github.com/Azure/go-autorest/autorest/azure"
+	runtime "github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	armcompute "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
 	gomock "go.uber.org/mock/gomock"
-	v1beta1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
-	azure0 "sigs.k8s.io/cluster-api-provider-azure/azure"
+	azure "sigs.k8s.io/cluster-api-provider-azure/azure"
 )
 
 // MockClient is a mock of Client interface.
@@ -56,38 +54,38 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 }
 
 // CreateOrUpdateAsync mocks base method.
-func (m *MockClient) CreateOrUpdateAsync(ctx context.Context, spec azure0.ResourceSpecGetter, parameters interface{}) (interface{}, azure.FutureAPI, error) {
+func (m *MockClient) CreateOrUpdateAsync(ctx context.Context, spec azure.ResourceSpecGetter, resumeToken string, parameters interface{}) (interface{}, *runtime.Poller[armcompute.VirtualMachinesClientCreateOrUpdateResponse], error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateOrUpdateAsync", ctx, spec, parameters)
+	ret := m.ctrl.Call(m, "CreateOrUpdateAsync", ctx, spec, resumeToken, parameters)
 	ret0, _ := ret[0].(interface{})
-	ret1, _ := ret[1].(azure.FutureAPI)
+	ret1, _ := ret[1].(*runtime.Poller[armcompute.VirtualMachinesClientCreateOrUpdateResponse])
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
 }
 
 // CreateOrUpdateAsync indicates an expected call of CreateOrUpdateAsync.
-func (mr *MockClientMockRecorder) CreateOrUpdateAsync(ctx, spec, parameters interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) CreateOrUpdateAsync(ctx, spec, resumeToken, parameters interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateOrUpdateAsync", reflect.TypeOf((*MockClient)(nil).CreateOrUpdateAsync), ctx, spec, parameters)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateOrUpdateAsync", reflect.TypeOf((*MockClient)(nil).CreateOrUpdateAsync), ctx, spec, resumeToken, parameters)
 }
 
 // DeleteAsync mocks base method.
-func (m *MockClient) DeleteAsync(ctx context.Context, spec azure0.ResourceSpecGetter) (azure.FutureAPI, error) {
+func (m *MockClient) DeleteAsync(ctx context.Context, spec azure.ResourceSpecGetter, resumeToken string) (*runtime.Poller[armcompute.VirtualMachinesClientDeleteResponse], error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteAsync", ctx, spec)
-	ret0, _ := ret[0].(azure.FutureAPI)
+	ret := m.ctrl.Call(m, "DeleteAsync", ctx, spec, resumeToken)
+	ret0, _ := ret[0].(*runtime.Poller[armcompute.VirtualMachinesClientDeleteResponse])
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // DeleteAsync indicates an expected call of DeleteAsync.
-func (mr *MockClientMockRecorder) DeleteAsync(ctx, spec interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) DeleteAsync(ctx, spec, resumeToken interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteAsync", reflect.TypeOf((*MockClient)(nil).DeleteAsync), ctx, spec)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteAsync", reflect.TypeOf((*MockClient)(nil).DeleteAsync), ctx, spec, resumeToken)
 }
 
 // Get mocks base method.
-func (m *MockClient) Get(arg0 context.Context, arg1 azure0.ResourceSpecGetter) (interface{}, error) {
+func (m *MockClient) Get(arg0 context.Context, arg1 azure.ResourceSpecGetter) (interface{}, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Get", arg0, arg1)
 	ret0, _ := ret[0].(interface{})
@@ -102,10 +100,10 @@ func (mr *MockClientMockRecorder) Get(arg0, arg1 interface{}) *gomock.Call {
 }
 
 // GetByID mocks base method.
-func (m *MockClient) GetByID(arg0 context.Context, arg1 string) (compute.VirtualMachine, error) {
+func (m *MockClient) GetByID(arg0 context.Context, arg1 string) (armcompute.VirtualMachine, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetByID", arg0, arg1)
-	ret0, _ := ret[0].(compute.VirtualMachine)
+	ret0, _ := ret[0].(armcompute.VirtualMachine)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -114,102 +112,4 @@ func (m *MockClient) GetByID(arg0 context.Context, arg1 string) (compute.Virtual
 func (mr *MockClientMockRecorder) GetByID(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetByID", reflect.TypeOf((*MockClient)(nil).GetByID), arg0, arg1)
-}
-
-// GetResultIfDone mocks base method.
-func (m *MockClient) GetResultIfDone(ctx context.Context, future *v1beta1.Future) (compute.VirtualMachine, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetResultIfDone", ctx, future)
-	ret0, _ := ret[0].(compute.VirtualMachine)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetResultIfDone indicates an expected call of GetResultIfDone.
-func (mr *MockClientMockRecorder) GetResultIfDone(ctx, future interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetResultIfDone", reflect.TypeOf((*MockClient)(nil).GetResultIfDone), ctx, future)
-}
-
-// IsDone mocks base method.
-func (m *MockClient) IsDone(ctx context.Context, future azure.FutureAPI) (bool, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsDone", ctx, future)
-	ret0, _ := ret[0].(bool)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// IsDone indicates an expected call of IsDone.
-func (mr *MockClientMockRecorder) IsDone(ctx, future interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsDone", reflect.TypeOf((*MockClient)(nil).IsDone), ctx, future)
-}
-
-// Result mocks base method.
-func (m *MockClient) Result(ctx context.Context, future azure.FutureAPI, futureType string) (interface{}, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Result", ctx, future, futureType)
-	ret0, _ := ret[0].(interface{})
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// Result indicates an expected call of Result.
-func (mr *MockClientMockRecorder) Result(ctx, future, futureType interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Result", reflect.TypeOf((*MockClient)(nil).Result), ctx, future, futureType)
-}
-
-// MockgenericVMFuture is a mock of genericVMFuture interface.
-type MockgenericVMFuture struct {
-	ctrl     *gomock.Controller
-	recorder *MockgenericVMFutureMockRecorder
-}
-
-// MockgenericVMFutureMockRecorder is the mock recorder for MockgenericVMFuture.
-type MockgenericVMFutureMockRecorder struct {
-	mock *MockgenericVMFuture
-}
-
-// NewMockgenericVMFuture creates a new mock instance.
-func NewMockgenericVMFuture(ctrl *gomock.Controller) *MockgenericVMFuture {
-	mock := &MockgenericVMFuture{ctrl: ctrl}
-	mock.recorder = &MockgenericVMFutureMockRecorder{mock}
-	return mock
-}
-
-// EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockgenericVMFuture) EXPECT() *MockgenericVMFutureMockRecorder {
-	return m.recorder
-}
-
-// DoneWithContext mocks base method.
-func (m *MockgenericVMFuture) DoneWithContext(ctx context.Context, sender autorest.Sender) (bool, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DoneWithContext", ctx, sender)
-	ret0, _ := ret[0].(bool)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// DoneWithContext indicates an expected call of DoneWithContext.
-func (mr *MockgenericVMFutureMockRecorder) DoneWithContext(ctx, sender interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DoneWithContext", reflect.TypeOf((*MockgenericVMFuture)(nil).DoneWithContext), ctx, sender)
-}
-
-// Result mocks base method.
-func (m *MockgenericVMFuture) Result(client compute.VirtualMachinesClient) (compute.VirtualMachine, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Result", client)
-	ret0, _ := ret[0].(compute.VirtualMachine)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// Result indicates an expected call of Result.
-func (mr *MockgenericVMFutureMockRecorder) Result(client interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Result", reflect.TypeOf((*MockgenericVMFuture)(nil).Result), client)
 }

--- a/azure/services/virtualmachines/spec.go
+++ b/azure/services/virtualmachines/spec.go
@@ -21,7 +21,7 @@ import (
 	"encoding/base64"
 	"fmt"
 
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
 	"github.com/pkg/errors"
 	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
@@ -77,8 +77,8 @@ func (s *VMSpec) OwnerResourceName() string {
 // Parameters returns the parameters for the virtual machine.
 func (s *VMSpec) Parameters(ctx context.Context, existing interface{}) (params interface{}, err error) {
 	if existing != nil {
-		if _, ok := existing.(compute.VirtualMachine); !ok {
-			return nil, errors.Errorf("%T is not a compute.VirtualMachine", existing)
+		if _, ok := existing.(armcompute.VirtualMachine); !ok {
+			return nil, errors.Errorf("%T is not an armcompute.VirtualMachine", existing)
 		}
 		// vm already exists
 		return nil, nil
@@ -114,7 +114,7 @@ func (s *VMSpec) Parameters(ctx context.Context, existing interface{}) (params i
 		return nil, errors.Wrap(err, "failed to generate VM identity")
 	}
 
-	return compute.VirtualMachine{
+	return armcompute.VirtualMachine{
 		Plan:             converters.ImageToPlan(s.Image),
 		Location:         ptr.To(s.Location),
 		ExtendedLocation: converters.ExtendedLocationToComputeSDK(s.ExtendedLocation),
@@ -125,16 +125,16 @@ func (s *VMSpec) Parameters(ctx context.Context, existing interface{}) (params i
 			Role:        ptr.To(s.Role),
 			Additional:  s.AdditionalTags,
 		})),
-		VirtualMachineProperties: &compute.VirtualMachineProperties{
+		Properties: &armcompute.VirtualMachineProperties{
 			AdditionalCapabilities: s.generateAdditionalCapabilities(),
 			AvailabilitySet:        s.getAvailabilitySet(),
-			HardwareProfile: &compute.HardwareProfile{
-				VMSize: compute.VirtualMachineSizeTypes(s.Size),
+			HardwareProfile: &armcompute.HardwareProfile{
+				VMSize: ptr.To(armcompute.VirtualMachineSizeTypes(s.Size)),
 			},
 			StorageProfile:  storageProfile,
 			SecurityProfile: securityProfile,
-			OsProfile:       osProfile,
-			NetworkProfile: &compute.NetworkProfile{
+			OSProfile:       osProfile,
+			NetworkProfile: &armcompute.NetworkProfile{
 				NetworkInterfaces: s.generateNICRefs(),
 			},
 			Priority:           priority,
@@ -147,16 +147,19 @@ func (s *VMSpec) Parameters(ctx context.Context, existing interface{}) (params i
 	}, nil
 }
 
-// generateStorageProfile generates a pointer to a compute.StorageProfile which can utilized for VM creation.
-func (s *VMSpec) generateStorageProfile() (*compute.StorageProfile, error) {
-	storageProfile := &compute.StorageProfile{
-		OsDisk: &compute.OSDisk{
-			Name:         ptr.To(azure.GenerateOSDiskName(s.Name)),
-			OsType:       compute.OperatingSystemTypes(s.OSDisk.OSType),
-			CreateOption: compute.DiskCreateOptionTypesFromImage,
-			DiskSizeGB:   s.OSDisk.DiskSizeGB,
-			Caching:      compute.CachingTypes(s.OSDisk.CachingType),
-		},
+// generateStorageProfile generates a pointer to an armcompute.StorageProfile which can utilized for VM creation.
+func (s *VMSpec) generateStorageProfile() (*armcompute.StorageProfile, error) {
+	osDisk := &armcompute.OSDisk{
+		Name:         ptr.To(azure.GenerateOSDiskName(s.Name)),
+		OSType:       ptr.To(armcompute.OperatingSystemTypes(s.OSDisk.OSType)),
+		CreateOption: ptr.To(armcompute.DiskCreateOptionTypesFromImage),
+		DiskSizeGB:   s.OSDisk.DiskSizeGB,
+	}
+	if s.OSDisk.CachingType != "" {
+		osDisk.Caching = ptr.To(armcompute.CachingTypes(s.OSDisk.CachingType))
+	}
+	storageProfile := &armcompute.StorageProfile{
+		OSDisk: osDisk,
 	}
 
 	// Checking if the requested VM size has at least 2 vCPUS
@@ -183,61 +186,63 @@ func (s *VMSpec) generateStorageProfile() (*compute.StorageProfile, error) {
 			return nil, azure.WithTerminalError(fmt.Errorf("VM size %s does not support ephemeral os. Select a different VM size or disable ephemeral os", s.Size))
 		}
 
-		storageProfile.OsDisk.DiffDiskSettings = &compute.DiffDiskSettings{
-			Option: compute.DiffDiskOptions(s.OSDisk.DiffDiskSettings.Option),
+		storageProfile.OSDisk.DiffDiskSettings = &armcompute.DiffDiskSettings{
+			Option: ptr.To(armcompute.DiffDiskOptions(s.OSDisk.DiffDiskSettings.Option)),
 		}
 	}
 
 	if s.OSDisk.ManagedDisk != nil {
-		storageProfile.OsDisk.ManagedDisk = &compute.ManagedDiskParameters{}
+		storageProfile.OSDisk.ManagedDisk = &armcompute.ManagedDiskParameters{}
 		if s.OSDisk.ManagedDisk.StorageAccountType != "" {
-			storageProfile.OsDisk.ManagedDisk.StorageAccountType = compute.StorageAccountTypes(s.OSDisk.ManagedDisk.StorageAccountType)
+			storageProfile.OSDisk.ManagedDisk.StorageAccountType = ptr.To(armcompute.StorageAccountTypes(s.OSDisk.ManagedDisk.StorageAccountType))
 		}
 		if s.OSDisk.ManagedDisk.DiskEncryptionSet != nil {
-			storageProfile.OsDisk.ManagedDisk.DiskEncryptionSet = &compute.DiskEncryptionSetParameters{ID: ptr.To(s.OSDisk.ManagedDisk.DiskEncryptionSet.ID)}
+			storageProfile.OSDisk.ManagedDisk.DiskEncryptionSet = &armcompute.DiskEncryptionSetParameters{ID: ptr.To(s.OSDisk.ManagedDisk.DiskEncryptionSet.ID)}
 		}
 		if s.OSDisk.ManagedDisk.SecurityProfile != nil {
 			if _, exists := s.SKU.GetCapability(resourceskus.ConfidentialComputingType); !exists {
 				return nil, azure.WithTerminalError(fmt.Errorf("VM size %s does not support confidential computing. Select a different VM size or remove the security profile of the OS disk", s.Size))
 			}
 
-			storageProfile.OsDisk.ManagedDisk.SecurityProfile = &compute.VMDiskSecurityProfile{}
+			storageProfile.OSDisk.ManagedDisk.SecurityProfile = &armcompute.VMDiskSecurityProfile{}
 
 			if s.OSDisk.ManagedDisk.SecurityProfile.DiskEncryptionSet != nil {
-				storageProfile.OsDisk.ManagedDisk.SecurityProfile.DiskEncryptionSet = &compute.DiskEncryptionSetParameters{ID: ptr.To(s.OSDisk.ManagedDisk.SecurityProfile.DiskEncryptionSet.ID)}
+				storageProfile.OSDisk.ManagedDisk.SecurityProfile.DiskEncryptionSet = &armcompute.DiskEncryptionSetParameters{ID: ptr.To(s.OSDisk.ManagedDisk.SecurityProfile.DiskEncryptionSet.ID)}
 			}
 			if s.OSDisk.ManagedDisk.SecurityProfile.SecurityEncryptionType != "" {
-				storageProfile.OsDisk.ManagedDisk.SecurityProfile.SecurityEncryptionType = compute.SecurityEncryptionTypes(string(s.OSDisk.ManagedDisk.SecurityProfile.SecurityEncryptionType))
+				storageProfile.OSDisk.ManagedDisk.SecurityProfile.SecurityEncryptionType = ptr.To(armcompute.SecurityEncryptionTypes(string(s.OSDisk.ManagedDisk.SecurityProfile.SecurityEncryptionType)))
 			}
 		}
 	}
 
-	dataDisks := make([]compute.DataDisk, len(s.DataDisks))
+	dataDisks := make([]*armcompute.DataDisk, len(s.DataDisks))
 	for i, disk := range s.DataDisks {
-		dataDisks[i] = compute.DataDisk{
-			CreateOption: compute.DiskCreateOptionTypesEmpty,
+		dataDisks[i] = &armcompute.DataDisk{
+			CreateOption: ptr.To(armcompute.DiskCreateOptionTypesEmpty),
 			DiskSizeGB:   ptr.To[int32](disk.DiskSizeGB),
 			Lun:          disk.Lun,
 			Name:         ptr.To(azure.GenerateDataDiskName(s.Name, disk.NameSuffix)),
-			Caching:      compute.CachingTypes(disk.CachingType),
+		}
+		if disk.CachingType != "" {
+			dataDisks[i].Caching = ptr.To(armcompute.CachingTypes(disk.CachingType))
 		}
 
 		if disk.ManagedDisk != nil {
-			dataDisks[i].ManagedDisk = &compute.ManagedDiskParameters{
-				StorageAccountType: compute.StorageAccountTypes(disk.ManagedDisk.StorageAccountType),
+			dataDisks[i].ManagedDisk = &armcompute.ManagedDiskParameters{
+				StorageAccountType: ptr.To(armcompute.StorageAccountTypes(disk.ManagedDisk.StorageAccountType)),
 			}
 
 			if disk.ManagedDisk.DiskEncryptionSet != nil {
-				dataDisks[i].ManagedDisk.DiskEncryptionSet = &compute.DiskEncryptionSetParameters{ID: ptr.To(disk.ManagedDisk.DiskEncryptionSet.ID)}
+				dataDisks[i].ManagedDisk.DiskEncryptionSet = &armcompute.DiskEncryptionSetParameters{ID: ptr.To(disk.ManagedDisk.DiskEncryptionSet.ID)}
 			}
 
 			// check the support for ultra disks based on location and vm size
-			if disk.ManagedDisk.StorageAccountType == string(compute.StorageAccountTypesUltraSSDLRS) && !s.SKU.HasLocationCapability(resourceskus.UltraSSDAvailable, s.Location, s.Zone) {
+			if disk.ManagedDisk.StorageAccountType == string(armcompute.StorageAccountTypesUltraSSDLRS) && !s.SKU.HasLocationCapability(resourceskus.UltraSSDAvailable, s.Location, s.Zone) {
 				return nil, azure.WithTerminalError(fmt.Errorf("VM size %s does not support ultra disks in location %s. Select a different VM size or disable ultra disks", s.Size, s.Location))
 			}
 		}
 	}
-	storageProfile.DataDisks = &dataDisks
+	storageProfile.DataDisks = dataDisks
 
 	imageRef, err := converters.ImageToSDK(s.Image)
 	if err != nil {
@@ -249,20 +254,20 @@ func (s *VMSpec) generateStorageProfile() (*compute.StorageProfile, error) {
 	return storageProfile, nil
 }
 
-func (s *VMSpec) generateOSProfile() (*compute.OSProfile, error) {
+func (s *VMSpec) generateOSProfile() (*armcompute.OSProfile, error) {
 	sshKey, err := base64.StdEncoding.DecodeString(s.SSHKeyData)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to decode ssh public key")
 	}
 
-	osProfile := &compute.OSProfile{
+	osProfile := &armcompute.OSProfile{
 		ComputerName:  ptr.To(s.Name),
 		AdminUsername: ptr.To(azure.DefaultUserName),
 		CustomData:    ptr.To(s.BootstrapData),
 	}
 
 	switch s.OSDisk.OSType {
-	case string(compute.OperatingSystemTypesWindows):
+	case string(armcompute.OperatingSystemTypesWindows):
 		// Cloudbase-init is used to generate a password.
 		// https://cloudbase-init.readthedocs.io/en/latest/plugins.html#setting-password-main
 		//
@@ -271,14 +276,14 @@ func (s *VMSpec) generateOSProfile() (*compute.OSProfile, error) {
 		// Access is provided via SSH public key that is set during deployment
 		// Azure also provides a way to reset user passwords in the case of need.
 		osProfile.AdminPassword = ptr.To(generators.SudoRandomPassword(123))
-		osProfile.WindowsConfiguration = &compute.WindowsConfiguration{
+		osProfile.WindowsConfiguration = &armcompute.WindowsConfiguration{
 			EnableAutomaticUpdates: ptr.To(false),
 		}
 	default:
-		osProfile.LinuxConfiguration = &compute.LinuxConfiguration{
+		osProfile.LinuxConfiguration = &armcompute.LinuxConfiguration{
 			DisablePasswordAuthentication: ptr.To(true),
-			SSH: &compute.SSHConfiguration{
-				PublicKeys: &[]compute.SSHPublicKey{
+			SSH: &armcompute.SSHConfiguration{
+				PublicKeys: []*armcompute.SSHPublicKey{
 					{
 						Path:    ptr.To(fmt.Sprintf("/home/%s/.ssh/authorized_keys", azure.DefaultUserName)),
 						KeyData: ptr.To(string(sshKey)),
@@ -291,19 +296,19 @@ func (s *VMSpec) generateOSProfile() (*compute.OSProfile, error) {
 	return osProfile, nil
 }
 
-func (s *VMSpec) generateSecurityProfile(storageProfile *compute.StorageProfile) (*compute.SecurityProfile, error) {
+func (s *VMSpec) generateSecurityProfile(storageProfile *armcompute.StorageProfile) (*armcompute.SecurityProfile, error) {
 	if s.SecurityProfile == nil {
 		return nil, nil
 	}
 
-	securityProfile := &compute.SecurityProfile{}
+	securityProfile := &armcompute.SecurityProfile{}
 
-	if storageProfile.OsDisk.ManagedDisk != nil &&
-		storageProfile.OsDisk.ManagedDisk.SecurityProfile != nil &&
-		storageProfile.OsDisk.ManagedDisk.SecurityProfile.SecurityEncryptionType != "" {
+	if storageProfile.OSDisk.ManagedDisk != nil &&
+		storageProfile.OSDisk.ManagedDisk.SecurityProfile != nil &&
+		ptr.Deref(storageProfile.OSDisk.ManagedDisk.SecurityProfile.SecurityEncryptionType, "") != "" {
 		if s.SecurityProfile.EncryptionAtHost != nil && *s.SecurityProfile.EncryptionAtHost &&
-			storageProfile.OsDisk.ManagedDisk.SecurityProfile.SecurityEncryptionType == compute.SecurityEncryptionTypesDiskWithVMGuestState {
-			return nil, azure.WithTerminalError(errors.Errorf("encryption at host is not supported when securityEncryptionType is set to %s", compute.SecurityEncryptionTypesDiskWithVMGuestState))
+			*storageProfile.OSDisk.ManagedDisk.SecurityProfile.SecurityEncryptionType == armcompute.SecurityEncryptionTypesDiskWithVMGuestState {
+			return nil, azure.WithTerminalError(errors.Errorf("encryption at host is not supported when securityEncryptionType is set to %s", armcompute.SecurityEncryptionTypesDiskWithVMGuestState))
 		}
 
 		if s.SecurityProfile.SecurityType != infrav1.SecurityTypesConfidentialVM {
@@ -314,18 +319,18 @@ func (s *VMSpec) generateSecurityProfile(storageProfile *compute.StorageProfile)
 			return nil, azure.WithTerminalError(errors.New("vTpmEnabled should be true when securityEncryptionType is set"))
 		}
 
-		if storageProfile.OsDisk.ManagedDisk.SecurityProfile.SecurityEncryptionType == compute.SecurityEncryptionTypesDiskWithVMGuestState &&
+		if ptr.Deref(storageProfile.OSDisk.ManagedDisk.SecurityProfile.SecurityEncryptionType, "") == armcompute.SecurityEncryptionTypesDiskWithVMGuestState &&
 			!*s.SecurityProfile.UefiSettings.SecureBootEnabled {
-			return nil, azure.WithTerminalError(errors.Errorf("secureBootEnabled should be true when securityEncryptionType is set to %s", compute.SecurityEncryptionTypesDiskWithVMGuestState))
+			return nil, azure.WithTerminalError(errors.Errorf("secureBootEnabled should be true when securityEncryptionType is set to %s", armcompute.SecurityEncryptionTypesDiskWithVMGuestState))
 		}
 
 		if s.SecurityProfile.UefiSettings.VTpmEnabled != nil && !*s.SecurityProfile.UefiSettings.VTpmEnabled {
 			return nil, azure.WithTerminalError(errors.New("vTpmEnabled should be true when securityEncryptionType is set"))
 		}
 
-		securityProfile.SecurityType = compute.SecurityTypesConfidentialVM
+		securityProfile.SecurityType = ptr.To(armcompute.SecurityTypesConfidentialVM)
 
-		securityProfile.UefiSettings = &compute.UefiSettings{
+		securityProfile.UefiSettings = &armcompute.UefiSettings{
 			SecureBootEnabled: s.SecurityProfile.UefiSettings.SecureBootEnabled,
 			VTpmEnabled:       s.SecurityProfile.UefiSettings.VTpmEnabled,
 		}
@@ -344,7 +349,7 @@ func (s *VMSpec) generateSecurityProfile(storageProfile *compute.StorageProfile)
 	hasTrustedLaunchDisabled := s.SKU.HasCapability(resourceskus.TrustedLaunchDisabled)
 
 	if s.SecurityProfile.UefiSettings != nil {
-		securityProfile.UefiSettings = &compute.UefiSettings{}
+		securityProfile.UefiSettings = &armcompute.UefiSettings{}
 
 		if s.SecurityProfile.UefiSettings.SecureBootEnabled != nil && *s.SecurityProfile.UefiSettings.SecureBootEnabled {
 			if hasTrustedLaunchDisabled {
@@ -355,7 +360,7 @@ func (s *VMSpec) generateSecurityProfile(storageProfile *compute.StorageProfile)
 				return nil, azure.WithTerminalError(errors.Errorf("securityType should be set to %s when secureBootEnabled is true", infrav1.SecurityTypesTrustedLaunch))
 			}
 
-			securityProfile.SecurityType = compute.SecurityTypesTrustedLaunch
+			securityProfile.SecurityType = ptr.To(armcompute.SecurityTypesTrustedLaunch)
 			securityProfile.UefiSettings.SecureBootEnabled = ptr.To(true)
 		}
 
@@ -368,7 +373,7 @@ func (s *VMSpec) generateSecurityProfile(storageProfile *compute.StorageProfile)
 				return nil, azure.WithTerminalError(errors.Errorf("securityType should be set to %s when vTpmEnabled is true", infrav1.SecurityTypesTrustedLaunch))
 			}
 
-			securityProfile.SecurityType = compute.SecurityTypesTrustedLaunch
+			securityProfile.SecurityType = ptr.To(armcompute.SecurityTypesTrustedLaunch)
 			securityProfile.UefiSettings.VTpmEnabled = ptr.To(true)
 		}
 	}
@@ -376,28 +381,28 @@ func (s *VMSpec) generateSecurityProfile(storageProfile *compute.StorageProfile)
 	return securityProfile, nil
 }
 
-func (s *VMSpec) generateNICRefs() *[]compute.NetworkInterfaceReference {
-	nicRefs := make([]compute.NetworkInterfaceReference, len(s.NICIDs))
+func (s *VMSpec) generateNICRefs() []*armcompute.NetworkInterfaceReference {
+	nicRefs := make([]*armcompute.NetworkInterfaceReference, len(s.NICIDs))
 	for i, id := range s.NICIDs {
 		primary := i == 0
-		nicRefs[i] = compute.NetworkInterfaceReference{
+		nicRefs[i] = &armcompute.NetworkInterfaceReference{
 			ID: ptr.To(id),
-			NetworkInterfaceReferenceProperties: &compute.NetworkInterfaceReferenceProperties{
+			Properties: &armcompute.NetworkInterfaceReferenceProperties{
 				Primary: ptr.To(primary),
 			},
 		}
 	}
-	return &nicRefs
+	return nicRefs
 }
 
-func (s *VMSpec) generateAdditionalCapabilities() *compute.AdditionalCapabilities {
-	var capabilities *compute.AdditionalCapabilities
+func (s *VMSpec) generateAdditionalCapabilities() *armcompute.AdditionalCapabilities {
+	var capabilities *armcompute.AdditionalCapabilities
 
 	// Provisionally detect whether there is any Data Disk defined which uses UltraSSDs.
 	// If that's the case, enable the UltraSSD capability.
 	for _, dataDisk := range s.DataDisks {
-		if dataDisk.ManagedDisk != nil && dataDisk.ManagedDisk.StorageAccountType == string(compute.StorageAccountTypesUltraSSDLRS) {
-			capabilities = &compute.AdditionalCapabilities{
+		if dataDisk.ManagedDisk != nil && dataDisk.ManagedDisk.StorageAccountType == string(armcompute.StorageAccountTypesUltraSSDLRS) {
+			capabilities = &armcompute.AdditionalCapabilities{
 				UltraSSDEnabled: ptr.To(true),
 			}
 			break
@@ -407,7 +412,7 @@ func (s *VMSpec) generateAdditionalCapabilities() *compute.AdditionalCapabilitie
 	// Set Additional Capabilities if any is present on the spec.
 	if s.AdditionalCapabilities != nil {
 		if capabilities == nil {
-			capabilities = &compute.AdditionalCapabilities{}
+			capabilities = &armcompute.AdditionalCapabilities{}
 		}
 		// Set UltraSSDEnabled if a specific value is set on the spec for it.
 		if s.AdditionalCapabilities.UltraSSDEnabled != nil {
@@ -418,18 +423,18 @@ func (s *VMSpec) generateAdditionalCapabilities() *compute.AdditionalCapabilitie
 	return capabilities
 }
 
-func (s *VMSpec) getAvailabilitySet() *compute.SubResource {
-	var as *compute.SubResource
+func (s *VMSpec) getAvailabilitySet() *armcompute.SubResource {
+	var as *armcompute.SubResource
 	if s.AvailabilitySetID != "" {
-		as = &compute.SubResource{ID: &s.AvailabilitySetID}
+		as = &armcompute.SubResource{ID: &s.AvailabilitySetID}
 	}
 	return as
 }
 
-func (s *VMSpec) getZones() *[]string {
-	var zones *[]string
+func (s *VMSpec) getZones() []*string {
+	var zones []*string
 	if s.Zone != "" {
-		zones = &[]string{s.Zone}
+		zones = []*string{ptr.To(s.Zone)}
 	}
 	return zones
 }

--- a/azure/services/virtualmachines/virtualmachines.go
+++ b/azure/services/virtualmachines/virtualmachines.go
@@ -20,9 +20,8 @@ import (
 	"context"
 	"strings"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v4"
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute"
-	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-08-01/network"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/ptr"
@@ -31,6 +30,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/converters"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/services/async"
+	"sigs.k8s.io/cluster-api-provider-azure/azure/services/asyncpoller"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/services/identities"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/services/networkinterfaces"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/services/publicips"
@@ -57,7 +57,7 @@ type VMScope interface {
 // Service provides operations on Azure resources.
 type Service struct {
 	Scope VMScope
-	async.Reconciler
+	asyncpoller.Reconciler
 	interfacesGetter async.Getter
 	publicIPsGetter  async.Getter
 	identitiesGetter identities.Client
@@ -65,7 +65,10 @@ type Service struct {
 
 // New creates a new service.
 func New(scope VMScope) (*Service, error) {
-	Client := NewClient(scope)
+	Client, err := NewClient(scope)
+	if err != nil {
+		return nil, err
+	}
 	identitiesSvc, err := identities.NewClient(scope)
 	if err != nil {
 		return nil, err
@@ -83,7 +86,8 @@ func New(scope VMScope) (*Service, error) {
 		interfacesGetter: interfacesSvc,
 		publicIPsGetter:  publicIPsSvc,
 		identitiesGetter: identitiesSvc,
-		Reconciler:       async.New(scope, Client, Client),
+		Reconciler: asyncpoller.New[armcompute.VirtualMachinesClientCreateOrUpdateResponse,
+			armcompute.VirtualMachinesClientDeleteResponse](scope, Client, Client),
 	}, nil
 }
 
@@ -110,9 +114,9 @@ func (s *Service) Reconcile(ctx context.Context) error {
 	// Set the DiskReady condition here since the disk gets created with the VM.
 	s.Scope.UpdatePutStatus(infrav1.DisksReadyCondition, serviceName, err)
 	if err == nil && result != nil {
-		vm, ok := result.(compute.VirtualMachine)
+		vm, ok := result.(armcompute.VirtualMachine)
 		if !ok {
-			return errors.Errorf("%T is not a compute.VirtualMachine", result)
+			return errors.Errorf("%T is not an armcompute.VirtualMachine", result)
 		}
 		infraVM := converters.SDKToVM(vm)
 		// Transform the VM resource representation to conform to the cloud-provider-azure representation
@@ -197,7 +201,7 @@ func (s *Service) checkUserAssignedIdentities(ctx context.Context, specIdentitie
 	return nil
 }
 
-func (s *Service) getAddresses(ctx context.Context, vm compute.VirtualMachine, rgName string) ([]corev1.NodeAddress, error) {
+func (s *Service) getAddresses(ctx context.Context, vm armcompute.VirtualMachine, rgName string) ([]corev1.NodeAddress, error) {
 	ctx, _, done := tele.StartSpanWithLogger(ctx, "virtualmachines.Service.getAddresses")
 	defer done()
 
@@ -207,10 +211,10 @@ func (s *Service) getAddresses(ctx context.Context, vm compute.VirtualMachine, r
 			Address: ptr.Deref(vm.Name, ""),
 		},
 	}
-	if vm.NetworkProfile.NetworkInterfaces == nil {
+	if vm.Properties.NetworkProfile.NetworkInterfaces == nil {
 		return addresses, nil
 	}
-	for _, nicRef := range *vm.NetworkProfile.NetworkInterfaces {
+	for _, nicRef := range vm.Properties.NetworkProfile.NetworkInterfaces {
 		// The full ID includes the name at the very end. Split the string and pull the last element
 		// Ex: /subscriptions/$SUB/resourceGroups/$RG/providers/Microsoft.Network/networkInterfaces/$NICNAME
 		// We'll check to see if ID is nil and bail early if we don't have it
@@ -277,13 +281,13 @@ func (s *Service) getPublicIPAddress(ctx context.Context, publicIPAddressName st
 		return retAddress, err
 	}
 
-	publicIP, ok := result.(network.PublicIPAddress)
+	publicIP, ok := result.(armnetwork.PublicIPAddress)
 	if !ok {
-		return retAddress, errors.Errorf("%T is not a network.PublicIPAddress", result)
+		return retAddress, errors.Errorf("%T is not an armnetwork.PublicIPAddress", result)
 	}
 
 	retAddress.Type = corev1.NodeExternalIP
-	retAddress.Address = ptr.Deref(publicIP.IPAddress, "")
+	retAddress.Address = ptr.Deref(publicIP.Properties.IPAddress, "")
 
 	return retAddress, nil
 }

--- a/azure/services/virtualmachines/virtualmachines_test.go
+++ b/azure/services/virtualmachines/virtualmachines_test.go
@@ -21,9 +21,8 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v4"
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute"
-	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-08-01/network"
 	"github.com/Azure/go-autorest/autorest"
 	. "github.com/onsi/gomega"
 	"github.com/pkg/errors"
@@ -56,13 +55,13 @@ var (
 		Image:             &infrav1.Image{ID: ptr.To("fake-image-id")},
 		BootstrapData:     "fake data",
 	}
-	fakeExistingVM = compute.VirtualMachine{
+	fakeExistingVM = armcompute.VirtualMachine{
 		ID:   ptr.To("subscriptions/123/resourceGroups/my_resource_group/providers/Microsoft.Compute/virtualMachines/my-vm"),
 		Name: ptr.To("test-vm-name"),
-		VirtualMachineProperties: &compute.VirtualMachineProperties{
+		Properties: &armcompute.VirtualMachineProperties{
 			ProvisioningState: ptr.To("Succeeded"),
-			NetworkProfile: &compute.NetworkProfile{
-				NetworkInterfaces: &[]compute.NetworkInterfaceReference{
+			NetworkProfile: &armcompute.NetworkProfile{
+				NetworkInterfaces: []*armcompute.NetworkInterfaceReference{
 					{
 						ID: ptr.To("/subscriptions/123/resourceGroups/test-rg/providers/Microsoft.Network/networkInterfaces/nic-1"),
 					},
@@ -92,8 +91,8 @@ var (
 		Name:          "pip-1",
 		ResourceGroup: "test-group",
 	}
-	fakePublicIPs = network.PublicIPAddress{
-		PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
+	fakePublicIPs = armnetwork.PublicIPAddress{
+		Properties: &armnetwork.PublicIPAddressPropertiesFormat{
 			IPAddress: ptr.To("10.0.0.6"),
 		},
 	}
@@ -183,7 +182,7 @@ func TestReconcileVM(t *testing.T) {
 				s.SetProviderID("azure://subscriptions/123/resourceGroups/my_resource_group/providers/Microsoft.Compute/virtualMachines/my-vm")
 				s.SetAnnotation("cluster-api-provider-azure", "true")
 				mnic.Get(gomockinternal.AContext(), &fakeNetworkInterfaceGetterSpec).Return(fakeNetworkInterface, nil)
-				mpip.Get(gomockinternal.AContext(), &fakePublicIPSpec).Return(network.PublicIPAddress{}, internalError)
+				mpip.Get(gomockinternal.AContext(), &fakePublicIPSpec).Return(armnetwork.PublicIPAddress{}, internalError)
 			},
 		},
 	}

--- a/controllers/azuremanagedmachinepool_controller_test.go
+++ b/controllers/azuremanagedmachinepool_controller_test.go
@@ -23,7 +23,6 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute"
 	"github.com/Azure/go-autorest/autorest/azure/auth"
 	. "github.com/onsi/gomega"
 	"go.uber.org/mock/gomock"
@@ -357,7 +356,7 @@ func fakeVirtualMachineScaleSet() []armcompute.VirtualMachineScaleSet {
 			Tags:     tags,
 			Properties: &armcompute.VirtualMachineScaleSetProperties{
 				SinglePlacementGroup: ptr.To(false),
-				ProvisioningState:    ptr.To(string(compute.ProvisioningState1Succeeded)),
+				ProvisioningState:    ptr.To("Succeeded"),
 			},
 		},
 	}


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Converts the virtualmachines service to azure-sdk-for-go version 2 and the `asyncpoller` framework.

**Which issue(s) this PR fixes**:

Fixes #3918

**Special notes for your reviewer**:

- [ ] cherry-pick candidate

**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests

**Release note**:

```release-note
NONE
```
