### PR TITLE
remove redundant natgateway's Service struct

### DIFF
--- a/azure/services/natgateways/natgateways.go
+++ b/azure/services/natgateways/natgateways.go
@@ -35,22 +35,13 @@ type NatGatewayScope interface {
 	NatGatewaySpecs() []azure.ASOResourceSpecGetter[*asonetworkv1.NatGateway]
 }
 
-// Service provides operations on azure resources.
-type Service struct {
-	Scope NatGatewayScope
-	*aso.Service[*asonetworkv1.NatGateway, NatGatewayScope]
-}
-
 // New creates a new service.
-func New(scope NatGatewayScope) *Service {
+func New(scope NatGatewayScope) *aso.Service[*asonetworkv1.NatGateway, NatGatewayScope] {
 	svc := aso.NewService[*asonetworkv1.NatGateway, NatGatewayScope](serviceName, scope)
 	svc.Specs = scope.NatGatewaySpecs()
 	svc.ConditionType = infrav1.NATGatewaysReadyCondition
 	svc.PostCreateOrUpdateResourceHook = postCreateOrUpdateResourceHook
-	return &Service{
-		Scope:   scope,
-		Service: svc,
-	}
+	return svc
 }
 
 func postCreateOrUpdateResourceHook(_ context.Context, scope NatGatewayScope, result *asonetworkv1.NatGateway, err error) error {


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind cleanup

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change

/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
- This PR removes the redundant Service Struct in `NatGateways_service.go`
- This change branches off of the comment at https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/4108/files#r1379399365

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
