### PR TITLE
[release-1.11] don't wait for ASO resources to be ready for updates

### DIFF
--- a/azure/services/aso/aso_test.go
+++ b/azure/services/aso/aso_test.go
@@ -175,6 +175,10 @@ func TestCreateOrUpdateResource(t *testing.T) {
 				Namespace: "namespace",
 			},
 		})
+		specMock.EXPECT().Parameters(gomockinternal.AContext(), gomock.Not(gomock.Nil())).DoAndReturn(func(_ context.Context, group *asoresourcesv1.ResourceGroup) (*asoresourcesv1.ResourceGroup, error) {
+			return group, nil
+		})
+		specMock.EXPECT().WasManaged(gomock.Any()).Return(false)
 
 		ctx := context.Background()
 		g.Expect(c.Create(ctx, &asoresourcesv1.ResourceGroup{
@@ -183,6 +187,9 @@ func TestCreateOrUpdateResource(t *testing.T) {
 				Namespace: "namespace",
 				Labels: map[string]string{
 					infrav1.OwnedByClusterLabelKey: clusterName,
+				},
+				Annotations: map[string]string{
+					asoannotations.PerResourceSecret: "cluster-aso-secret",
 				},
 			},
 			Status: asoresourcesv1.ResourceGroup_STATUS{
@@ -203,6 +210,7 @@ func TestCreateOrUpdateResource(t *testing.T) {
 		var recerr azure.ReconcileError
 		g.Expect(errors.As(err, &recerr)).To(BeTrue())
 		g.Expect(recerr.IsTransient()).To(BeTrue())
+		g.Expect(recerr.IsTerminal()).To(BeFalse())
 	})
 
 	t.Run("resource is not ready in reconciling state", func(t *testing.T) {
@@ -223,6 +231,10 @@ func TestCreateOrUpdateResource(t *testing.T) {
 				Namespace: "namespace",
 			},
 		})
+		specMock.EXPECT().Parameters(gomockinternal.AContext(), gomock.Not(gomock.Nil())).DoAndReturn(func(_ context.Context, group *asoresourcesv1.ResourceGroup) (*asoresourcesv1.ResourceGroup, error) {
+			return group, nil
+		})
+		specMock.EXPECT().WasManaged(gomock.Any()).Return(false)
 
 		ctx := context.Background()
 		g.Expect(c.Create(ctx, &asoresourcesv1.ResourceGroup{
@@ -231,6 +243,9 @@ func TestCreateOrUpdateResource(t *testing.T) {
 				Namespace: "namespace",
 				Labels: map[string]string{
 					infrav1.OwnedByClusterLabelKey: clusterName,
+				},
+				Annotations: map[string]string{
+					asoannotations.PerResourceSecret: "cluster-aso-secret",
 				},
 			},
 			Status: asoresourcesv1.ResourceGroup_STATUS{
@@ -268,6 +283,10 @@ func TestCreateOrUpdateResource(t *testing.T) {
 				Namespace: "namespace",
 			},
 		})
+		specMock.EXPECT().Parameters(gomockinternal.AContext(), gomock.Not(gomock.Nil())).DoAndReturn(func(_ context.Context, group *asoresourcesv1.ResourceGroup) (*asoresourcesv1.ResourceGroup, error) {
+			return group, nil
+		})
+		specMock.EXPECT().WasManaged(gomock.Any()).Return(false)
 
 		ctx := context.Background()
 		g.Expect(c.Create(ctx, &asoresourcesv1.ResourceGroup{
@@ -276,6 +295,9 @@ func TestCreateOrUpdateResource(t *testing.T) {
 				Namespace: "namespace",
 				Labels: map[string]string{
 					infrav1.OwnedByClusterLabelKey: clusterName,
+				},
+				Annotations: map[string]string{
+					asoannotations.PerResourceSecret: "cluster-aso-secret",
 				},
 			},
 			Status: asoresourcesv1.ResourceGroup_STATUS{
@@ -296,6 +318,7 @@ func TestCreateOrUpdateResource(t *testing.T) {
 		var recerr azure.ReconcileError
 		g.Expect(errors.As(err, &recerr)).To(BeTrue())
 		g.Expect(recerr.IsTerminal()).To(BeTrue())
+		g.Expect(recerr.IsTransient()).To(BeFalse())
 	})
 
 	t.Run("error getting existing resource", func(t *testing.T) {


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

Manual cherry-pick of #4148:

> ASO will serialize updates to Azure as necessary, so CAPZ should not worry about not updating ASO resource specs while an Azure update is in progress.
>
> From https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/4069/files#r1344629003:
> > The changes around here are because I noticed that before, if an ASO resource got stuck in a failed state, attempting to fix it by updating the CAPZ spec would never work because we were always returning an error here without calling `Parameters` and updating the ASO resource. These changes defer the equivalent check to after `Parameters` is called and generates no diff.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [ ] includes documentation
- [X] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixed a bug causing ASO resources to potentially get stuck in a failed state
```
