### PR TITLE
Removed kubectl --short flag (deprecated)

### DIFF
--- a/templates/test/ci/cluster-template-prow-ci-version-dual-stack.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version-dual-stack.yaml
@@ -174,7 +174,7 @@ spec:
         echo "* checking binary versions"
         echo "ctr version: " $(ctr version)
         echo "kubeadm version: " $(kubeadm version -o=short)
-        echo "kubectl version: " $(kubectl version --client=true --short=true)
+        echo "kubectl version: " $(kubectl version --client=true)
         echo "kubelet version: " $(kubelet --version)
         echo "$$LINE_SEPARATOR"
       owner: root:root
@@ -371,7 +371,7 @@ spec:
           echo "* checking binary versions"
           echo "ctr version: " $(ctr version)
           echo "kubeadm version: " $(kubeadm version -o=short)
-          echo "kubectl version: " $(kubectl version --client=true --short=true)
+          echo "kubectl version: " $(kubectl version --client=true)
           echo "kubelet version: " $(kubelet --version)
           echo "$$LINE_SEPARATOR"
         owner: root:root

--- a/templates/test/ci/cluster-template-prow-ci-version-ipv6.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version-ipv6.yaml
@@ -177,7 +177,7 @@ spec:
         echo "* checking binary versions"
         echo "ctr version: " $(ctr version)
         echo "kubeadm version: " $(kubeadm version -o=short)
-        echo "kubectl version: " $(kubectl version --client=true --short=true)
+        echo "kubectl version: " $(kubectl version --client=true)
         echo "kubelet version: " $(kubelet --version)
         echo "$$LINE_SEPARATOR"
       owner: root:root
@@ -388,7 +388,7 @@ spec:
           echo "* checking binary versions"
           echo "ctr version: " $(ctr version)
           echo "kubeadm version: " $(kubeadm version -o=short)
-          echo "kubectl version: " $(kubectl version --client=true --short=true)
+          echo "kubectl version: " $(kubectl version --client=true)
           echo "kubelet version: " $(kubelet --version)
           echo "$$LINE_SEPARATOR"
         owner: root:root

--- a/templates/test/ci/cluster-template-prow-ci-version-windows-containerd-2022.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version-windows-containerd-2022.yaml
@@ -159,7 +159,7 @@ spec:
         echo "* checking binary versions"
         echo "ctr version: " $(ctr version)
         echo "kubeadm version: " $(kubeadm version -o=short)
-        echo "kubectl version: " $(kubectl version --client=true --short=true)
+        echo "kubectl version: " $(kubectl version --client=true)
         echo "kubelet version: " $(kubelet --version)
         echo "$$LINE_SEPARATOR"
       owner: root:root
@@ -345,7 +345,7 @@ spec:
           echo "* checking binary versions"
           echo "ctr version: " $(ctr version)
           echo "kubeadm version: " $(kubeadm version -o=short)
-          echo "kubectl version: " $(kubectl version --client=true --short=true)
+          echo "kubectl version: " $(kubectl version --client=true)
           echo "kubelet version: " $(kubelet --version)
           echo "$$LINE_SEPARATOR"
         owner: root:root
@@ -493,7 +493,7 @@ spec:
           ctr.exe -n k8s.io images tag docker.io/sigwindowstools/kube-proxy:v1.23.1-calico-hostprocess "docker.io/sigwindowstools/kube-proxy:${CI_VERSION/+/_}-calico-hostprocess"
 
           kubeadm.exe version -o=short
-          kubectl.exe version --client=true --short=true
+          kubectl.exe version --client=true
           kubelet.exe --version
           kube-proxy.exe --version
         path: C:/replace-ci-binaries.ps1

--- a/templates/test/ci/cluster-template-prow-ci-version.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version.yaml
@@ -158,7 +158,7 @@ spec:
         echo "* checking binary versions"
         echo "ctr version: " $(ctr version)
         echo "kubeadm version: " $(kubeadm version -o=short)
-        echo "kubectl version: " $(kubectl version --client=true --short=true)
+        echo "kubectl version: " $(kubectl version --client=true)
         echo "kubelet version: " $(kubelet --version)
         echo "$$LINE_SEPARATOR"
       owner: root:root
@@ -344,7 +344,7 @@ spec:
           echo "* checking binary versions"
           echo "ctr version: " $(ctr version)
           echo "kubeadm version: " $(kubeadm version -o=short)
-          echo "kubectl version: " $(kubectl version --client=true --short=true)
+          echo "kubectl version: " $(kubectl version --client=true)
           echo "kubelet version: " $(kubelet --version)
           echo "$$LINE_SEPARATOR"
         owner: root:root
@@ -492,7 +492,7 @@ spec:
           ctr.exe -n k8s.io images tag docker.io/sigwindowstools/kube-proxy:v1.23.1-calico-hostprocess "docker.io/sigwindowstools/kube-proxy:${CI_VERSION/+/_}-calico-hostprocess"
 
           kubeadm.exe version -o=short
-          kubectl.exe version --client=true --short=true
+          kubectl.exe version --client=true
           kubelet.exe --version
           kube-proxy.exe --version
         path: C:/replace-ci-binaries.ps1

--- a/templates/test/ci/cluster-template-prow-machine-pool-ci-version.yaml
+++ b/templates/test/ci/cluster-template-prow-machine-pool-ci-version.yaml
@@ -156,7 +156,7 @@ spec:
         echo "* checking binary versions"
         echo "ctr version: " $(ctr version)
         echo "kubeadm version: " $(kubeadm version -o=short)
-        echo "kubectl version: " $(kubectl version --client=true --short=true)
+        echo "kubectl version: " $(kubectl version --client=true)
         echo "kubelet version: " $(kubelet --version)
         echo "$$LINE_SEPARATOR"
       owner: root:root
@@ -338,7 +338,7 @@ spec:
       echo "* checking binary versions"
       echo "ctr version: " $(ctr version)
       echo "kubeadm version: " $(kubeadm version -o=short)
-      echo "kubectl version: " $(kubectl version --client=true --short=true)
+      echo "kubectl version: " $(kubectl version --client=true)
       echo "kubelet version: " $(kubelet --version)
       echo "$$LINE_SEPARATOR"
     owner: root:root
@@ -463,7 +463,7 @@ spec:
       ctr.exe -n k8s.io images tag docker.io/sigwindowstools/kube-proxy:v1.23.1-calico-hostprocess "docker.io/sigwindowstools/kube-proxy:${CI_VERSION/+/_}-calico-hostprocess"
 
       kubeadm.exe version -o=short
-      kubectl.exe version --client=true --short=true
+      kubectl.exe version --client=true
       kubelet.exe --version
     path: C:/replace-k8s-binaries.ps1
     permissions: "0744"

--- a/templates/test/ci/patches/control-plane-kubeadm-boostrap-ci-version.yaml
+++ b/templates/test/ci/patches/control-plane-kubeadm-boostrap-ci-version.yaml
@@ -59,7 +59,7 @@
       echo "* checking binary versions"
       echo "ctr version: " $(ctr version)
       echo "kubeadm version: " $(kubeadm version -o=short)
-      echo "kubectl version: " $(kubectl version --client=true --short=true)
+      echo "kubectl version: " $(kubectl version --client=true)
       echo "kubelet version: " $(kubelet --version)
       echo "$$LINE_SEPARATOR"
     path: /tmp/kubeadm-bootstrap.sh

--- a/templates/test/ci/prow-ci-version/patches/kubeadm-bootstrap-windows-k8s-ci-binaries.yaml
+++ b/templates/test/ci/prow-ci-version/patches/kubeadm-bootstrap-windows-k8s-ci-binaries.yaml
@@ -24,7 +24,7 @@
       ctr.exe -n k8s.io images tag docker.io/sigwindowstools/kube-proxy:v1.23.1-calico-hostprocess "docker.io/sigwindowstools/kube-proxy:${CI_VERSION/+/_}-calico-hostprocess"
 
       kubeadm.exe version -o=short
-      kubectl.exe version --client=true --short=true
+      kubectl.exe version --client=true
       kubelet.exe --version
       kube-proxy.exe --version
     path: C:/replace-ci-binaries.ps1

--- a/templates/test/ci/prow-ci-version/patches/kubeadm-bootstrap.yaml
+++ b/templates/test/ci/prow-ci-version/patches/kubeadm-bootstrap.yaml
@@ -59,7 +59,7 @@
       echo "* checking binary versions"
       echo "ctr version: " $(ctr version)
       echo "kubeadm version: " $(kubeadm version -o=short)
-      echo "kubectl version: " $(kubectl version --client=true --short=true)
+      echo "kubectl version: " $(kubectl version --client=true)
       echo "kubelet version: " $(kubelet --version)
       echo "$$LINE_SEPARATOR"
     path: /tmp/kubeadm-bootstrap.sh

--- a/templates/test/ci/prow-machine-pool-ci-version/patches/kubeadm-bootstrap-windows-k8s-ci-binaries.yaml
+++ b/templates/test/ci/prow-machine-pool-ci-version/patches/kubeadm-bootstrap-windows-k8s-ci-binaries.yaml
@@ -24,7 +24,7 @@
       ctr.exe -n k8s.io images tag docker.io/sigwindowstools/kube-proxy:v1.23.1-calico-hostprocess "docker.io/sigwindowstools/kube-proxy:${CI_VERSION/+/_}-calico-hostprocess"
 
       kubeadm.exe version -o=short
-      kubectl.exe version --client=true --short=true
+      kubectl.exe version --client=true
       kubelet.exe --version
     path: C:/replace-k8s-binaries.ps1
     permissions: "0744"

--- a/templates/test/ci/prow-machine-pool-ci-version/patches/machine-pool-ci-version.yaml
+++ b/templates/test/ci/prow-machine-pool-ci-version/patches/machine-pool-ci-version.yaml
@@ -68,7 +68,7 @@ spec:
         echo "* checking binary versions"
         echo "ctr version: " $(ctr version)
         echo "kubeadm version: " $(kubeadm version -o=short)
-        echo "kubectl version: " $(kubectl version --client=true --short=true)
+        echo "kubectl version: " $(kubectl version --client=true)
         echo "kubelet version: " $(kubelet --version)
         echo "$$LINE_SEPARATOR"
     - path: /etc/kubernetes/azure.json

--- a/templates/test/dev/cluster-template-custom-builds-machine-pool.yaml
+++ b/templates/test/dev/cluster-template-custom-builds-machine-pool.yaml
@@ -119,7 +119,7 @@ spec:
         done
 
         echo "kubeadm version: $(kubeadm version -o=short)"
-        echo "kubectl version: $(kubectl version --client=true --short=true)"
+        echo "kubectl version: $(kubectl version --client=true)"
         echo "kubelet version: $(kubelet --version)"
       owner: root:root
       path: /tmp/replace-k8s-binaries.sh
@@ -286,7 +286,7 @@ spec:
       systemctl restart kubelet
 
       echo "kubeadm version: $(kubeadm version -o=short)"
-      echo "kubectl version: $(kubectl version --client=true --short=true)"
+      echo "kubectl version: $(kubectl version --client=true)"
       echo "kubelet version: $(kubelet --version)"
     owner: root:root
     path: /tmp/replace-k8s-binaries.sh
@@ -410,7 +410,7 @@ spec:
       ctr.exe -n k8s.io images tag docker.io/sigwindowstools/kube-proxy:v1.23.1-calico-hostprocess "docker.io/sigwindowstools/kube-proxy:${CI_VERSION/+/_}-calico-hostprocess"
 
       kubeadm.exe version -o=short
-      kubectl.exe version --client=true --short=true
+      kubectl.exe version --client=true
       kubelet.exe --version
       kube-proxy.exe --version
     path: C:/replace-pr-binaries.ps1

--- a/templates/test/dev/cluster-template-custom-builds.yaml
+++ b/templates/test/dev/cluster-template-custom-builds.yaml
@@ -128,7 +128,7 @@ spec:
         done
 
         echo "kubeadm version: $(kubeadm version -o=short)"
-        echo "kubectl version: $(kubectl version --client=true --short=true)"
+        echo "kubectl version: $(kubectl version --client=true)"
         echo "kubelet version: $(kubelet --version)"
       owner: root:root
       path: /tmp/replace-k8s-binaries.sh
@@ -293,7 +293,7 @@ spec:
           systemctl restart kubelet
 
           echo "kubeadm version: $(kubeadm version -o=short)"
-          echo "kubectl version: $(kubectl version --client=true --short=true)"
+          echo "kubectl version: $(kubectl version --client=true)"
           echo "kubelet version: $(kubelet --version)"
         owner: root:root
         path: /tmp/replace-k8s-binaries.sh
@@ -439,7 +439,7 @@ spec:
           ctr.exe -n k8s.io images tag docker.io/sigwindowstools/kube-proxy:v1.23.1-calico-hostprocess "docker.io/sigwindowstools/kube-proxy:${CI_VERSION/+/_}-calico-hostprocess"
 
           kubeadm.exe version -o=short
-          kubectl.exe version --client=true --short=true
+          kubectl.exe version --client=true
           kubelet.exe --version
           kube-proxy.exe --version
         path: C:/replace-pr-binaries.ps1

--- a/templates/test/dev/custom-builds-machine-pool/patches/custom-builds.yaml
+++ b/templates/test/dev/custom-builds-machine-pool/patches/custom-builds.yaml
@@ -25,7 +25,7 @@ spec:
       systemctl restart kubelet
 
       echo "kubeadm version: $(kubeadm version -o=short)"
-      echo "kubectl version: $(kubectl version --client=true --short=true)"
+      echo "kubectl version: $(kubectl version --client=true)"
       echo "kubelet version: $(kubelet --version)"
   - path: /etc/kubernetes/azure.json
     owner: "root:root"

--- a/templates/test/dev/custom-builds-machine-pool/patches/kubeadm-bootstrap-machine-pool-windows-k8s-pr-binaries.yaml
+++ b/templates/test/dev/custom-builds-machine-pool/patches/kubeadm-bootstrap-machine-pool-windows-k8s-pr-binaries.yaml
@@ -24,7 +24,7 @@
       ctr.exe -n k8s.io images tag docker.io/sigwindowstools/kube-proxy:v1.23.1-calico-hostprocess "docker.io/sigwindowstools/kube-proxy:${CI_VERSION/+/_}-calico-hostprocess"
 
       kubeadm.exe version -o=short
-      kubectl.exe version --client=true --short=true
+      kubectl.exe version --client=true
       kubelet.exe --version
       kube-proxy.exe --version
     path: C:/replace-pr-binaries.ps1

--- a/templates/test/dev/custom-builds/patches/kubeadm-bootstrap-windows-k8s-pr-binaries.yaml
+++ b/templates/test/dev/custom-builds/patches/kubeadm-bootstrap-windows-k8s-pr-binaries.yaml
@@ -24,7 +24,7 @@
       ctr.exe -n k8s.io images tag docker.io/sigwindowstools/kube-proxy:v1.23.1-calico-hostprocess "docker.io/sigwindowstools/kube-proxy:${CI_VERSION/+/_}-calico-hostprocess"
 
       kubeadm.exe version -o=short
-      kubectl.exe version --client=true --short=true
+      kubectl.exe version --client=true
       kubelet.exe --version
       kube-proxy.exe --version
     path: C:/replace-pr-binaries.ps1

--- a/templates/test/dev/custom-builds/patches/kubeadm-bootstrap.yaml
+++ b/templates/test/dev/custom-builds/patches/kubeadm-bootstrap.yaml
@@ -17,7 +17,7 @@
       systemctl restart kubelet
 
       echo "kubeadm version: $(kubeadm version -o=short)"
-      echo "kubectl version: $(kubectl version --client=true --short=true)"
+      echo "kubectl version: $(kubectl version --client=true)"
       echo "kubelet version: $(kubelet --version)"
     path: /tmp/replace-k8s-binaries.sh
     owner: "root:root"

--- a/templates/test/dev/custom-builds/patches/kubeadm-controlplane-bootstrap.yaml
+++ b/templates/test/dev/custom-builds/patches/kubeadm-controlplane-bootstrap.yaml
@@ -27,7 +27,7 @@
         done
 
         echo "kubeadm version: $(kubeadm version -o=short)"
-        echo "kubectl version: $(kubectl version --client=true --short=true)"
+        echo "kubectl version: $(kubectl version --client=true)"
         echo "kubelet version: $(kubelet --version)"
     path: /tmp/replace-k8s-binaries.sh
     owner: "root:root"

--- a/templates/test/dev/patches/control-plane-custom-builds.yaml
+++ b/templates/test/dev/patches/control-plane-custom-builds.yaml
@@ -43,7 +43,7 @@ spec:
         done
 
         echo "kubeadm version: $(kubeadm version -o=short)"
-        echo "kubectl version: $(kubectl version --client=true --short=true)"
+        echo "kubectl version: $(kubectl version --client=true)"
         echo "kubelet version: $(kubelet --version)"
     - path: /tmp/replace-k8s-components.sh
       owner: "root:root"


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind deprecation
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**: Removed the deprecated kubectl's --short flag

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4164 

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Usual cleanup upon deprecation
```
