### PR TITLE
fix vnet in separate resource group

### DIFF
--- a/azure/scope/cluster.go
+++ b/azure/scope/cluster.go
@@ -310,7 +310,7 @@ func (s *ClusterScope) RouteTableSpecs() []azure.ResourceSpecGetter {
 			specs = append(specs, &routetables.RouteTableSpec{
 				Name:           subnet.RouteTable.Name,
 				Location:       s.Location(),
-				ResourceGroup:  s.ResourceGroup(),
+				ResourceGroup:  s.Vnet().ResourceGroup,
 				ClusterName:    s.ClusterName(),
 				AdditionalTags: s.AdditionalTags(),
 			})
@@ -358,7 +358,7 @@ func (s *ClusterScope) NSGSpecs() []azure.ResourceSpecGetter {
 		nsgspecs[i] = &securitygroups.NSGSpec{
 			Name:                     subnet.SecurityGroup.Name,
 			SecurityRules:            subnet.SecurityGroup.SecurityRules,
-			ResourceGroup:            s.ResourceGroup(),
+			ResourceGroup:            s.Vnet().ResourceGroup,
 			Location:                 s.Location(),
 			ClusterName:              s.ClusterName(),
 			AdditionalTags:           s.AdditionalTags(),

--- a/azure/scope/cluster_test.go
+++ b/azure/scope/cluster_test.go
@@ -810,11 +810,13 @@ func TestRouteTableSpecs(t *testing.T) {
 				},
 				AzureCluster: &infrav1.AzureCluster{
 					Spec: infrav1.AzureClusterSpec{
-						ResourceGroup: "my-rg",
 						AzureClusterClassSpec: infrav1.AzureClusterClassSpec{
 							Location: "centralIndia",
 						},
 						NetworkSpec: infrav1.NetworkSpec{
+							Vnet: infrav1.VnetSpec{
+								ResourceGroup: "my-rg",
+							},
 							Subnets: infrav1.Subnets{
 								{
 									RouteTable: infrav1.RouteTable{
@@ -1216,11 +1218,13 @@ func TestNSGSpecs(t *testing.T) {
 				},
 				AzureCluster: &infrav1.AzureCluster{
 					Spec: infrav1.AzureClusterSpec{
-						ResourceGroup: "my-rg",
 						AzureClusterClassSpec: infrav1.AzureClusterClassSpec{
 							Location: "centralIndia",
 						},
 						NetworkSpec: infrav1.NetworkSpec{
+							Vnet: infrav1.VnetSpec{
+								ResourceGroup: "my-rg",
+							},
 							Subnets: infrav1.Subnets{
 								{
 									SecurityGroup: infrav1.SecurityGroup{

--- a/templates/test/ci/cluster-template-prow-custom-vnet.yaml
+++ b/templates/test/ci/cluster-template-prow-custom-vnet.yaml
@@ -48,7 +48,7 @@ spec:
         name: node-nsg
     vnet:
       name: ${AZURE_CUSTOM_VNET_NAME}
-      resourceGroup: ${AZURE_RESOURCE_GROUP}
+      resourceGroup: ${AZURE_CUSTOM_VNET_RESOURCE_GROUP}
   resourceGroup: ${AZURE_RESOURCE_GROUP:=${CLUSTER_NAME}}
   subscriptionID: ${AZURE_SUBSCRIPTION_ID}
 ---

--- a/templates/test/ci/cluster-template-prow-private.yaml
+++ b/templates/test/ci/cluster-template-prow-private.yaml
@@ -72,7 +72,7 @@ spec:
       name: ${AZURE_VNET_NAME}
       peerings:
       - remoteVnetName: ${AZURE_CUSTOM_VNET_NAME}
-        resourceGroup: ${AZURE_RESOURCE_GROUP}
+        resourceGroup: ${AZURE_CUSTOM_VNET_RESOURCE_GROUP}
   resourceGroup: ${AZURE_RESOURCE_GROUP:=${CLUSTER_NAME}}
   subscriptionID: ${AZURE_SUBSCRIPTION_ID}
 ---

--- a/templates/test/ci/prow-custom-vnet/patches/custom-vnet.yaml
+++ b/templates/test/ci/prow-custom-vnet/patches/custom-vnet.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   networkSpec:
     vnet:
-      resourceGroup: ${AZURE_RESOURCE_GROUP}
+      resourceGroup: ${AZURE_CUSTOM_VNET_RESOURCE_GROUP}
       name: ${AZURE_CUSTOM_VNET_NAME}
     subnets:
       - name: ${AZURE_CUSTOM_VNET_NAME}-controlplane-subnet

--- a/templates/test/ci/prow-private/patches/vnet-peerings.yaml
+++ b/templates/test/ci/prow-private/patches/vnet-peerings.yaml
@@ -15,7 +15,7 @@ spec:
       cidrBlocks:
       - ${AZURE_PRIVATE_VNET_CIDR}
       peerings:
-      - resourceGroup: ${AZURE_RESOURCE_GROUP}
+      - resourceGroup: ${AZURE_CUSTOM_VNET_RESOURCE_GROUP}
         remoteVnetName: ${AZURE_CUSTOM_VNET_NAME}
     subnets:
       - name: private-cp-subnet

--- a/test/e2e/azure_privatecluster.go
+++ b/test/e2e/azure_privatecluster.go
@@ -228,7 +228,7 @@ func SetupExistingVNet(ctx context.Context, vnetCidr string, cpSubnetCidrs, node
 	routetableClient.Authorizer = authorizer
 
 	By("creating a resource group")
-	groupName := os.Getenv(AzureResourceGroup)
+	groupName := os.Getenv(AzureCustomVnetResourceGroup)
 	_, err = groupClient.CreateOrUpdate(ctx, groupName, resources.Group{
 		Location: ptr.To(os.Getenv(AzureLocation)),
 		Tags: map[string]*string{

--- a/test/e2e/azure_test.go
+++ b/test/e2e/azure_test.go
@@ -135,6 +135,7 @@ var _ = Describe("Workload cluster creation", func() {
 		}
 		dumpSpecResourcesAndCleanup(ctx, cleanInput)
 		Expect(os.Unsetenv(AzureResourceGroup)).To(Succeed())
+		Expect(os.Unsetenv(AzureCustomVnetResourceGroup)).To(Succeed())
 		Expect(os.Unsetenv(AzureVNetName)).To(Succeed())
 		Expect(os.Unsetenv(ClusterIdentityName)).To(Succeed())
 		Expect(os.Unsetenv(ClusterIdentityNamespace)).To(Succeed())
@@ -155,6 +156,7 @@ var _ = Describe("Workload cluster creation", func() {
 				clusterName = getClusterName(clusterNamePrefix, "public-custom-vnet")
 				By("Creating a custom virtual network", func() {
 					Expect(os.Setenv(AzureCustomVNetName, "custom-vnet")).To(Succeed())
+					Expect(os.Setenv(AzureCustomVnetResourceGroup, clusterName+"-vnetrg")).To(Succeed())
 					additionalCleanup = SetupExistingVNet(ctx,
 						"10.0.0.0/16",
 						map[string]string{fmt.Sprintf("%s-controlplane-subnet", os.Getenv(AzureCustomVNetName)): "10.0.0.0/24"},

--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -57,6 +57,7 @@ const (
 	AzureExtendedLocationType       = "AZURE_EXTENDEDLOCATION_TYPE"
 	AzureExtendedLocationName       = "AZURE_EXTENDEDLOCATION_NAME"
 	AzureResourceGroup              = "AZURE_RESOURCE_GROUP"
+	AzureCustomVnetResourceGroup    = "AZURE_CUSTOM_VNET_RESOURCE_GROUP"
 	AzureVNetName                   = "AZURE_VNET_NAME"
 	AzureCustomVNetName             = "AZURE_CUSTOM_VNET_NAME"
 	AzureInternalLBIP               = "AZURE_INTERNAL_LB_IP"


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind cleanup

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

This PR updates the custom vnet e2e test to use different resource groups for the vnet and the rest of the cluster resources. I was trying to test this same scenario for #3528 and was running into issues that didn't seem related, so I'd like to make sure this scenario works on main first.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixed a bug where AzureCluster's spec.networkSpec.vnet.resourceGroup was not always properly honored
```
