### PR TITLE
update ignored_dirs in boilerplate.py and update pylint in pre-commit config to ignore boilerplate.py

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,6 +20,7 @@ repos:
   rev: v2.17.2
   hooks:
   - id: pylint
+    exclude: ^hack/boilerplate/boilerplate.py$
 - repo: local
   hooks:
   - id: make-verify-boilerplate

--- a/hack/boilerplate/boilerplate.py
+++ b/hack/boilerplate/boilerplate.py
@@ -149,7 +149,7 @@ def file_extension(filename):
 
 skipped_dirs = ['Godeps', 'third_party', '_gopath', '_output', '.git', 'cluster/env.sh',
                 "vendor", "test/e2e/generated/bindata.go", "hack/boilerplate/test",
-                "pkg/kubectl/generated/bindata.go", "tilt_modules"]
+                "pkg/kubectl/generated/bindata.go", "tilt_modules", "_artifacts", "hack/tools/bin"]
 
 # list all the files contain 'DO NOT EDIT', but are not generated
 skipped_ungenerated_files = ['hack/lib/swagger.sh', 'hack/boilerplate/boilerplate.py']


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind cleanup

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
- This PR will add `"_artifacts"`, `"hack/tools/bin"` folders to the list of _ignored_dirs_ in `boilerplate.py`.
- This PR also updates `pylint` config in the pre-commit framework to ignore linting to `boilerplate.py`. 


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
- This PR is for https://github.com/kubernetes-sigs/cluster-api-provider-azure/issues/4038

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->
- This PR solves the errors I see on running pre-commit-config locally.
  - Boilerplate errors due to local files
```bash
Boilerplate header is wrong for: /Users/nawazhussain/msftcode/cluster-api-provider-azure/hack/tools/bin/codespell_dist/codespell_lib/_codespell.py
Boilerplate header is wrong for: /Users/nawazhussain/msftcode/cluster-api-provider-azure/hack/tools/bin/codespell_dist/codespell_lib/_version.py
Boilerplate header is wrong for: /Users/nawazhussain/msftcode/cluster-api-provider-azure/hack/tools/bin/codespell_dist/codespell_lib/__init__.py
Boilerplate header is wrong for: /Users/nawazhussain/msftcode/cluster-api-provider-azure/hack/tools/bin/codespell_dist/codespell_lib/__main__.py
Boilerplate header is wrong for: /Users/nawazhussain/msftcode/cluster-api-provider-azure/hack/tools/bin/codespell_dist/codespell_lib/tests/test_dictionary.py
Boilerplate header is wrong for: /Users/nawazhussain/msftcode/cluster-api-provider-azure/hack/tools/bin/codespell_dist/codespell_lib/tests/test_basic.py
Boilerplate header is wrong for: /Users/nawazhussain/msftcode/cluster-api-provider-azure/hack/tools/bin/codespell_dist/codespell_lib/tests/__init__.py
Boilerplate header is wrong for: /Users/nawazhussain/msftcode/cluster-api-provider-azure/hack/tools/bin/codespell_dist/codespell_lib/data/__init__.py
Boilerplate header is wrong for: /Users/nawazhussain/msftcode/cluster-api-provider-azure/_artifacts/calico/release-v3.26.1/manifests/.!65523!generate.sh
Boilerplate header is wrong for: /Users/nawazhussain/msftcode/cluster-api-provider-azure/_artifacts/calico/release-v3.26.1/manifests/.!57237!generate.sh
Boilerplate header is wrong for: /Users/nawazhussain/msftcode/cluster-api-provider-azure/_artifacts/calico/release-v3.26.1/manifests/generate.sh
Boilerplate header is wrong for: /Users/nawazhussain/msftcode/cluster-api-provider-azure/_artifacts/calico/release-v3.26.1/manifests/.!9501!generate.sh
Boilerplate header is wrong for: /Users/nawazhussain/msftcode/cluster-api-provider-azure/_artifacts/calico/release-v3.25.1/manifests/.!66305!generate.sh
Boilerplate header is wrong for: /Users/nawazhussain/msftcode/cluster-api-provider-azure/_artifacts/calico/release-v3.25.1/manifests/.!77716!generate.sh
Boilerplate header is wrong for: /Users/nawazhussain/msftcode/cluster-api-provider-azure/_artifacts/calico/release-v3.25.1/manifests/.!53990!generate.sh
Boilerplate header is wrong for: /Users/nawazhussain/msftcode/cluster-api-provider-azure/_artifacts/calico/release-v3.25.1/manifests/.!28694!generate.sh
Boilerplate header is wrong for: /Users/nawazhussain/msftcode/cluster-api-provider-azure/_artifacts/calico/release-v3.25.1/manifests/.!11900!generate.sh
Boilerplate header is wrong for: /Users/nawazhussain/msftcode/cluster-api-provider-azure/_artifacts/calico/release-v3.25.1/manifests/generate.sh
Boilerplate header is wrong for: /Users/nawazhussain/msftcode/cluster-api-provider-azure/_artifacts/calico/release-v3.25.1/manifests/.!75046!generate.sh
Boilerplate header is wrong for: /Users/nawazhussain/msftcode/cluster-api-provider-azure/_artifacts/calico/release-v3.25.1/manifests/.!19917!generate.sh
Boilerplate header is wrong for: /Users/nawazhussain/msftcode/cluster-api-provider-azure/_artifacts/calico/release-v3.25.1/manifests/.!87949!generate.sh
```


- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
