### PR TITLE
[WIP] Deploy aks clusters using major and minor versions

### DIFF
--- a/api/v1beta1/azuremanagedcontrolplane_webhook.go
+++ b/api/v1beta1/azuremanagedcontrolplane_webhook.go
@@ -42,7 +42,7 @@ import (
 )
 
 var (
-	kubeSemver                 = regexp.MustCompile(`^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)([-0-9a-zA-Z_\.+]*)?$`)
+	kubeSemver                 = regexp.MustCompile(`^v\d+\.\d+(\.\d+)?$`)
 	rMaxNodeProvisionTime      = regexp.MustCompile(`^(\d+)m$`)
 	rScaleDownTime             = regexp.MustCompile(`^(\d+)m$`)
 	rScaleDownDelayAfterDelete = regexp.MustCompile(`^(\d+)s$`)

--- a/api/v1beta1/azuremanagedcontrolplane_webhook_test.go
+++ b/api/v1beta1/azuremanagedcontrolplane_webhook_test.go
@@ -124,6 +124,46 @@ func TestValidatingWebhook(t *testing.T) {
 		expectErr bool
 	}{
 		{
+			name: "InValid Version ..",
+			amcp: AzureManagedControlPlane{
+				Spec: AzureManagedControlPlaneSpec{
+					DNSServiceIP: ptr.To("192.168.0.0"),
+					Version:      "..",
+				},
+			},
+			expectErr: true,
+		},
+		{
+			name: "InValid Version v1.20.",
+			amcp: AzureManagedControlPlane{
+				Spec: AzureManagedControlPlaneSpec{
+					DNSServiceIP: ptr.To("192.168.0.0"),
+					Version:      "v1.20.",
+				},
+			},
+			expectErr: true,
+		},
+		{
+			name: "InValid Version v1.20.a",
+			amcp: AzureManagedControlPlane{
+				Spec: AzureManagedControlPlaneSpec{
+					DNSServiceIP: ptr.To("192.168.0.0"),
+					Version:      "v1.20.a",
+				},
+			},
+			expectErr: true,
+		},
+		{
+			name: "Valid Version",
+			amcp: AzureManagedControlPlane{
+				Spec: AzureManagedControlPlaneSpec{
+					DNSServiceIP: ptr.To("192.168.0.0"),
+					Version:      "v1.17",
+				},
+			},
+			expectErr: false,
+		},
+		{
 			name: "Testing valid DNSServiceIP",
 			amcp: AzureManagedControlPlane{
 				ObjectMeta: getAMCPMetaData(),


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind feature

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
Allows deployment of AKS clusters using major and minor version, with the new sdk version, we can now deploy AKS clusters by just using major and minor version, patch version with which the cluster will be the highest available version corresponding to that major.minor. 
Eg: v1.26 can be used to deploy v1.26.6 version AKS. (6 is the highest patch currently available for 1.26)
The same is supported with the latest SDK
https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v4@v4.3.0#ManagedClusterProperties

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4117, #4111

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [X] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
