### PR TITLE
[release-1.11] wait for ASO tags to converge before updating

### DIFF
--- a/azure/services/aso/aso_test.go
+++ b/azure/services/aso/aso_test.go
@@ -736,7 +736,7 @@ func TestCreateOrUpdateResource(t *testing.T) {
 
 		specMock.MockTagsGetterSetter.EXPECT().GetActualTags(gomock.Any()).Return(nil, nil)
 		specMock.MockTagsGetterSetter.EXPECT().GetAdditionalTags().Return(nil)
-		specMock.MockTagsGetterSetter.EXPECT().GetDesiredTags(gomock.Any()).Return(nil, nil)
+		specMock.MockTagsGetterSetter.EXPECT().GetDesiredTags(gomock.Any()).Return(nil, nil).Times(2)
 		specMock.MockTagsGetterSetter.EXPECT().SetTags(gomock.Any(), gomock.Any())
 
 		ctx := context.Background()


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

Manual cherry-pick of #4149:

> From https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/4069/files#r1344633228:
> 
> > I had noticed a race condition while running the tags e2e test where if the tags have not converged, then CAPZ could lose track of some tags that have been deleted from `spec.additionalTags` and treat them like tags that existed outside of `spec.additionalTags` and keep them around without ever deleting them. Waiting for the tags to converge on the ASO resource fixes that issue AFAICT.
> > Overall, this makes tags reconciliation work more similarly to the more synchronous method used before when calling the tags APIs directly.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [ ] includes documentation
- [X] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixed a bug causing some tags on ASO resources not to be deleted
```
