### PR TITLE
Remove usage of autorest.NullAuthorizer

### DIFF
--- a/azure/scope/clients_test.go
+++ b/azure/scope/clients_test.go
@@ -19,7 +19,6 @@ package scope
 import (
 	"testing"
 
-	"github.com/Azure/go-autorest/autorest"
 	. "github.com/onsi/gomega"
 )
 
@@ -67,9 +66,7 @@ func TestGettingEnvironment(t *testing.T) {
 		}}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			c := AzureClients{
-				Authorizer: autorest.NullAuthorizer{},
-			}
+			c := AzureClients{}
 			err := c.setCredentials("1234", test.azureEnv)
 			if test.expectedError {
 				g.Expect(err).To(HaveOccurred())

--- a/azure/scope/cluster_test.go
+++ b/azure/scope/cluster_test.go
@@ -24,7 +24,6 @@ import (
 	"testing"
 
 	asonetworkv1 "github.com/Azure/azure-service-operator/v2/api/network/v1api20220701"
-	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/azure/auth"
 	"github.com/google/go-cmp/cmp"
 	. "github.com/onsi/gomega"
@@ -174,9 +173,6 @@ func TestAPIServerHost(t *testing.T) {
 		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(initObjects...).Build()
 
 		clusterScope, err := NewClusterScope(context.TODO(), ClusterScopeParams{
-			AzureClients: AzureClients{
-				Authorizer: autorest.NullAuthorizer{},
-			},
 			Cluster:      cluster,
 			AzureCluster: &tc.azureCluster,
 			Client:       fakeClient,
@@ -233,9 +229,6 @@ func TestGettingSecurityRules(t *testing.T) {
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(initObjects...).Build()
 
 	clusterScope, err := NewClusterScope(context.TODO(), ClusterScopeParams{
-		AzureClients: AzureClients{
-			Authorizer: autorest.NullAuthorizer{},
-		},
 		Cluster:      cluster,
 		AzureCluster: azureCluster,
 		Client:       fakeClient,
@@ -764,9 +757,6 @@ func TestPublicIPSpecs(t *testing.T) {
 			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(initObjects...).Build()
 
 			clusterScope, err := NewClusterScope(context.TODO(), ClusterScopeParams{
-				AzureClients: AzureClients{
-					Authorizer: autorest.NullAuthorizer{},
-				},
 				Cluster:      cluster,
 				AzureCluster: tc.azureCluster,
 				Client:       fakeClient,
@@ -1826,9 +1816,6 @@ func TestSubnet(t *testing.T) {
 			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(initObjects...).Build()
 
 			clusterScope, err := NewClusterScope(context.TODO(), ClusterScopeParams{
-				AzureClients: AzureClients{
-					Authorizer: autorest.NullAuthorizer{},
-				},
 				Cluster:      cluster,
 				AzureCluster: azureCluster,
 				Client:       fakeClient,
@@ -1925,9 +1912,6 @@ func TestControlPlaneRouteTable(t *testing.T) {
 			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(initObjects...).Build()
 
 			clusterScope, err := NewClusterScope(context.TODO(), ClusterScopeParams{
-				AzureClients: AzureClients{
-					Authorizer: autorest.NullAuthorizer{},
-				},
 				Cluster:      cluster,
 				AzureCluster: azureCluster,
 				Client:       fakeClient,
@@ -1994,9 +1978,6 @@ func TestGetPrivateDNSZoneName(t *testing.T) {
 			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(initObjects...).Build()
 
 			clusterScope, err := NewClusterScope(context.TODO(), ClusterScopeParams{
-				AzureClients: AzureClients{
-					Authorizer: autorest.NullAuthorizer{},
-				},
 				Cluster:      cluster,
 				AzureCluster: azureCluster,
 				Client:       fakeClient,
@@ -2064,9 +2045,6 @@ func TestAPIServerLBPoolName(t *testing.T) {
 			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(initObjects...).Build()
 
 			clusterScope, err := NewClusterScope(context.TODO(), ClusterScopeParams{
-				AzureClients: AzureClients{
-					Authorizer: autorest.NullAuthorizer{},
-				},
 				Cluster:      cluster,
 				AzureCluster: azureCluster,
 				Client:       fakeClient,
@@ -2205,9 +2183,6 @@ func TestOutboundLBName(t *testing.T) {
 			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(initObjects...).Build()
 
 			clusterScope, err := NewClusterScope(context.TODO(), ClusterScopeParams{
-				AzureClients: AzureClients{
-					Authorizer: autorest.NullAuthorizer{},
-				},
 				Cluster:      cluster,
 				AzureCluster: azureCluster,
 				Client:       fakeClient,
@@ -2334,9 +2309,6 @@ func TestBackendPoolName(t *testing.T) {
 			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(initObjects...).Build()
 
 			clusterScope, err := NewClusterScope(context.TODO(), ClusterScopeParams{
-				AzureClients: AzureClients{
-					Authorizer: autorest.NullAuthorizer{},
-				},
 				Cluster:      cluster,
 				AzureCluster: azureCluster,
 				Client:       fakeClient,
@@ -2426,9 +2398,6 @@ func TestOutboundPoolName(t *testing.T) {
 			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(initObjects...).Build()
 
 			clusterScope, err := NewClusterScope(context.TODO(), ClusterScopeParams{
-				AzureClients: AzureClients{
-					Authorizer: autorest.NullAuthorizer{},
-				},
 				Cluster:      cluster,
 				AzureCluster: azureCluster,
 				Client:       fakeClient,
@@ -2508,9 +2477,6 @@ func TestGenerateFQDN(t *testing.T) {
 			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(initObjects...).Build()
 
 			clusterScope, err := NewClusterScope(context.TODO(), ClusterScopeParams{
-				AzureClients: AzureClients{
-					Authorizer: autorest.NullAuthorizer{},
-				},
 				Cluster:      cluster,
 				AzureCluster: azureCluster,
 				Client:       fakeClient,
@@ -2596,9 +2562,6 @@ func TestAdditionalTags(t *testing.T) {
 			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(initObjects...).Build()
 
 			clusterScope, err := NewClusterScope(context.TODO(), ClusterScopeParams{
-				AzureClients: AzureClients{
-					Authorizer: autorest.NullAuthorizer{},
-				},
 				Cluster:      cluster,
 				AzureCluster: azureCluster,
 				Client:       fakeClient,
@@ -2675,9 +2638,6 @@ func TestAPIServerPort(t *testing.T) {
 			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(initObjects...).Build()
 
 			clusterScope, err := NewClusterScope(context.TODO(), ClusterScopeParams{
-				AzureClients: AzureClients{
-					Authorizer: autorest.NullAuthorizer{},
-				},
 				Cluster:      cluster,
 				AzureCluster: azureCluster,
 				Client:       fakeClient,
@@ -2760,9 +2720,6 @@ func TestFailureDomains(t *testing.T) {
 			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(initObjects...).Build()
 
 			clusterScope, err := NewClusterScope(context.TODO(), ClusterScopeParams{
-				AzureClients: AzureClients{
-					Authorizer: autorest.NullAuthorizer{},
-				},
 				Cluster:      cluster,
 				AzureCluster: azureCluster,
 				Client:       fakeClient,
@@ -3040,9 +2997,6 @@ func TestClusterScope_LBSpecs(t *testing.T) {
 			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(initObjects...).Build()
 
 			clusterScope, err := NewClusterScope(context.TODO(), ClusterScopeParams{
-				AzureClients: AzureClients{
-					Authorizer: autorest.NullAuthorizer{},
-				},
 				Cluster:      cluster,
 				AzureCluster: tc.azureCluster,
 				Client:       fakeClient,
@@ -3118,9 +3072,6 @@ func TestExtendedLocationName(t *testing.T) {
 			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(initObjects...).Build()
 
 			clusterScope, err := NewClusterScope(context.TODO(), ClusterScopeParams{
-				AzureClients: AzureClients{
-					Authorizer: autorest.NullAuthorizer{},
-				},
 				Cluster:      cluster,
 				AzureCluster: azureCluster,
 				Client:       fakeClient,
@@ -3196,9 +3147,6 @@ func TestExtendedLocationType(t *testing.T) {
 			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(initObjects...).Build()
 
 			clusterScope, err := NewClusterScope(context.TODO(), ClusterScopeParams{
-				AzureClients: AzureClients{
-					Authorizer: autorest.NullAuthorizer{},
-				},
 				Cluster:      cluster,
 				AzureCluster: azureCluster,
 				Client:       fakeClient,
@@ -3429,9 +3377,6 @@ func TestVNetPeerings(t *testing.T) {
 			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(initObjects...).Build()
 
 			clusterScope, err := NewClusterScope(context.TODO(), ClusterScopeParams{
-				AzureClients: AzureClients{
-					Authorizer: autorest.NullAuthorizer{},
-				},
 				Cluster:      cluster,
 				AzureCluster: azureCluster,
 				Client:       fakeClient,

--- a/azure/scope/managedcontrolplane_test.go
+++ b/azure/scope/managedcontrolplane_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/Azure/go-autorest/autorest"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -109,9 +108,6 @@ func TestManagedControlPlaneScope_PoolVersion(t *testing.T) {
 		{
 			Name: "Without Version",
 			Input: ManagedControlPlaneScopeParams{
-				AzureClients: AzureClients{
-					Authorizer: autorest.NullAuthorizer{},
-				},
 				Cluster: &clusterv1.Cluster{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "cluster1",
@@ -149,9 +145,6 @@ func TestManagedControlPlaneScope_PoolVersion(t *testing.T) {
 		{
 			Name: "With Version",
 			Input: ManagedControlPlaneScopeParams{
-				AzureClients: AzureClients{
-					Authorizer: autorest.NullAuthorizer{},
-				},
 				Cluster: &clusterv1.Cluster{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "cluster1",
@@ -191,9 +184,6 @@ func TestManagedControlPlaneScope_PoolVersion(t *testing.T) {
 		{
 			Name: "With bad version",
 			Input: ManagedControlPlaneScopeParams{
-				AzureClients: AzureClients{
-					Authorizer: autorest.NullAuthorizer{},
-				},
 				Cluster: &clusterv1.Cluster{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "cluster1",
@@ -252,9 +242,6 @@ func TestManagedControlPlaneScope_AddonProfiles(t *testing.T) {
 		{
 			Name: "Without add-ons",
 			Input: ManagedControlPlaneScopeParams{
-				AzureClients: AzureClients{
-					Authorizer: autorest.NullAuthorizer{},
-				},
 				Cluster: &clusterv1.Cluster{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "cluster1",
@@ -282,9 +269,6 @@ func TestManagedControlPlaneScope_AddonProfiles(t *testing.T) {
 		{
 			Name: "With add-ons",
 			Input: ManagedControlPlaneScopeParams{
-				AzureClients: AzureClients{
-					Authorizer: autorest.NullAuthorizer{},
-				},
 				Cluster: &clusterv1.Cluster{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "cluster1",
@@ -346,9 +330,6 @@ func TestManagedControlPlaneScope_OSType(t *testing.T) {
 		{
 			Name: "with Linux and Windows pools",
 			Input: ManagedControlPlaneScopeParams{
-				AzureClients: AzureClients{
-					Authorizer: autorest.NullAuthorizer{},
-				},
 				Cluster: &clusterv1.Cluster{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "cluster1",
@@ -415,9 +396,6 @@ func TestManagedControlPlaneScope_OSType(t *testing.T) {
 		{
 			Name: "system pool required",
 			Input: ManagedControlPlaneScopeParams{
-				AzureClients: AzureClients{
-					Authorizer: autorest.NullAuthorizer{},
-				},
 				Cluster: &clusterv1.Cluster{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "cluster1",
@@ -486,9 +464,6 @@ func TestManagedControlPlaneScope_IsVnetManagedCache(t *testing.T) {
 		{
 			Name: "no Cache value",
 			Input: ManagedControlPlaneScopeParams{
-				AzureClients: AzureClients{
-					Authorizer: autorest.NullAuthorizer{},
-				},
 				Cluster: &clusterv1.Cluster{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "cluster1",
@@ -522,9 +497,6 @@ func TestManagedControlPlaneScope_IsVnetManagedCache(t *testing.T) {
 		{
 			Name: "with Cache value of true",
 			Input: ManagedControlPlaneScopeParams{
-				AzureClients: AzureClients{
-					Authorizer: autorest.NullAuthorizer{},
-				},
 				Cluster: &clusterv1.Cluster{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "cluster1",
@@ -560,9 +532,6 @@ func TestManagedControlPlaneScope_IsVnetManagedCache(t *testing.T) {
 		{
 			Name: "with Cache value of false",
 			Input: ManagedControlPlaneScopeParams{
-				AzureClients: AzureClients{
-					Authorizer: autorest.NullAuthorizer{},
-				},
 				Cluster: &clusterv1.Cluster{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "cluster1",
@@ -623,9 +592,6 @@ func TestManagedControlPlaneScope_AADProfile(t *testing.T) {
 		{
 			Name: "Without AADProfile",
 			Input: ManagedControlPlaneScopeParams{
-				AzureClients: AzureClients{
-					Authorizer: autorest.NullAuthorizer{},
-				},
 				Cluster: &clusterv1.Cluster{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "cluster1",
@@ -653,9 +619,6 @@ func TestManagedControlPlaneScope_AADProfile(t *testing.T) {
 		{
 			Name: "With AADProfile",
 			Input: ManagedControlPlaneScopeParams{
-				AzureClients: AzureClients{
-					Authorizer: autorest.NullAuthorizer{},
-				},
 				Cluster: &clusterv1.Cluster{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "cluster1",
@@ -717,9 +680,6 @@ func TestManagedControlPlaneScope_DisableLocalAccounts(t *testing.T) {
 		{
 			Name: "Without DisableLocalAccounts",
 			Input: ManagedControlPlaneScopeParams{
-				AzureClients: AzureClients{
-					Authorizer: autorest.NullAuthorizer{},
-				},
 				Cluster: &clusterv1.Cluster{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "cluster1",
@@ -747,9 +707,6 @@ func TestManagedControlPlaneScope_DisableLocalAccounts(t *testing.T) {
 		{
 			Name: "Without AAdProfile and With DisableLocalAccounts",
 			Input: ManagedControlPlaneScopeParams{
-				AzureClients: AzureClients{
-					Authorizer: autorest.NullAuthorizer{},
-				},
 				Cluster: &clusterv1.Cluster{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "cluster1",
@@ -778,9 +735,6 @@ func TestManagedControlPlaneScope_DisableLocalAccounts(t *testing.T) {
 		{
 			Name: "With AAdProfile and With DisableLocalAccounts",
 			Input: ManagedControlPlaneScopeParams{
-				AzureClients: AzureClients{
-					Authorizer: autorest.NullAuthorizer{},
-				},
 				Cluster: &clusterv1.Cluster{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "cluster1",
@@ -839,9 +793,6 @@ func TestIsAADEnabled(t *testing.T) {
 		{
 			Name: "AAD is not enabled",
 			Input: ManagedControlPlaneScopeParams{
-				AzureClients: AzureClients{
-					Authorizer: autorest.NullAuthorizer{},
-				},
 				Cluster: &clusterv1.Cluster{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "cluster1",
@@ -869,9 +820,6 @@ func TestIsAADEnabled(t *testing.T) {
 		{
 			Name: "AAdProfile and With DisableLocalAccounts",
 			Input: ManagedControlPlaneScopeParams{
-				AzureClients: AzureClients{
-					Authorizer: autorest.NullAuthorizer{},
-				},
 				Cluster: &clusterv1.Cluster{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "cluster1",
@@ -928,9 +876,6 @@ func TestAreLocalAccountsDisabled(t *testing.T) {
 		{
 			Name: "DisbaleLocalAccount is not enabled",
 			Input: ManagedControlPlaneScopeParams{
-				AzureClients: AzureClients{
-					Authorizer: autorest.NullAuthorizer{},
-				},
 				Cluster: &clusterv1.Cluster{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "cluster1",
@@ -958,9 +903,6 @@ func TestAreLocalAccountsDisabled(t *testing.T) {
 		{
 			Name: "With AAdProfile and Without DisableLocalAccounts",
 			Input: ManagedControlPlaneScopeParams{
-				AzureClients: AzureClients{
-					Authorizer: autorest.NullAuthorizer{},
-				},
 				Cluster: &clusterv1.Cluster{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "cluster1",
@@ -992,9 +934,6 @@ func TestAreLocalAccountsDisabled(t *testing.T) {
 		{
 			Name: "With AAdProfile and With DisableLocalAccounts",
 			Input: ManagedControlPlaneScopeParams{
-				AzureClients: AzureClients{
-					Authorizer: autorest.NullAuthorizer{},
-				},
 				Cluster: &clusterv1.Cluster{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "cluster1",

--- a/controllers/azuremachine_controller_test.go
+++ b/controllers/azuremachine_controller_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Azure/go-autorest/autorest"
 	. "github.com/onsi/gomega"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
@@ -729,9 +728,6 @@ func TestConditions(t *testing.T) {
 			reconciler := NewAzureMachineReconciler(client, recorder, reconciler.DefaultLoopTimeout, "")
 
 			clusterScope, err := scope.NewClusterScope(context.TODO(), scope.ClusterScopeParams{
-				AzureClients: scope.AzureClients{
-					Authorizer: autorest.NullAuthorizer{},
-				},
 				Client:       client,
 				Cluster:      cluster,
 				AzureCluster: azureCluster,

--- a/controllers/helpers_test.go
+++ b/controllers/helpers_test.go
@@ -23,7 +23,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/azure/auth"
 	"github.com/go-logr/logr"
 	"github.com/google/go-cmp/cmp"
@@ -179,9 +178,6 @@ func TestGetCloudProviderConfig(t *testing.T) {
 			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(initObjects...).Build()
 
 			clusterScope, err := scope.NewClusterScope(context.Background(), scope.ClusterScopeParams{
-				AzureClients: scope.AzureClients{
-					Authorizer: autorest.NullAuthorizer{},
-				},
 				Cluster:      tc.cluster,
 				AzureCluster: tc.azureCluster,
 				Client:       fakeClient,
@@ -288,9 +284,6 @@ func TestReconcileAzureSecret(t *testing.T) {
 	kubeclient := fake.NewClientBuilder().WithScheme(scheme).Build()
 
 	clusterScope, err := scope.NewClusterScope(context.Background(), scope.ClusterScopeParams{
-		AzureClients: scope.AzureClients{
-			Authorizer: autorest.NullAuthorizer{},
-		},
 		Cluster:      cluster,
 		AzureCluster: azureCluster,
 		Client:       kubeclient,


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Removes unit test usage of `autorest.NullAuthorizer` as it is no longer accessed and the go-autorest project is unsupported now.

**Which issue(s) this PR fixes**:

Refs #2974

**Special notes for your reviewer**:

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:

```release-note
NONE
```
