### PR TITLE
Escape dots in hostname regexps

### DIFF
--- a/internal/test/env/env.go
+++ b/internal/test/env/env.go
@@ -49,7 +49,7 @@ var (
 	logger                 = record.NewLogger(record.WithThreshold(ptr.To(1)), record.WithWriter(ginkgo.GinkgoWriter))
 	scheme                 = runtime.NewScheme()
 	env                    *envtest.Environment
-	clusterAPIVersionRegex = regexp.MustCompile(`^(\W)sigs.k8s.io/cluster-api v(.+)`)
+	clusterAPIVersionRegex = regexp.MustCompile(`^(\W)sigs\.k8s\.io/cluster-api v(.+)`)
 )
 
 func init() {

--- a/internal/test/env/env_test.go
+++ b/internal/test/env/env_test.go
@@ -28,5 +28,5 @@ func TestGetFilePathToCAPICRDs(t *testing.T) {
 	_, filename, _, _ := goruntime.Caller(0) //nolint:dogsled // Ignore "declaration has 3 blank identifiers" check.
 	root := path.Join(path.Dir(filename), "..", "..", "..")
 	g := gomega.NewWithT(t)
-	g.Expect(getFilePathToCAPICRDs(root)).To(gomega.MatchRegexp("(.+)/pkg/mod/sigs.k8s.io/cluster-api@v(.+)/config/crd/bases"))
+	g.Expect(getFilePathToCAPICRDs(root)).To(gomega.MatchRegexp(`(.+)/pkg/mod/sigs\.k8s\.io/cluster-api@v(.+)/config/crd/bases`))
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Updates two regular expressions to properly escape the dot (`.`) character in hostnames. Without this, there is the potential to match something unintended.

**Which issue(s) this PR fixes**:

Fixes a code scanning security [alert](https://github.com/kubernetes-sigs/cluster-api-provider-azure/security/code-scanning/1).

**Special notes for your reviewer**:

- [x] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
