### PR TITLE
default spec.spotMaxPrice in AzureManagedMachinePool

### DIFF
--- a/api/v1beta1/azuremanagedmachinepool_webhook.go
+++ b/api/v1beta1/azuremanagedmachinepool_webhook.go
@@ -25,8 +25,10 @@ import (
 	"strings"
 	"unicode"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v4"
 	"github.com/pkg/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -78,6 +80,10 @@ func (mw *azureManagedMachinePoolWebhook) Default(ctx context.Context, obj runti
 
 	if m.Spec.OSType == nil {
 		m.Spec.OSType = ptr.To(DefaultOSType)
+	}
+
+	if ptr.Deref(m.Spec.ScaleSetPriority, "") == string(armcontainerservice.ScaleSetPrioritySpot) && m.Spec.SpotMaxPrice == nil {
+		m.Spec.SpotMaxPrice = ptr.To(resource.MustParse("-1"))
 	}
 
 	return nil

--- a/api/v1beta1/azuremanagedmachinepool_webhook_test.go
+++ b/api/v1beta1/azuremanagedmachinepool_webhook_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v4"
 	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilfeature "k8s.io/component-base/featuregate/testing"
@@ -59,6 +60,7 @@ func TestAzureManagedMachinePoolDefaultingWebhook(t *testing.T) {
 	g.Expect(val).To(Equal("System"))
 	g.Expect(*ammp.Spec.Name).To(Equal("fooname"))
 	g.Expect(*ammp.Spec.OSType).To(Equal(LinuxOS))
+	g.Expect(ammp.Spec.SpotMaxPrice).To(BeNil())
 
 	t.Logf("Testing ammp defaulting webhook with empty string name specified in Spec")
 	emptyName := ""
@@ -80,6 +82,18 @@ func TestAzureManagedMachinePoolDefaultingWebhook(t *testing.T) {
 	err = mw.Default(context.Background(), ammp)
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(*ammp.Spec.OsDiskType).To(Equal("Ephemeral"))
+
+	t.Logf("Testing ammp defaulting webhook with scaleSetPriority Spot")
+	ammp.Spec.ScaleSetPriority = ptr.To(string(armcontainerservice.ScaleSetPrioritySpot))
+	err = mw.Default(context.Background(), ammp)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(ammp.Spec.SpotMaxPrice.Equal(resource.MustParse("-1"))).To(BeTrue())
+
+	t.Logf("Testing ammp defaulting webhook with scaleSetPriority Spot with max price set")
+	ammp.Spec.SpotMaxPrice = ptr.To(resource.MustParse("100"))
+	err = mw.Default(context.Background(), ammp)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(ammp.Spec.SpotMaxPrice.Equal(resource.MustParse("100"))).To(BeTrue())
 }
 
 func TestAzureManagedMachinePoolUpdatingWebhook(t *testing.T) {

--- a/test/e2e/aks_spot.go
+++ b/test/e2e/aks_spot.go
@@ -22,6 +22,7 @@ package e2e
 import (
 	"context"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v4"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -67,7 +68,7 @@ func AKSSpotSpec(ctx context.Context, inputGetter func() AKSSpotSpecInput) {
 		Spec: infrav1.AzureManagedMachinePoolSpec{
 			Mode:             "User",
 			SKU:              "Standard_D2s_v3",
-			ScaleSetPriority: ptr.To("Spot"),
+			ScaleSetPriority: ptr.To(string(armcontainerservice.ScaleSetPrioritySpot)),
 			Scaling:          &scaling,
 			SpotMaxPrice:     &spotMaxPrice,
 			ScaleDownMode:    ptr.To("Deallocate"),


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

This PR fixes the AzureManagedMachinePool controller from futilely endlessly reconciling based on a diff when no `spec.spotMaxPrice` is defined for CAPZ and the value for the AKS resource in Azure gets defaulted to -1. This PR adds logic to the defaulting webhook that will mirror the same defaulting done by AKS for Spot node pools.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4112

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [X] cherry-pick candidate <- to 1.11, this feature does not exist in 1.10

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [ ] includes documentation
- [X] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixed a bug that caused AzureManagedMachinePools to endlessly reconcile Spot node pools when no `spec.spotMaxPrice` is set
```
