### PR TITLE
Fix "typeHandlerVersion is invalid" azure API error when using Arm64 machine pool

### DIFF
--- a/azure/defaults.go
+++ b/azure/defaults.go
@@ -300,12 +300,13 @@ func GetBootstrappingVMExtension(osType string, cloud string, vmName string, cpu
 	// currently, the bootstrap extension is only available in AzurePublicCloud.
 	if osType == LinuxOS && cloud == PublicCloudName {
 		// The command checks for the existence of the bootstrapSentinelFile on the machine, with retries and sleep between retries.
-		// We set the version to 1.1.1 for arm64 machines and 1.0 for x64. This is due to a known issue with newer versions of
+		// We set the version to 1.1 (will target 1.1.1) for arm64 machines and 1.0 for x64. This is due to a known issue with newer versions of
 		// Go on Ubuntu 20.04. The issue is being tracked here: https://github.com/golang/go/issues/58550
 		// TODO: Remove this once the issue is fixed, or when Ubuntu 20.04 is no longer supported.
+		// We are using 1.1 instead of 1.1.1 for Arm64 as AzureAPI do not allow us to specify the full version.
 		extensionVersion := "1.0"
 		if cpuArchitectureType == string(armcompute.ArchitectureTypesArm64) {
-			extensionVersion = "1.1.1"
+			extensionVersion = "1.1"
 		}
 		return &ExtensionSpec{
 			Name:      BootstrappingExtensionLinux,

--- a/azure/defaults_test.go
+++ b/azure/defaults_test.go
@@ -326,7 +326,7 @@ func TestGetBootstrappingVMExtension(t *testing.T) {
 			cloud:           PublicCloudName,
 			vmName:          "test-vm",
 			cpuArchitecture: "Arm64",
-			expectedVersion: "1.1.1",
+			expectedVersion: "1.1",
 		},
 		{
 			name:            "Windows OS, Public Cloud",


### PR DESCRIPTION

 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Azure API do not seems to accept that we include the minor version when we define the specs of vmExtension for BootstrappingExtensionLinux. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4022 

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
