### PR TITLE
[release-1.10] Restart containerd in ipv6 templates when restarting systemd-resolved

### DIFF
--- a/templates/cluster-template-dual-stack.yaml
+++ b/templates/cluster-template-dual-stack.yaml
@@ -128,7 +128,7 @@ spec:
     - echo "DNSStubListener=no" >> /etc/systemd/resolved.conf
     - mv /etc/resolv.conf /etc/resolv.conf.OLD && ln -s /run/systemd/resolve/resolv.conf
       /etc/resolv.conf
-    - systemctl restart systemd-resolved
+    - systemctl restart systemd-resolved containerd
     preKubeadmCommands: []
   machineTemplate:
     infrastructureRef:
@@ -240,4 +240,4 @@ spec:
       - echo "DNSStubListener=no" >> /etc/systemd/resolved.conf
       - mv /etc/resolv.conf /etc/resolv.conf.OLD && ln -s /run/systemd/resolve/resolv.conf
         /etc/resolv.conf
-      - systemctl restart systemd-resolved
+      - systemctl restart systemd-resolved containerd

--- a/templates/cluster-template-ipv6.yaml
+++ b/templates/cluster-template-ipv6.yaml
@@ -133,7 +133,7 @@ spec:
     - echo "DNSStubListener=no" >> /etc/systemd/resolved.conf
     - mv /etc/resolv.conf /etc/resolv.conf.OLD && ln -s /run/systemd/resolve/resolv.conf
       /etc/resolv.conf
-    - systemctl restart systemd-resolved
+    - systemctl restart systemd-resolved containerd
     preKubeadmCommands: []
   machineTemplate:
     infrastructureRef:
@@ -256,4 +256,4 @@ spec:
       - echo "DNSStubListener=no" >> /etc/systemd/resolved.conf
       - mv /etc/resolv.conf /etc/resolv.conf.OLD && ln -s /run/systemd/resolve/resolv.conf
         /etc/resolv.conf
-      - systemctl restart systemd-resolved
+      - systemctl restart systemd-resolved containerd

--- a/templates/flavors/dual-stack/machine-deployment.yaml
+++ b/templates/flavors/dual-stack/machine-deployment.yaml
@@ -49,7 +49,7 @@ spec:
         # This frees up :53 on the host for the coredns pods
         - echo "DNSStubListener=no" >> /etc/systemd/resolved.conf
         - mv /etc/resolv.conf /etc/resolv.conf.OLD && ln -s /run/systemd/resolve/resolv.conf /etc/resolv.conf
-        - systemctl restart systemd-resolved
+        - systemctl restart systemd-resolved containerd
       joinConfiguration:
         nodeRegistration:
           name: '{{ ds.meta_data["local_hostname"] }}'

--- a/templates/flavors/dual-stack/patches/kubeadm-controlplane.yaml
+++ b/templates/flavors/dual-stack/patches/kubeadm-controlplane.yaml
@@ -8,7 +8,7 @@ spec:
       # This frees up :53 on the host for the coredns pods
       - echo "DNSStubListener=no" >> /etc/systemd/resolved.conf
       - mv /etc/resolv.conf /etc/resolv.conf.OLD && ln -s /run/systemd/resolve/resolv.conf /etc/resolv.conf
-      - systemctl restart systemd-resolved
+      - systemctl restart systemd-resolved containerd
     initConfiguration:
       nodeRegistration:
         name: '{{ ds.meta_data["local_hostname"] }}'

--- a/templates/flavors/ipv6/machine-deployment.yaml
+++ b/templates/flavors/ipv6/machine-deployment.yaml
@@ -49,7 +49,7 @@ spec:
         # This frees up :53 on the host for the coredns pods
         - echo "DNSStubListener=no" >> /etc/systemd/resolved.conf
         - mv /etc/resolv.conf /etc/resolv.conf.OLD && ln -s /run/systemd/resolve/resolv.conf /etc/resolv.conf
-        - systemctl restart systemd-resolved
+        - systemctl restart systemd-resolved containerd
       joinConfiguration:
         nodeRegistration:
           name: '{{ ds.meta_data["local_hostname"] }}'

--- a/templates/flavors/ipv6/patches/kubeadm-controlplane.yaml
+++ b/templates/flavors/ipv6/patches/kubeadm-controlplane.yaml
@@ -8,7 +8,7 @@ spec:
       # This frees up :53 on the host for the coredns pods
       - echo "DNSStubListener=no" >> /etc/systemd/resolved.conf
       - mv /etc/resolv.conf /etc/resolv.conf.OLD && ln -s /run/systemd/resolve/resolv.conf /etc/resolv.conf
-      - systemctl restart systemd-resolved
+      - systemctl restart systemd-resolved containerd
     initConfiguration:
       nodeRegistration:
         name: '{{ ds.meta_data["local_hostname"] }}'

--- a/templates/test/ci/cluster-template-prow-dual-stack.yaml
+++ b/templates/test/ci/cluster-template-prow-dual-stack.yaml
@@ -133,7 +133,7 @@ spec:
     - echo "DNSStubListener=no" >> /etc/systemd/resolved.conf
     - mv /etc/resolv.conf /etc/resolv.conf.OLD && ln -s /run/systemd/resolve/resolv.conf
       /etc/resolv.conf
-    - systemctl restart systemd-resolved
+    - systemctl restart systemd-resolved containerd
     preKubeadmCommands: []
   machineTemplate:
     infrastructureRef:
@@ -251,7 +251,7 @@ spec:
       - echo "DNSStubListener=no" >> /etc/systemd/resolved.conf
       - mv /etc/resolv.conf /etc/resolv.conf.OLD && ln -s /run/systemd/resolve/resolv.conf
         /etc/resolv.conf
-      - systemctl restart systemd-resolved
+      - systemctl restart systemd-resolved containerd
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachinePool
@@ -323,4 +323,4 @@ spec:
   - echo "DNSStubListener=no" >> /etc/systemd/resolved.conf
   - mv /etc/resolv.conf /etc/resolv.conf.OLD && ln -s /run/systemd/resolve/resolv.conf
     /etc/resolv.conf
-  - systemctl restart systemd-resolved
+  - systemctl restart systemd-resolved containerd

--- a/templates/test/ci/cluster-template-prow-ipv6.yaml
+++ b/templates/test/ci/cluster-template-prow-ipv6.yaml
@@ -138,7 +138,7 @@ spec:
     - echo "DNSStubListener=no" >> /etc/systemd/resolved.conf
     - mv /etc/resolv.conf /etc/resolv.conf.OLD && ln -s /run/systemd/resolve/resolv.conf
       /etc/resolv.conf
-    - systemctl restart systemd-resolved
+    - systemctl restart systemd-resolved containerd
     preKubeadmCommands: []
   machineTemplate:
     infrastructureRef:
@@ -261,7 +261,7 @@ spec:
       - echo "DNSStubListener=no" >> /etc/systemd/resolved.conf
       - mv /etc/resolv.conf /etc/resolv.conf.OLD && ln -s /run/systemd/resolve/resolv.conf
         /etc/resolv.conf
-      - systemctl restart systemd-resolved
+      - systemctl restart systemd-resolved containerd
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachinePool
@@ -343,4 +343,4 @@ spec:
   - echo "DNSStubListener=no" >> /etc/systemd/resolved.conf
   - mv /etc/resolv.conf /etc/resolv.conf.OLD && ln -s /run/systemd/resolve/resolv.conf
     /etc/resolv.conf
-  - systemctl restart systemd-resolved
+  - systemctl restart systemd-resolved containerd

--- a/templates/test/ci/prow-dual-stack/machine-pool-dualstack.yaml
+++ b/templates/test/ci/prow-dual-stack/machine-pool-dualstack.yaml
@@ -68,4 +68,4 @@ spec:
   - echo "DNSStubListener=no" >> /etc/systemd/resolved.conf
   - mv /etc/resolv.conf /etc/resolv.conf.OLD && ln -s /run/systemd/resolve/resolv.conf
     /etc/resolv.conf
-  - systemctl restart systemd-resolved
+  - systemctl restart systemd-resolved containerd

--- a/templates/test/ci/prow-ipv6/machine-pool-ipv6.yaml
+++ b/templates/test/ci/prow-ipv6/machine-pool-ipv6.yaml
@@ -78,4 +78,4 @@ spec:
   - echo "DNSStubListener=no" >> /etc/systemd/resolved.conf
   - mv /etc/resolv.conf /etc/resolv.conf.OLD && ln -s /run/systemd/resolve/resolv.conf
     /etc/resolv.conf
-  - systemctl restart systemd-resolved
+  - systemctl restart systemd-resolved containerd


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

/kind failing-test

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**: Cherry-pick part of https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/4209 (the ci-version templates only exist in the main branch so this wasn't a clean cherry-pick).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Restart containerd in ipv6 templates when restarting systemd-resolved
```
