### PR TITLE
[release-1.10] fix NodeTaints and NodeLabels return type for AzureManagedMachinePools

### DIFF
--- a/azure/services/agentpools/spec.go
+++ b/azure/services/agentpools/spec.go
@@ -370,46 +370,55 @@ func (s *AgentPoolSpec) Parameters(ctx context.Context, existing interface{}) (p
 
 // mergeSystemNodeLabels appends any kubernetes.azure.com-prefixed labels from the AKS label set
 // into the local capz label set.
-func mergeSystemNodeLabels(capz, aks map[string]*string) map[string]*string {
-	ret := capz
-	if ret == nil {
+func mergeSystemNodeLabels(capzLabels, aksLabels map[string]*string) map[string]*string {
+	// if both are nil, return nil for no change
+	if capzLabels == nil && aksLabels == nil {
+		return nil
+	}
+
+	// Either one of the capzLabels or aksLabels is nil.
+	// Prioritize capzLabels if it is not nil.
+	var ret map[string]*string
+	if capzLabels != nil {
+		ret = capzLabels
+	} else {
 		ret = make(map[string]*string)
 	}
+
 	// Look for labels returned from the AKS node pool API that begin with kubernetes.azure.com
-	for aksNodeLabelKey := range aks {
+	for aksNodeLabelKey := range aksLabels {
 		if azureutil.IsAzureSystemNodeLabelKey(aksNodeLabelKey) {
-			ret[aksNodeLabelKey] = aks[aksNodeLabelKey]
+			ret[aksNodeLabelKey] = aksLabels[aksNodeLabelKey]
 		}
 	}
-	// Preserve nil-ness of capz
-	if capz == nil && len(ret) == 0 {
-		ret = nil
-	}
+
+	// if no labels are found, ret will be an empty map to clear out the NodeLabels at AKS API
 	return ret
 }
 
 // mergeSystemNodeTaints appends any kubernetes.azure.com-prefixed taints from the AKS taint set
 // into the local capz taint set.
-func mergeSystemNodeTaints(capz, aks *[]string) *[]string {
-	var ret []string
-	if capz != nil {
-		ret = *capz
+func mergeSystemNodeTaints(capzNodeTaints, aksNodeTaints *[]string) *[]string {
+	if capzNodeTaints == nil && aksNodeTaints == nil {
+		return nil
 	}
-	if ret == nil {
+
+	var ret []string
+	if capzNodeTaints != nil {
+		ret = *capzNodeTaints
+	} else {
 		ret = make([]string, 0)
 	}
-	// Look for labels returned from the AKS node pool API that begin with kubernetes.azure.com
-	if aks != nil {
-		for _, aksNodeTaint := range *aks {
+
+	// Look for taints returned from the AKS node pool API that begin with kubernetes.azure.com
+	if aksNodeTaints != nil {
+		for _, aksNodeTaint := range *aksNodeTaints {
 			if azureutil.IsAzureSystemNodeLabelKey(aksNodeTaint) {
 				ret = append(ret, aksNodeTaint)
 			}
 		}
 	}
 
-	// Preserve nil-ness of capz
-	if capz == nil && len(ret) == 0 {
-		return nil
-	}
+	// if no taints are found, ret will be an empty array to clear out the nodeTaints at AKS API
 	return &ret
 }


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
- Manual cherry-pick of https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/4122. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:


**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
fix NodeTaints and NodeLabels return type for AzureManagedMachinePools
```
