### PR TITLE
handle clusterctl block-move annotation

### DIFF
--- a/controllers/helpers.go
+++ b/controllers/helpers.go
@@ -44,6 +44,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-azure/util/reconciler"
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	clusterctlv1 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
 	expv1 "sigs.k8s.io/cluster-api/exp/api/v1beta1"
 	capifeature "sigs.k8s.io/cluster-api/feature"
 	"sigs.k8s.io/cluster-api/util"
@@ -1119,4 +1120,30 @@ func GetClusterScoper(ctx context.Context, logger logr.Logger, c client.Client, 
 	}
 
 	return nil, errors.Errorf("unsupported infrastructure type %q, should be AzureCluster or AzureManagedCluster", cluster.Spec.InfrastructureRef.Kind)
+}
+
+// AddBlockMoveAnnotation adds CAPI's block-move annotation and returns whether or not the annotation was added.
+func AddBlockMoveAnnotation(obj metav1.Object) bool {
+	annotations := obj.GetAnnotations()
+
+	if _, exists := annotations[clusterctlv1.BlockMoveAnnotation]; exists {
+		return false
+	}
+
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+
+	// this value doesn't mean anything, only the presence of the annotation matters.
+	annotations[clusterctlv1.BlockMoveAnnotation] = "true"
+	obj.SetAnnotations(annotations)
+
+	return true
+}
+
+// RemoveBlockMoveAnnotation removes CAPI's block-move annotation from the object.
+func RemoveBlockMoveAnnotation(obj metav1.Object) {
+	azClusterAnnotations := obj.GetAnnotations()
+	delete(azClusterAnnotations, clusterctlv1.BlockMoveAnnotation)
+	obj.SetAnnotations(azClusterAnnotations)
 }


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind feature

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

This PR makes CAPZ aware of the clusterctl `clusterctl.cluster.x-k8s.io/block-move` annotation added by https://github.com/kubernetes-sigs/cluster-api/pull/8690 and uses it to block `clusterctl move` when ASO resources have not yet been paused. These changes modify the necessary controllers to add the annotation at the beginning of a "normal" reconciliation and remove it at the end of a "pause" reconciliation.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3839

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

These changes are not expected to build until #4182 or any other CAPI bump to v1.6.0+.

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [ ] includes documentation
- [X] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
CAPZ now adds the `clusterctl.cluster.x-k8s.io/block-move` annotation during `clusterctl move` to better synchronize pause operations
```
