### PR TITLE
add contexts to aso service hooks

### DIFF
--- a/azure/services/natgateways/natgateways.go
+++ b/azure/services/natgateways/natgateways.go
@@ -17,6 +17,8 @@ limitations under the License.
 package natgateways
 
 import (
+	"context"
+
 	asonetworkv1 "github.com/Azure/azure-service-operator/v2/api/network/v1api20220701"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
@@ -51,10 +53,14 @@ func New(scope NatGatewayScope) *Service {
 	}
 }
 
-func postCreateOrUpdateResourceHook(scope NatGatewayScope, result *asonetworkv1.NatGateway, err error) {
+func postCreateOrUpdateResourceHook(_ context.Context, scope NatGatewayScope, result *asonetworkv1.NatGateway, err error) error {
+	if err != nil {
+		return err
+	}
 	// TODO: ideally we wouldn't need to set the subnet spec based on the result of the create operation
 	// result only gets populated when the resource is created or if it already exists
 	if result != nil && result.Status.Id != nil {
 		scope.SetNatGatewayIDInSubnets(result.Name, *result.Status.Id)
 	}
+	return nil
 }

--- a/azure/services/natgateways/natgateways_test.go
+++ b/azure/services/natgateways/natgateways_test.go
@@ -17,9 +17,11 @@ limitations under the License.
 package natgateways
 
 import (
+	"context"
 	"testing"
 
 	asonetworkv1 "github.com/Azure/azure-service-operator/v2/api/network/v1api20220701"
+	. "github.com/onsi/gomega"
 	"github.com/pkg/errors"
 	"go.uber.org/mock/gomock"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -29,13 +31,16 @@ import (
 
 func TestPostCreateOrUpdateResourceHook(t *testing.T) {
 	t.Run("error creating or updating", func(t *testing.T) {
+		g := NewGomegaWithT(t)
 		mockCtrl := gomock.NewController(t)
 		scope := mock_natgateways.NewMockNatGatewayScope(mockCtrl)
 
-		postCreateOrUpdateResourceHook(scope, nil, errors.New("an error"))
+		err := postCreateOrUpdateResourceHook(context.Background(), scope, nil, errors.New("an error"))
+		g.Expect(err).To(HaveOccurred())
 	})
 
 	t.Run("successful create or update", func(t *testing.T) {
+		g := NewGomegaWithT(t)
 		mockCtrl := gomock.NewController(t)
 		scope := mock_natgateways.NewMockNatGatewayScope(mockCtrl)
 
@@ -51,6 +56,7 @@ func TestPostCreateOrUpdateResourceHook(t *testing.T) {
 			},
 		}
 
-		postCreateOrUpdateResourceHook(scope, natGateway, nil)
+		err := postCreateOrUpdateResourceHook(context.Background(), scope, natGateway, nil)
+		g.Expect(err).NotTo(HaveOccurred())
 	})
 }


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind cleanup

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**: 

This PR adds `context.Context`s to the hooks invoked by the generic ASO `Service` for services that need to consume a context in those hooks. Additionally, `PostCreateOrUpdateResourceHook` can now return an error.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [ ] includes documentation
- [X] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
