### PR TITLE
add ux for workload identity for cloud provider azure

### DIFF
--- a/api/v1beta1/types.go
+++ b/api/v1beta1/types.go
@@ -534,7 +534,7 @@ type AzureSharedGalleryImage struct {
 }
 
 // VMIdentity defines the identity of the virtual machine, if configured.
-// +kubebuilder:validation:Enum=None;SystemAssigned;UserAssigned
+// +kubebuilder:validation:Enum=None;SystemAssigned;UserAssigned;WorkloadIdentity
 type VMIdentity string
 
 const (
@@ -544,6 +544,8 @@ const (
 	VMIdentitySystemAssigned VMIdentity = "SystemAssigned"
 	// VMIdentityUserAssigned ...
 	VMIdentityUserAssigned VMIdentity = "UserAssigned"
+	// VMIdentityWorkloadIdentity ...
+	VMIdentityWorkloadIdentity VMIdentity = "WorkloadIdentity"
 )
 
 // SpotEvictionPolicy defines the eviction policy for spot VMs, if configured.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremachinepools.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremachinepools.yaml
@@ -96,6 +96,7 @@ spec:
                 - None
                 - SystemAssigned
                 - UserAssigned
+                - WorkloadIdentity
                 type: string
               location:
                 description: Location is the Azure region location e.g. westus2

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremachines.yaml
@@ -260,6 +260,7 @@ spec:
                 - None
                 - SystemAssigned
                 - UserAssigned
+                - WorkloadIdentity
                 type: string
               image:
                 description: Image is used to provide details of an image to use during

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremachinetemplates.yaml
@@ -283,6 +283,7 @@ spec:
                         - None
                         - SystemAssigned
                         - UserAssigned
+                        - WorkloadIdentity
                         type: string
                       image:
                         description: Image is used to provide details of an image


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds capability to specify to use workload identity for cloud provider azure on workload clusters on azure.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3589 

**Special notes for your reviewer**:
- Contains an API change where there is one more acceptable value for `AzureMachineTemplate` .spec.identity and the new acceptable value is `WorkloadIdentity`

- To create a workload cluster with workload identity enabled, certain flags needs to be passed on kube-apiserver and kube-controller-manager which is describe in a comment in the full workload cluster YAML pasted below. 

- [ ] cherry-pick candidate


**How this will work:** 

Assume you have a management cluster with the workload identity enabled. Now, you can create a workload cluster which will have workload identity enabled on it. 

Here are the pre-reqiuistes steps that should be followed which is already documented [here](https://capz.sigs.k8s.io/topics/workload-identity)  
- Generate a public/private key pair
- Generate OIDC and JWKS document. 
- Upload the OIDC and JWKS documents on a public accessible URL. This is called `SERVICE_ISSUER_URL`
- Create a federated credential for cloud provider azure. 

Distribute the key pairs using the following steps: 
- Encode the public and private key into base64 and put that into a secret with the name `<your-workload-cluster-name>-sa`  in the same namespace as that you the workload cluster `Cluster` object.
```yaml
apiVersion: v1
kind: Secret
metadata:
  name: azwi-cluster-sa
type: kubernetes.io/tls
data:
  tls.crt: "<base64-encoded-public-key>"
  tls.key: "<base-64-encoded-private-key>"
  ```
  
  Now following is a sample workload cluster YAML that can be used to create a workload cluster which will ensure that the cloud provider azure uses workload identity. 

```yaml
apiVersion: cluster.x-k8s.io/v1beta1
kind: Cluster
metadata:
  name: azwi-cluster
  namespace: default
spec:
  clusterNetwork:
    pods:
      cidrBlocks:
      - 192.168.0.0/16
  controlPlaneRef:
    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
    kind: KubeadmControlPlane
    name: azwi-cluster-control-plane
  infrastructureRef:
    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
    kind: AzureCluster
    name: azwi-cluster
---
apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
kind: AzureCluster
metadata:
  name: azwi-cluster
  namespace: default
spec:
  identityRef:
    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
    kind: AzureClusterIdentity
    name: cluster-identity
  location: eastus
  networkSpec:
    subnets:
    - name: control-plane-subnet
      role: control-plane
    - name: node-subnet
      role: node
    vnet:
      name: azwi-cluster-vnet
  resourceGroup: azwi-cluster
  subscriptionID: <your-subscription-id>
---
apiVersion: controlplane.cluster.x-k8s.io/v1beta1
kind: KubeadmControlPlane
metadata:
  name: azwi-cluster-control-plane
  namespace: default
spec:
  kubeadmConfigSpec:
    clusterConfiguration:
      apiServer:
        extraArgs:
          cloud-provider: external
          # This flag needs to be passed for the workload cluster to be able to use workload identity
          service-account-issuer: <your-service-issuer-url>
          # This flag needs to be passed for the workload cluster to be able to use workload identity
          service-account-key-file: /etc/kubernetes/pki/sa.pub
          # This flag needs to be passed for the workload cluster to be able to use workload identity
          service-account-signing-key-file: /etc/kubernetes/pki/sa.key
        timeoutForControlPlane: 20m
      controllerManager:
        extraArgs:
          allocate-node-cidrs: "false"
          cloud-provider: external
          cluster-name: azwi-cluster
          # This flag needs to be passed for the workload cluster to be able to use workload identity
          service-account-private-key-file: /etc/kubernetes/pki/sa.key
      etcd:
        local:
          dataDir: /var/lib/etcddisk/etcd
          extraArgs:
            quota-backend-bytes: "8589934592"
    diskSetup:
      filesystems:
      - device: /dev/disk/azure/scsi1/lun0
        extraOpts:
        - -E
        - lazy_itable_init=1,lazy_journal_init=1
        filesystem: ext4
        label: etcd_disk
      - device: ephemeral0.1
        filesystem: ext4
        label: ephemeral0
        replaceFS: ntfs
      partitions:
      - device: /dev/disk/azure/scsi1/lun0
        layout: true
        overwrite: false
        tableType: gpt
    files:
    - contentFrom:
        secret:
          key: control-plane-azure.json
          name: azwi-cluster-control-plane-azure-json
      owner: root:root
      path: /etc/kubernetes/azure.json
      permissions: "0644"
    initConfiguration:
      nodeRegistration:
        kubeletExtraArgs:
          azure-container-registry-config: /etc/kubernetes/azure.json
          cloud-provider: external
        name: '{{ ds.meta_data["local_hostname"] }}'
    joinConfiguration:
      nodeRegistration:
        kubeletExtraArgs:
          azure-container-registry-config: /etc/kubernetes/azure.json
          cloud-provider: external
        name: '{{ ds.meta_data["local_hostname"] }}'
    mounts:
    - - LABEL=etcd_disk
      - /var/lib/etcddisk
    postKubeadmCommands: []
    preKubeadmCommands: []
  machineTemplate:
    infrastructureRef:
      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
      kind: AzureMachineTemplate
      name: azwi-cluster-control-plane
  replicas: 1
  version: v1.27.3
---
apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
kind: AzureMachineTemplate
metadata:
  name: azwi-cluster-control-plane
  namespace: default
spec:
  template:
    spec:
      dataDisks:
      - diskSizeGB: 256
        lun: 0
        nameSuffix: etcddisk
      osDisk:
        diskSizeGB: 128
        osType: Linux
      # This is the API change which introduce a new value for the identity key
      identity: WorkloadIdentity
      vmSize: Standard_B2s
---
apiVersion: cluster.x-k8s.io/v1beta1
kind: MachineDeployment
metadata:
  name: azwi-cluster-md-0
  namespace: default
spec:
  clusterName: azwi-cluster
  replicas: 1
  selector:
    matchLabels: null
  template:
    spec:
      bootstrap:
        configRef:
          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
          kind: KubeadmConfigTemplate
          name: azwi-cluster-md-0
      clusterName: azwi-cluster
      infrastructureRef:
        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
        kind: AzureMachineTemplate
        name: azwi-cluster-md-0
      version: v1.27.3
---
apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
kind: AzureMachineTemplate
metadata:
  name: azwi-cluster-md-0
  namespace: default
spec:
  template:
    spec:
      osDisk:
        diskSizeGB: 128
        osType: Linux
      # This is the API change which introduce a new value for the identity key  
      identity: WorkloadIdentity
      vmSize: Standard_B2s
---
apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
kind: KubeadmConfigTemplate
metadata:
  name: azwi-cluster-md-0
  namespace: default
spec:
  template:
    spec:
      files:
      - contentFrom:
          secret:
            key: worker-node-azure.json
            name: azwi-cluster-md-0-azure-json
        owner: root:root
        path: /etc/kubernetes/azure.json
        permissions: "0644"
      joinConfiguration:
        nodeRegistration:
          kubeletExtraArgs:
            azure-container-registry-config: /etc/kubernetes/azure.json
            cloud-provider: external
          name: '{{ ds.meta_data["local_hostname"] }}'
      preKubeadmCommands: []
---
apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
kind: AzureClusterIdentity
metadata:
  labels:
    clusterctl.cluster.x-k8s.io/move-hierarchy: "true"
  name: cluster-identity
  namespace: default
spec:
  allowedNamespaces: {}
  clientID: <your-client-id>
  tenantID: <your-tenant-id>
  type: WorkloadIdentity
  ```


**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add UX to use wrokload identity for cloud provider azure
```
