### PR TITLE
wait for ASO tags to converge before updating

### DIFF
--- a/azure/services/aso/aso_test.go
+++ b/azure/services/aso/aso_test.go
@@ -710,7 +710,7 @@ func TestCreateOrUpdateResource(t *testing.T) {
 
 		specMock.MockTagsGetterSetter.EXPECT().GetActualTags(gomock.Any()).Return(nil)
 		specMock.MockTagsGetterSetter.EXPECT().GetAdditionalTags().Return(nil)
-		specMock.MockTagsGetterSetter.EXPECT().GetDesiredTags(gomock.Any()).Return(nil)
+		specMock.MockTagsGetterSetter.EXPECT().GetDesiredTags(gomock.Any()).Return(nil).Times(2)
 		specMock.MockTagsGetterSetter.EXPECT().SetTags(gomock.Any(), gomock.Any())
 
 		ctx := context.Background()

--- a/azure/services/aso/tags.go
+++ b/azure/services/aso/tags.go
@@ -18,10 +18,13 @@ package aso
 
 import (
 	"encoding/json"
+	"reflect"
 
+	asoannotations "github.com/Azure/azure-service-operator/v2/pkg/common/annotations"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	"github.com/pkg/errors"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
+	"sigs.k8s.io/cluster-api-provider-azure/azure"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/converters"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/services/tags"
 	"sigs.k8s.io/cluster-api-provider-azure/util/maps"
@@ -47,6 +50,16 @@ func reconcileTags[T genruntime.MetaObject](t TagsGetterSetter[T], existing T, r
 		}
 
 		existingTags = t.GetActualTags(existing)
+		// Wait for tags to converge so we know for sure which ones are deleted from additionalTags (and
+		// should be deleted) and which were added manually (and should be kept).
+		if !reflect.DeepEqual(t.GetDesiredTags(existing), existingTags) &&
+			existing.GetAnnotations()[asoannotations.ReconcilePolicy] == string(asoannotations.ReconcilePolicyManage) {
+			return azure.WithTransientError(azure.NewOperationNotDoneError(&infrav1.Future{
+				Type:          createOrUpdateFutureType,
+				ResourceGroup: existing.GetNamespace(),
+				Name:          existing.GetName(),
+			}), requeueInterval)
+		}
 	}
 
 	existingTagsMap := converters.TagsToMap(existingTags)

--- a/azure/services/aso/tags_test.go
+++ b/azure/services/aso/tags_test.go
@@ -18,13 +18,16 @@ package aso
 
 import (
 	"encoding/json"
+	"errors"
 	"testing"
 
 	asoresourcesv1 "github.com/Azure/azure-service-operator/v2/api/resources/v1api20200601"
+	asoannotations "github.com/Azure/azure-service-operator/v2/pkg/common/annotations"
 	. "github.com/onsi/gomega"
 	"go.uber.org/mock/gomock"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
+	"sigs.k8s.io/cluster-api-provider-azure/azure"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/services/aso/mock_aso"
 )
 
@@ -43,6 +46,7 @@ func TestReconcileTags(t *testing.T) {
 				"oldAdditionalTag": "oldAdditionalVal",
 			},
 			existingTags: infrav1.Tags{
+				"oldAdditionalTag": "oldAdditionalVal",
 				"nonAdditionalTag": "nonAdditionalVal",
 			},
 			additionalTagsSpec: infrav1.Tags{
@@ -94,6 +98,7 @@ func TestReconcileTags(t *testing.T) {
 				})
 			}
 			tag.EXPECT().GetActualTags(existing).Return(test.existingTags)
+			tag.EXPECT().GetDesiredTags(existing).Return(test.existingTags)
 			tag.EXPECT().GetAdditionalTags().Return(test.additionalTagsSpec)
 
 			parameters := &asoresourcesv1.ResourceGroup{}
@@ -122,5 +127,28 @@ func TestReconcileTags(t *testing.T) {
 
 		err := reconcileTags[*asoresourcesv1.ResourceGroup](tag, existing, existing != nil, nil)
 		g.Expect(err).To(HaveOccurred())
+	})
+
+	t.Run("existing tags not up to date", func(t *testing.T) {
+		g := NewWithT(t)
+
+		mockCtrl := gomock.NewController(t)
+		tag := mock_aso.NewMockTagsGetterSetter[*asoresourcesv1.ResourceGroup](mockCtrl)
+
+		existing := &asoresourcesv1.ResourceGroup{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					asoannotations.ReconcilePolicy: string(asoannotations.ReconcilePolicyManage),
+				},
+			},
+		}
+		tag.EXPECT().GetActualTags(existing).Return(infrav1.Tags{"new": "value"})
+		tag.EXPECT().GetDesiredTags(existing).Return(infrav1.Tags{"old": "tag"})
+
+		err := reconcileTags[*asoresourcesv1.ResourceGroup](tag, existing, existing != nil, nil)
+		g.Expect(azure.IsOperationNotDoneError(err)).To(BeTrue())
+		var recerr azure.ReconcileError
+		g.Expect(errors.As(err, &recerr)).To(BeTrue())
+		g.Expect(recerr.IsTransient()).To(BeTrue())
 	})
 }


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

From https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/4069/files#r1344633228:

> I had noticed a race condition while running the tags e2e test where if the tags have not converged, then CAPZ could lose track of some tags that have been deleted from `spec.additionalTags` and treat them like tags that existed outside of `spec.additionalTags` and keep them around without ever deleting them. Waiting for the tags to converge on the ASO resource fixes that issue AFAICT.
> 
> Overall, this makes tags reconciliation work more similarly to the more synchronous method used before when calling the tags APIs directly.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [X] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [ ] includes documentation
- [X] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixed a bug causing some tags on ASO resources not to be deleted
```
