### PR TITLE
Replace Paid SKU tier with Standard

### DIFF
--- a/api/v1beta1/azuremanagedcontrolplane_types.go
+++ b/api/v1beta1/azuremanagedcontrolplane_types.go
@@ -262,14 +262,17 @@ type AddonProfile struct {
 }
 
 // AzureManagedControlPlaneSkuTier - Tier of a managed cluster SKU.
-// +kubebuilder:validation:Enum=Free;Paid
+// +kubebuilder:validation:Enum=Free;Paid;Standard
 type AzureManagedControlPlaneSkuTier string
 
 const (
 	// FreeManagedControlPlaneTier is the free tier of AKS without corresponding SLAs.
 	FreeManagedControlPlaneTier AzureManagedControlPlaneSkuTier = "Free"
 	// PaidManagedControlPlaneTier is the paid tier of AKS with corresponding SLAs.
+	// Deprecated. It has been replaced with StandardManagedControlPlaneTier.
 	PaidManagedControlPlaneTier AzureManagedControlPlaneSkuTier = "Paid"
+	// StandardManagedControlPlaneTier is the standard tier of AKS with corresponding SLAs.
+	StandardManagedControlPlaneTier AzureManagedControlPlaneSkuTier = "Standard"
 )
 
 // AKSSku - AKS SKU.

--- a/api/v1beta1/azuremanagedcontrolplane_webhook.go
+++ b/api/v1beta1/azuremanagedcontrolplane_webhook.go
@@ -96,6 +96,12 @@ func (mw *azureManagedControlPlaneWebhook) Default(ctx context.Context, obj runt
 		ctrl.Log.WithName("AzureManagedControlPlaneWebHookLogger").Error(err, "setDefaultSSHPublicKey failed")
 	}
 
+	// PaidManagedControlPlaneTier has been replaced with StandardManagedControlPlaneTier since v2023-02-01.
+	if m.Spec.SKU != nil && m.Spec.SKU.Tier == PaidManagedControlPlaneTier {
+		m.Spec.SKU.Tier = StandardManagedControlPlaneTier
+		ctrl.Log.WithName("AzureManagedControlPlaneWebHookLogger").Info("Paid SKU tier is deprecated and has been replaced by Standard")
+	}
+
 	m.setDefaultNodeResourceGroupName()
 	m.setDefaultVirtualNetwork()
 	m.setDefaultSubnet()

--- a/api/v1beta1/azuremanagedcontrolplane_webhook_test.go
+++ b/api/v1beta1/azuremanagedcontrolplane_webhook_test.go
@@ -87,7 +87,7 @@ func TestDefaultingWebhook(t *testing.T) {
 	g.Expect(amcp.Spec.NodeResourceGroupName).To(Equal("fooNodeRg"))
 	g.Expect(amcp.Spec.VirtualNetwork.Name).To(Equal("fooVnetName"))
 	g.Expect(amcp.Spec.VirtualNetwork.Subnet.Name).To(Equal("fooSubnetName"))
-	g.Expect(amcp.Spec.SKU.Tier).To(Equal(PaidManagedControlPlaneTier))
+	g.Expect(amcp.Spec.SKU.Tier).To(Equal(StandardManagedControlPlaneTier))
 	g.Expect(*amcp.Spec.OIDCIssuerProfile.Enabled).To(BeTrue())
 
 	t.Logf("Testing amcp defaulting webhook with overlay")

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremanagedcontrolplanes.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremanagedcontrolplanes.yaml
@@ -421,6 +421,7 @@ spec:
                     enum:
                     - Free
                     - Paid
+                    - Standard
                     type: string
                 required:
                 - tier

--- a/docs/book/src/topics/managedcluster.md
+++ b/docs/book/src/topics/managedcluster.md
@@ -130,7 +130,7 @@ spec:
   networkPolicy: azure # or calico
   networkPlugin: azure # or kubenet
   sku:
-    tier: Free # or Paid
+    tier: Free # or Standard
   addonProfiles:
   - name: azureKeyvaultSecretsProvider
     enabled: true


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**: Current SKU tiers seem to be not compatible with the API.

When trying to create Azure managed cluster with SKU tier set to `Paid` I got:
```
E0927 11:16:27.943586       1 controller.go:324]  "msg"="Reconciler error" "error"="error creating AzureManagedControlPlane bootstrap/x: failed to reconcile AzureManagedControlPlane service managedcluster: failed to create or update resource x/x (service: managedcluster): PUT https://management.azure.com/subscriptions/x/resourceGroups/x/providers/Microsoft.ContainerService/managedClusters/x\n--------------------------------------------------------------------------------\nRESPONSE 400: 400 Bad Request\nERROR CODE: SkuNotAvailable\n--------------------------------------------------------------------------------\n{\n  \"code\": \"SkuNotAvailable\",\n  \"details\": null,\n  \"message\": \"Paid managed cluster SKU tier is invalid. 'Paid' has been replaced by 'Standard' since v2023-02-01. \",\n  \"subcode\": \"\"\n}\n--------------------------------------------------------------------------------\n" "AzureManagedControlPlane"={"name":"x","namespace":"bootstrap"} "controller"="azuremanagedcontrolplane" "controllerGroup"="infrastructure.cluster.x-k8s.io" "controllerKind"="AzureManagedControlPlane" "name"="x" "namespace"="bootstrap" "reconcileID"="x"
```

Setting it to `Standard` is not allowed at the moment:
```
2023/09/27 12:56:58 failed to create resource: AzureManagedControlPlane.infrastructure.cluster.x-k8s.io "x" is invalid: spec.sku.tier: Unsupported value: "Standard": supported values: "Free", "Paid"
```

It makes the field unusable.

This PR updates Paid SKU tier to Standard.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

**Special notes for your reviewer**:
- [x] cherry-pick candidate

**TODOs**:
- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Replace Paid SKU tier with Standard
```
