### PR TITLE
Set correct fqdn on private cluster

### DIFF
--- a/azure/services/managedclusters/managedclusters.go
+++ b/azure/services/managedclusters/managedclusters.go
@@ -109,6 +109,14 @@ func (s *Service) Reconcile(ctx context.Context) error {
 			Host: ptr.Deref(managedCluster.Properties.Fqdn, ""),
 			Port: 443,
 		}
+		if managedCluster.Properties.APIServerAccessProfile != nil &&
+			ptr.Deref(managedCluster.Properties.APIServerAccessProfile.EnablePrivateCluster, false) &&
+			!ptr.Deref(managedCluster.Properties.APIServerAccessProfile.EnablePrivateClusterPublicFQDN, false) {
+			endpoint = clusterv1.APIEndpoint{
+				Host: ptr.Deref(managedCluster.Properties.PrivateFQDN, ""),
+				Port: 443,
+			}
+		}
 		s.Scope.SetControlPlaneEndpoint(endpoint)
 
 		// Update kubeconfig data

--- a/azure/services/managedclusters/managedclusters_test.go
+++ b/azure/services/managedclusters/managedclusters_test.go
@@ -103,6 +103,48 @@ func TestReconcile(t *testing.T) {
 			},
 		},
 		{
+			name:          "create managed private cluster succeeds",
+			expectedError: "",
+			expect: func(m *mock_managedclusters.MockCredentialGetterMockRecorder, s *mock_managedclusters.MockManagedClusterScopeMockRecorder, r *mock_async.MockReconcilerMockRecorder) {
+				var userKubeConfigData []byte
+				s.ManagedClusterSpec().Return(fakeManagedClusterSpec)
+				r.CreateOrUpdateResource(gomockinternal.AContext(), fakeManagedClusterSpec, serviceName).Return(armcontainerservice.ManagedCluster{
+					Properties: &armcontainerservice.ManagedClusterProperties{
+						APIServerAccessProfile: &armcontainerservice.ManagedClusterAPIServerAccessProfile{
+							EnablePrivateCluster:           ptr.To(true),
+							EnablePrivateClusterPublicFQDN: ptr.To(false),
+						},
+						PrivateFQDN:       ptr.To("my-managedcluster-fqdn.private"),
+						ProvisioningState: ptr.To("Succeeded"),
+						IdentityProfile: map[string]*armcontainerservice.UserAssignedIdentity{
+							kubeletIdentityKey: {
+								ResourceID: ptr.To("kubelet-id"),
+							},
+						},
+						OidcIssuerProfile: &armcontainerservice.ManagedClusterOIDCIssuerProfile{
+							Enabled:   ptr.To(true),
+							IssuerURL: ptr.To("oidc issuer url"),
+						},
+					},
+				}, nil)
+				s.SetControlPlaneEndpoint(clusterv1.APIEndpoint{
+					Host: "my-managedcluster-fqdn.private",
+					Port: 443,
+				})
+				s.IsAADEnabled().Return(false)
+				s.AreLocalAccountsDisabled().Return(false)
+				m.GetCredentials(gomockinternal.AContext(), "my-rg", "my-managedcluster").Return([]byte("credentials"), nil)
+				s.SetAdminKubeconfigData([]byte("credentials"))
+				s.SetUserKubeconfigData(userKubeConfigData)
+				s.SetKubeletIdentity("kubelet-id")
+				s.SetOIDCIssuerProfileStatus(nil)
+				s.SetOIDCIssuerProfileStatus(&infrav1.OIDCIssuerProfileStatus{
+					IssuerURL: ptr.To("oidc issuer url"),
+				})
+				s.UpdatePutStatus(infrav1.ManagedClusterRunningCondition, serviceName, nil)
+			},
+		},
+		{
 			name:          "create managed cluster succeeds with user kubeconfig",
 			expectedError: "",
 			expect: func(m *mock_managedclusters.MockCredentialGetterMockRecorder, s *mock_managedclusters.MockManagedClusterScopeMockRecorder, r *mock_async.MockReconcilerMockRecorder) {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug


**What this PR does / why we need it**:
On private cluster with the managedcontrolplane
- EnablePrivateCluster: true
- EnablePrivateClusterPublicFQDN: false
The fqdn property is not available. The cluster defaults to the `privateFQDN`
The Cluster resource remains in provisioning state due to the capz error 
``` 
spec.controlPlaneEndpoint.host: Required value" "AzureManagedCluster"
```

**TODOs**:

- [X] squashed commits
- [X] includes documentation
- [X] adds unit tests

**Release note**:

```release-note
 Fix: Set correct host on private cluster with public fqdn disabled
```
