### PR TITLE
fix default azurecluster subnet webhook

### DIFF
--- a/api/v1beta1/azurecluster_default.go
+++ b/api/v1beta1/azurecluster_default.go
@@ -119,7 +119,7 @@ func (c *AzureCluster) setSubnetDefaults() {
 		if subnet.SecurityGroup.Name == "" {
 			subnet.SecurityGroup.Name = generateNodeSecurityGroupName(c.ObjectMeta.Name)
 		}
-		cpSubnet.SecurityGroup.SecurityGroupClass.setDefaults()
+		subnet.SecurityGroup.SecurityGroupClass.setDefaults()
 
 		if subnet.RouteTable.Name == "" {
 			subnet.RouteTable.Name = generateNodeRouteTableName(c.ObjectMeta.Name)

--- a/api/v1beta1/azurecluster_default_test.go
+++ b/api/v1beta1/azurecluster_default_test.go
@@ -703,6 +703,30 @@ func TestSubnetDefaults(t *testing.T) {
 									Name: "my-custom-sg",
 								},
 							},
+							{
+								SubnetClassSpec: SubnetClassSpec{
+									Role: "node",
+									Name: "cluster-test-node-subnet",
+								},
+								SecurityGroup: SecurityGroup{
+									SecurityGroupClass: SecurityGroupClass{
+										SecurityRules: []SecurityRule{
+											{
+												Name:             "allow_port_50000",
+												Description:      "allow port 50000",
+												Protocol:         "*",
+												Priority:         2202,
+												SourcePorts:      ptr.To("*"),
+												DestinationPorts: ptr.To("*"),
+												Source:           ptr.To("*"),
+												Destination:      ptr.To("*"),
+												Action:           SecurityRuleActionAllow,
+											},
+										},
+									},
+									Name: "my-custom-node-sg",
+								},
+							},
 						},
 					},
 				},
@@ -746,14 +770,32 @@ func TestSubnetDefaults(t *testing.T) {
 									CIDRBlocks: []string{DefaultNodeSubnetCIDR},
 									Name:       "cluster-test-node-subnet",
 								},
-								SecurityGroup: SecurityGroup{Name: "cluster-test-node-nsg"},
-								RouteTable:    RouteTable{Name: "cluster-test-node-routetable"},
+								SecurityGroup: SecurityGroup{
+									Name: "my-custom-node-sg",
+									SecurityGroupClass: SecurityGroupClass{
+										SecurityRules: []SecurityRule{
+											{
+												Name:             "allow_port_50000",
+												Description:      "allow port 50000",
+												Protocol:         "*",
+												Priority:         2202,
+												SourcePorts:      ptr.To("*"),
+												DestinationPorts: ptr.To("*"),
+												Source:           ptr.To("*"),
+												Destination:      ptr.To("*"),
+												Direction:        SecurityRuleDirectionInbound,
+												Action:           SecurityRuleActionAllow,
+											},
+										},
+									},
+								},
+								RouteTable: RouteTable{Name: "cluster-test-node-routetable"},
 								NatGateway: NatGateway{
 									NatGatewayIP: PublicIPSpec{
-										Name: "",
+										Name: "pip-cluster-test-node-natgw-1",
 									},
 									NatGatewayClassSpec: NatGatewayClassSpec{
-										Name: "cluster-test-node-natgw",
+										Name: "cluster-test-node-natgw-1",
 									},
 								},
 							},

--- a/api/v1beta1/azureclustertemplate_default.go
+++ b/api/v1beta1/azureclustertemplate_default.go
@@ -71,7 +71,7 @@ func (c *AzureClusterTemplate) setSubnetsTemplateDefaults() {
 		nodeSubnetCounter++
 		nodeSubnetFound = true
 		subnet.SubnetClassSpec.setDefaults(fmt.Sprintf(DefaultNodeSubnetCIDRPattern, nodeSubnetCounter))
-		cpSubnet.SecurityGroup.setDefaults()
+		subnet.SecurityGroup.setDefaults()
 		c.Spec.Template.Spec.NetworkSpec.Subnets[i] = subnet
 	}
 

--- a/api/v1beta1/azureclustertemplate_default_test.go
+++ b/api/v1beta1/azureclustertemplate_default_test.go
@@ -264,6 +264,129 @@ func TestSubnetsTemplateDefaults(t *testing.T) {
 			},
 		},
 		{
+			name: "subnet with custom attributes and security groups",
+			clusterTemplate: &AzureClusterTemplate{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-cluster-template",
+				},
+				Spec: AzureClusterTemplateSpec{
+					Template: AzureClusterTemplateResource{
+						Spec: AzureClusterTemplateResourceSpec{
+							NetworkSpec: NetworkTemplateSpec{
+								Subnets: SubnetTemplatesSpec{
+									{
+										SubnetClassSpec: SubnetClassSpec{
+											Role:       SubnetControlPlane,
+											CIDRBlocks: []string{"10.0.0.16/24"},
+										},
+										SecurityGroup: SecurityGroupClass{
+											SecurityRules: []SecurityRule{
+												{
+													Name:             "allow_port_50000",
+													Description:      "allow port 50000",
+													Protocol:         "*",
+													Priority:         2202,
+													SourcePorts:      ptr.To("*"),
+													DestinationPorts: ptr.To("*"),
+													Source:           ptr.To("*"),
+													Destination:      ptr.To("*"),
+													Action:           SecurityRuleActionAllow,
+												},
+											},
+										},
+									},
+									{
+										SubnetClassSpec: SubnetClassSpec{
+											Role:       SubnetNode,
+											CIDRBlocks: []string{"10.1.0.16/24"},
+										},
+										NatGateway: NatGatewayClassSpec{
+											Name: "foo-natgw",
+										},
+										SecurityGroup: SecurityGroupClass{
+											SecurityRules: []SecurityRule{
+												{
+													Name:             "allow_port_50000",
+													Description:      "allow port 50000",
+													Protocol:         "*",
+													Priority:         2202,
+													SourcePorts:      ptr.To("*"),
+													DestinationPorts: ptr.To("*"),
+													Source:           ptr.To("*"),
+													Destination:      ptr.To("*"),
+													Action:           SecurityRuleActionAllow,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			outputTemplate: &AzureClusterTemplate{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-cluster-template",
+				},
+				Spec: AzureClusterTemplateSpec{
+					Template: AzureClusterTemplateResource{
+						Spec: AzureClusterTemplateResourceSpec{
+							NetworkSpec: NetworkTemplateSpec{
+								Subnets: SubnetTemplatesSpec{
+									{
+										SubnetClassSpec: SubnetClassSpec{
+											Role:       SubnetControlPlane,
+											CIDRBlocks: []string{"10.0.0.16/24"},
+										},
+										SecurityGroup: SecurityGroupClass{
+											SecurityRules: SecurityRules{
+												{
+													Name:             "allow_port_50000",
+													Description:      "allow port 50000",
+													Protocol:         "*",
+													Priority:         2202,
+													SourcePorts:      ptr.To("*"),
+													DestinationPorts: ptr.To("*"),
+													Source:           ptr.To("*"),
+													Destination:      ptr.To("*"),
+													Direction:        SecurityRuleDirectionInbound,
+													Action:           SecurityRuleActionAllow,
+												},
+											},
+										},
+									},
+									{
+										SubnetClassSpec: SubnetClassSpec{
+											Role:       SubnetNode,
+											CIDRBlocks: []string{"10.1.0.16/24"},
+										},
+										NatGateway: NatGatewayClassSpec{Name: "foo-natgw"},
+										SecurityGroup: SecurityGroupClass{
+											SecurityRules: SecurityRules{
+												{
+													Name:             "allow_port_50000",
+													Description:      "allow port 50000",
+													Protocol:         "*",
+													Priority:         2202,
+													SourcePorts:      ptr.To("*"),
+													DestinationPorts: ptr.To("*"),
+													Source:           ptr.To("*"),
+													Destination:      ptr.To("*"),
+													Direction:        SecurityRuleDirectionInbound,
+													Action:           SecurityRuleActionAllow,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "subnets specified",
 			clusterTemplate: &AzureClusterTemplate{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
Fixes the bug in azure_cluster_default and azure_cluster_template_default webhhoks.

Default security groups for node subnet are not being set. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [x] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
