### PR TITLE
generalize "if AKS" check in Tilt for custom flavors

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -346,7 +346,7 @@ def deploy_worker_templates(template, substitutions):
         "CLUSTER_CLASS_NAME": "default",
     }
 
-    if flavor == "aks":
+    if "aks" in flavor:
         # AKS version support is usually a bit behind CAPI version, so use an older version
         substitutions["KUBERNETES_VERSION"] = settings.get("aks_kubernetes_version")
 


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind cleanup

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

The existing check in the Tiltfile used to select a `KUBERNETES_VERSION` based on whether the flavor describes a managed cluster or not only ever applies to the standard `aks` flavor. Changing that to check only if `aks` appears somewhere in the flavor name allows Tilt users to create custom versions of the `aks` flavor that automatically resolve to the correct `KUBERNETES_VERSION`. This same logic is already used below in the Tiltfile to decide whether or not to install CNI and cloud provider.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
