### PR TITLE
fix privateendpoints panic and diff

### DIFF
--- a/azure/services/privateendpoints/spec_test.go
+++ b/azure/services/privateendpoints/spec_test.go
@@ -84,14 +84,54 @@ func TestParameters(t *testing.T) {
 				Properties: &armnetwork.PrivateEndpointProperties{
 					Subnet: &armnetwork.Subnet{
 						ID: ptr.To("test-subnet"),
-						Properties: &armnetwork.SubnetPropertiesFormat{
-							PrivateEndpointNetworkPolicies:    ptr.To(armnetwork.VirtualNetworkPrivateEndpointNetworkPoliciesDisabled),
-							PrivateLinkServiceNetworkPolicies: ptr.To(armnetwork.VirtualNetworkPrivateLinkServiceNetworkPoliciesEnabled),
-						},
 					},
 					ApplicationSecurityGroups: []*armnetwork.ApplicationSecurityGroup{{
 						ID: ptr.To("asg1"),
 					}},
+					CustomNetworkInterfaceName: ptr.To(""),
+					IPConfigurations:           []*armnetwork.PrivateEndpointIPConfiguration{},
+					PrivateLinkServiceConnections: []*armnetwork.PrivateLinkServiceConnection{{
+						Name: ptr.To(privateEndpoint1.PrivateLinkServiceConnections[0].Name),
+						Properties: &armnetwork.PrivateLinkServiceConnectionProperties{
+							PrivateLinkServiceID: ptr.To(privateEndpoint1.PrivateLinkServiceConnections[0].PrivateLinkServiceID),
+							GroupIDs:             nil,
+							RequestMessage:       ptr.To(privateEndpoint1.PrivateLinkServiceConnections[0].RequestMessage),
+						},
+					}},
+					ManualPrivateLinkServiceConnections: []*armnetwork.PrivateLinkServiceConnection{},
+					ProvisioningState:                   ptr.To(armnetwork.ProvisioningStateSucceeded),
+				},
+				Tags: map[string]*string{"sigs.k8s.io_cluster-api-provider-azure_cluster_my-cluster": ptr.To("owned"), "Name": ptr.To("test-private-endpoint1")},
+			},
+			expect: func(g *WithT, result interface{}) {
+				g.Expect(result).To(BeNil())
+			},
+		},
+		{
+			name: "PrivateEndpoint without AppplicationSecurityGroups already exists with the same config",
+			spec: &PrivateEndpointSpec{
+				Name:                      privateEndpoint1.Name,
+				ResourceGroup:             "test-group",
+				ClusterName:               "my-cluster",
+				ApplicationSecurityGroups: nil,
+				PrivateLinkServiceConnections: []PrivateLinkServiceConnection{{
+					Name:                 privateEndpoint1.PrivateLinkServiceConnections[0].Name,
+					GroupIDs:             privateEndpoint1.PrivateLinkServiceConnections[0].GroupIDs,
+					PrivateLinkServiceID: privateEndpoint1.PrivateLinkServiceConnections[0].PrivateLinkServiceID,
+					RequestMessage:       privateEndpoint1.PrivateLinkServiceConnections[0].RequestMessage,
+				}},
+				SubnetID: "test-subnet",
+			},
+			// See https://learn.microsoft.com/en-us/rest/api/virtualnetwork/private-endpoints/get?tabs=Go for more options
+			existing: armnetwork.PrivateEndpoint{
+				Name: ptr.To("test-private-endpoint1"),
+				Properties: &armnetwork.PrivateEndpointProperties{
+					Subnet: &armnetwork.Subnet{
+						ID: ptr.To("test-subnet"),
+					},
+					ApplicationSecurityGroups:  nil,
+					CustomNetworkInterfaceName: ptr.To(""),
+					IPConfigurations:           []*armnetwork.PrivateEndpointIPConfiguration{},
 					PrivateLinkServiceConnections: []*armnetwork.PrivateLinkServiceConnection{{
 						Name: ptr.To(privateEndpoint1.PrivateLinkServiceConnections[0].Name),
 						Properties: &armnetwork.PrivateLinkServiceConnectionProperties{
@@ -131,14 +171,12 @@ func TestParameters(t *testing.T) {
 				Properties: &armnetwork.PrivateEndpointProperties{
 					Subnet: &armnetwork.Subnet{
 						ID: ptr.To("test-subnet"),
-						Properties: &armnetwork.SubnetPropertiesFormat{
-							PrivateEndpointNetworkPolicies:    ptr.To(armnetwork.VirtualNetworkPrivateEndpointNetworkPoliciesDisabled),
-							PrivateLinkServiceNetworkPolicies: ptr.To(armnetwork.VirtualNetworkPrivateLinkServiceNetworkPoliciesEnabled),
-						},
 					},
 					ApplicationSecurityGroups: []*armnetwork.ApplicationSecurityGroup{{
 						ID: ptr.To("asg1"),
 					}},
+					CustomNetworkInterfaceName: ptr.To(""),
+					IPConfigurations:           []*armnetwork.PrivateEndpointIPConfiguration{},
 					ManualPrivateLinkServiceConnections: []*armnetwork.PrivateLinkServiceConnection{{
 						Name: ptr.To(privateEndpoint1Manual.PrivateLinkServiceConnections[0].Name),
 						Properties: &armnetwork.PrivateLinkServiceConnectionProperties{
@@ -180,10 +218,6 @@ func TestParameters(t *testing.T) {
 				Properties: &armnetwork.PrivateEndpointProperties{
 					Subnet: &armnetwork.Subnet{
 						ID: ptr.To("test-subnet"),
-						Properties: &armnetwork.SubnetPropertiesFormat{
-							PrivateEndpointNetworkPolicies:    ptr.To(armnetwork.VirtualNetworkPrivateEndpointNetworkPoliciesDisabled),
-							PrivateLinkServiceNetworkPolicies: ptr.To(armnetwork.VirtualNetworkPrivateLinkServiceNetworkPoliciesEnabled),
-						},
 					},
 					ApplicationSecurityGroups: []*armnetwork.ApplicationSecurityGroup{{
 						ID: ptr.To("asg1"),


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

This PR fixes four neighboring issues with how private endpoints are constructed:
1. The Azure API does not populate `properties.subnet.properties` when GET-ing an existing private endpoints resource, which was assumed to be populated and would cause CAPZ to panic (#4013)
2. The Azure API populates `properties.customNetworkInterfaceName` as the non-nil empty string `""` in GETs after passing `nil` in an initial PUT. This was causing the `Parameters` method to always log a diff (but not reconcile forever since `CreateOrUpdateAsync` was finishing more-or-less immediately and successfully).
3. Similarly, the Azure API populates `properties.ipConfigurations` as the non-nil empty array `[]` in GETs when created as `nil`, causing the same issue as 2.
4. The inverse of 2. and 3. but causing the same issue, the Azure API nulls out `properties.applicationSecurityGroups` when created as the non-nil empty array `[]`.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4013

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [X] cherry-pick candidate

/cherry-pick release-1.11

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [ ] includes documentation
- [X] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
5. If no release note is required, just write "NONE".
-->
```release-note
Fix panic when reconciling private endpoints resources
```
