### PR TITLE
flatcar: Run kubeadm after containerd

### DIFF
--- a/templates/cluster-template-flatcar.yaml
+++ b/templates/cluster-template-flatcar.yaml
@@ -91,6 +91,8 @@ spec:
                 contents: |
                   [Unit]
                   After=oem-cloudinit.service
+                  # kubeadm must run after containerd - see https://github.com/kubernetes-sigs/image-builder/issues/939.
+                  After=containerd.service
           # Workaround for https://github.com/kubernetes-sigs/cluster-api/issues/7679.
           storage:
             disks:
@@ -218,6 +220,8 @@ spec:
                   contents: |
                     [Unit]
                     After=oem-cloudinit.service
+                    # kubeadm must run after containerd - see https://github.com/kubernetes-sigs/image-builder/issues/939.
+                    After=containerd.service
       joinConfiguration:
         nodeRegistration:
           kubeletExtraArgs:

--- a/templates/flavors/flatcar/machine-deployment.yaml
+++ b/templates/flavors/flatcar/machine-deployment.yaml
@@ -67,6 +67,8 @@ spec:
                   contents: |
                     [Unit]
                     After=oem-cloudinit.service
+                    # kubeadm must run after containerd - see https://github.com/kubernetes-sigs/image-builder/issues/939.
+                    After=containerd.service
       joinConfiguration:
         nodeRegistration:
           kubeletExtraArgs:

--- a/templates/flavors/flatcar/patches/kubeadm-controlplane.yaml
+++ b/templates/flavors/flatcar/patches/kubeadm-controlplane.yaml
@@ -28,6 +28,8 @@ spec:
                 contents: |
                   [Unit]
                   After=oem-cloudinit.service
+                  # kubeadm must run after containerd - see https://github.com/kubernetes-sigs/image-builder/issues/939.
+                  After=containerd.service
           # Workaround for https://github.com/kubernetes-sigs/cluster-api/issues/7679.
           storage:
             disks:

--- a/templates/test/ci/cluster-template-prow-flatcar.yaml
+++ b/templates/test/ci/cluster-template-prow-flatcar.yaml
@@ -96,6 +96,8 @@ spec:
                 contents: |
                   [Unit]
                   After=oem-cloudinit.service
+                  # kubeadm must run after containerd - see https://github.com/kubernetes-sigs/image-builder/issues/939.
+                  After=containerd.service
           # Workaround for https://github.com/kubernetes-sigs/cluster-api/issues/7679.
           storage:
             disks:
@@ -223,6 +225,8 @@ spec:
                   contents: |
                     [Unit]
                     After=oem-cloudinit.service
+                    # kubeadm must run after containerd - see https://github.com/kubernetes-sigs/image-builder/issues/939.
+                    After=containerd.service
       joinConfiguration:
         nodeRegistration:
           kubeletExtraArgs:


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

/kind bug

**What this PR does / why we need it**:

Ensure kubeadm runs after containerd to avoid a race condition between the two.

We intentionally add an `After=` directive and not a `Requires=` directive to avoid breaking things for distros which use Ignition and don't use containerd.

See https://github.com/kubernetes-sigs/image-builder/issues/939.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
None

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Ensure kubeadm runs after containerd on Flatcar
```
