### PR TITLE
[release-1.10] Set correct fqdn on private cluster

### DIFF
--- a/azure/services/managedclusters/managedclusters.go
+++ b/azure/services/managedclusters/managedclusters.go
@@ -93,6 +93,14 @@ func (s *Service) Reconcile(ctx context.Context) error {
 			Host: pointer.StringDeref(managedCluster.ManagedClusterProperties.Fqdn, ""),
 			Port: 443,
 		}
+		if managedCluster.ManagedClusterProperties.APIServerAccessProfile != nil &&
+			pointer.BoolDeref(managedCluster.ManagedClusterProperties.APIServerAccessProfile.EnablePrivateCluster, false) &&
+			!pointer.BoolDeref(managedCluster.ManagedClusterProperties.APIServerAccessProfile.EnablePrivateClusterPublicFQDN, false) {
+			endpoint = clusterv1.APIEndpoint{
+				Host: pointer.StringDeref(managedCluster.ManagedClusterProperties.PrivateFQDN, ""),
+				Port: 443,
+			}
+		}
 		s.Scope.SetControlPlaneEndpoint(endpoint)
 
 		// Update kubeconfig data


### PR DESCRIPTION
**What type of PR is this?**
Adapted from https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/4225
/kind bug


**What this PR does / why we need it**:
On private cluster with the managedcontrolplane
- EnablePrivateCluster: true
- EnablePrivateClusterPublicFQDN: false
The fqdn property is not available. The cluster defaults to the `privateFQDN`
The Cluster resource remains in provisioning state due to the capz error 
``` 
spec.controlPlaneEndpoint.host: Required value" "AzureManagedCluster"
```
**Special notes for your reviewer**:

- [x] cherry-pick candidate
- to cherry-pick into release-1.11

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [X] includes documentation
- [X] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
 Fix: Set correct host on private cluster with public fqdn disabled
```
