### PR TITLE
Arm64 should be upper cased and a const

### DIFF
--- a/azure/defaults.go
+++ b/azure/defaults.go
@@ -23,6 +23,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
 	"github.com/Azure/go-autorest/autorest"
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
 	"sigs.k8s.io/cluster-api-provider-azure/version"
@@ -303,7 +304,7 @@ func GetBootstrappingVMExtension(osType string, cloud string, vmName string, cpu
 		// Go on Ubuntu 20.04. The issue is being tracked here: https://github.com/golang/go/issues/58550
 		// TODO: Remove this once the issue is fixed, or when Ubuntu 20.04 is no longer supported.
 		extensionVersion := "1.0"
-		if cpuArchitectureType == "arm64" {
+		if cpuArchitectureType == string(armcompute.ArchitectureTypesArm64) {
 			extensionVersion = "1.1.1"
 		}
 		return &ExtensionSpec{

--- a/azure/defaults_test.go
+++ b/azure/defaults_test.go
@@ -321,11 +321,11 @@ func TestGetBootstrappingVMExtension(t *testing.T) {
 			expectedVersion: "1.0",
 		},
 		{
-			name:            "Linux OS, Public Cloud, arm64 CPU Architecture",
+			name:            "Linux OS, Public Cloud, ARM64 CPU Architecture",
 			osType:          LinuxOS,
 			cloud:           PublicCloudName,
 			vmName:          "test-vm",
-			cpuArchitecture: "arm64",
+			cpuArchitecture: "Arm64",
 			expectedVersion: "1.1.1",
 		},
 		{


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**: Azure VM SKU cpuArchitectureType property is `Arm64`, not `arm64`. ~Note: I tried to find a const in the Azure SDK to use directly but couldn't find one.~ @mboersma to the rescue!

Special thanks to @arsiesys for finding the issue

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes-sigs/cluster-api-provider-azure/issues/4016

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [x] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
fix arm64 extension selection
```
