### PR TITLE
fix: fix API server access profile diff

### DIFF
--- a/azure/services/managedclusters/spec.go
+++ b/azure/services/managedclusters/spec.go
@@ -614,13 +614,13 @@ func computeDiffOfNormalizedClusters(managedCluster armcontainerservice.ManagedC
 		}
 	}
 
-	if managedCluster.Properties.APIServerAccessProfile != nil {
+	if managedCluster.Properties.APIServerAccessProfile != nil && managedCluster.Properties.APIServerAccessProfile.AuthorizedIPRanges != nil {
 		propertiesNormalized.APIServerAccessProfile = &armcontainerservice.ManagedClusterAPIServerAccessProfile{
 			AuthorizedIPRanges: managedCluster.Properties.APIServerAccessProfile.AuthorizedIPRanges,
 		}
 	}
 
-	if existingMC.Properties.APIServerAccessProfile != nil {
+	if existingMC.Properties.APIServerAccessProfile != nil && existingMC.Properties.APIServerAccessProfile.AuthorizedIPRanges != nil {
 		existingMCPropertiesNormalized.APIServerAccessProfile = &armcontainerservice.ManagedClusterAPIServerAccessProfile{
 			AuthorizedIPRanges: existingMC.Properties.APIServerAccessProfile.AuthorizedIPRanges,
 		}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
If `APIServerAccessProfile.AuthorizedIPRanges` is `nil` but `APIServerAccessProfile` is not `nil` then managed cluster diff will not be empty and thus CAPZ controller manager will be stuck in reconcile loop. 

Example config causing issues:
```yaml
apiServerAccessProfile:
  enablePrivateCluster: false
```

Simples solution for now seems to adding check for `APIServerAccessProfile.AuthorizedIPRanges` being not `nil`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
https://kubernetes.slack.com/archives/CEX9HENG7/p1696597573669669

**Special notes for your reviewer**:
- [x] cherry-pick candidate

**TODOs**:
- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
```release-note
Fix API server access profile diff
```
