### PR TITLE
fix webhook for CNI overlay

### DIFF
--- a/api/v1beta1/azuremanagedcontrolplane_webhook.go
+++ b/api/v1beta1/azuremanagedcontrolplane_webhook.go
@@ -588,8 +588,10 @@ func (m *AzureManagedControlPlane) validateVirtualNetworkUpdate(old *AzureManage
 func (m *AzureManagedControlPlane) validateNetworkPluginModeUpdate(old *AzureManagedControlPlane) field.ErrorList {
 	var allErrs field.ErrorList
 
-	if ptr.Deref(m.Spec.NetworkPluginMode, "") == NetworkPluginModeOverlay && old.Spec.NetworkPolicy != nil {
-		allErrs = append(allErrs, field.Forbidden(field.NewPath("Spec", "NetworkPluginMode"), fmt.Sprintf("%q NetworkPolicyMode cannot be enabled when NetworkPolicy is set", NetworkPluginModeOverlay)))
+	if ptr.Deref(old.Spec.NetworkPluginMode, "") != NetworkPluginModeOverlay &&
+		ptr.Deref(m.Spec.NetworkPluginMode, "") == NetworkPluginModeOverlay &&
+		old.Spec.NetworkPolicy != nil {
+		allErrs = append(allErrs, field.Forbidden(field.NewPath("Spec", "NetworkPluginMode"), fmt.Sprintf("%q NetworkPluginMode cannot be enabled when NetworkPolicy is set", NetworkPluginModeOverlay)))
 	}
 
 	return allErrs

--- a/api/v1beta1/azuremanagedcontrolplane_webhook_test.go
+++ b/api/v1beta1/azuremanagedcontrolplane_webhook_test.go
@@ -1556,6 +1556,7 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 					Name: "test-cluster",
 				},
 				Spec: AzureManagedControlPlaneSpec{
+					NetworkPolicy:     ptr.To("anything"),
 					NetworkPluginMode: ptr.To(NetworkPluginModeOverlay),
 				},
 			},
@@ -1577,6 +1578,29 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 					Name: "test-cluster",
 				},
 				Spec: AzureManagedControlPlaneSpec{
+					NetworkPluginMode: ptr.To(NetworkPluginModeOverlay),
+					Version:           "v0.0.0",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "NetworkPolicy is allowed when NetworkPluginMode is not changed",
+			oldAMCP: &AzureManagedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-cluster",
+				},
+				Spec: AzureManagedControlPlaneSpec{
+					NetworkPolicy:     ptr.To("anything"),
+					NetworkPluginMode: ptr.To(NetworkPluginModeOverlay),
+				},
+			},
+			amcp: &AzureManagedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-cluster",
+				},
+				Spec: AzureManagedControlPlaneSpec{
+					NetworkPolicy:     ptr.To("anything"),
 					NetworkPluginMode: ptr.To(NetworkPluginModeOverlay),
 					Version:           "v0.0.0",
 				},


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug
/area managedclusters

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

This PR fixes a bug in the AzureManagedControlPlane update webhook when checking `spec.networkPluginMode`. The intent is to disallow changing the `networkPluginMode` to `overlay` when `spec.networkPolicy` is already enabled without overlay. The bug was disallowing updates to AzureManagedControlPlane whenever `overlay` is specified and `networkPolicy` was specified without verifying that the update modifies `networkPluginMode`. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4093

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [X] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [ ] includes documentation
- [X] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixed a bug disallowing certain valid updates to AzureManagedControlPlane with Azure CNI overlay enabled
```