### PR TITLE
Fix containerd and systemd-resolved race condition in ipv6 clusters

### DIFF
--- a/templates/cluster-template-dual-stack.yaml
+++ b/templates/cluster-template-dual-stack.yaml
@@ -128,7 +128,7 @@ spec:
     - echo "DNSStubListener=no" >> /etc/systemd/resolved.conf
     - mv /etc/resolv.conf /etc/resolv.conf.OLD && ln -s /run/systemd/resolve/resolv.conf
       /etc/resolv.conf
-    - systemctl restart systemd-resolved
+    - systemctl restart systemd-resolved containerd
     preKubeadmCommands: []
   machineTemplate:
     infrastructureRef:
@@ -240,4 +240,4 @@ spec:
       - echo "DNSStubListener=no" >> /etc/systemd/resolved.conf
       - mv /etc/resolv.conf /etc/resolv.conf.OLD && ln -s /run/systemd/resolve/resolv.conf
         /etc/resolv.conf
-      - systemctl restart systemd-resolved
+      - systemctl restart systemd-resolved containerd

--- a/templates/cluster-template-ipv6.yaml
+++ b/templates/cluster-template-ipv6.yaml
@@ -133,7 +133,7 @@ spec:
     - echo "DNSStubListener=no" >> /etc/systemd/resolved.conf
     - mv /etc/resolv.conf /etc/resolv.conf.OLD && ln -s /run/systemd/resolve/resolv.conf
       /etc/resolv.conf
-    - systemctl restart systemd-resolved
+    - systemctl restart systemd-resolved containerd
     preKubeadmCommands: []
   machineTemplate:
     infrastructureRef:
@@ -256,4 +256,4 @@ spec:
       - echo "DNSStubListener=no" >> /etc/systemd/resolved.conf
       - mv /etc/resolv.conf /etc/resolv.conf.OLD && ln -s /run/systemd/resolve/resolv.conf
         /etc/resolv.conf
-      - systemctl restart systemd-resolved
+      - systemctl restart systemd-resolved containerd

--- a/templates/flavors/dual-stack/machine-deployment.yaml
+++ b/templates/flavors/dual-stack/machine-deployment.yaml
@@ -49,7 +49,7 @@ spec:
         # This frees up :53 on the host for the coredns pods
         - echo "DNSStubListener=no" >> /etc/systemd/resolved.conf
         - mv /etc/resolv.conf /etc/resolv.conf.OLD && ln -s /run/systemd/resolve/resolv.conf /etc/resolv.conf
-        - systemctl restart systemd-resolved
+        - systemctl restart systemd-resolved containerd
       joinConfiguration:
         nodeRegistration:
           name: '{{ ds.meta_data["local_hostname"] }}'

--- a/templates/flavors/dual-stack/patches/kubeadm-controlplane.yaml
+++ b/templates/flavors/dual-stack/patches/kubeadm-controlplane.yaml
@@ -8,7 +8,7 @@ spec:
       # This frees up :53 on the host for the coredns pods
       - echo "DNSStubListener=no" >> /etc/systemd/resolved.conf
       - mv /etc/resolv.conf /etc/resolv.conf.OLD && ln -s /run/systemd/resolve/resolv.conf /etc/resolv.conf
-      - systemctl restart systemd-resolved
+      - systemctl restart systemd-resolved containerd
     initConfiguration:
       nodeRegistration:
         name: '{{ ds.meta_data["local_hostname"] }}'

--- a/templates/flavors/ipv6/machine-deployment.yaml
+++ b/templates/flavors/ipv6/machine-deployment.yaml
@@ -49,7 +49,7 @@ spec:
         # This frees up :53 on the host for the coredns pods
         - echo "DNSStubListener=no" >> /etc/systemd/resolved.conf
         - mv /etc/resolv.conf /etc/resolv.conf.OLD && ln -s /run/systemd/resolve/resolv.conf /etc/resolv.conf
-        - systemctl restart systemd-resolved
+        - systemctl restart systemd-resolved containerd
       joinConfiguration:
         nodeRegistration:
           name: '{{ ds.meta_data["local_hostname"] }}'

--- a/templates/flavors/ipv6/patches/kubeadm-controlplane.yaml
+++ b/templates/flavors/ipv6/patches/kubeadm-controlplane.yaml
@@ -8,7 +8,7 @@ spec:
       # This frees up :53 on the host for the coredns pods
       - echo "DNSStubListener=no" >> /etc/systemd/resolved.conf
       - mv /etc/resolv.conf /etc/resolv.conf.OLD && ln -s /run/systemd/resolve/resolv.conf /etc/resolv.conf
-      - systemctl restart systemd-resolved
+      - systemctl restart systemd-resolved containerd
     initConfiguration:
       nodeRegistration:
         name: '{{ ds.meta_data["local_hostname"] }}'

--- a/templates/test/ci/cluster-template-prow-ci-version-dual-stack.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version-dual-stack.yaml
@@ -204,7 +204,7 @@ spec:
     - echo "DNSStubListener=no" >> /etc/systemd/resolved.conf
     - mv /etc/resolv.conf /etc/resolv.conf.OLD && ln -s /run/systemd/resolve/resolv.conf
       /etc/resolv.conf
-    - systemctl restart systemd-resolved
+    - systemctl restart systemd-resolved containerd
     preKubeadmCommands:
     - bash -c /tmp/kubeadm-bootstrap.sh
     verbosity: 5
@@ -387,7 +387,7 @@ spec:
       - echo "DNSStubListener=no" >> /etc/systemd/resolved.conf
       - mv /etc/resolv.conf /etc/resolv.conf.OLD && ln -s /run/systemd/resolve/resolv.conf
         /etc/resolv.conf
-      - systemctl restart systemd-resolved
+      - systemctl restart systemd-resolved containerd
       preKubeadmCommands:
       - bash -c /tmp/kubeadm-bootstrap.sh
       verbosity: 5

--- a/templates/test/ci/cluster-template-prow-ci-version-dual-stack.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version-dual-stack.yaml
@@ -234,7 +234,7 @@ spec:
           offer: capi
           publisher: cncf-upstream
           sku: ubuntu-2204-gen1
-          version: 128.2.20230918
+          version: latest
       osDisk:
         diskSizeGB: 128
         osType: Linux
@@ -281,7 +281,7 @@ spec:
           offer: capi
           publisher: cncf-upstream
           sku: ubuntu-2204-gen1
-          version: 128.2.20230918
+          version: latest
       osDisk:
         diskSizeGB: 128
         osType: Linux

--- a/templates/test/ci/cluster-template-prow-ci-version-ipv6.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version-ipv6.yaml
@@ -211,7 +211,7 @@ spec:
     - echo "DNSStubListener=no" >> /etc/systemd/resolved.conf
     - mv /etc/resolv.conf /etc/resolv.conf.OLD && ln -s /run/systemd/resolve/resolv.conf
       /etc/resolv.conf
-    - systemctl restart systemd-resolved
+    - systemctl restart systemd-resolved containerd
     preKubeadmCommands:
     - bash -c /tmp/kubeadm-bootstrap.sh
     verbosity: 5
@@ -405,7 +405,7 @@ spec:
       - echo "DNSStubListener=no" >> /etc/systemd/resolved.conf
       - mv /etc/resolv.conf /etc/resolv.conf.OLD && ln -s /run/systemd/resolve/resolv.conf
         /etc/resolv.conf
-      - systemctl restart systemd-resolved
+      - systemctl restart systemd-resolved containerd
       preKubeadmCommands:
       - bash -c /tmp/kubeadm-bootstrap.sh
       verbosity: 5

--- a/templates/test/ci/cluster-template-prow-ci-version-ipv6.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version-ipv6.yaml
@@ -241,7 +241,7 @@ spec:
           offer: capi
           publisher: cncf-upstream
           sku: ubuntu-2204-gen1
-          version: 128.2.20230918
+          version: latest
       osDisk:
         diskSizeGB: 128
         osType: Linux
@@ -288,7 +288,7 @@ spec:
           offer: capi
           publisher: cncf-upstream
           sku: ubuntu-2204-gen1
-          version: 128.2.20230918
+          version: latest
       osDisk:
         diskSizeGB: 128
         osType: Linux

--- a/templates/test/ci/cluster-template-prow-ci-version.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version.yaml
@@ -208,7 +208,7 @@ spec:
           offer: capi
           publisher: cncf-upstream
           sku: ubuntu-2204-gen1
-          version: 128.2.20230918
+          version: latest
       osDisk:
         diskSizeGB: 128
         osType: Linux
@@ -254,7 +254,7 @@ spec:
           offer: capi
           publisher: cncf-upstream
           sku: ubuntu-2204-gen1
-          version: 128.2.20230918
+          version: latest
       osDisk:
         diskSizeGB: 128
         osType: Linux

--- a/templates/test/ci/cluster-template-prow-dual-stack.yaml
+++ b/templates/test/ci/cluster-template-prow-dual-stack.yaml
@@ -133,7 +133,7 @@ spec:
     - echo "DNSStubListener=no" >> /etc/systemd/resolved.conf
     - mv /etc/resolv.conf /etc/resolv.conf.OLD && ln -s /run/systemd/resolve/resolv.conf
       /etc/resolv.conf
-    - systemctl restart systemd-resolved
+    - systemctl restart systemd-resolved containerd
     preKubeadmCommands: []
   machineTemplate:
     infrastructureRef:
@@ -251,7 +251,7 @@ spec:
       - echo "DNSStubListener=no" >> /etc/systemd/resolved.conf
       - mv /etc/resolv.conf /etc/resolv.conf.OLD && ln -s /run/systemd/resolve/resolv.conf
         /etc/resolv.conf
-      - systemctl restart systemd-resolved
+      - systemctl restart systemd-resolved containerd
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachinePool
@@ -323,7 +323,7 @@ spec:
   - echo "DNSStubListener=no" >> /etc/systemd/resolved.conf
   - mv /etc/resolv.conf /etc/resolv.conf.OLD && ln -s /run/systemd/resolve/resolv.conf
     /etc/resolv.conf
-  - systemctl restart systemd-resolved
+  - systemctl restart systemd-resolved containerd
 ---
 apiVersion: addons.cluster.x-k8s.io/v1alpha1
 kind: HelmChartProxy

--- a/templates/test/ci/cluster-template-prow-ipv6.yaml
+++ b/templates/test/ci/cluster-template-prow-ipv6.yaml
@@ -140,7 +140,7 @@ spec:
     - echo "DNSStubListener=no" >> /etc/systemd/resolved.conf
     - mv /etc/resolv.conf /etc/resolv.conf.OLD && ln -s /run/systemd/resolve/resolv.conf
       /etc/resolv.conf
-    - systemctl restart systemd-resolved
+    - systemctl restart systemd-resolved containerd
     preKubeadmCommands: []
   machineTemplate:
     infrastructureRef:
@@ -263,7 +263,7 @@ spec:
       - echo "DNSStubListener=no" >> /etc/systemd/resolved.conf
       - mv /etc/resolv.conf /etc/resolv.conf.OLD && ln -s /run/systemd/resolve/resolv.conf
         /etc/resolv.conf
-      - systemctl restart systemd-resolved
+      - systemctl restart systemd-resolved containerd
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachinePool
@@ -345,7 +345,7 @@ spec:
   - echo "DNSStubListener=no" >> /etc/systemd/resolved.conf
   - mv /etc/resolv.conf /etc/resolv.conf.OLD && ln -s /run/systemd/resolve/resolv.conf
     /etc/resolv.conf
-  - systemctl restart systemd-resolved
+  - systemctl restart systemd-resolved containerd
 ---
 apiVersion: addons.cluster.x-k8s.io/v1alpha1
 kind: HelmChartProxy

--- a/templates/test/ci/cluster-template-prow-machine-pool-ci-version.yaml
+++ b/templates/test/ci/cluster-template-prow-machine-pool-ci-version.yaml
@@ -206,7 +206,7 @@ spec:
           offer: capi
           publisher: cncf-upstream
           sku: ubuntu-2204-gen1
-          version: 128.2.20230918
+          version: latest
       osDisk:
         diskSizeGB: 128
         osType: Linux

--- a/templates/test/ci/patches/control-plane-image-ci-version.yaml
+++ b/templates/test/ci/patches/control-plane-image-ci-version.yaml
@@ -12,4 +12,4 @@ spec:
           publisher: cncf-upstream
           offer: capi
           sku: ubuntu-2204-gen1
-          version: "128.2.20230918"
+          version: latest

--- a/templates/test/ci/prow-ci-version-dual-stack/patches/machine-deployment.yaml
+++ b/templates/test/ci/prow-ci-version-dual-stack/patches/machine-deployment.yaml
@@ -19,4 +19,4 @@ spec:
         # This frees up :53 on the host for the coredns pods
         - echo "DNSStubListener=no" >> /etc/systemd/resolved.conf
         - mv /etc/resolv.conf /etc/resolv.conf.OLD && ln -s /run/systemd/resolve/resolv.conf /etc/resolv.conf
-        - systemctl restart systemd-resolved
+        - systemctl restart systemd-resolved containerd

--- a/templates/test/ci/prow-ci-version-ipv6/patches/machine-deployment.yaml
+++ b/templates/test/ci/prow-ci-version-ipv6/patches/machine-deployment.yaml
@@ -9,7 +9,7 @@ spec:
         # This frees up :53 on the host for the coredns pods
         - echo "DNSStubListener=no" >> /etc/systemd/resolved.conf
         - mv /etc/resolv.conf /etc/resolv.conf.OLD && ln -s /run/systemd/resolve/resolv.conf /etc/resolv.conf
-        - systemctl restart systemd-resolved
+        - systemctl restart systemd-resolved containerd
       joinConfiguration:
         nodeRegistration:
           name: '{{ ds.meta_data["local_hostname"] }}'

--- a/templates/test/ci/prow-ci-version/patches/machine-deployment-ci-version.yaml
+++ b/templates/test/ci/prow-ci-version/patches/machine-deployment-ci-version.yaml
@@ -12,4 +12,4 @@ spec:
           publisher: cncf-upstream
           offer: capi
           sku: ubuntu-2204-gen1
-          version: "128.2.20230918"
+          version: "latest"

--- a/templates/test/ci/prow-dual-stack/machine-pool-dualstack.yaml
+++ b/templates/test/ci/prow-dual-stack/machine-pool-dualstack.yaml
@@ -68,4 +68,4 @@ spec:
   - echo "DNSStubListener=no" >> /etc/systemd/resolved.conf
   - mv /etc/resolv.conf /etc/resolv.conf.OLD && ln -s /run/systemd/resolve/resolv.conf
     /etc/resolv.conf
-  - systemctl restart systemd-resolved
+  - systemctl restart systemd-resolved containerd

--- a/templates/test/ci/prow-ipv6/machine-pool-ipv6.yaml
+++ b/templates/test/ci/prow-ipv6/machine-pool-ipv6.yaml
@@ -78,4 +78,4 @@ spec:
   - echo "DNSStubListener=no" >> /etc/systemd/resolved.conf
   - mv /etc/resolv.conf /etc/resolv.conf.OLD && ln -s /run/systemd/resolve/resolv.conf
     /etc/resolv.conf
-  - systemctl restart systemd-resolved
+  - systemctl restart systemd-resolved containerd


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [x] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix containerd and systemd-resolved race condition in ipv6 templates
```
