### PR TITLE
Add Unit Tests for all Parameters() of the service libraries that don't have them.

### DIFF
--- a/azure/services/bastionhosts/spec_test.go
+++ b/azure/services/bastionhosts/spec_test.go
@@ -1,0 +1,119 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bastionhosts
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v4"
+	. "github.com/onsi/gomega"
+	"k8s.io/utils/ptr"
+	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
+)
+
+var (
+	fakeSKU         = armnetwork.BastionHostSKUName("fake-SKU")
+	fakeBastionHost = armnetwork.BastionHost{
+		Location: &fakeAzureBastionSpec.Location,
+		Name:     ptr.To("my-bastion-host"),
+		SKU:      &armnetwork.SKU{Name: &fakeSKU},
+	}
+	fakeAzureBastionSpec1 = AzureBastionSpec{
+		Name:            "my-bastion",
+		ClusterName:     "cluster",
+		Location:        "westus",
+		SubnetID:        "my-subnet-id",
+		PublicIPID:      "my-public-ip-id",
+		Sku:             infrav1.BastionHostSkuName("fake-SKU"),
+		EnableTunneling: false,
+	}
+
+	fakeBastionHostTags = map[string]*string{
+		"sigs.k8s.io_cluster-api-provider-azure_cluster_cluster": ptr.To("owned"),
+		"sigs.k8s.io_cluster-api-provider-azure_role":            ptr.To("Bastion"),
+		"Name": ptr.To("my-bastion"),
+	}
+)
+
+func TestAzureBastionSpec_Parameters(t *testing.T) {
+	testCases := []struct {
+		name          string
+		spec          *AzureBastionSpec
+		existing      interface{}
+		expect        func(g *WithT, result interface{})
+		expectedError string
+	}{
+		{
+			name:     "error when existing host is not of BastionHost type",
+			spec:     &AzureBastionSpec{},
+			existing: struct{}{},
+			expect: func(g *WithT, result interface{}) {
+				g.Expect(result).To(BeNil())
+			},
+			expectedError: "struct {} is not an armnetwork.BastionHost",
+		},
+		{
+			name:     "get result as nil when existing BastionHost is present",
+			spec:     &AzureBastionSpec{},
+			existing: fakeBastionHost,
+			expect: func(g *WithT, result interface{}) {
+				g.Expect(result).To(BeNil())
+			},
+			expectedError: "",
+		},
+		{
+			name:     "get result as nil when existing BastionHost is present with empty data",
+			spec:     &AzureBastionSpec{},
+			existing: armnetwork.BastionHost{},
+			expect: func(g *WithT, result interface{}) {
+				g.Expect(result).To(BeNil())
+			},
+			expectedError: "",
+		},
+		{
+			name:     "get BastionHost when all values are present",
+			spec:     &fakeAzureBastionSpec1,
+			existing: nil,
+			expect: func(g *WithT, result interface{}) {
+				g.Expect(result).To(BeAssignableToTypeOf(armnetwork.BastionHost{}))
+				g.Expect(result.(armnetwork.BastionHost).Location).To(Equal(ptr.To[string](fakeAzureBastionSpec1.Location)))
+				g.Expect(result.(armnetwork.BastionHost).Name).To(Equal(ptr.To[string](fakeAzureBastionSpec1.ResourceName())))
+				g.Expect(result.(armnetwork.BastionHost).SKU.Name).To(Equal(ptr.To(armnetwork.BastionHostSKUName(fakeAzureBastionSpec1.Sku))))
+				g.Expect(result.(armnetwork.BastionHost).Properties.EnableTunneling).To(Equal(ptr.To(fakeAzureBastionSpec1.EnableTunneling)))
+				g.Expect(result.(armnetwork.BastionHost).Tags).To(Equal(fakeBastionHostTags))
+			},
+			expectedError: "",
+		},
+	}
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			t.Parallel()
+
+			result, err := tc.spec.Parameters(context.TODO(), tc.existing)
+			if tc.expectedError != "" {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err).To(MatchError(tc.expectedError))
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
+			}
+			tc.expect(g, result)
+		})
+	}
+}

--- a/azure/services/natgateways/spec_test.go
+++ b/azure/services/natgateways/spec_test.go
@@ -1,0 +1,123 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package natgateways
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v4"
+	. "github.com/onsi/gomega"
+	"k8s.io/utils/ptr"
+	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
+	"sigs.k8s.io/cluster-api-provider-azure/azure"
+)
+
+var (
+	fakeNatGateway = armnetwork.NatGateway{
+		ID: ptr.To("/subscriptions/my-sub/resourceGroups/my-rg/providers/Microsoft.Network/natGateways/my-node-natgateway-1"),
+		Properties: &armnetwork.NatGatewayPropertiesFormat{
+			PublicIPAddresses: []*armnetwork.SubResource{
+				{ID: ptr.To("/subscriptions/my-sub/resourceGroups/my-rg/providers/Microsoft.Network/natGateways/pip-node-subnet")},
+			},
+		},
+	}
+	fakeNatGatewaySpec = NatGatewaySpec{
+		Name:           "my-node-natgateway-1",
+		ResourceGroup:  "my-rg",
+		SubscriptionID: "my-sub",
+		Location:       "westus",
+		ClusterName:    "cluster",
+		NatGatewayIP:   infrav1.PublicIPSpec{Name: "pip-node-subnet"},
+	}
+	fakeNatGatewaysTags = map[string]*string{
+		"sigs.k8s.io_cluster-api-provider-azure_cluster_cluster": ptr.To("owned"),
+		"Name": ptr.To("my-node-natgateway-1"),
+	}
+)
+
+func TestNatGatewaySpec_Parameters(t *testing.T) {
+	testCases := []struct {
+		name          string
+		spec          *NatGatewaySpec
+		existing      interface{}
+		expect        func(g *WithT, result interface{})
+		expectedError string
+	}{
+		{
+			name:     "error when existing is not of NatGateway type",
+			spec:     &NatGatewaySpec{},
+			existing: struct{}{},
+			expect: func(g *WithT, result interface{}) {
+				g.Expect(result).To(BeNil())
+			},
+			expectedError: "struct {} is not an armnetwork.NatGateway",
+		},
+		{
+			name:     "get result as nil when existing NatGateway is present",
+			spec:     &fakeNatGatewaySpec,
+			existing: fakeNatGateway,
+			expect: func(g *WithT, result interface{}) {
+				g.Expect(result).To(BeNil())
+			},
+			expectedError: "",
+		},
+		{
+			name: "get NatGateway when existing NatGateway is present but PublicIPAddresses is empty",
+			spec: &fakeNatGatewaySpec,
+			existing: armnetwork.NatGateway{
+				Properties: &armnetwork.NatGatewayPropertiesFormat{PublicIPAddresses: []*armnetwork.SubResource{}},
+			},
+			expect: func(g *WithT, result interface{}) {
+				g.Expect(result).To(BeAssignableToTypeOf(armnetwork.NatGateway{}))
+				g.Expect(result.(armnetwork.NatGateway).Location).To(Equal(ptr.To[string](fakeNatGatewaySpec.Location)))
+				g.Expect(result.(armnetwork.NatGateway).Name).To(Equal(ptr.To[string](fakeNatGatewaySpec.ResourceName())))
+			},
+			expectedError: "",
+		},
+		{
+			name:     "get NatGateway when all values are present",
+			spec:     &fakeNatGatewaySpec,
+			existing: nil,
+			expect: func(g *WithT, result interface{}) {
+				g.Expect(result).To(BeAssignableToTypeOf(armnetwork.NatGateway{}))
+				g.Expect(result.(armnetwork.NatGateway).Location).To(Equal(ptr.To[string](fakeNatGatewaySpec.Location)))
+				g.Expect(result.(armnetwork.NatGateway).Name).To(Equal(ptr.To[string](fakeNatGatewaySpec.ResourceName())))
+				g.Expect(result.(armnetwork.NatGateway).Properties.PublicIPAddresses[0].ID).To(Equal(ptr.To[string](azure.PublicIPID(fakeNatGatewaySpec.SubscriptionID,
+					fakeNatGatewaySpec.ResourceGroupName(), fakeNatGatewaySpec.NatGatewayIP.Name))))
+				g.Expect(result.(armnetwork.NatGateway).Tags).To(Equal(fakeNatGatewaysTags))
+			},
+			expectedError: "",
+		},
+	}
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			t.Parallel()
+
+			result, err := tc.spec.Parameters(context.TODO(), tc.existing)
+			if tc.expectedError != "" {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err).To(MatchError(tc.expectedError))
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
+			}
+			tc.expect(g, result)
+		})
+	}
+}

--- a/azure/services/roleassignments/spec_test.go
+++ b/azure/services/roleassignments/spec_test.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package roleassignments
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/utils/ptr"
+)
+
+var (
+	fakeRoleAssignment = armauthorization.RoleAssignment{
+		ID:   ptr.To("fake-id"),
+		Name: ptr.To("fake-name"),
+		Type: ptr.To("fake-type"),
+	}
+	fakeRoleAssignmentSpec = RoleAssignmentSpec{
+		PrincipalID:      ptr.To("fake-principal-id"),
+		RoleDefinitionID: "fake-role-definition-id",
+	}
+)
+
+func TestRoleAssignmentSpec_Parameters(t *testing.T) {
+	testCases := []struct {
+		name          string
+		spec          *RoleAssignmentSpec
+		existing      interface{}
+		expect        func(g *WithT, result interface{})
+		expectedError string
+	}{
+		{
+			name:     "error when existing is not of RoleAssignment type",
+			spec:     &RoleAssignmentSpec{},
+			existing: struct{}{},
+			expect: func(g *WithT, result interface{}) {
+				g.Expect(result).To(BeNil())
+			},
+			expectedError: "struct {} is not an armauthorization.RoleAssignment",
+		},
+		{
+			name:     "get result as nil when existing NatGateway is present",
+			spec:     &fakeRoleAssignmentSpec,
+			existing: fakeRoleAssignment,
+			expect: func(g *WithT, result interface{}) {
+				g.Expect(result).To(BeNil())
+			},
+			expectedError: "",
+		},
+		{
+			name:     "get result as nil when existing NatGateway is present with empty data",
+			spec:     &fakeRoleAssignmentSpec,
+			existing: armauthorization.RoleAssignment{},
+			expect: func(g *WithT, result interface{}) {
+				g.Expect(result).To(BeNil())
+			},
+			expectedError: "",
+		},
+		{
+			name:     "get RoleAssignment when all values are present",
+			spec:     &fakeRoleAssignmentSpec,
+			existing: nil,
+			expect: func(g *WithT, result interface{}) {
+				g.Expect(result).To(BeAssignableToTypeOf(armauthorization.RoleAssignmentCreateParameters{}))
+				g.Expect(result.(armauthorization.RoleAssignmentCreateParameters).Properties.RoleDefinitionID).To(Equal(ptr.To[string](fakeRoleAssignmentSpec.RoleDefinitionID)))
+				g.Expect(result.(armauthorization.RoleAssignmentCreateParameters).Properties.PrincipalID).To(Equal(fakeRoleAssignmentSpec.PrincipalID))
+			},
+			expectedError: "",
+		},
+	}
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			t.Parallel()
+
+			result, err := tc.spec.Parameters(context.TODO(), tc.existing)
+			if tc.expectedError != "" {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err).To(MatchError(tc.expectedError))
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
+			}
+			tc.expect(g, result)
+		})
+	}
+}

--- a/azure/services/routetables/spec_test.go
+++ b/azure/services/routetables/spec_test.go
@@ -1,0 +1,112 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package routetables
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v4"
+	. "github.com/onsi/gomega"
+	"k8s.io/utils/ptr"
+)
+
+var (
+	fakeRouteTable = armnetwork.RouteTable{
+		ID:       ptr.To("fake-id"),
+		Location: ptr.To("fake-location"),
+		Name:     ptr.To("fake-name"),
+	}
+	fakeRouteTableSpec = RouteTableSpec{
+		Name:        "test-rt-1",
+		Location:    "fake-location",
+		ClusterName: "cluster",
+		AdditionalTags: map[string]string{
+			"foo": "bar",
+		},
+	}
+	fakeRouteTableTags = map[string]*string{
+		"sigs.k8s.io_cluster-api-provider-azure_cluster_cluster": ptr.To("owned"),
+		"foo":  ptr.To("bar"),
+		"Name": ptr.To("test-rt-1"),
+	}
+)
+
+func TestRouteTableSpec_Parameters(t *testing.T) {
+	testCases := []struct {
+		name          string
+		spec          *RouteTableSpec
+		existing      interface{}
+		expect        func(g *WithT, result interface{})
+		expectedError string
+	}{
+		{
+			name:     "error when existing is not of RouteTable type",
+			spec:     &RouteTableSpec{},
+			existing: struct{}{},
+			expect: func(g *WithT, result interface{}) {
+				g.Expect(result).To(BeNil())
+			},
+			expectedError: "struct {} is not an armnetwork.RouteTable",
+		},
+		{
+			name:     "get result as nil when existing RouteTable is present",
+			spec:     &fakeRouteTableSpec,
+			existing: fakeRouteTable,
+			expect: func(g *WithT, result interface{}) {
+				g.Expect(result).To(BeNil())
+			},
+			expectedError: "",
+		},
+		{
+			name:     "get result as nil when existing RouteTable is present with empty data",
+			spec:     &fakeRouteTableSpec,
+			existing: armnetwork.RouteTable{},
+			expect: func(g *WithT, result interface{}) {
+				g.Expect(result).To(BeNil())
+			},
+			expectedError: "",
+		},
+		{
+			name:     "get RouteTable when all values are present",
+			spec:     &fakeRouteTableSpec,
+			existing: nil,
+			expect: func(g *WithT, result interface{}) {
+				g.Expect(result).To(BeAssignableToTypeOf(armnetwork.RouteTable{}))
+				g.Expect(result.(armnetwork.RouteTable).Location).To(Equal(ptr.To[string](fakeRouteTableSpec.Location)))
+				g.Expect(result.(armnetwork.RouteTable).Tags).To(Equal(fakeRouteTableTags))
+			},
+			expectedError: "",
+		},
+	}
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			t.Parallel()
+
+			result, err := tc.spec.Parameters(context.TODO(), tc.existing)
+			if tc.expectedError != "" {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err).To(MatchError(tc.expectedError))
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
+			}
+			tc.expect(g, result)
+		})
+	}
+}

--- a/azure/services/virtualnetworks/spec_test.go
+++ b/azure/services/virtualnetworks/spec_test.go
@@ -1,0 +1,137 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package virtualnetworks
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v4"
+	. "github.com/onsi/gomega"
+	"k8s.io/utils/ptr"
+	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
+)
+
+var (
+	fakeVirtualNetwork = armnetwork.VirtualNetwork{
+		ID:   ptr.To("/subscriptions/subscription/resourceGroups/test-group/providers/Microsoft.Network/virtualNetworks/test-vnet"),
+		Name: ptr.To("test-vnet"),
+		Tags: map[string]*string{
+			"foo":       ptr.To("bar"),
+			"something": ptr.To("else"),
+		},
+		Properties: &armnetwork.VirtualNetworkPropertiesFormat{
+			AddressSpace: &armnetwork.AddressSpace{
+				AddressPrefixes: []*string{ptr.To("fake-cidr")},
+			},
+			Subnets: []*armnetwork.Subnet{
+				{
+					Name: ptr.To("test-subnet"),
+					Properties: &armnetwork.SubnetPropertiesFormat{
+						AddressPrefix: ptr.To("subnet-cidr"),
+					},
+				},
+				{
+					Name: ptr.To("test-subnet-2"),
+					Properties: &armnetwork.SubnetPropertiesFormat{
+						AddressPrefixes: []*string{
+							ptr.To("subnet-cidr-1"),
+							ptr.To("subnet-cidr-2"),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	fakeVNetSpec1 = VNetSpec{
+		Name:        "test-vnet",
+		ClusterName: "cluster",
+		CIDRs:       []string{"10.0.0.0/8"},
+		Location:    "test-location",
+		ExtendedLocation: &infrav1.ExtendedLocationSpec{
+			Name: "test-extended-location-name",
+			Type: "test-extended-location-type",
+		},
+		AdditionalTags: map[string]string{"foo": "bar"},
+	}
+	fakeVNetTags = map[string]*string{
+		"sigs.k8s.io_cluster-api-provider-azure_cluster_cluster": ptr.To("owned"),
+		"sigs.k8s.io_cluster-api-provider-azure_role":            ptr.To("common"),
+		"foo":  ptr.To("bar"),
+		"Name": ptr.To("test-vnet"),
+	}
+)
+
+func TestVNetSpec_Parameters(t *testing.T) {
+	testCases := []struct {
+		name          string
+		spec          *VNetSpec
+		existing      interface{}
+		expect        func(g *WithT, result interface{})
+		expectedError string
+	}{
+		{
+			name:     "get result as nil when existing VirtualNetwork is present",
+			spec:     &fakeVNetSpec1,
+			existing: fakeVirtualNetwork,
+			expect: func(g *WithT, result interface{}) {
+				g.Expect(result).To(BeNil())
+			},
+			expectedError: "",
+		},
+		{
+			name:     "get result as nil when existing VirtualNetwork is present with empty data",
+			spec:     &fakeVNetSpec1,
+			existing: armnetwork.VirtualNetwork{},
+			expect: func(g *WithT, result interface{}) {
+				g.Expect(result).To(BeNil())
+			},
+			expectedError: "",
+		},
+		{
+			name:     "get VirtualNetwork when all values are present",
+			spec:     &fakeVNetSpec1,
+			existing: nil,
+			expect: func(g *WithT, result interface{}) {
+				g.Expect(result).To(BeAssignableToTypeOf(armnetwork.VirtualNetwork{}))
+				g.Expect(result.(armnetwork.VirtualNetwork).Location).To(Equal(ptr.To[string](fakeVNetSpec1.Location)))
+				g.Expect(result.(armnetwork.VirtualNetwork).Tags).To(Equal(fakeVNetTags))
+				g.Expect(result.(armnetwork.VirtualNetwork).ExtendedLocation.Name).To(Equal(ptr.To[string](fakeVNetSpec1.ExtendedLocation.Name)))
+				g.Expect(result.(armnetwork.VirtualNetwork).ExtendedLocation.Type).To(Equal(ptr.To(armnetwork.ExtendedLocationTypes(fakeVNetSpec1.ExtendedLocation.Type))))
+				g.Expect(result.(armnetwork.VirtualNetwork).Properties.AddressSpace.AddressPrefixes[0]).To(Equal(ptr.To(fakeVNetSpec1.CIDRs[0])))
+			},
+			expectedError: "",
+		},
+	}
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			t.Parallel()
+
+			result, err := tc.spec.Parameters(context.TODO(), tc.existing)
+			if tc.expectedError != "" {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err).To(MatchError(tc.expectedError))
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
+			}
+			tc.expect(g, result)
+		})
+	}
+}

--- a/azure/services/vnetpeerings/spec_test.go
+++ b/azure/services/vnetpeerings/spec_test.go
@@ -1,0 +1,115 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vnetpeerings
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v4"
+	. "github.com/onsi/gomega"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/cluster-api-provider-azure/azure"
+)
+
+var (
+	fakeVnetPeering = armnetwork.VirtualNetworkPeering{
+		ID:   ptr.To("fake-id"),
+		Name: ptr.To("fake-name"),
+		Type: ptr.To("fake-type"),
+	}
+	fakeVnetPeeringSpec = VnetPeeringSpec{
+		PeeringName:               "hub-to-spoke",
+		RemoteVnetName:            "spoke-vnet",
+		RemoteResourceGroup:       "spoke-group",
+		SubscriptionID:            "sub1",
+		AllowForwardedTraffic:     ptr.To(true),
+		AllowGatewayTransit:       ptr.To(true),
+		AllowVirtualNetworkAccess: ptr.To(true),
+		UseRemoteGateways:         ptr.To(false),
+	}
+)
+
+func TestVnetPeeringSpec_Parameters(t *testing.T) {
+	testCases := []struct {
+		name          string
+		spec          *VnetPeeringSpec
+		existing      interface{}
+		expect        func(g *WithT, result interface{})
+		expectedError string
+	}{
+		{
+			name:     "error when existing is not of VnetPeering type",
+			spec:     &VnetPeeringSpec{},
+			existing: struct{}{},
+			expect: func(g *WithT, result interface{}) {
+				g.Expect(result).To(BeNil())
+			},
+			expectedError: "struct {} is not an armnetwork.VnetPeering",
+		},
+		{
+			name:     "get result as nil when existing VnetPeering is present",
+			spec:     &fakeVnetPeeringSpec,
+			existing: fakeVnetPeering,
+			expect: func(g *WithT, result interface{}) {
+				g.Expect(result).To(BeNil())
+			},
+			expectedError: "",
+		},
+		{
+			name:     "get result as nil when existing VnetPeering is present with empty data",
+			spec:     &fakeVnetPeeringSpec,
+			existing: armnetwork.VirtualNetworkPeering{},
+			expect: func(g *WithT, result interface{}) {
+				g.Expect(result).To(BeNil())
+			},
+			expectedError: "",
+		},
+		{
+			name:     "get VirtualNetworkPeering when all values are present",
+			spec:     &fakeVnetPeeringSpec,
+			existing: nil,
+			expect: func(g *WithT, result interface{}) {
+				g.Expect(result).To(BeAssignableToTypeOf(armnetwork.VirtualNetworkPeering{}))
+				g.Expect(result.(armnetwork.VirtualNetworkPeering).Name).To(Equal(ptr.To[string](fakeVnetPeeringSpec.ResourceName())))
+				g.Expect(result.(armnetwork.VirtualNetworkPeering).Properties.RemoteVirtualNetwork.ID).To(Equal(ptr.To[string](azure.VNetID(fakeVnetPeeringSpec.SubscriptionID,
+					fakeVnetPeeringSpec.RemoteResourceGroup, fakeVnetPeeringSpec.RemoteVnetName))))
+				g.Expect(result.(armnetwork.VirtualNetworkPeering).Properties.AllowForwardedTraffic).To(Equal(fakeVnetPeeringSpec.AllowForwardedTraffic))
+				g.Expect(result.(armnetwork.VirtualNetworkPeering).Properties.AllowGatewayTransit).To(Equal(fakeVnetPeeringSpec.AllowGatewayTransit))
+				g.Expect(result.(armnetwork.VirtualNetworkPeering).Properties.AllowVirtualNetworkAccess).To(Equal(fakeVnetPeeringSpec.AllowVirtualNetworkAccess))
+				g.Expect(result.(armnetwork.VirtualNetworkPeering).Properties.UseRemoteGateways).To(Equal(fakeVnetPeeringSpec.UseRemoteGateways))
+			},
+			expectedError: "",
+		},
+	}
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			t.Parallel()
+
+			result, err := tc.spec.Parameters(context.TODO(), tc.existing)
+			if tc.expectedError != "" {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err).To(MatchError(tc.expectedError))
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
+			}
+			tc.expect(g, result)
+		})
+	}
+}


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind feature

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
This PR add the Unit Test cases for all Parameters() of the service libraries that don't have them currently.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes-sigs/cluster-api-provider-azure/issues/2946

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [X] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
