### PR TITLE
Ensure Gomega handles are created in subtests

### DIFF
--- a/api/v1beta1/azurecluster_validation_test.go
+++ b/api/v1beta1/azurecluster_validation_test.go
@@ -27,7 +27,6 @@ import (
 )
 
 func TestClusterNameValidation(t *testing.T) {
-	g := NewWithT(t)
 	tests := []struct {
 		name        string
 		clusterName string
@@ -86,6 +85,7 @@ func TestClusterNameValidation(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
 			azureCluster := AzureCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: tc.clusterName,
@@ -103,8 +103,6 @@ func TestClusterNameValidation(t *testing.T) {
 }
 
 func TestClusterWithPreexistingVnetValid(t *testing.T) {
-	g := NewWithT(t)
-
 	type test struct {
 		name    string
 		cluster *AzureCluster
@@ -116,14 +114,13 @@ func TestClusterWithPreexistingVnetValid(t *testing.T) {
 	}
 
 	t.Run(testCase.name, func(t *testing.T) {
+		g := NewWithT(t)
 		_, err := testCase.cluster.validateCluster(nil)
 		g.Expect(err).To(BeNil())
 	})
 }
 
 func TestClusterWithPreexistingVnetInvalid(t *testing.T) {
-	g := NewWithT(t)
-
 	type test struct {
 		name    string
 		cluster *AzureCluster
@@ -143,14 +140,13 @@ func TestClusterWithPreexistingVnetInvalid(t *testing.T) {
 	}
 
 	t.Run(testCase.name, func(t *testing.T) {
+		g := NewWithT(t)
 		_, err := testCase.cluster.validateCluster(nil)
 		g.Expect(err).NotTo(BeNil())
 	})
 }
 
 func TestClusterWithoutPreexistingVnetValid(t *testing.T) {
-	g := NewWithT(t)
-
 	type test struct {
 		name    string
 		cluster *AzureCluster
@@ -166,14 +162,13 @@ func TestClusterWithoutPreexistingVnetValid(t *testing.T) {
 	testCase.cluster.Spec.NetworkSpec.Vnet.ResourceGroup = ""
 
 	t.Run(testCase.name, func(t *testing.T) {
+		g := NewWithT(t)
 		_, err := testCase.cluster.validateCluster(nil)
 		g.Expect(err).To(BeNil())
 	})
 }
 
 func TestClusterSpecWithPreexistingVnetValid(t *testing.T) {
-	g := NewWithT(t)
-
 	type test struct {
 		name    string
 		cluster *AzureCluster
@@ -185,14 +180,13 @@ func TestClusterSpecWithPreexistingVnetValid(t *testing.T) {
 	}
 
 	t.Run(testCase.name, func(t *testing.T) {
+		g := NewWithT(t)
 		errs := testCase.cluster.validateClusterSpec(nil)
 		g.Expect(errs).To(BeNil())
 	})
 }
 
 func TestClusterSpecWithPreexistingVnetInvalid(t *testing.T) {
-	g := NewWithT(t)
-
 	type test struct {
 		name    string
 		cluster *AzureCluster
@@ -212,14 +206,13 @@ func TestClusterSpecWithPreexistingVnetInvalid(t *testing.T) {
 	}
 
 	t.Run(testCase.name, func(t *testing.T) {
+		g := NewWithT(t)
 		errs := testCase.cluster.validateClusterSpec(nil)
 		g.Expect(len(errs)).To(BeNumerically(">", 0))
 	})
 }
 
 func TestClusterSpecWithoutPreexistingVnetValid(t *testing.T) {
-	g := NewWithT(t)
-
 	type test struct {
 		name    string
 		cluster *AzureCluster
@@ -235,14 +228,13 @@ func TestClusterSpecWithoutPreexistingVnetValid(t *testing.T) {
 	testCase.cluster.Spec.NetworkSpec.Vnet.ResourceGroup = ""
 
 	t.Run(testCase.name, func(t *testing.T) {
+		g := NewWithT(t)
 		errs := testCase.cluster.validateClusterSpec(nil)
 		g.Expect(errs).To(BeNil())
 	})
 }
 
 func TestClusterSpecWithoutIdentityRefInvalid(t *testing.T) {
-	g := NewWithT(t)
-
 	type test struct {
 		name    string
 		cluster *AzureCluster
@@ -257,14 +249,13 @@ func TestClusterSpecWithoutIdentityRefInvalid(t *testing.T) {
 	testCase.cluster.Spec.IdentityRef = nil
 
 	t.Run(testCase.name, func(t *testing.T) {
+		g := NewWithT(t)
 		errs := testCase.cluster.validateClusterSpec(nil)
 		g.Expect(len(errs)).To(BeNumerically(">", 0))
 	})
 }
 
 func TestClusterSpecWithWrongKindInvalid(t *testing.T) {
-	g := NewWithT(t)
-
 	type test struct {
 		name    string
 		cluster *AzureCluster
@@ -279,14 +270,13 @@ func TestClusterSpecWithWrongKindInvalid(t *testing.T) {
 	testCase.cluster.Spec.IdentityRef.Kind = "bad"
 
 	t.Run(testCase.name, func(t *testing.T) {
+		g := NewWithT(t)
 		errs := testCase.cluster.validateClusterSpec(nil)
 		g.Expect(len(errs)).To(BeNumerically(">", 0))
 	})
 }
 
 func TestNetworkSpecWithPreexistingVnetValid(t *testing.T) {
-	g := NewWithT(t)
-
 	type test struct {
 		name        string
 		networkSpec NetworkSpec
@@ -298,14 +288,13 @@ func TestNetworkSpecWithPreexistingVnetValid(t *testing.T) {
 	}
 
 	t.Run(testCase.name, func(t *testing.T) {
+		g := NewWithT(t)
 		errs := validateNetworkSpec(testCase.networkSpec, NetworkSpec{}, field.NewPath("spec").Child("networkSpec"))
 		g.Expect(errs).To(BeNil())
 	})
 }
 
 func TestNetworkSpecWithPreexistingVnetLackRequiredSubnets(t *testing.T) {
-	g := NewWithT(t)
-
 	type test struct {
 		name        string
 		networkSpec NetworkSpec
@@ -320,6 +309,7 @@ func TestNetworkSpecWithPreexistingVnetLackRequiredSubnets(t *testing.T) {
 	testCase.networkSpec.Subnets = testCase.networkSpec.Subnets[:1]
 
 	t.Run(testCase.name, func(t *testing.T) {
+		g := NewWithT(t)
 		errs := validateNetworkSpec(testCase.networkSpec, NetworkSpec{}, field.NewPath("spec").Child("networkSpec"))
 		g.Expect(errs).To(HaveLen(1))
 		g.Expect(errs[0].Type).To(Equal(field.ErrorTypeRequired))
@@ -329,8 +319,6 @@ func TestNetworkSpecWithPreexistingVnetLackRequiredSubnets(t *testing.T) {
 }
 
 func TestNetworkSpecWithPreexistingVnetInvalidResourceGroup(t *testing.T) {
-	g := NewWithT(t)
-
 	type test struct {
 		name        string
 		networkSpec NetworkSpec
@@ -344,6 +332,7 @@ func TestNetworkSpecWithPreexistingVnetInvalidResourceGroup(t *testing.T) {
 	testCase.networkSpec.Vnet.ResourceGroup = "invalid-name###"
 
 	t.Run(testCase.name, func(t *testing.T) {
+		g := NewWithT(t)
 		errs := validateNetworkSpec(testCase.networkSpec, NetworkSpec{}, field.NewPath("spec").Child("networkSpec"))
 		g.Expect(errs).To(HaveLen(1))
 		g.Expect(errs[0].Type).To(Equal(field.ErrorTypeInvalid))
@@ -353,8 +342,6 @@ func TestNetworkSpecWithPreexistingVnetInvalidResourceGroup(t *testing.T) {
 }
 
 func TestNetworkSpecWithoutPreexistingVnetValid(t *testing.T) {
-	g := NewWithT(t)
-
 	type test struct {
 		name        string
 		networkSpec NetworkSpec
@@ -368,14 +355,13 @@ func TestNetworkSpecWithoutPreexistingVnetValid(t *testing.T) {
 	testCase.networkSpec.Vnet.ResourceGroup = ""
 
 	t.Run(testCase.name, func(t *testing.T) {
+		g := NewWithT(t)
 		errs := validateNetworkSpec(testCase.networkSpec, NetworkSpec{}, field.NewPath("spec").Child("networkSpec"))
 		g.Expect(errs).To(BeNil())
 	})
 }
 
 func TestResourceGroupValid(t *testing.T) {
-	g := NewWithT(t)
-
 	type test struct {
 		name          string
 		resourceGroup string
@@ -387,6 +373,7 @@ func TestResourceGroupValid(t *testing.T) {
 	}
 
 	t.Run(testCase.name, func(t *testing.T) {
+		g := NewWithT(t)
 		err := validateResourceGroup(testCase.resourceGroup,
 			field.NewPath("spec").Child("networkSpec").Child("vnet").Child("resourceGroup"))
 		g.Expect(err).To(BeNil())
@@ -394,8 +381,6 @@ func TestResourceGroupValid(t *testing.T) {
 }
 
 func TestResourceGroupInvalid(t *testing.T) {
-	g := NewWithT(t)
-
 	type test struct {
 		name          string
 		resourceGroup string
@@ -407,6 +392,7 @@ func TestResourceGroupInvalid(t *testing.T) {
 	}
 
 	t.Run(testCase.name, func(t *testing.T) {
+		g := NewWithT(t)
 		err := validateResourceGroup(testCase.resourceGroup,
 			field.NewPath("spec").Child("networkSpec").Child("vnet").Child("resourceGroup"))
 		g.Expect(err).NotTo(BeNil())
@@ -417,8 +403,6 @@ func TestResourceGroupInvalid(t *testing.T) {
 }
 
 func TestValidateVnetCIDR(t *testing.T) {
-	g := NewWithT(t)
-
 	tests := []struct {
 		name           string
 		vnetCidrBlocks []string
@@ -444,6 +428,7 @@ func TestValidateVnetCIDR(t *testing.T) {
 	}
 	for _, testCase := range tests {
 		t.Run(testCase.name, func(t *testing.T) {
+			g := NewWithT(t)
 			err := validateVnetCIDR(testCase.vnetCidrBlocks, field.NewPath("vnet.cidrBlocks"))
 			if testCase.wantErr {
 				g.Expect(err).To(ContainElement(MatchError(testCase.expectedErr.Error())))
@@ -455,8 +440,6 @@ func TestValidateVnetCIDR(t *testing.T) {
 }
 
 func TestSubnetsValid(t *testing.T) {
-	g := NewWithT(t)
-
 	type test struct {
 		name    string
 		subnets Subnets
@@ -468,6 +451,7 @@ func TestSubnetsValid(t *testing.T) {
 	}
 
 	t.Run(testCase.name, func(t *testing.T) {
+		g := NewWithT(t)
 		errs := validateSubnets(testCase.subnets, createValidVnet(),
 			field.NewPath("spec").Child("networkSpec").Child("subnets"))
 		g.Expect(errs).To(BeNil())
@@ -475,8 +459,6 @@ func TestSubnetsValid(t *testing.T) {
 }
 
 func TestSubnetsInvalidSubnetName(t *testing.T) {
-	g := NewWithT(t)
-
 	type test struct {
 		name    string
 		subnets Subnets
@@ -490,6 +472,7 @@ func TestSubnetsInvalidSubnetName(t *testing.T) {
 	testCase.subnets[0].Name = "invalid-subnet-name-due-to-bracket)"
 
 	t.Run(testCase.name, func(t *testing.T) {
+		g := NewWithT(t)
 		errs := validateSubnets(testCase.subnets, createValidVnet(),
 			field.NewPath("spec").Child("networkSpec").Child("subnets"))
 		g.Expect(errs).To(HaveLen(1))
@@ -500,8 +483,6 @@ func TestSubnetsInvalidSubnetName(t *testing.T) {
 }
 
 func TestSubnetsInvalidLackRequiredSubnet(t *testing.T) {
-	g := NewWithT(t)
-
 	type test struct {
 		name    string
 		subnets Subnets
@@ -515,6 +496,7 @@ func TestSubnetsInvalidLackRequiredSubnet(t *testing.T) {
 	testCase.subnets[0].Role = "random-role"
 
 	t.Run(testCase.name, func(t *testing.T) {
+		g := NewWithT(t)
 		errs := validateSubnets(testCase.subnets, createValidVnet(),
 			field.NewPath("spec").Child("networkSpec").Child("subnets"))
 		g.Expect(errs).To(HaveLen(1))
@@ -525,8 +507,6 @@ func TestSubnetsInvalidLackRequiredSubnet(t *testing.T) {
 }
 
 func TestSubnetNamesNotUnique(t *testing.T) {
-	g := NewWithT(t)
-
 	type test struct {
 		name    string
 		subnets Subnets
@@ -541,6 +521,7 @@ func TestSubnetNamesNotUnique(t *testing.T) {
 	testCase.subnets[1].Name = "subnet-name"
 
 	t.Run(testCase.name, func(t *testing.T) {
+		g := NewWithT(t)
 		errs := validateSubnets(testCase.subnets, createValidVnet(),
 			field.NewPath("spec").Child("networkSpec").Child("subnets"))
 		g.Expect(errs).To(HaveLen(1))
@@ -550,8 +531,6 @@ func TestSubnetNamesNotUnique(t *testing.T) {
 }
 
 func TestSubnetNameValid(t *testing.T) {
-	g := NewWithT(t)
-
 	type test struct {
 		name       string
 		subnetName string
@@ -563,6 +542,7 @@ func TestSubnetNameValid(t *testing.T) {
 	}
 
 	t.Run(testCase.name, func(t *testing.T) {
+		g := NewWithT(t)
 		err := validateSubnetName(testCase.subnetName,
 			field.NewPath("spec").Child("networkSpec").Child("subnets").Index(0).Child("name"))
 		g.Expect(err).To(BeNil())
@@ -570,8 +550,6 @@ func TestSubnetNameValid(t *testing.T) {
 }
 
 func TestSubnetNameInvalid(t *testing.T) {
-	g := NewWithT(t)
-
 	type test struct {
 		name       string
 		subnetName string
@@ -583,6 +561,7 @@ func TestSubnetNameInvalid(t *testing.T) {
 	}
 
 	t.Run(testCase.name, func(t *testing.T) {
+		g := NewWithT(t)
 		err := validateSubnetName(testCase.subnetName,
 			field.NewPath("spec").Child("networkSpec").Child("subnets").Index(0).Child("name"))
 		g.Expect(err).NotTo(BeNil())
@@ -593,8 +572,6 @@ func TestSubnetNameInvalid(t *testing.T) {
 }
 
 func TestValidateSubnetCIDR(t *testing.T) {
-	g := NewWithT(t)
-
 	tests := []struct {
 		name             string
 		vnetCidrBlocks   []string
@@ -641,6 +618,7 @@ func TestValidateSubnetCIDR(t *testing.T) {
 	}
 	for _, testCase := range tests {
 		t.Run(testCase.name, func(t *testing.T) {
+			g := NewWithT(t)
 			err := validateSubnetCIDR(testCase.subnetCidrBlocks, testCase.vnetCidrBlocks, field.NewPath("subnets.cidrBlocks"))
 			if testCase.wantErr {
 				// Searches for expected error in list of thrown errors
@@ -653,8 +631,6 @@ func TestValidateSubnetCIDR(t *testing.T) {
 }
 
 func TestValidateSecurityRule(t *testing.T) {
-	g := NewWithT(t)
-
 	tests := []struct {
 		name      string
 		validRule SecurityRule
@@ -692,6 +668,7 @@ func TestValidateSecurityRule(t *testing.T) {
 		testCase := testCase
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
+			g := NewWithT(t)
 			err := validateSecurityRule(
 				testCase.validRule,
 				field.NewPath("spec").Child("networkSpec").Child("subnets").Index(0).Child("securityGroup").Child("securityRules").Index(0),
@@ -706,8 +683,6 @@ func TestValidateSecurityRule(t *testing.T) {
 }
 
 func TestValidateAPIServerLB(t *testing.T) {
-	g := NewWithT(t)
-
 	testcases := []struct {
 		name        string
 		lb          LoadBalancerSpec
@@ -910,6 +885,7 @@ func TestValidateAPIServerLB(t *testing.T) {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
+			g := NewWithT(t)
 			err := validateAPIServerLB(test.lb, test.old, test.cpCIDRS, field.NewPath("apiServerLB"))
 			if test.wantErr {
 				g.Expect(err).To(ContainElement(MatchError(test.expectedErr.Error())))
@@ -920,8 +896,6 @@ func TestValidateAPIServerLB(t *testing.T) {
 	}
 }
 func TestPrivateDNSZoneName(t *testing.T) {
-	g := NewWithT(t)
-
 	testcases := []struct {
 		name        string
 		network     NetworkSpec
@@ -991,6 +965,7 @@ func TestPrivateDNSZoneName(t *testing.T) {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
+			g := NewWithT(t)
 			err := validatePrivateDNSZoneName(test.network.PrivateDNSZoneName, test.network.APIServerLB.Type, field.NewPath("spec", "networkSpec", "privateDNSZoneName"))
 			if test.wantErr {
 				g.Expect(err).To(ContainElement(MatchError(test.expectedErr.Error())))
@@ -1002,8 +977,6 @@ func TestPrivateDNSZoneName(t *testing.T) {
 }
 
 func TestValidateNodeOutboundLB(t *testing.T) {
-	g := NewWithT(t)
-
 	testcases := []struct {
 		name        string
 		lb          *LoadBalancerSpec
@@ -1149,6 +1122,7 @@ func TestValidateNodeOutboundLB(t *testing.T) {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
+			g := NewWithT(t)
 			err := validateNodeOutboundLB(test.lb, test.old, test.apiServerLB, field.NewPath("nodeOutboundLB"))
 			if test.wantErr {
 				g.Expect(err).To(ContainElement(MatchError(test.expectedErr.Error())))
@@ -1160,8 +1134,6 @@ func TestValidateNodeOutboundLB(t *testing.T) {
 }
 
 func TestValidateControlPlaneNodeOutboundLB(t *testing.T) {
-	g := NewWithT(t)
-
 	testcases := []struct {
 		name        string
 		lb          *LoadBalancerSpec
@@ -1230,6 +1202,7 @@ func TestValidateControlPlaneNodeOutboundLB(t *testing.T) {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
+			g := NewWithT(t)
 			err := validateControlPlaneOutboundLB(test.lb, test.apiServerLB, field.NewPath("controlPlaneOutboundLB"))
 			if test.wantErr {
 				g.Expect(err).To(ContainElement(MatchError(test.expectedErr.Error())))
@@ -1241,8 +1214,6 @@ func TestValidateControlPlaneNodeOutboundLB(t *testing.T) {
 }
 
 func TestValidateCloudProviderConfigOverrides(t *testing.T) {
-	g := NewWithT(t)
-
 	tests := []struct {
 		name        string
 		oldConfig   *CloudProviderConfigOverrides
@@ -1321,6 +1292,7 @@ func TestValidateCloudProviderConfigOverrides(t *testing.T) {
 	}
 	for _, testCase := range tests {
 		t.Run(testCase.name, func(t *testing.T) {
+			g := NewWithT(t)
 			err := validateCloudProviderConfigOverrides(testCase.oldConfig, testCase.newConfig, field.NewPath("spec.cloudProviderConfigOverrides"))
 			if testCase.wantErr {
 				g.Expect(err).To(ContainElement(MatchError(testCase.expectedErr.Error())))
@@ -1430,8 +1402,6 @@ func createValidAPIServerInternalLB() LoadBalancerSpec {
 }
 
 func TestValidateServiceEndpoints(t *testing.T) {
-	g := NewWithT(t)
-
 	tests := []struct {
 		name             string
 		serviceEndpoints ServiceEndpoints
@@ -1497,6 +1467,7 @@ func TestValidateServiceEndpoints(t *testing.T) {
 	}
 	for _, testCase := range tests {
 		t.Run(testCase.name, func(t *testing.T) {
+			g := NewWithT(t)
 			err := validateServiceEndpoints(testCase.serviceEndpoints, field.NewPath("subnets[0].serviceEndpoints"))
 			if testCase.wantErr {
 				// Searches for expected error in list of thrown errors
@@ -1509,8 +1480,6 @@ func TestValidateServiceEndpoints(t *testing.T) {
 }
 
 func TestServiceEndpointsLackRequiredFieldService(t *testing.T) {
-	g := NewWithT(t)
-
 	type test struct {
 		name             string
 		serviceEndpoints ServiceEndpoints
@@ -1524,6 +1493,7 @@ func TestServiceEndpointsLackRequiredFieldService(t *testing.T) {
 	}
 
 	t.Run(testCase.name, func(t *testing.T) {
+		g := NewWithT(t)
 		errs := validateServiceEndpoints(testCase.serviceEndpoints, field.NewPath("subnets[0].serviceEndpoints"))
 		g.Expect(errs).To(HaveLen(1))
 		g.Expect(errs[0].Type).To(Equal(field.ErrorTypeRequired))
@@ -1533,8 +1503,6 @@ func TestServiceEndpointsLackRequiredFieldService(t *testing.T) {
 }
 
 func TestServiceEndpointsLackRequiredFieldLocations(t *testing.T) {
-	g := NewWithT(t)
-
 	type test struct {
 		name             string
 		serviceEndpoints ServiceEndpoints
@@ -1548,6 +1516,7 @@ func TestServiceEndpointsLackRequiredFieldLocations(t *testing.T) {
 	}
 
 	t.Run(testCase.name, func(t *testing.T) {
+		g := NewWithT(t)
 		errs := validateServiceEndpoints(testCase.serviceEndpoints, field.NewPath("subnets[0].serviceEndpoints"))
 		g.Expect(errs).To(HaveLen(1))
 		g.Expect(errs[0].Type).To(Equal(field.ErrorTypeRequired))
@@ -1557,8 +1526,6 @@ func TestServiceEndpointsLackRequiredFieldLocations(t *testing.T) {
 }
 
 func TestClusterWithExtendedLocationInvalid(t *testing.T) {
-	g := NewWithT(t)
-
 	type test struct {
 		name    string
 		cluster *AzureCluster
@@ -1575,6 +1542,7 @@ func TestClusterWithExtendedLocationInvalid(t *testing.T) {
 	}
 
 	t.Run(testCase.name, func(t *testing.T) {
+		g := NewWithT(t)
 		err := testCase.cluster.validateClusterSpec(nil)
 		g.Expect(err).NotTo(BeNil())
 	})

--- a/api/v1beta1/azurecluster_webhook_test.go
+++ b/api/v1beta1/azurecluster_webhook_test.go
@@ -24,8 +24,6 @@ import (
 )
 
 func TestAzureCluster_ValidateCreate(t *testing.T) {
-	g := NewWithT(t)
-
 	tests := []struct {
 		name    string
 		cluster *AzureCluster
@@ -109,6 +107,7 @@ func TestAzureCluster_ValidateCreate(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
 			_, err := tc.cluster.ValidateCreate()
 			if tc.wantErr {
 				g.Expect(err).To(HaveOccurred())
@@ -120,8 +119,6 @@ func TestAzureCluster_ValidateCreate(t *testing.T) {
 }
 
 func TestAzureCluster_ValidateUpdate(t *testing.T) {
-	g := NewWithT(t)
-
 	tests := []struct {
 		name       string
 		oldCluster *AzureCluster
@@ -347,6 +344,7 @@ func TestAzureCluster_ValidateUpdate(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
+			g := NewWithT(t)
 			_, err := tc.cluster.ValidateUpdate(tc.oldCluster)
 			if tc.wantErr {
 				g.Expect(err).To(HaveOccurred())

--- a/api/v1beta1/azureclusteridentity_webhook_test.go
+++ b/api/v1beta1/azureclusteridentity_webhook_test.go
@@ -27,8 +27,6 @@ const fakeTenantID = "fake-tenant-id"
 const fakeResourceID = "fake-resource-id"
 
 func TestAzureClusterIdentity_ValidateCreate(t *testing.T) {
-	g := NewWithT(t)
-
 	tests := []struct {
 		name            string
 		clusterIdentity *AzureClusterIdentity
@@ -84,6 +82,7 @@ func TestAzureClusterIdentity_ValidateCreate(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
 			_, err := tc.clusterIdentity.ValidateCreate()
 			if tc.wantErr {
 				g.Expect(err).To(HaveOccurred())
@@ -95,8 +94,6 @@ func TestAzureClusterIdentity_ValidateCreate(t *testing.T) {
 }
 
 func TestAzureClusterIdentity_ValidateUpdate(t *testing.T) {
-	g := NewWithT(t)
-
 	tests := []struct {
 		name               string
 		oldClusterIdentity *AzureClusterIdentity
@@ -165,6 +162,7 @@ func TestAzureClusterIdentity_ValidateUpdate(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
 			_, err := tc.clusterIdentity.ValidateUpdate(tc.oldClusterIdentity)
 			if tc.wantErr {
 				g.Expect(err).To(HaveOccurred())

--- a/api/v1beta1/azureimage_validation_test.go
+++ b/api/v1beta1/azureimage_validation_test.go
@@ -62,8 +62,6 @@ func TestImageTooManyDetails(t *testing.T) {
 }
 
 func TestComputeImageGalleryValid(t *testing.T) {
-	g := NewWithT(t)
-
 	testCases := map[string]struct {
 		image          *Image
 		expectedErrors int
@@ -87,13 +85,12 @@ func TestComputeImageGalleryValid(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		g := NewWithT(t)
 		g.Expect(ValidateImage(tc.image, field.NewPath("image"))).To(HaveLen(tc.expectedErrors))
 	}
 }
 
 func TestSharedImageGalleryValid(t *testing.T) {
-	g := NewWithT(t)
-
 	testCases := map[string]struct {
 		image          *Image
 		expectedErrors int
@@ -125,13 +122,12 @@ func TestSharedImageGalleryValid(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		g := NewWithT(t)
 		g.Expect(ValidateImage(tc.image, field.NewPath("image"))).To(HaveLen(tc.expectedErrors))
 	}
 }
 
 func TestMarketPlaceImageValid(t *testing.T) {
-	g := NewWithT(t)
-
 	testCases := map[string]struct {
 		image          *Image
 		expectedErrors int
@@ -159,13 +155,12 @@ func TestMarketPlaceImageValid(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		g := NewWithT(t)
 		g.Expect(ValidateImage(tc.image, field.NewPath("image"))).To(HaveLen(tc.expectedErrors))
 	}
 }
 
 func TestImageByIDValid(t *testing.T) {
-	g := NewWithT(t)
-
 	testCases := map[string]struct {
 		image          *Image
 		expectedErrors int
@@ -181,6 +176,7 @@ func TestImageByIDValid(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		g := NewWithT(t)
 		g.Expect(ValidateImage(tc.image, field.NewPath("image"))).To(HaveLen(tc.expectedErrors))
 	}
 }

--- a/api/v1beta1/azuremachine_default_test.go
+++ b/api/v1beta1/azuremachine_default_test.go
@@ -348,8 +348,6 @@ func TestAzureMachineSpec_SetDataDisksDefaults(t *testing.T) {
 }
 
 func TestAzureMachineSpec_SetNetworkInterfacesDefaults(t *testing.T) {
-	g := NewWithT(t)
-
 	tests := []struct {
 		name    string
 		machine *AzureMachine
@@ -442,6 +440,7 @@ func TestAzureMachineSpec_SetNetworkInterfacesDefaults(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
 			tc.machine.Spec.SetNetworkInterfacesDefaults()
 			g.Expect(tc.machine).To(Equal(tc.want))
 		})
@@ -496,8 +495,6 @@ func TestAzureMachineSpec_GetOwnerCluster(t *testing.T) {
 }
 
 func TestAzureMachineSpec_GetSubscriptionID(t *testing.T) {
-	g := NewWithT(t)
-
 	tests := []struct {
 		name                       string
 		maxAttempts                int
@@ -541,6 +538,7 @@ func TestAzureMachineSpec_GetSubscriptionID(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
 			client := mockClient{ReturnError: tc.wantErr}
 			result, err := GetSubscriptionID(client, tc.ownerAzureClusterName, tc.ownerAzureClusterNamespace, tc.maxAttempts)
 			if tc.wantErr {

--- a/api/v1beta1/azuremachine_validation_test.go
+++ b/api/v1beta1/azuremachine_validation_test.go
@@ -32,8 +32,6 @@ import (
 )
 
 func TestAzureMachine_ValidateSSHKey(t *testing.T) {
-	g := NewWithT(t)
-
 	tests := []struct {
 		name    string
 		sshKey  string
@@ -58,6 +56,7 @@ func TestAzureMachine_ValidateSSHKey(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
 			err := ValidateSSHKey(tc.sshKey, field.NewPath("sshPublicKey"))
 			if tc.wantErr {
 				g.Expect(err).NotTo(BeEmpty())
@@ -84,8 +83,6 @@ type osDiskTestInput struct {
 }
 
 func TestAzureMachine_ValidateOSDisk(t *testing.T) {
-	g := NewWithT(t)
-
 	testcases := []osDiskTestInput{
 		{
 			name:    "valid os disk spec",
@@ -135,6 +132,7 @@ func TestAzureMachine_ValidateOSDisk(t *testing.T) {
 
 	for _, test := range testcases {
 		t.Run(test.name, func(t *testing.T) {
+			g := NewWithT(t)
 			err := ValidateOSDisk(test.osDisk, field.NewPath("osDisk"))
 			if test.wantErr {
 				g.Expect(err).NotTo(BeEmpty())
@@ -227,8 +225,6 @@ func createOSDiskWithCacheType(cacheType string) OSDisk {
 }
 
 func TestAzureMachine_ValidateDataDisks(t *testing.T) {
-	g := NewWithT(t)
-
 	testcases := []struct {
 		name    string
 		disks   []DataDisk
@@ -434,6 +430,7 @@ func TestAzureMachine_ValidateDataDisks(t *testing.T) {
 
 	for _, test := range testcases {
 		t.Run(test.name, func(t *testing.T) {
+			g := NewWithT(t)
 			err := ValidateDataDisks(test.disks, field.NewPath("dataDisks"))
 			if test.wantErr {
 				g.Expect(err).NotTo(BeEmpty())
@@ -445,8 +442,6 @@ func TestAzureMachine_ValidateDataDisks(t *testing.T) {
 }
 
 func TestAzureMachine_ValidateSystemAssignedIdentity(t *testing.T) {
-	g := NewWithT(t)
-
 	tests := []struct {
 		name               string
 		roleAssignmentName string
@@ -489,6 +484,7 @@ func TestAzureMachine_ValidateSystemAssignedIdentity(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
 			err := ValidateSystemAssignedIdentity(tc.Identity, tc.old, tc.roleAssignmentName, field.NewPath("sshPublicKey"))
 			if tc.wantErr {
 				g.Expect(err).NotTo(BeEmpty())
@@ -500,8 +496,6 @@ func TestAzureMachine_ValidateSystemAssignedIdentity(t *testing.T) {
 }
 
 func TestAzureMachine_ValidateSystemAssignedIdentityRole(t *testing.T) {
-	g := NewWithT(t)
-
 	tests := []struct {
 		name               string
 		Identity           VMIdentity
@@ -570,6 +564,7 @@ func TestAzureMachine_ValidateSystemAssignedIdentityRole(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
 			err := ValidateSystemAssignedIdentityRole(tc.Identity, tc.roleAssignmentName, tc.role, field.NewPath("systemAssignedIdentityRole"))
 			if tc.wantErr {
 				g.Expect(err).NotTo(BeEmpty())
@@ -581,8 +576,6 @@ func TestAzureMachine_ValidateSystemAssignedIdentityRole(t *testing.T) {
 }
 
 func TestAzureMachine_ValidateUserAssignedIdentity(t *testing.T) {
-	g := NewWithT(t)
-
 	tests := []struct {
 		name       string
 		idType     VMIdentity
@@ -639,6 +632,7 @@ func TestAzureMachine_ValidateUserAssignedIdentity(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
 			errs := ValidateUserAssignedIdentity(tc.idType, tc.identities, field.NewPath("userAssignedIdentities"))
 			if tc.wantErr {
 				g.Expect(errs).NotTo(BeEmpty())
@@ -650,8 +644,6 @@ func TestAzureMachine_ValidateUserAssignedIdentity(t *testing.T) {
 }
 
 func TestAzureMachine_ValidateDataDisksUpdate(t *testing.T) {
-	g := NewWithT(t)
-
 	tests := []struct {
 		name     string
 		disks    []DataDisk
@@ -835,6 +827,7 @@ func TestAzureMachine_ValidateDataDisksUpdate(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			g := NewWithT(t)
 			err := ValidateDataDisksUpdate(test.oldDisks, test.disks, field.NewPath("dataDisks"))
 			if test.wantErr {
 				g.Expect(err).NotTo(BeEmpty())
@@ -846,8 +839,6 @@ func TestAzureMachine_ValidateDataDisksUpdate(t *testing.T) {
 }
 
 func TestAzureMachine_ValidateNetwork(t *testing.T) {
-	g := NewWithT(t)
-
 	tests := []struct {
 		name                  string
 		subnetName            string
@@ -928,6 +919,7 @@ func TestAzureMachine_ValidateNetwork(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			g := NewWithT(t)
 			err := ValidateNetwork(test.subnetName, test.acceleratedNetworking, test.networkInterfaces, field.NewPath("networkInterfaces"))
 			if test.wantErr {
 				g.Expect(err).ToNot(BeEmpty())
@@ -939,8 +931,6 @@ func TestAzureMachine_ValidateNetwork(t *testing.T) {
 }
 
 func TestAzureMachine_ValidateConfidentialCompute(t *testing.T) {
-	g := NewWithT(t)
-
 	tests := []struct {
 		name            string
 		managedDisk     *ManagedDiskParameters
@@ -1111,6 +1101,7 @@ func TestAzureMachine_ValidateConfidentialCompute(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
 			err := ValidateConfidentialCompute(tc.managedDisk, tc.securityProfile, field.NewPath("securityProfile"))
 			if tc.wantErr {
 				g.Expect(err).NotTo(BeEmpty())

--- a/api/v1beta1/azuremachine_webhook_test.go
+++ b/api/v1beta1/azuremachine_webhook_test.go
@@ -37,8 +37,6 @@ var (
 )
 
 func TestAzureMachine_ValidateCreate(t *testing.T) {
-	g := NewWithT(t)
-
 	tests := []struct {
 		name    string
 		machine *AzureMachine
@@ -220,6 +218,7 @@ func TestAzureMachine_ValidateCreate(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
 			mw := &azureMachineWebhook{}
 			_, err := mw.ValidateCreate(context.Background(), tc.machine)
 			if tc.wantErr {
@@ -232,8 +231,6 @@ func TestAzureMachine_ValidateCreate(t *testing.T) {
 }
 
 func TestAzureMachine_ValidateUpdate(t *testing.T) {
-	g := NewWithT(t)
-
 	tests := []struct {
 		name       string
 		oldMachine *AzureMachine
@@ -812,6 +809,7 @@ func TestAzureMachine_ValidateUpdate(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
 			mw := &azureMachineWebhook{}
 			_, err := mw.ValidateUpdate(context.Background(), tc.oldMachine, tc.newMachine)
 			if tc.wantErr {

--- a/api/v1beta1/azuremachinetemplate_webhook_test.go
+++ b/api/v1beta1/azuremachinetemplate_webhook_test.go
@@ -29,8 +29,6 @@ import (
 )
 
 func TestAzureMachineTemplate_ValidateCreate(t *testing.T) {
-	g := NewWithT(t)
-
 	tests := []struct {
 		name            string
 		machineTemplate *AzureMachineTemplate
@@ -240,6 +238,7 @@ func TestAzureMachineTemplate_ValidateCreate(t *testing.T) {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
+			g := NewWithT(t)
 			ctx := context.Background()
 			_, err := test.machineTemplate.ValidateCreate(ctx, test.machineTemplate)
 			if test.wantErr {
@@ -252,7 +251,6 @@ func TestAzureMachineTemplate_ValidateCreate(t *testing.T) {
 }
 
 func TestAzureMachineTemplate_ValidateUpdate(t *testing.T) {
-	g := NewWithT(t)
 	failureDomain := "domaintest"
 
 	tests := []struct {
@@ -587,6 +585,7 @@ func TestAzureMachineTemplate_ValidateUpdate(t *testing.T) {
 	for _, amt := range tests {
 		amt := amt
 		t.Run(amt.name, func(t *testing.T) {
+			g := NewWithT(t)
 			ctx := admission.NewContextWithRequest(context.Background(), admission.Request{AdmissionRequest: admissionv1.AdmissionRequest{DryRun: ptr.To(true)}})
 			_, err := amt.template.ValidateUpdate(ctx, amt.oldTemplate, amt.template)
 			if amt.wantErr {
@@ -601,6 +600,7 @@ func TestAzureMachineTemplate_ValidateUpdate(t *testing.T) {
 		amt := amt
 		t.Run(amt.name, func(t *testing.T) {
 			t.Parallel()
+			g := NewWithT(t)
 			ctx := admission.NewContextWithRequest(context.Background(), admission.Request{AdmissionRequest: admissionv1.AdmissionRequest{DryRun: ptr.To(false)}})
 			_, err := amt.template.ValidateUpdate(ctx, amt.oldTemplate, amt.template)
 			if amt.wantErr {

--- a/api/v1beta1/azuremanagedcluster_webhook_test.go
+++ b/api/v1beta1/azuremanagedcluster_webhook_test.go
@@ -32,8 +32,6 @@ func TestAzureManagedCluster_ValidateUpdate(t *testing.T) {
 	// must prevent creating new objects in case the feature flag is disabled.
 	defer utilfeature.SetFeatureGateDuringTest(t, feature.Gates, capifeature.MachinePool, true)()
 
-	g := NewWithT(t)
-
 	tests := []struct {
 		name    string
 		oldAMC  *AzureManagedCluster
@@ -166,6 +164,7 @@ func TestAzureManagedCluster_ValidateUpdate(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
 			_, err := tc.amc.ValidateUpdate(tc.oldAMC)
 			if tc.wantErr {
 				g.Expect(err).To(HaveOccurred())
@@ -180,8 +179,6 @@ func TestAzureManagedCluster_ValidateCreate(t *testing.T) {
 	// NOTE: AzureManagedCluster is behind AKS feature gate flag; the webhook
 	// must prevent creating new objects in case the feature flag is disabled.
 	defer utilfeature.SetFeatureGateDuringTest(t, feature.Gates, capifeature.MachinePool, true)()
-
-	g := NewWithT(t)
 
 	tests := []struct {
 		name    string
@@ -214,6 +211,7 @@ func TestAzureManagedCluster_ValidateCreate(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
 			_, err := tc.amc.ValidateCreate()
 			if tc.wantErr {
 				g.Expect(err).To(HaveOccurred())
@@ -225,8 +223,6 @@ func TestAzureManagedCluster_ValidateCreate(t *testing.T) {
 }
 
 func TestAzureManagedCluster_ValidateCreateFailure(t *testing.T) {
-	g := NewWithT(t)
-
 	tests := []struct {
 		name      string
 		amc       *AzureManagedCluster
@@ -246,6 +242,7 @@ func TestAzureManagedCluster_ValidateCreateFailure(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			defer tc.deferFunc()
+			g := NewWithT(t)
 			_, err := tc.amc.ValidateCreate()
 			g.Expect(err).To(HaveOccurred())
 		})

--- a/api/v1beta1/azuremanagedcontrolplane_webhook_test.go
+++ b/api/v1beta1/azuremanagedcontrolplane_webhook_test.go
@@ -117,7 +117,7 @@ func TestValidatingWebhook(t *testing.T) {
 	// NOTE: AzureManageControlPlane is behind AKS feature gate flag; the webhook
 	// must prevent creating new objects in case the feature flag is disabled.
 	defer utilfeature.SetFeatureGateDuringTest(t, feature.Gates, capifeature.MachinePool, true)()
-	g := NewWithT(t)
+
 	tests := []struct {
 		name      string
 		amcp      AzureManagedControlPlane
@@ -722,6 +722,7 @@ func TestValidatingWebhook(t *testing.T) {
 		// client is used to fetch the AzureManagedControlPlane, we do not want to return an error on client.Get
 		client := mockClient{ReturnError: false}
 		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
 			mcpw := &azureManagedControlPlaneWebhook{
 				Client: client,
 			}
@@ -739,7 +740,6 @@ func TestAzureManagedControlPlane_ValidateCreate(t *testing.T) {
 	// NOTE: AzureManageControlPlane is behind AKS feature gate flag; the webhook
 	// must prevent creating new objects in case the feature flag is disabled.
 	defer utilfeature.SetFeatureGateDuringTest(t, feature.Gates, capifeature.MachinePool, true)()
-	g := NewWithT(t)
 
 	tests := []struct {
 		name     string
@@ -950,6 +950,7 @@ func TestAzureManagedControlPlane_ValidateCreate(t *testing.T) {
 	client := mockClient{ReturnError: false}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
 			mcpw := &azureManagedControlPlaneWebhook{
 				Client: client,
 			}
@@ -967,8 +968,6 @@ func TestAzureManagedControlPlane_ValidateCreate(t *testing.T) {
 }
 
 func TestAzureManagedControlPlane_ValidateCreateFailure(t *testing.T) {
-	g := NewWithT(t)
-
 	tests := []struct {
 		name      string
 		amcp      *AzureManagedControlPlane
@@ -989,6 +988,7 @@ func TestAzureManagedControlPlane_ValidateCreateFailure(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			defer tc.deferFunc()
+			g := NewWithT(t)
 			mcpw := &azureManagedControlPlaneWebhook{
 				Client: client,
 			}
@@ -999,7 +999,6 @@ func TestAzureManagedControlPlane_ValidateCreateFailure(t *testing.T) {
 }
 
 func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
-	g := NewWithT(t)
 	commonSSHKey := generateSSHPublicKey(true)
 	tests := []struct {
 		name    string
@@ -1924,6 +1923,7 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 	client := mockClient{ReturnError: false}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
 			mcpw := &azureManagedControlPlaneWebhook{
 				Client: client,
 			}

--- a/api/v1beta1/azuremanagedmachinepool_webhook_test.go
+++ b/api/v1beta1/azuremanagedmachinepool_webhook_test.go
@@ -97,8 +97,6 @@ func TestAzureManagedMachinePoolDefaultingWebhook(t *testing.T) {
 }
 
 func TestAzureManagedMachinePoolUpdatingWebhook(t *testing.T) {
-	g := NewWithT(t)
-
 	t.Logf("Testing ammp updating webhook with mode system")
 
 	tests := []struct {
@@ -619,6 +617,7 @@ func TestAzureManagedMachinePoolUpdatingWebhook(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
+			g := NewWithT(t)
 			mw := &azureManagedMachinePoolWebhook{
 				Client: client,
 			}
@@ -1189,8 +1188,6 @@ func TestAzureManagedMachinePool_ValidateCreate(t *testing.T) {
 }
 
 func TestAzureManagedMachinePool_ValidateCreateFailure(t *testing.T) {
-	g := NewWithT(t)
-
 	tests := []struct {
 		name      string
 		ammp      *AzureManagedMachinePool
@@ -1210,6 +1207,7 @@ func TestAzureManagedMachinePool_ValidateCreateFailure(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			defer tc.deferFunc()
+			g := NewWithT(t)
 			mw := &azureManagedMachinePoolWebhook{}
 			_, err := mw.ValidateCreate(context.Background(), tc.ammp)
 			g.Expect(err).To(HaveOccurred())

--- a/api/v1beta1/tags_test.go
+++ b/api/v1beta1/tags_test.go
@@ -23,8 +23,6 @@ import (
 )
 
 func TestTags_Merge(t *testing.T) {
-	g := NewWithT(t)
-
 	tests := []struct {
 		name     string
 		other    Tags
@@ -78,6 +76,7 @@ func TestTags_Merge(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
+			g := NewWithT(t)
 			tags := Tags{
 				"a": "b",
 				"c": "d",

--- a/exp/api/v1beta1/azuremachinepool_default_test.go
+++ b/exp/api/v1beta1/azuremachinepool_default_test.go
@@ -242,8 +242,6 @@ func TestAzureMachinePool_SetSpotEvictionPolicyDefaults(t *testing.T) {
 }
 
 func TestAzureMachinePool_SetNetworkInterfacesDefaults(t *testing.T) {
-	g := NewWithT(t)
-
 	testCases := []struct {
 		name        string
 		machinePool *AzureMachinePool
@@ -328,6 +326,7 @@ func TestAzureMachinePool_SetNetworkInterfacesDefaults(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
 			tc.machinePool.SetNetworkInterfacesDefaults()
 			g.Expect(tc.machinePool).To(Equal(tc.want))
 		})

--- a/exp/api/v1beta1/azuremachinepool_webhook_test.go
+++ b/exp/api/v1beta1/azuremachinepool_webhook_test.go
@@ -76,8 +76,6 @@ func TestAzureMachinePool_ValidateCreate(t *testing.T) {
 	// must prevent creating new objects in case the feature flag is disabled.
 	defer utilfeature.SetFeatureGateDuringTest(t, feature.Gates, capifeature.MachinePool, true)()
 
-	g := NewWithT(t)
-
 	tests := []struct {
 		name          string
 		amp           *AzureMachinePool
@@ -244,6 +242,7 @@ func TestAzureMachinePool_ValidateCreate(t *testing.T) {
 	for _, tc := range tests {
 		client := mockClient{Version: tc.version, ReturnError: tc.ownerNotFound}
 		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
 			ampw := &azureMachinePoolWebhook{
 				Client: client,
 			}
@@ -304,8 +303,6 @@ func TestAzureMachinePool_ValidateUpdate(t *testing.T) {
 	// NOTE: AzureMachinePool is behind MachinePool feature gate flag; the webhook
 	// must prevent creating new objects in case the feature flag is disabled.
 	defer utilfeature.SetFeatureGateDuringTest(t, feature.Gates, capifeature.MachinePool, true)()
-
-	g := NewWithT(t)
 
 	var (
 		zero = intstr.FromInt(0)
@@ -387,6 +384,7 @@ func TestAzureMachinePool_ValidateUpdate(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
 			ampw := &azureMachinePoolWebhook{}
 			_, err := ampw.ValidateUpdate(context.Background(), tc.oldAMP, tc.amp)
 			if tc.wantErr {

--- a/util/azure/azure_test.go
+++ b/util/azure/azure_test.go
@@ -30,7 +30,6 @@ import (
 
 func TestFindParentMachinePool(t *testing.T) {
 	defer utilfeature.SetFeatureGateDuringTest(t, feature.Gates, capifeature.MachinePool, true)()
-	g := NewWithT(t)
 	client := mockClient{}
 
 	tests := []struct {
@@ -52,6 +51,7 @@ func TestFindParentMachinePool(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
 			mp, err := FindParentMachinePool(tc.mpName, client)
 			if tc.wantErr {
 				g.Expect(err).To(HaveOccurred())
@@ -65,7 +65,6 @@ func TestFindParentMachinePool(t *testing.T) {
 
 func TestFindParentMachinePoolWithRetry(t *testing.T) {
 	defer utilfeature.SetFeatureGateDuringTest(t, feature.Gates, capifeature.MachinePool, true)()
-	g := NewWithT(t)
 	client := mockClient{}
 
 	tests := []struct {
@@ -102,6 +101,7 @@ func TestFindParentMachinePoolWithRetry(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
 			mp, err := FindParentMachinePoolWithRetry(tc.mpName, client, tc.maxAttempts)
 			if tc.wantErr {
 				g.Expect(err).To(HaveOccurred())
@@ -126,8 +126,6 @@ func (m mockClient) List(ctx context.Context, list client.ObjectList, opts ...cl
 }
 
 func TestParseResourceID(t *testing.T) {
-	g := NewWithT(t)
-
 	tests := []struct {
 		name         string
 		id           string
@@ -166,6 +164,7 @@ func TestParseResourceID(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
 			resourceID, err := ParseResourceID(tt.id)
 			if tt.errExpected {
 				g.Expect(err).To(HaveOccurred())

--- a/util/webhook/validator_test.go
+++ b/util/webhook/validator_test.go
@@ -241,8 +241,6 @@ func TestValidateImmutableInt32(t *testing.T) {
 }
 
 func TestEnsureStringSlicesAreEquivalent(t *testing.T) {
-	g := NewWithT(t)
-
 	tests := []struct {
 		name           string
 		input1         []string
@@ -294,6 +292,7 @@ func TestEnsureStringSlicesAreEquivalent(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
 			ret := EnsureStringSlicesAreEquivalent(tc.input1, tc.input2)
 			g.Expect(ret).To(Equal(tc.expectedOutput))
 		})


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
Move the gomega handles in the subtests to fix the logging issue while multiple test case is failing.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3870 

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
