### PR TITLE
Revert "workaround cloud provider chart federated token bug"

### DIFF
--- a/scripts/ci-entrypoint.sh
+++ b/scripts/ci-entrypoint.sh
@@ -209,7 +209,6 @@ install_cloud_provider_azure() {
         --set cloudControllerManager.cloudConfig="${CLOUD_CONFIG}" \
         --set cloudControllerManager.cloudConfigSecretName="${CONFIG_SECRET_NAME}" \
         --set cloudControllerManager.logVerbosity="${CCM_LOG_VERBOSITY}" \
-        --set-string cloudControllerManager.federatedTokenPath= \
         --set-string cloudControllerManager.clusterCIDR="${CCM_CLUSTER_CIDR}" "${CCM_IMG_ARGS[@]}" || return 1
 }
 

--- a/test/e2e/cloud-provider-azure.go
+++ b/test/e2e/cloud-provider-azure.go
@@ -48,10 +48,7 @@ func InstallCNIAndCloudProviderAzureHelmChart(ctx context.Context, input cluster
 			fmt.Sprintf("infra.clusterName=%s", input.ClusterName),
 			"cloudControllerManager.logVerbosity=4",
 		},
-		StringValues: []string{
-			fmt.Sprintf("cloudControllerManager.clusterCIDR=%s", strings.Join(cidrBlocks, `\,`)),
-			"cloudControllerManager.federatedTokenPath=",
-		},
+		StringValues: []string{fmt.Sprintf("cloudControllerManager.clusterCIDR=%s", strings.Join(cidrBlocks, `\,`))},
 	}
 	// If testing a CI version of Kubernetes, use CCM and CNM images built from source.
 	if useCIArtifacts || usePRArtifacts {


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind cleanup

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

This reverts commit d6420d060ef9769c0a8931742e9e02f1cb891bb2 (#4226) since the cloud-provider Helm chart has been updated (https://github.com/kubernetes-sigs/cloud-provider-azure/pull/4921).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [X] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
