### PR TITLE
Update jaeger all-in-one chart to v0.1.11

### DIFF
--- a/hack/observability/jaeger/chart/Chart.yaml
+++ b/hack/observability/jaeger/chart/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 1.22.0
+appVersion: "1.47"
 description: Jaeger all-in-one helm chart for Kubernetes
 home: https://github.com/hansehe/jaeger-all-in-one
 icon: https://raw.githubusercontent.com/hansehe/jaeger-all-in-one/master/helm/jaeger.png
@@ -13,4 +13,4 @@ name: jaeger-all-in-one
 sources:
 - https://github.com/hansehe/jaeger-all-in-one
 type: application
-version: 0.1.5
+version: 0.1.11

--- a/hack/observability/jaeger/chart/templates/_helpers.tpl
+++ b/hack/observability/jaeger/chart/templates/_helpers.tpl
@@ -37,10 +37,19 @@ Common labels
 {{- define "jaeger-all-in-one.labels" -}}
 helm.sh/chart: {{ include "jaeger-all-in-one.chart" . }}
 {{ include "jaeger-all-in-one.selectorLabels" . }}
-{{- if .Chart.AppVersion }}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
-{{- end }}
+app.kubernetes.io/version: "{{ include "jaeger-all-in-one.jaegerVersion" . }}"
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Version is either the Chart's AppVersion or the image versionOverride, if specified
+*/}}
+{{- define "jaeger-all-in-one.jaegerVersion" -}}
+{{- if ne .Values.image.versionOverride "*" -}}
+{{- .Values.image.versionOverride -}}
+{{- else -}}
+{{ .Chart.AppVersion }}
+{{- end -}}
 {{- end -}}
 
 {{/*

--- a/hack/observability/jaeger/chart/templates/ingress.yaml
+++ b/hack/observability/jaeger/chart/templates/ingress.yaml
@@ -2,7 +2,14 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "jaeger-all-in-one.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1beta1
 {{- else -}}
 apiVersion: extensions/v1beta1
@@ -10,6 +17,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "jaeger-all-in-one.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}
@@ -17,27 +25,40 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-{{- if .Values.ingress.tls }}
-  tls:
-  {{- range .Values.ingress.tls }}
-    - hosts:
-      {{- range .hosts }}
-        - {{ . | quote }}
-      {{- end }}
-      secretName: {{ .secretName }}
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
   {{- end }}
-{{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
   rules:
-  {{- range .Values.ingress.hosts }}
+    {{- range .Values.ingress.hosts }}
     - host: {{ .host | quote }}
       http:
         paths:
-        {{- range .paths }}
-          - path: {{ . }}
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
             backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
               serviceName: {{ $fullName }}
               servicePort: {{ $svcPort }}
-        {{- end }}
-  {{- end }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
 {{- end }}
 {{- end }}

--- a/hack/observability/jaeger/chart/templates/jaeger-volume.yaml
+++ b/hack/observability/jaeger/chart/templates/jaeger-volume.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ include "jaeger-all-in-one.fullname" . }}
+  namespace: {{ .Release.Namespace }}
 spec:
   {{- if .Values.volume.className }}
   storageClassName: {{ .Values.volume.className }}

--- a/hack/observability/jaeger/chart/templates/service-headless.yaml
+++ b/hack/observability/jaeger/chart/templates/service-headless.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "jaeger-all-in-one.fullname" . }}-headless
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "jaeger-all-in-one.labels" . | nindent 4 }}
   {{- with .Values.service.headless.annotations }}
@@ -28,6 +29,16 @@ spec:
       targetPort: http-configs
       protocol: TCP
       name: http-configs
+    {{- if .Values.enableHttpOpenTelemetryCollector }}
+    - port: 4317
+      targetPort: http-otlp-grpc
+      protocol: TCP
+      name: http-otlp-grpc
+    - port: 4318
+      targetPort: http-otlp
+      protocol: TCP
+      name: http-otlp
+    {{- end }}
     - port: {{ .Values.service.port }}
       targetPort: http-ui
       protocol: TCP
@@ -49,7 +60,7 @@ spec:
       targetPort: http-zipkin
       protocol: TCP
       name: http-zipkin
-    {{- end }}  
+    {{- end }}
   selector:
     {{- include "jaeger-all-in-one.selectorLabels" . | nindent 4 }}
 {{- end }}

--- a/hack/observability/jaeger/chart/templates/service.yaml
+++ b/hack/observability/jaeger/chart/templates/service.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "jaeger-all-in-one.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "jaeger-all-in-one.labels" . | nindent 4 }}
   {{- with .Values.service.annotations }}
@@ -28,6 +29,16 @@ spec:
       targetPort: http-configs
       protocol: TCP
       name: http-configs
+    {{- if .Values.enableHttpOpenTelemetryCollector }}
+    - port: 4317
+      targetPort: http-otlp-grpc
+      protocol: TCP
+      name: http-otlp-grpc
+    - port: 4318
+      targetPort: http-otlp
+      protocol: TCP
+      name: http-otlp
+    {{- end }}
     - port: {{ .Values.service.port }}
       targetPort: http-ui
       protocol: TCP
@@ -49,7 +60,7 @@ spec:
       targetPort: http-zipkin
       protocol: TCP
       name: http-zipkin
-    {{- end }}  
+    {{- end }}
   selector:
     {{- include "jaeger-all-in-one.selectorLabels" . | nindent 4 }}
 {{- end }}

--- a/hack/observability/jaeger/chart/templates/serviceaccount.yaml
+++ b/hack/observability/jaeger/chart/templates/serviceaccount.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "jaeger-all-in-one.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
 {{ include "jaeger-all-in-one.labels" . | nindent 4 }}
 {{- end -}}

--- a/hack/observability/jaeger/chart/templates/statefulset.yaml
+++ b/hack/observability/jaeger/chart/templates/statefulset.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ include "jaeger-all-in-one.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "jaeger-all-in-one.labels" . | nindent 4 }}
 spec:
@@ -38,7 +39,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Chart.AppVersion }}"
+          image: "{{ .Values.image.repository }}:{{ include "jaeger-all-in-one.jaegerVersion" . }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: udp-com-thr
@@ -53,6 +54,14 @@ spec:
             - name: http-configs
               containerPort: 5778
               protocol: TCP
+            {{- if .Values.enableHttpOpenTelemetryCollector }}
+            - name: http-otlp-grpc
+              containerPort: 4317
+              protocol: TCP
+            - name: http-otlp
+              containerPort: 4318
+              protocol: TCP
+            {{- end }}
             - name: http-ui
               containerPort: 16686
               protocol: TCP
@@ -69,7 +78,7 @@ spec:
             - name: http-zipkin
               containerPort: 9411
               protocol: TCP
-            {{- end }}  
+            {{- end }}
           {{- if .Values.volume.enabled }}
           volumeMounts:
             - mountPath: "/badger"
@@ -90,10 +99,14 @@ spec:
           - name: {{ $key }}
             value: {{ $value | quote }}
           {{- end }}
+          {{- if .Values.enableHttpOpenTelemetryCollector }}
+          - name: COLLECTOR_OTLP_ENABLED
+            value: "true"
+          {{- end }}
           {{- if .Values.enableHttpZipkinCollector }}
           - name: COLLECTOR_ZIPKIN_HOST_PORT
-            value: "9411"
-          {{- end }}  
+            value: ":9411"
+          {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/hack/observability/jaeger/chart/templates/tests/test-connection.yaml
+++ b/hack/observability/jaeger/chart/templates/tests/test-connection.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.tests.enabled }}
 apiVersion: v1
 kind: Pod
 metadata:
@@ -13,3 +14,4 @@ spec:
       command: ['wget']
       args:  ['{{ include "jaeger-all-in-one.fullname" . }}:{{ .Values.service.port }}']
   restartPolicy: Never
+{{- end }}

--- a/hack/observability/jaeger/chart/values.yaml
+++ b/hack/observability/jaeger/chart/values.yaml
@@ -8,6 +8,7 @@ replicaCount: 1
 image:
   repository: jaegertracing/all-in-one
   pullPolicy: IfNotPresent
+  versionOverride: "*"
 
 healthCheckUrl: /
 imagePullSecrets: []
@@ -22,6 +23,7 @@ environmentVariables:
   BADGER_DIRECTORY_KEY: /badger/key
 
 enableHttpZipkinCollector: false
+enableHttpOpenTelemetryCollector: false
 
 serviceAccount:
   # Specifies whether a service account should be created
@@ -30,7 +32,7 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name:
 
-podAnnotations: 
+podAnnotations:
   prometheus.io/scrape: "true"
   prometheus.io/path: "/metrics"
   prometheus.io/port: "14269"
@@ -57,19 +59,21 @@ service:
 
 ingress:
   enabled: false
+  className: ""
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # cert-manager.io/cluster-issuer: letsencrypt
     # nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
     # nginx.ingress.kubernetes.io/from-to-www-redirect: "true"
-  hosts: []
-    # - host: jaeger.localhost
-    #   paths: 
-    #     - /
+  hosts:
+    - host: jaeger.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
   tls: []
-    # - secretName: tls-secret
-    #   hosts:
-    #     - jaeger.localhost
+  #  - secretName: jaeger-tls
+  #    hosts:
+  #      - jaeger.local
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
@@ -93,3 +97,6 @@ volume:
   enabled: true
   className: ""
   size: 3Gi
+
+tests:
+  enabled: true

--- a/hack/observability/jaeger/fetch-jaeger-resources.sh
+++ b/hack/observability/jaeger/fetch-jaeger-resources.sh
@@ -18,7 +18,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-CHART_RELEASE=${CHART_RELEASE:-0.1.5}
+CHART_RELEASE=${CHART_RELEASE:-0.1.11}
 JAEGER_ROOT=$(dirname "${BASH_SOURCE[0]}")
 CHART_ROOT=$JAEGER_ROOT/chart
 


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Updates the [Jaeger all-in-one](https://github.com/hansehe/jaeger-all-in-one) Helm chart to v0.1.11. This updates Jaeger to a recent version that supports `otlp` input, since the `jaeger` exporter itself was removed in opentelemetry 1.18.

**Which issue(s) this PR fixes**:

Refs #4004

**Special notes for your reviewer**:

This is only relevant to the Tilt developer environment. I've tested it manually and traces in Jaeger seem fine.

This update was created by changing the Chart version in `./hack/observability/jaeger/fetch-jaeger-resources.sh` and running that script.

- [ ] cherry-pick candidate

**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:

```release-note
NONE
```
