### PR TITLE
Install cloud provider azure Helm chart with CAAPH

### DIFF
--- a/templates/addons/cluster-api-helm/cloud-provider-azure-ci.yaml
+++ b/templates/addons/cluster-api-helm/cloud-provider-azure-ci.yaml
@@ -1,0 +1,24 @@
+apiVersion: addons.cluster.x-k8s.io/v1alpha1
+kind: HelmChartProxy
+metadata:
+  name: cloud-provider-azure-chart-ci
+spec:
+  clusterSelector:
+    matchLabels:
+      cloud-provider: "azure-ci"
+  repoURL: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/helm/repo
+  chartName: cloud-provider-azure
+  releaseName: cloud-provider-azure
+  valuesTemplate: |
+    infra:
+      clusterName: {{ .Cluster.metadata.name }}
+    cloudControllerManager:
+      clusterCIDR: {{ .Cluster.spec.clusterNetwork.pods.cidrBlocks | join "," }}
+      imageName: ${CCM_IMAGE_NAME}
+      imageRepository: ${CCM_IMAGE_REGISTRY}
+      imageTag: ${IMAGE_TAG_CCM}
+      logVerbosity: 4
+    cloudNodeManager:
+      imageName: ${CNM_IMAGE_NAME}
+      imageRepository: ${CNM_IMAGE_REGISTRY}
+      imageTag: ${IMAGE_TAG_CCM}

--- a/templates/addons/cluster-api-helm/cloud-provider-azure.yaml
+++ b/templates/addons/cluster-api-helm/cloud-provider-azure.yaml
@@ -1,0 +1,17 @@
+apiVersion: addons.cluster.x-k8s.io/v1alpha1
+kind: HelmChartProxy
+metadata:
+  name: cloud-provider-azure-chart
+spec:
+  clusterSelector:
+    matchLabels:
+      cloud-provider: "azure"
+  repoURL: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/helm/repo
+  chartName: cloud-provider-azure
+  releaseName: cloud-provider-azure
+  valuesTemplate: |
+    infra:
+      clusterName: {{ .Cluster.metadata.name }}
+    cloudControllerManager:
+      clusterCIDR: {{ .Cluster.spec.clusterNetwork.pods.cidrBlocks | join "," }}
+      logVerbosity: 4

--- a/templates/test/ci/cluster-template-prow-azure-cni-v1.yaml
+++ b/templates/test/ci/cluster-template-prow-azure-cni-v1.yaml
@@ -3,6 +3,7 @@ kind: Cluster
 metadata:
   labels:
     azuredisk-csi: "true"
+    cloud-provider: ${CLOUD_PROVIDER_AZURE_LABEL}
   name: ${CLUSTER_NAME}
   namespace: default
 spec:
@@ -242,3 +243,48 @@ spec:
       runOnControlPlane: true
     windows:
       useHostProcessContainers: {{ hasKey .Cluster.metadata.labels "cni-windows" }}
+---
+apiVersion: addons.cluster.x-k8s.io/v1alpha1
+kind: HelmChartProxy
+metadata:
+  name: cloud-provider-azure-chart
+  namespace: default
+spec:
+  chartName: cloud-provider-azure
+  clusterSelector:
+    matchLabels:
+      cloud-provider: azure
+  releaseName: cloud-provider-azure
+  repoURL: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/helm/repo
+  valuesTemplate: |-
+    infra:
+      clusterName: {{ .Cluster.metadata.name }}
+    cloudControllerManager:
+      clusterCIDR: {{ .Cluster.spec.clusterNetwork.pods.cidrBlocks | join "," }}
+      logVerbosity: 4
+---
+apiVersion: addons.cluster.x-k8s.io/v1alpha1
+kind: HelmChartProxy
+metadata:
+  name: cloud-provider-azure-chart-ci
+  namespace: default
+spec:
+  chartName: cloud-provider-azure
+  clusterSelector:
+    matchLabels:
+      cloud-provider: azure-ci
+  releaseName: cloud-provider-azure
+  repoURL: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/helm/repo
+  valuesTemplate: |-
+    infra:
+      clusterName: {{ .Cluster.metadata.name }}
+    cloudControllerManager:
+      clusterCIDR: {{ .Cluster.spec.clusterNetwork.pods.cidrBlocks | join "," }}
+      imageName: ${CCM_IMAGE_NAME}
+      imageRepository: ${CCM_IMAGE_REGISTRY}
+      imageTag: ${IMAGE_TAG_CCM}
+      logVerbosity: 4
+    cloudNodeManager:
+      imageName: ${CNM_IMAGE_NAME}
+      imageRepository: ${CNM_IMAGE_REGISTRY}
+      imageTag: ${IMAGE_TAG_CCM}

--- a/templates/test/ci/cluster-template-prow-ci-version-dual-stack.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version-dual-stack.yaml
@@ -3,6 +3,7 @@ kind: Cluster
 metadata:
   labels:
     azuredisk-csi: "true"
+    cloud-provider: ${CLOUD_PROVIDER_AZURE_LABEL}
     cni: calico-dual-stack
     cni-windows: ${CLUSTER_NAME}-calico
     containerd-logger: disabled
@@ -514,6 +515,51 @@ spec:
       runOnControlPlane: true
     windows:
       useHostProcessContainers: {{ hasKey .Cluster.metadata.labels "cni-windows" }}
+---
+apiVersion: addons.cluster.x-k8s.io/v1alpha1
+kind: HelmChartProxy
+metadata:
+  name: cloud-provider-azure-chart
+  namespace: default
+spec:
+  chartName: cloud-provider-azure
+  clusterSelector:
+    matchLabels:
+      cloud-provider: azure
+  releaseName: cloud-provider-azure
+  repoURL: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/helm/repo
+  valuesTemplate: |-
+    infra:
+      clusterName: {{ .Cluster.metadata.name }}
+    cloudControllerManager:
+      clusterCIDR: {{ .Cluster.spec.clusterNetwork.pods.cidrBlocks | join "," }}
+      logVerbosity: 4
+---
+apiVersion: addons.cluster.x-k8s.io/v1alpha1
+kind: HelmChartProxy
+metadata:
+  name: cloud-provider-azure-chart-ci
+  namespace: default
+spec:
+  chartName: cloud-provider-azure
+  clusterSelector:
+    matchLabels:
+      cloud-provider: azure-ci
+  releaseName: cloud-provider-azure
+  repoURL: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/helm/repo
+  valuesTemplate: |-
+    infra:
+      clusterName: {{ .Cluster.metadata.name }}
+    cloudControllerManager:
+      clusterCIDR: {{ .Cluster.spec.clusterNetwork.pods.cidrBlocks | join "," }}
+      imageName: ${CCM_IMAGE_NAME}
+      imageRepository: ${CCM_IMAGE_REGISTRY}
+      imageTag: ${IMAGE_TAG_CCM}
+      logVerbosity: 4
+    cloudNodeManager:
+      imageName: ${CNM_IMAGE_NAME}
+      imageRepository: ${CNM_IMAGE_REGISTRY}
+      imageTag: ${IMAGE_TAG_CCM}
 ---
 apiVersion: v1
 data:

--- a/templates/test/ci/cluster-template-prow-ci-version-ipv6.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version-ipv6.yaml
@@ -3,6 +3,7 @@ kind: Cluster
 metadata:
   labels:
     azuredisk-csi: "true"
+    cloud-provider: ${CLOUD_PROVIDER_AZURE_LABEL}
     cni: calico-ipv6
     cni-windows: ${CLUSTER_NAME}-calico
     containerd-logger: disabled
@@ -532,6 +533,51 @@ spec:
       runOnControlPlane: true
     windows:
       useHostProcessContainers: {{ hasKey .Cluster.metadata.labels "cni-windows" }}
+---
+apiVersion: addons.cluster.x-k8s.io/v1alpha1
+kind: HelmChartProxy
+metadata:
+  name: cloud-provider-azure-chart
+  namespace: default
+spec:
+  chartName: cloud-provider-azure
+  clusterSelector:
+    matchLabels:
+      cloud-provider: azure
+  releaseName: cloud-provider-azure
+  repoURL: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/helm/repo
+  valuesTemplate: |-
+    infra:
+      clusterName: {{ .Cluster.metadata.name }}
+    cloudControllerManager:
+      clusterCIDR: {{ .Cluster.spec.clusterNetwork.pods.cidrBlocks | join "," }}
+      logVerbosity: 4
+---
+apiVersion: addons.cluster.x-k8s.io/v1alpha1
+kind: HelmChartProxy
+metadata:
+  name: cloud-provider-azure-chart-ci
+  namespace: default
+spec:
+  chartName: cloud-provider-azure
+  clusterSelector:
+    matchLabels:
+      cloud-provider: azure-ci
+  releaseName: cloud-provider-azure
+  repoURL: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/helm/repo
+  valuesTemplate: |-
+    infra:
+      clusterName: {{ .Cluster.metadata.name }}
+    cloudControllerManager:
+      clusterCIDR: {{ .Cluster.spec.clusterNetwork.pods.cidrBlocks | join "," }}
+      imageName: ${CCM_IMAGE_NAME}
+      imageRepository: ${CCM_IMAGE_REGISTRY}
+      imageTag: ${IMAGE_TAG_CCM}
+      logVerbosity: 4
+    cloudNodeManager:
+      imageName: ${CNM_IMAGE_NAME}
+      imageRepository: ${CNM_IMAGE_REGISTRY}
+      imageTag: ${IMAGE_TAG_CCM}
 ---
 apiVersion: v1
 data:

--- a/templates/test/ci/cluster-template-prow-ci-version.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version.yaml
@@ -3,6 +3,7 @@ kind: Cluster
 metadata:
   labels:
     azuredisk-csi: "true"
+    cloud-provider: ${CLOUD_PROVIDER_AZURE_LABEL}
     cni: calico
     cni-windows: ${CLUSTER_NAME}-calico
     containerd-logger: enabled
@@ -703,6 +704,51 @@ spec:
       runOnControlPlane: true
     windows:
       useHostProcessContainers: {{ hasKey .Cluster.metadata.labels "cni-windows" }}
+---
+apiVersion: addons.cluster.x-k8s.io/v1alpha1
+kind: HelmChartProxy
+metadata:
+  name: cloud-provider-azure-chart
+  namespace: default
+spec:
+  chartName: cloud-provider-azure
+  clusterSelector:
+    matchLabels:
+      cloud-provider: azure
+  releaseName: cloud-provider-azure
+  repoURL: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/helm/repo
+  valuesTemplate: |-
+    infra:
+      clusterName: {{ .Cluster.metadata.name }}
+    cloudControllerManager:
+      clusterCIDR: {{ .Cluster.spec.clusterNetwork.pods.cidrBlocks | join "," }}
+      logVerbosity: 4
+---
+apiVersion: addons.cluster.x-k8s.io/v1alpha1
+kind: HelmChartProxy
+metadata:
+  name: cloud-provider-azure-chart-ci
+  namespace: default
+spec:
+  chartName: cloud-provider-azure
+  clusterSelector:
+    matchLabels:
+      cloud-provider: azure-ci
+  releaseName: cloud-provider-azure
+  repoURL: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/helm/repo
+  valuesTemplate: |-
+    infra:
+      clusterName: {{ .Cluster.metadata.name }}
+    cloudControllerManager:
+      clusterCIDR: {{ .Cluster.spec.clusterNetwork.pods.cidrBlocks | join "," }}
+      imageName: ${CCM_IMAGE_NAME}
+      imageRepository: ${CCM_IMAGE_REGISTRY}
+      imageTag: ${IMAGE_TAG_CCM}
+      logVerbosity: 4
+    cloudNodeManager:
+      imageName: ${CNM_IMAGE_NAME}
+      imageRepository: ${CNM_IMAGE_REGISTRY}
+      imageTag: ${IMAGE_TAG_CCM}
 ---
 apiVersion: v1
 data:

--- a/templates/test/ci/cluster-template-prow-custom-vnet.yaml
+++ b/templates/test/ci/cluster-template-prow-custom-vnet.yaml
@@ -3,6 +3,7 @@ kind: Cluster
 metadata:
   labels:
     azuredisk-csi: "true"
+    cloud-provider: ${CLOUD_PROVIDER_AZURE_LABEL}
     cni: calico
   name: ${CLUSTER_NAME}
   namespace: default
@@ -298,3 +299,48 @@ spec:
       runOnControlPlane: true
     windows:
       useHostProcessContainers: {{ hasKey .Cluster.metadata.labels "cni-windows" }}
+---
+apiVersion: addons.cluster.x-k8s.io/v1alpha1
+kind: HelmChartProxy
+metadata:
+  name: cloud-provider-azure-chart
+  namespace: default
+spec:
+  chartName: cloud-provider-azure
+  clusterSelector:
+    matchLabels:
+      cloud-provider: azure
+  releaseName: cloud-provider-azure
+  repoURL: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/helm/repo
+  valuesTemplate: |-
+    infra:
+      clusterName: {{ .Cluster.metadata.name }}
+    cloudControllerManager:
+      clusterCIDR: {{ .Cluster.spec.clusterNetwork.pods.cidrBlocks | join "," }}
+      logVerbosity: 4
+---
+apiVersion: addons.cluster.x-k8s.io/v1alpha1
+kind: HelmChartProxy
+metadata:
+  name: cloud-provider-azure-chart-ci
+  namespace: default
+spec:
+  chartName: cloud-provider-azure
+  clusterSelector:
+    matchLabels:
+      cloud-provider: azure-ci
+  releaseName: cloud-provider-azure
+  repoURL: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/helm/repo
+  valuesTemplate: |-
+    infra:
+      clusterName: {{ .Cluster.metadata.name }}
+    cloudControllerManager:
+      clusterCIDR: {{ .Cluster.spec.clusterNetwork.pods.cidrBlocks | join "," }}
+      imageName: ${CCM_IMAGE_NAME}
+      imageRepository: ${CCM_IMAGE_REGISTRY}
+      imageTag: ${IMAGE_TAG_CCM}
+      logVerbosity: 4
+    cloudNodeManager:
+      imageName: ${CNM_IMAGE_NAME}
+      imageRepository: ${CNM_IMAGE_REGISTRY}
+      imageTag: ${IMAGE_TAG_CCM}

--- a/templates/test/ci/cluster-template-prow-dual-stack.yaml
+++ b/templates/test/ci/cluster-template-prow-dual-stack.yaml
@@ -3,6 +3,7 @@ kind: Cluster
 metadata:
   labels:
     azuredisk-csi: "true"
+    cloud-provider: ${CLOUD_PROVIDER_AZURE_LABEL}
     cni: calico-dual-stack
   name: ${CLUSTER_NAME}
   namespace: default
@@ -387,3 +388,48 @@ spec:
       runOnControlPlane: true
     windows:
       useHostProcessContainers: {{ hasKey .Cluster.metadata.labels "cni-windows" }}
+---
+apiVersion: addons.cluster.x-k8s.io/v1alpha1
+kind: HelmChartProxy
+metadata:
+  name: cloud-provider-azure-chart
+  namespace: default
+spec:
+  chartName: cloud-provider-azure
+  clusterSelector:
+    matchLabels:
+      cloud-provider: azure
+  releaseName: cloud-provider-azure
+  repoURL: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/helm/repo
+  valuesTemplate: |-
+    infra:
+      clusterName: {{ .Cluster.metadata.name }}
+    cloudControllerManager:
+      clusterCIDR: {{ .Cluster.spec.clusterNetwork.pods.cidrBlocks | join "," }}
+      logVerbosity: 4
+---
+apiVersion: addons.cluster.x-k8s.io/v1alpha1
+kind: HelmChartProxy
+metadata:
+  name: cloud-provider-azure-chart-ci
+  namespace: default
+spec:
+  chartName: cloud-provider-azure
+  clusterSelector:
+    matchLabels:
+      cloud-provider: azure-ci
+  releaseName: cloud-provider-azure
+  repoURL: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/helm/repo
+  valuesTemplate: |-
+    infra:
+      clusterName: {{ .Cluster.metadata.name }}
+    cloudControllerManager:
+      clusterCIDR: {{ .Cluster.spec.clusterNetwork.pods.cidrBlocks | join "," }}
+      imageName: ${CCM_IMAGE_NAME}
+      imageRepository: ${CCM_IMAGE_REGISTRY}
+      imageTag: ${IMAGE_TAG_CCM}
+      logVerbosity: 4
+    cloudNodeManager:
+      imageName: ${CNM_IMAGE_NAME}
+      imageRepository: ${CNM_IMAGE_REGISTRY}
+      imageTag: ${IMAGE_TAG_CCM}

--- a/templates/test/ci/cluster-template-prow-edgezone.yaml
+++ b/templates/test/ci/cluster-template-prow-edgezone.yaml
@@ -3,6 +3,7 @@ kind: Cluster
 metadata:
   labels:
     azuredisk-csi: "true"
+    cloud-provider: ${CLOUD_PROVIDER_AZURE_LABEL}
     cni: calico
   name: ${CLUSTER_NAME}
   namespace: default
@@ -282,3 +283,48 @@ spec:
       runOnControlPlane: true
     windows:
       useHostProcessContainers: {{ hasKey .Cluster.metadata.labels "cni-windows" }}
+---
+apiVersion: addons.cluster.x-k8s.io/v1alpha1
+kind: HelmChartProxy
+metadata:
+  name: cloud-provider-azure-chart
+  namespace: default
+spec:
+  chartName: cloud-provider-azure
+  clusterSelector:
+    matchLabels:
+      cloud-provider: azure
+  releaseName: cloud-provider-azure
+  repoURL: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/helm/repo
+  valuesTemplate: |-
+    infra:
+      clusterName: {{ .Cluster.metadata.name }}
+    cloudControllerManager:
+      clusterCIDR: {{ .Cluster.spec.clusterNetwork.pods.cidrBlocks | join "," }}
+      logVerbosity: 4
+---
+apiVersion: addons.cluster.x-k8s.io/v1alpha1
+kind: HelmChartProxy
+metadata:
+  name: cloud-provider-azure-chart-ci
+  namespace: default
+spec:
+  chartName: cloud-provider-azure
+  clusterSelector:
+    matchLabels:
+      cloud-provider: azure-ci
+  releaseName: cloud-provider-azure
+  repoURL: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/helm/repo
+  valuesTemplate: |-
+    infra:
+      clusterName: {{ .Cluster.metadata.name }}
+    cloudControllerManager:
+      clusterCIDR: {{ .Cluster.spec.clusterNetwork.pods.cidrBlocks | join "," }}
+      imageName: ${CCM_IMAGE_NAME}
+      imageRepository: ${CCM_IMAGE_REGISTRY}
+      imageTag: ${IMAGE_TAG_CCM}
+      logVerbosity: 4
+    cloudNodeManager:
+      imageName: ${CNM_IMAGE_NAME}
+      imageRepository: ${CNM_IMAGE_REGISTRY}
+      imageTag: ${IMAGE_TAG_CCM}

--- a/templates/test/ci/cluster-template-prow-flatcar.yaml
+++ b/templates/test/ci/cluster-template-prow-flatcar.yaml
@@ -3,6 +3,7 @@ kind: Cluster
 metadata:
   labels:
     azuredisk-csi: "true"
+    cloud-provider: ${CLOUD_PROVIDER_AZURE_LABEL}
     cni: calico
   name: ${CLUSTER_NAME}
   namespace: default
@@ -309,3 +310,48 @@ spec:
       runOnControlPlane: true
     windows:
       useHostProcessContainers: {{ hasKey .Cluster.metadata.labels "cni-windows" }}
+---
+apiVersion: addons.cluster.x-k8s.io/v1alpha1
+kind: HelmChartProxy
+metadata:
+  name: cloud-provider-azure-chart
+  namespace: default
+spec:
+  chartName: cloud-provider-azure
+  clusterSelector:
+    matchLabels:
+      cloud-provider: azure
+  releaseName: cloud-provider-azure
+  repoURL: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/helm/repo
+  valuesTemplate: |-
+    infra:
+      clusterName: {{ .Cluster.metadata.name }}
+    cloudControllerManager:
+      clusterCIDR: {{ .Cluster.spec.clusterNetwork.pods.cidrBlocks | join "," }}
+      logVerbosity: 4
+---
+apiVersion: addons.cluster.x-k8s.io/v1alpha1
+kind: HelmChartProxy
+metadata:
+  name: cloud-provider-azure-chart-ci
+  namespace: default
+spec:
+  chartName: cloud-provider-azure
+  clusterSelector:
+    matchLabels:
+      cloud-provider: azure-ci
+  releaseName: cloud-provider-azure
+  repoURL: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/helm/repo
+  valuesTemplate: |-
+    infra:
+      clusterName: {{ .Cluster.metadata.name }}
+    cloudControllerManager:
+      clusterCIDR: {{ .Cluster.spec.clusterNetwork.pods.cidrBlocks | join "," }}
+      imageName: ${CCM_IMAGE_NAME}
+      imageRepository: ${CCM_IMAGE_REGISTRY}
+      imageTag: ${IMAGE_TAG_CCM}
+      logVerbosity: 4
+    cloudNodeManager:
+      imageName: ${CNM_IMAGE_NAME}
+      imageRepository: ${CNM_IMAGE_REGISTRY}
+      imageTag: ${IMAGE_TAG_CCM}

--- a/templates/test/ci/cluster-template-prow-intree-cloud-provider-machine-pool.yaml
+++ b/templates/test/ci/cluster-template-prow-intree-cloud-provider-machine-pool.yaml
@@ -3,6 +3,7 @@ kind: Cluster
 metadata:
   labels:
     azuredisk-csi: "true"
+    cloud-provider: ${CLOUD_PROVIDER_AZURE_LABEL}
     cni: calico
     cni-windows: ${CLUSTER_NAME}-calico
     containerd-logger: enabled
@@ -418,6 +419,51 @@ spec:
       runOnControlPlane: true
     windows:
       useHostProcessContainers: {{ hasKey .Cluster.metadata.labels "cni-windows" }}
+---
+apiVersion: addons.cluster.x-k8s.io/v1alpha1
+kind: HelmChartProxy
+metadata:
+  name: cloud-provider-azure-chart
+  namespace: default
+spec:
+  chartName: cloud-provider-azure
+  clusterSelector:
+    matchLabels:
+      cloud-provider: azure
+  releaseName: cloud-provider-azure
+  repoURL: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/helm/repo
+  valuesTemplate: |-
+    infra:
+      clusterName: {{ .Cluster.metadata.name }}
+    cloudControllerManager:
+      clusterCIDR: {{ .Cluster.spec.clusterNetwork.pods.cidrBlocks | join "," }}
+      logVerbosity: 4
+---
+apiVersion: addons.cluster.x-k8s.io/v1alpha1
+kind: HelmChartProxy
+metadata:
+  name: cloud-provider-azure-chart-ci
+  namespace: default
+spec:
+  chartName: cloud-provider-azure
+  clusterSelector:
+    matchLabels:
+      cloud-provider: azure-ci
+  releaseName: cloud-provider-azure
+  repoURL: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/helm/repo
+  valuesTemplate: |-
+    infra:
+      clusterName: {{ .Cluster.metadata.name }}
+    cloudControllerManager:
+      clusterCIDR: {{ .Cluster.spec.clusterNetwork.pods.cidrBlocks | join "," }}
+      imageName: ${CCM_IMAGE_NAME}
+      imageRepository: ${CCM_IMAGE_REGISTRY}
+      imageTag: ${IMAGE_TAG_CCM}
+      logVerbosity: 4
+    cloudNodeManager:
+      imageName: ${CNM_IMAGE_NAME}
+      imageRepository: ${CNM_IMAGE_REGISTRY}
+      imageTag: ${IMAGE_TAG_CCM}
 ---
 apiVersion: v1
 data:

--- a/templates/test/ci/cluster-template-prow-intree-cloud-provider.yaml
+++ b/templates/test/ci/cluster-template-prow-intree-cloud-provider.yaml
@@ -3,6 +3,7 @@ kind: Cluster
 metadata:
   labels:
     azuredisk-csi: "true"
+    cloud-provider: ${CLOUD_PROVIDER_AZURE_LABEL}
     cni: calico
     cni-windows: ${CLUSTER_NAME}-calico
     containerd-logger: enabled
@@ -482,6 +483,51 @@ spec:
       runOnControlPlane: true
     windows:
       useHostProcessContainers: {{ hasKey .Cluster.metadata.labels "cni-windows" }}
+---
+apiVersion: addons.cluster.x-k8s.io/v1alpha1
+kind: HelmChartProxy
+metadata:
+  name: cloud-provider-azure-chart
+  namespace: default
+spec:
+  chartName: cloud-provider-azure
+  clusterSelector:
+    matchLabels:
+      cloud-provider: azure
+  releaseName: cloud-provider-azure
+  repoURL: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/helm/repo
+  valuesTemplate: |-
+    infra:
+      clusterName: {{ .Cluster.metadata.name }}
+    cloudControllerManager:
+      clusterCIDR: {{ .Cluster.spec.clusterNetwork.pods.cidrBlocks | join "," }}
+      logVerbosity: 4
+---
+apiVersion: addons.cluster.x-k8s.io/v1alpha1
+kind: HelmChartProxy
+metadata:
+  name: cloud-provider-azure-chart-ci
+  namespace: default
+spec:
+  chartName: cloud-provider-azure
+  clusterSelector:
+    matchLabels:
+      cloud-provider: azure-ci
+  releaseName: cloud-provider-azure
+  repoURL: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/helm/repo
+  valuesTemplate: |-
+    infra:
+      clusterName: {{ .Cluster.metadata.name }}
+    cloudControllerManager:
+      clusterCIDR: {{ .Cluster.spec.clusterNetwork.pods.cidrBlocks | join "," }}
+      imageName: ${CCM_IMAGE_NAME}
+      imageRepository: ${CCM_IMAGE_REGISTRY}
+      imageTag: ${IMAGE_TAG_CCM}
+      logVerbosity: 4
+    cloudNodeManager:
+      imageName: ${CNM_IMAGE_NAME}
+      imageRepository: ${CNM_IMAGE_REGISTRY}
+      imageTag: ${IMAGE_TAG_CCM}
 ---
 apiVersion: v1
 data:

--- a/templates/test/ci/cluster-template-prow-ipv6.yaml
+++ b/templates/test/ci/cluster-template-prow-ipv6.yaml
@@ -3,6 +3,7 @@ kind: Cluster
 metadata:
   labels:
     azuredisk-csi: "true"
+    cloud-provider: ${CLOUD_PROVIDER_AZURE_LABEL}
     cni: calico-ipv6
   name: ${CLUSTER_NAME}
   namespace: default
@@ -404,3 +405,48 @@ spec:
       runOnControlPlane: true
     windows:
       useHostProcessContainers: {{ hasKey .Cluster.metadata.labels "cni-windows" }}
+---
+apiVersion: addons.cluster.x-k8s.io/v1alpha1
+kind: HelmChartProxy
+metadata:
+  name: cloud-provider-azure-chart
+  namespace: default
+spec:
+  chartName: cloud-provider-azure
+  clusterSelector:
+    matchLabels:
+      cloud-provider: azure
+  releaseName: cloud-provider-azure
+  repoURL: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/helm/repo
+  valuesTemplate: |-
+    infra:
+      clusterName: {{ .Cluster.metadata.name }}
+    cloudControllerManager:
+      clusterCIDR: {{ .Cluster.spec.clusterNetwork.pods.cidrBlocks | join "," }}
+      logVerbosity: 4
+---
+apiVersion: addons.cluster.x-k8s.io/v1alpha1
+kind: HelmChartProxy
+metadata:
+  name: cloud-provider-azure-chart-ci
+  namespace: default
+spec:
+  chartName: cloud-provider-azure
+  clusterSelector:
+    matchLabels:
+      cloud-provider: azure-ci
+  releaseName: cloud-provider-azure
+  repoURL: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/helm/repo
+  valuesTemplate: |-
+    infra:
+      clusterName: {{ .Cluster.metadata.name }}
+    cloudControllerManager:
+      clusterCIDR: {{ .Cluster.spec.clusterNetwork.pods.cidrBlocks | join "," }}
+      imageName: ${CCM_IMAGE_NAME}
+      imageRepository: ${CCM_IMAGE_REGISTRY}
+      imageTag: ${IMAGE_TAG_CCM}
+      logVerbosity: 4
+    cloudNodeManager:
+      imageName: ${CNM_IMAGE_NAME}
+      imageRepository: ${CNM_IMAGE_REGISTRY}
+      imageTag: ${IMAGE_TAG_CCM}

--- a/templates/test/ci/cluster-template-prow-machine-pool-ci-version.yaml
+++ b/templates/test/ci/cluster-template-prow-machine-pool-ci-version.yaml
@@ -3,6 +3,7 @@ kind: Cluster
 metadata:
   labels:
     azuredisk-csi: "true"
+    cloud-provider: ${CLOUD_PROVIDER_AZURE_LABEL}
     cni: calico
     cni-windows: ${CLUSTER_NAME}-calico
     containerd-logger: enabled
@@ -637,6 +638,51 @@ spec:
       runOnControlPlane: true
     windows:
       useHostProcessContainers: {{ hasKey .Cluster.metadata.labels "cni-windows" }}
+---
+apiVersion: addons.cluster.x-k8s.io/v1alpha1
+kind: HelmChartProxy
+metadata:
+  name: cloud-provider-azure-chart
+  namespace: default
+spec:
+  chartName: cloud-provider-azure
+  clusterSelector:
+    matchLabels:
+      cloud-provider: azure
+  releaseName: cloud-provider-azure
+  repoURL: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/helm/repo
+  valuesTemplate: |-
+    infra:
+      clusterName: {{ .Cluster.metadata.name }}
+    cloudControllerManager:
+      clusterCIDR: {{ .Cluster.spec.clusterNetwork.pods.cidrBlocks | join "," }}
+      logVerbosity: 4
+---
+apiVersion: addons.cluster.x-k8s.io/v1alpha1
+kind: HelmChartProxy
+metadata:
+  name: cloud-provider-azure-chart-ci
+  namespace: default
+spec:
+  chartName: cloud-provider-azure
+  clusterSelector:
+    matchLabels:
+      cloud-provider: azure-ci
+  releaseName: cloud-provider-azure
+  repoURL: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/helm/repo
+  valuesTemplate: |-
+    infra:
+      clusterName: {{ .Cluster.metadata.name }}
+    cloudControllerManager:
+      clusterCIDR: {{ .Cluster.spec.clusterNetwork.pods.cidrBlocks | join "," }}
+      imageName: ${CCM_IMAGE_NAME}
+      imageRepository: ${CCM_IMAGE_REGISTRY}
+      imageTag: ${IMAGE_TAG_CCM}
+      logVerbosity: 4
+    cloudNodeManager:
+      imageName: ${CNM_IMAGE_NAME}
+      imageRepository: ${CNM_IMAGE_REGISTRY}
+      imageTag: ${IMAGE_TAG_CCM}
 ---
 apiVersion: v1
 data:

--- a/templates/test/ci/cluster-template-prow-machine-pool-flex.yaml
+++ b/templates/test/ci/cluster-template-prow-machine-pool-flex.yaml
@@ -3,6 +3,7 @@ kind: Cluster
 metadata:
   labels:
     azuredisk-csi: "true"
+    cloud-provider: ${CLOUD_PROVIDER_AZURE_LABEL}
     cni: calico
     cni-windows: ${CLUSTER_NAME}-calico
     containerd-logger: enabled
@@ -408,6 +409,51 @@ spec:
       runOnControlPlane: true
     windows:
       useHostProcessContainers: {{ hasKey .Cluster.metadata.labels "cni-windows" }}
+---
+apiVersion: addons.cluster.x-k8s.io/v1alpha1
+kind: HelmChartProxy
+metadata:
+  name: cloud-provider-azure-chart
+  namespace: default
+spec:
+  chartName: cloud-provider-azure
+  clusterSelector:
+    matchLabels:
+      cloud-provider: azure
+  releaseName: cloud-provider-azure
+  repoURL: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/helm/repo
+  valuesTemplate: |-
+    infra:
+      clusterName: {{ .Cluster.metadata.name }}
+    cloudControllerManager:
+      clusterCIDR: {{ .Cluster.spec.clusterNetwork.pods.cidrBlocks | join "," }}
+      logVerbosity: 4
+---
+apiVersion: addons.cluster.x-k8s.io/v1alpha1
+kind: HelmChartProxy
+metadata:
+  name: cloud-provider-azure-chart-ci
+  namespace: default
+spec:
+  chartName: cloud-provider-azure
+  clusterSelector:
+    matchLabels:
+      cloud-provider: azure-ci
+  releaseName: cloud-provider-azure
+  repoURL: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/helm/repo
+  valuesTemplate: |-
+    infra:
+      clusterName: {{ .Cluster.metadata.name }}
+    cloudControllerManager:
+      clusterCIDR: {{ .Cluster.spec.clusterNetwork.pods.cidrBlocks | join "," }}
+      imageName: ${CCM_IMAGE_NAME}
+      imageRepository: ${CCM_IMAGE_REGISTRY}
+      imageTag: ${IMAGE_TAG_CCM}
+      logVerbosity: 4
+    cloudNodeManager:
+      imageName: ${CNM_IMAGE_NAME}
+      imageRepository: ${CNM_IMAGE_REGISTRY}
+      imageTag: ${IMAGE_TAG_CCM}
 ---
 apiVersion: v1
 data:

--- a/templates/test/ci/cluster-template-prow-machine-pool.yaml
+++ b/templates/test/ci/cluster-template-prow-machine-pool.yaml
@@ -3,6 +3,7 @@ kind: Cluster
 metadata:
   labels:
     azuredisk-csi: "true"
+    cloud-provider: ${CLOUD_PROVIDER_AZURE_LABEL}
     cni: calico
     cni-windows: ${CLUSTER_NAME}-calico
     containerd-logger: enabled
@@ -402,6 +403,51 @@ spec:
       runOnControlPlane: true
     windows:
       useHostProcessContainers: {{ hasKey .Cluster.metadata.labels "cni-windows" }}
+---
+apiVersion: addons.cluster.x-k8s.io/v1alpha1
+kind: HelmChartProxy
+metadata:
+  name: cloud-provider-azure-chart
+  namespace: default
+spec:
+  chartName: cloud-provider-azure
+  clusterSelector:
+    matchLabels:
+      cloud-provider: azure
+  releaseName: cloud-provider-azure
+  repoURL: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/helm/repo
+  valuesTemplate: |-
+    infra:
+      clusterName: {{ .Cluster.metadata.name }}
+    cloudControllerManager:
+      clusterCIDR: {{ .Cluster.spec.clusterNetwork.pods.cidrBlocks | join "," }}
+      logVerbosity: 4
+---
+apiVersion: addons.cluster.x-k8s.io/v1alpha1
+kind: HelmChartProxy
+metadata:
+  name: cloud-provider-azure-chart-ci
+  namespace: default
+spec:
+  chartName: cloud-provider-azure
+  clusterSelector:
+    matchLabels:
+      cloud-provider: azure-ci
+  releaseName: cloud-provider-azure
+  repoURL: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/helm/repo
+  valuesTemplate: |-
+    infra:
+      clusterName: {{ .Cluster.metadata.name }}
+    cloudControllerManager:
+      clusterCIDR: {{ .Cluster.spec.clusterNetwork.pods.cidrBlocks | join "," }}
+      imageName: ${CCM_IMAGE_NAME}
+      imageRepository: ${CCM_IMAGE_REGISTRY}
+      imageTag: ${IMAGE_TAG_CCM}
+      logVerbosity: 4
+    cloudNodeManager:
+      imageName: ${CNM_IMAGE_NAME}
+      imageRepository: ${CNM_IMAGE_REGISTRY}
+      imageTag: ${IMAGE_TAG_CCM}
 ---
 apiVersion: v1
 data:

--- a/templates/test/ci/cluster-template-prow-nvidia-gpu.yaml
+++ b/templates/test/ci/cluster-template-prow-nvidia-gpu.yaml
@@ -3,6 +3,7 @@ kind: Cluster
 metadata:
   labels:
     azuredisk-csi: "true"
+    cloud-provider: ${CLOUD_PROVIDER_AZURE_LABEL}
     cni: calico
   name: ${CLUSTER_NAME}
   namespace: default
@@ -268,3 +269,48 @@ spec:
       runOnControlPlane: true
     windows:
       useHostProcessContainers: {{ hasKey .Cluster.metadata.labels "cni-windows" }}
+---
+apiVersion: addons.cluster.x-k8s.io/v1alpha1
+kind: HelmChartProxy
+metadata:
+  name: cloud-provider-azure-chart
+  namespace: default
+spec:
+  chartName: cloud-provider-azure
+  clusterSelector:
+    matchLabels:
+      cloud-provider: azure
+  releaseName: cloud-provider-azure
+  repoURL: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/helm/repo
+  valuesTemplate: |-
+    infra:
+      clusterName: {{ .Cluster.metadata.name }}
+    cloudControllerManager:
+      clusterCIDR: {{ .Cluster.spec.clusterNetwork.pods.cidrBlocks | join "," }}
+      logVerbosity: 4
+---
+apiVersion: addons.cluster.x-k8s.io/v1alpha1
+kind: HelmChartProxy
+metadata:
+  name: cloud-provider-azure-chart-ci
+  namespace: default
+spec:
+  chartName: cloud-provider-azure
+  clusterSelector:
+    matchLabels:
+      cloud-provider: azure-ci
+  releaseName: cloud-provider-azure
+  repoURL: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/helm/repo
+  valuesTemplate: |-
+    infra:
+      clusterName: {{ .Cluster.metadata.name }}
+    cloudControllerManager:
+      clusterCIDR: {{ .Cluster.spec.clusterNetwork.pods.cidrBlocks | join "," }}
+      imageName: ${CCM_IMAGE_NAME}
+      imageRepository: ${CCM_IMAGE_REGISTRY}
+      imageTag: ${IMAGE_TAG_CCM}
+      logVerbosity: 4
+    cloudNodeManager:
+      imageName: ${CNM_IMAGE_NAME}
+      imageRepository: ${CNM_IMAGE_REGISTRY}
+      imageTag: ${IMAGE_TAG_CCM}

--- a/templates/test/ci/cluster-template-prow-private.yaml
+++ b/templates/test/ci/cluster-template-prow-private.yaml
@@ -3,6 +3,7 @@ kind: Cluster
 metadata:
   labels:
     azuredisk-csi: "true"
+    cloud-provider: ${CLOUD_PROVIDER_AZURE_LABEL}
     cni: calico
   name: ${CLUSTER_NAME}
   namespace: default
@@ -87,26 +88,14 @@ spec:
     clusterConfiguration:
       apiServer:
         extraArgs:
-          cloud-config: /etc/kubernetes/azure.json
-          cloud-provider: azure
-        extraVolumes:
-        - hostPath: /etc/kubernetes/azure.json
-          mountPath: /etc/kubernetes/azure.json
-          name: cloud-config
-          readOnly: true
+          cloud-provider: external
         timeoutForControlPlane: 20m
       controllerManager:
         extraArgs:
           allocate-node-cidrs: "false"
-          cloud-config: /etc/kubernetes/azure.json
-          cloud-provider: azure
+          cloud-provider: external
           cluster-name: ${CLUSTER_NAME}
           v: "4"
-        extraVolumes:
-        - hostPath: /etc/kubernetes/azure.json
-          mountPath: /etc/kubernetes/azure.json
-          name: cloud-config
-          readOnly: true
       etcd:
         local:
           dataDir: /var/lib/etcddisk/etcd
@@ -141,15 +130,13 @@ spec:
       nodeRegistration:
         kubeletExtraArgs:
           azure-container-registry-config: /etc/kubernetes/azure.json
-          cloud-config: /etc/kubernetes/azure.json
-          cloud-provider: azure
+          cloud-provider: external
         name: '{{ ds.meta_data["local_hostname"] }}'
     joinConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
           azure-container-registry-config: /etc/kubernetes/azure.json
-          cloud-config: /etc/kubernetes/azure.json
-          cloud-provider: azure
+          cloud-provider: external
         name: '{{ ds.meta_data["local_hostname"] }}'
     mounts:
     - - LABEL=etcd_disk
@@ -251,8 +238,7 @@ spec:
         nodeRegistration:
           kubeletExtraArgs:
             azure-container-registry-config: /etc/kubernetes/azure.json
-            cloud-config: /etc/kubernetes/azure.json
-            cloud-provider: azure
+            cloud-provider: external
           name: '{{ ds.meta_data["local_hostname"] }}'
       preKubeadmCommands: []
 ---
@@ -336,6 +322,51 @@ spec:
       runOnControlPlane: true
     windows:
       useHostProcessContainers: {{ hasKey .Cluster.metadata.labels "cni-windows" }}
+---
+apiVersion: addons.cluster.x-k8s.io/v1alpha1
+kind: HelmChartProxy
+metadata:
+  name: cloud-provider-azure-chart
+  namespace: default
+spec:
+  chartName: cloud-provider-azure
+  clusterSelector:
+    matchLabels:
+      cloud-provider: azure
+  releaseName: cloud-provider-azure
+  repoURL: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/helm/repo
+  valuesTemplate: |-
+    infra:
+      clusterName: {{ .Cluster.metadata.name }}
+    cloudControllerManager:
+      clusterCIDR: {{ .Cluster.spec.clusterNetwork.pods.cidrBlocks | join "," }}
+      logVerbosity: 4
+---
+apiVersion: addons.cluster.x-k8s.io/v1alpha1
+kind: HelmChartProxy
+metadata:
+  name: cloud-provider-azure-chart-ci
+  namespace: default
+spec:
+  chartName: cloud-provider-azure
+  clusterSelector:
+    matchLabels:
+      cloud-provider: azure-ci
+  releaseName: cloud-provider-azure
+  repoURL: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/helm/repo
+  valuesTemplate: |-
+    infra:
+      clusterName: {{ .Cluster.metadata.name }}
+    cloudControllerManager:
+      clusterCIDR: {{ .Cluster.spec.clusterNetwork.pods.cidrBlocks | join "," }}
+      imageName: ${CCM_IMAGE_NAME}
+      imageRepository: ${CCM_IMAGE_REGISTRY}
+      imageTag: ${IMAGE_TAG_CCM}
+      logVerbosity: 4
+    cloudNodeManager:
+      imageName: ${CNM_IMAGE_NAME}
+      imageRepository: ${CNM_IMAGE_REGISTRY}
+      imageTag: ${IMAGE_TAG_CCM}
 ---
 apiVersion: v1
 data:

--- a/templates/test/ci/cluster-template-prow-topology.yaml
+++ b/templates/test/ci/cluster-template-prow-topology.yaml
@@ -3,6 +3,7 @@ kind: Cluster
 metadata:
   labels:
     azuredisk-csi: "true"
+    cloud-provider: ${CLOUD_PROVIDER_AZURE_LABEL}
     cni: calico
     cni-windows: ${CLUSTER_NAME}-calico
     containerd-logger: enabled
@@ -133,6 +134,51 @@ spec:
       runOnControlPlane: true
     windows:
       useHostProcessContainers: {{ hasKey .Cluster.metadata.labels "cni-windows" }}
+---
+apiVersion: addons.cluster.x-k8s.io/v1alpha1
+kind: HelmChartProxy
+metadata:
+  name: cloud-provider-azure-chart
+  namespace: default
+spec:
+  chartName: cloud-provider-azure
+  clusterSelector:
+    matchLabels:
+      cloud-provider: azure
+  releaseName: cloud-provider-azure
+  repoURL: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/helm/repo
+  valuesTemplate: |-
+    infra:
+      clusterName: {{ .Cluster.metadata.name }}
+    cloudControllerManager:
+      clusterCIDR: {{ .Cluster.spec.clusterNetwork.pods.cidrBlocks | join "," }}
+      logVerbosity: 4
+---
+apiVersion: addons.cluster.x-k8s.io/v1alpha1
+kind: HelmChartProxy
+metadata:
+  name: cloud-provider-azure-chart-ci
+  namespace: default
+spec:
+  chartName: cloud-provider-azure
+  clusterSelector:
+    matchLabels:
+      cloud-provider: azure-ci
+  releaseName: cloud-provider-azure
+  repoURL: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/helm/repo
+  valuesTemplate: |-
+    infra:
+      clusterName: {{ .Cluster.metadata.name }}
+    cloudControllerManager:
+      clusterCIDR: {{ .Cluster.spec.clusterNetwork.pods.cidrBlocks | join "," }}
+      imageName: ${CCM_IMAGE_NAME}
+      imageRepository: ${CCM_IMAGE_REGISTRY}
+      imageTag: ${IMAGE_TAG_CCM}
+      logVerbosity: 4
+    cloudNodeManager:
+      imageName: ${CNM_IMAGE_NAME}
+      imageRepository: ${CNM_IMAGE_REGISTRY}
+      imageTag: ${IMAGE_TAG_CCM}
 ---
 apiVersion: v1
 data:

--- a/templates/test/ci/cluster-template-prow-workload-identity.yaml
+++ b/templates/test/ci/cluster-template-prow-workload-identity.yaml
@@ -3,6 +3,7 @@ kind: Cluster
 metadata:
   labels:
     azuredisk-csi: "true"
+    cloud-provider: ${CLOUD_PROVIDER_AZURE_LABEL}
     cni: calico
   name: ${CLUSTER_NAME}
   namespace: default
@@ -274,3 +275,48 @@ spec:
       runOnControlPlane: true
     windows:
       useHostProcessContainers: {{ hasKey .Cluster.metadata.labels "cni-windows" }}
+---
+apiVersion: addons.cluster.x-k8s.io/v1alpha1
+kind: HelmChartProxy
+metadata:
+  name: cloud-provider-azure-chart
+  namespace: default
+spec:
+  chartName: cloud-provider-azure
+  clusterSelector:
+    matchLabels:
+      cloud-provider: azure
+  releaseName: cloud-provider-azure
+  repoURL: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/helm/repo
+  valuesTemplate: |-
+    infra:
+      clusterName: {{ .Cluster.metadata.name }}
+    cloudControllerManager:
+      clusterCIDR: {{ .Cluster.spec.clusterNetwork.pods.cidrBlocks | join "," }}
+      logVerbosity: 4
+---
+apiVersion: addons.cluster.x-k8s.io/v1alpha1
+kind: HelmChartProxy
+metadata:
+  name: cloud-provider-azure-chart-ci
+  namespace: default
+spec:
+  chartName: cloud-provider-azure
+  clusterSelector:
+    matchLabels:
+      cloud-provider: azure-ci
+  releaseName: cloud-provider-azure
+  repoURL: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/helm/repo
+  valuesTemplate: |-
+    infra:
+      clusterName: {{ .Cluster.metadata.name }}
+    cloudControllerManager:
+      clusterCIDR: {{ .Cluster.spec.clusterNetwork.pods.cidrBlocks | join "," }}
+      imageName: ${CCM_IMAGE_NAME}
+      imageRepository: ${CCM_IMAGE_REGISTRY}
+      imageTag: ${IMAGE_TAG_CCM}
+      logVerbosity: 4
+    cloudNodeManager:
+      imageName: ${CNM_IMAGE_NAME}
+      imageRepository: ${CNM_IMAGE_REGISTRY}
+      imageTag: ${IMAGE_TAG_CCM}

--- a/templates/test/ci/cluster-template-prow.yaml
+++ b/templates/test/ci/cluster-template-prow.yaml
@@ -3,6 +3,7 @@ kind: Cluster
 metadata:
   labels:
     azuredisk-csi: "true"
+    cloud-provider: ${CLOUD_PROVIDER_AZURE_LABEL}
     cni: calico
     cni-windows: ${CLUSTER_NAME}-calico
     containerd-logger: enabled
@@ -466,6 +467,51 @@ spec:
       runOnControlPlane: true
     windows:
       useHostProcessContainers: {{ hasKey .Cluster.metadata.labels "cni-windows" }}
+---
+apiVersion: addons.cluster.x-k8s.io/v1alpha1
+kind: HelmChartProxy
+metadata:
+  name: cloud-provider-azure-chart
+  namespace: default
+spec:
+  chartName: cloud-provider-azure
+  clusterSelector:
+    matchLabels:
+      cloud-provider: azure
+  releaseName: cloud-provider-azure
+  repoURL: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/helm/repo
+  valuesTemplate: |-
+    infra:
+      clusterName: {{ .Cluster.metadata.name }}
+    cloudControllerManager:
+      clusterCIDR: {{ .Cluster.spec.clusterNetwork.pods.cidrBlocks | join "," }}
+      logVerbosity: 4
+---
+apiVersion: addons.cluster.x-k8s.io/v1alpha1
+kind: HelmChartProxy
+metadata:
+  name: cloud-provider-azure-chart-ci
+  namespace: default
+spec:
+  chartName: cloud-provider-azure
+  clusterSelector:
+    matchLabels:
+      cloud-provider: azure-ci
+  releaseName: cloud-provider-azure
+  repoURL: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/helm/repo
+  valuesTemplate: |-
+    infra:
+      clusterName: {{ .Cluster.metadata.name }}
+    cloudControllerManager:
+      clusterCIDR: {{ .Cluster.spec.clusterNetwork.pods.cidrBlocks | join "," }}
+      imageName: ${CCM_IMAGE_NAME}
+      imageRepository: ${CCM_IMAGE_REGISTRY}
+      imageTag: ${IMAGE_TAG_CCM}
+      logVerbosity: 4
+    cloudNodeManager:
+      imageName: ${CNM_IMAGE_NAME}
+      imageRepository: ${CNM_IMAGE_REGISTRY}
+      imageTag: ${IMAGE_TAG_CCM}
 ---
 apiVersion: v1
 data:

--- a/templates/test/ci/patches/cluster-label-cloud-provider-azure.yaml
+++ b/templates/test/ci/patches/cluster-label-cloud-provider-azure.yaml
@@ -1,0 +1,6 @@
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  name: ${CLUSTER_NAME}
+  labels:
+    cloud-provider: ${CLOUD_PROVIDER_AZURE_LABEL}

--- a/templates/test/ci/prow-azure-cni-v1/kustomization.yaml
+++ b/templates/test/ci/prow-azure-cni-v1/kustomization.yaml
@@ -4,7 +4,10 @@ namespace: default
 resources:
   - ../../../flavors/azure-cni-v1/
   - ../../../addons/cluster-api-helm/azuredisk-csi-driver.yaml
+  - ../../../addons/cluster-api-helm/cloud-provider-azure.yaml
+  - ../../../addons/cluster-api-helm/cloud-provider-azure-ci.yaml
 patchesStrategicMerge:
   - ../patches/tags.yaml
   - ../patches/controller-manager.yaml
   - ../patches/cluster-label-azuredisk-csi-driver.yaml
+  - ../patches/cluster-label-cloud-provider-azure.yaml

--- a/templates/test/ci/prow-custom-vnet/kustomization.yaml
+++ b/templates/test/ci/prow-custom-vnet/kustomization.yaml
@@ -6,6 +6,8 @@ resources:
   - ../prow/mhc.yaml
   - ../../../addons/cluster-api-helm/calico.yaml
   - ../../../addons/cluster-api-helm/azuredisk-csi-driver.yaml
+  - ../../../addons/cluster-api-helm/cloud-provider-azure.yaml
+  - ../../../addons/cluster-api-helm/cloud-provider-azure-ci.yaml
 patchesStrategicMerge:
   - ../patches/tags.yaml
   - ../patches/mhc.yaml
@@ -15,3 +17,4 @@ patchesStrategicMerge:
   - ../patches/uami-control-plane.yaml
   - ../patches/cluster-label-calico.yaml
   - ../patches/cluster-label-azuredisk-csi-driver.yaml
+  - ../patches/cluster-label-cloud-provider-azure.yaml

--- a/templates/test/ci/prow-dual-stack/kustomization.yaml
+++ b/templates/test/ci/prow-dual-stack/kustomization.yaml
@@ -6,6 +6,8 @@ resources:
   - machine-pool-dualstack.yaml
   - ../../../addons/cluster-api-helm/calico-dual-stack.yaml
   - ../../../addons/cluster-api-helm/azuredisk-csi-driver.yaml
+  - ../../../addons/cluster-api-helm/cloud-provider-azure.yaml
+  - ../../../addons/cluster-api-helm/cloud-provider-azure-ci.yaml
 patchesStrategicMerge:
   - ../patches/tags.yaml
   - ../patches/controller-manager.yaml
@@ -13,3 +15,4 @@ patchesStrategicMerge:
   - patches/azure-machine-template.yaml
   - patches/cluster-label-calico-dual-stack.yaml
   - ../patches/cluster-label-azuredisk-csi-driver.yaml
+  - ../patches/cluster-label-cloud-provider-azure.yaml

--- a/templates/test/ci/prow-edgezone/kustomization.yaml
+++ b/templates/test/ci/prow-edgezone/kustomization.yaml
@@ -5,6 +5,8 @@ resources:
   - ../../../flavors/edgezone
   - ../../../addons/cluster-api-helm/calico.yaml
   - ../../../addons/cluster-api-helm/azuredisk-csi-driver.yaml
+  - ../../../addons/cluster-api-helm/cloud-provider-azure.yaml
+  - ../../../addons/cluster-api-helm/cloud-provider-azure-ci.yaml
 patchesStrategicMerge:
   - ../patches/tags.yaml
   - ../patches/controller-manager.yaml
@@ -17,3 +19,5 @@ patchesStrategicMerge:
   - patches/kubernetes-version.yaml
   - ../patches/cluster-label-calico.yaml
   - ../patches/cluster-label-azuredisk-csi-driver.yaml
+  - ../patches/cluster-label-cloud-provider-azure.yaml
+

--- a/templates/test/ci/prow-flatcar/kustomization.yaml
+++ b/templates/test/ci/prow-flatcar/kustomization.yaml
@@ -5,8 +5,11 @@ resources:
   - ../../../flavors/flatcar/
   - ../../../addons/cluster-api-helm/calico.yaml
   - ../../../addons/cluster-api-helm/azuredisk-csi-driver.yaml
+  - ../../../addons/cluster-api-helm/cloud-provider-azure.yaml
+  - ../../../addons/cluster-api-helm/cloud-provider-azure-ci.yaml
 patchesStrategicMerge:
   - ../patches/tags.yaml
   - ../patches/controller-manager.yaml
   - ../patches/cluster-label-calico.yaml
   - ../patches/cluster-label-azuredisk-csi-driver.yaml
+  - ../patches/cluster-label-cloud-provider-azure.yaml

--- a/templates/test/ci/prow-ipv6/kustomization.yaml
+++ b/templates/test/ci/prow-ipv6/kustomization.yaml
@@ -6,9 +6,11 @@ resources:
   - machine-pool-ipv6.yaml
   - ../../../addons/cluster-api-helm/calico-ipv6.yaml
   - ../../../addons/cluster-api-helm/azuredisk-csi-driver.yaml
+  - ../../../addons/cluster-api-helm/cloud-provider-azure.yaml
+  - ../../../addons/cluster-api-helm/cloud-provider-azure-ci.yaml
 patchesStrategicMerge:
   - ../patches/tags.yaml
   - ../patches/controller-manager.yaml
   - patches/cluster-label-calico-ipv6.yaml
   - ../patches/cluster-label-azuredisk-csi-driver.yaml
-
+  - ../patches/cluster-label-cloud-provider-azure.yaml

--- a/templates/test/ci/prow-machine-pool/kustomization.yaml
+++ b/templates/test/ci/prow-machine-pool/kustomization.yaml
@@ -8,6 +8,8 @@ resources:
   - ../../../addons/windows/containerd-logging/containerd-logger-resource-set.yaml
   - ../../../addons/cluster-api-helm/calico.yaml
   - ../../../addons/cluster-api-helm/azuredisk-csi-driver.yaml
+  - ../../../addons/cluster-api-helm/cloud-provider-azure.yaml
+  - ../../../addons/cluster-api-helm/cloud-provider-azure-ci.yaml
 patchesStrategicMerge:
   - ../patches/azuremachinepool-vmextension.yaml
   - ../patches/tags.yaml
@@ -16,6 +18,7 @@ patchesStrategicMerge:
   - ../patches/windows-containerd-labels.yaml
   - ../patches/cluster-label-calico.yaml
   - ../patches/cluster-label-azuredisk-csi-driver.yaml
+  - ../patches/cluster-label-cloud-provider-azure.yaml
 configMapGenerator:
   - name: cni-${CLUSTER_NAME}-calico-windows
     files:

--- a/templates/test/ci/prow-nvidia-gpu/kustomization.yaml
+++ b/templates/test/ci/prow-nvidia-gpu/kustomization.yaml
@@ -5,12 +5,15 @@ resources:
   - ../../../flavors/nvidia-gpu
   - ../../../addons/cluster-api-helm/calico.yaml
   - ../../../addons/cluster-api-helm/azuredisk-csi-driver.yaml
+  - ../../../addons/cluster-api-helm/cloud-provider-azure.yaml
+  - ../../../addons/cluster-api-helm/cloud-provider-azure-ci.yaml
 patchesStrategicMerge:
   - ../patches/tags.yaml
   - ../patches/controller-manager.yaml
   - ../patches/azurecluster-gpu.yaml
   - ../patches/cluster-label-calico.yaml
   - ../patches/cluster-label-azuredisk-csi-driver.yaml
+  - ../patches/cluster-label-cloud-provider-azure.yaml
 patches:
 - path: patches/node-storage-type.yaml
   target:

--- a/templates/test/ci/prow-private/kustomization.yaml
+++ b/templates/test/ci/prow-private/kustomization.yaml
@@ -6,6 +6,8 @@ resources:
   - cni-resource-set.yaml
   - ../../../addons/cluster-api-helm/calico.yaml
   - ../../../addons/cluster-api-helm/azuredisk-csi-driver.yaml
+  - ../../../addons/cluster-api-helm/cloud-provider-azure.yaml
+  - ../../../addons/cluster-api-helm/cloud-provider-azure-ci.yaml
 patchesStrategicMerge:
   - ../patches/tags.yaml
   - ../patches/controller-manager.yaml
@@ -13,10 +15,9 @@ patchesStrategicMerge:
   - patches/vnet-peerings.yaml
   - ../patches/uami-md-0.yaml
   - ../patches/uami-control-plane.yaml
-  - ../prow-intree-cloud-provider/patches/intree-cp.yaml # TODO: remove once CAPI supports Helm addons
-  - ../prow-intree-cloud-provider/patches/intree-md-0.yaml # TODO: remove once CAPI supports Helm addons
   - ../patches/cluster-label-calico.yaml
   - ../patches/cluster-label-azuredisk-csi-driver.yaml
+  - ../patches/cluster-label-cloud-provider-azure.yaml
 patches:
   - path: patches/user-assigned.yaml
     target:

--- a/templates/test/ci/prow-topology/kustomization.yaml
+++ b/templates/test/ci/prow-topology/kustomization.yaml
@@ -7,11 +7,14 @@ resources:
   - ../../../addons/windows/csi-proxy/csi-proxy-resource-set.yaml
   - ../../../addons/cluster-api-helm/calico.yaml
   - ../../../addons/cluster-api-helm/azuredisk-csi-driver.yaml
+  - ../../../addons/cluster-api-helm/cloud-provider-azure.yaml
+  - ../../../addons/cluster-api-helm/cloud-provider-azure-ci.yaml
 patchesStrategicMerge:
   - ../patches/windows-containerd-labels.yaml
   - cluster.yaml
   - ../patches/cluster-label-calico.yaml
   - ../patches/cluster-label-azuredisk-csi-driver.yaml
+  - ../patches/cluster-label-cloud-provider-azure.yaml
 configMapGenerator:
   - name: cni-${CLUSTER_NAME}-calico-windows
     files:

--- a/templates/test/ci/prow-workload-identity/kustomization.yaml
+++ b/templates/test/ci/prow-workload-identity/kustomization.yaml
@@ -5,6 +5,8 @@ resources:
   - ../../../flavors/default
   - ../../../addons/cluster-api-helm/calico.yaml
   - ../../../addons/cluster-api-helm/azuredisk-csi-driver.yaml
+  - ../../../addons/cluster-api-helm/cloud-provider-azure.yaml
+  - ../../../addons/cluster-api-helm/cloud-provider-azure-ci.yaml
 patchesStrategicMerge:
   - ../patches/azureclusteridentity-azwi.yaml
   - ../patches/tags.yaml
@@ -14,3 +16,5 @@ patchesStrategicMerge:
   - ../patches/uami-control-plane.yaml
   - ../patches/cluster-label-calico.yaml
   - ../patches/cluster-label-azuredisk-csi-driver.yaml
+  - ../patches/cluster-label-cloud-provider-azure.yaml
+

--- a/templates/test/ci/prow/kustomization.yaml
+++ b/templates/test/ci/prow/kustomization.yaml
@@ -12,6 +12,8 @@ resources:
   - ../../../addons/windows/containerd-logging/containerd-logger-resource-set.yaml
   - ../../../addons/cluster-api-helm/calico.yaml
   - ../../../addons/cluster-api-helm/azuredisk-csi-driver.yaml
+  - ../../../addons/cluster-api-helm/cloud-provider-azure.yaml
+  - ../../../addons/cluster-api-helm/cloud-provider-azure-ci.yaml
 patchesStrategicMerge:
   - ../patches/tags.yaml
   - ../patches/mhc.yaml
@@ -24,6 +26,7 @@ patchesStrategicMerge:
   - ../patches/windows-server-version.yaml
   - ../patches/cluster-label-calico.yaml
   - ../patches/cluster-label-azuredisk-csi-driver.yaml
+  - ../patches/cluster-label-cloud-provider-azure.yaml
 patches:
 - target:
     group: bootstrap.cluster.x-k8s.io

--- a/templates/test/dev/cluster-template-custom-builds-machine-pool.yaml
+++ b/templates/test/dev/cluster-template-custom-builds-machine-pool.yaml
@@ -3,6 +3,7 @@ kind: Cluster
 metadata:
   labels:
     azuredisk-csi: "true"
+    cloud-provider: ${CLOUD_PROVIDER_AZURE_LABEL}
     cni: calico
     cni-windows: ${CLUSTER_NAME}-calico
     containerd-logger: enabled
@@ -585,6 +586,51 @@ spec:
       runOnControlPlane: true
     windows:
       useHostProcessContainers: {{ hasKey .Cluster.metadata.labels "cni-windows" }}
+---
+apiVersion: addons.cluster.x-k8s.io/v1alpha1
+kind: HelmChartProxy
+metadata:
+  name: cloud-provider-azure-chart
+  namespace: default
+spec:
+  chartName: cloud-provider-azure
+  clusterSelector:
+    matchLabels:
+      cloud-provider: azure
+  releaseName: cloud-provider-azure
+  repoURL: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/helm/repo
+  valuesTemplate: |-
+    infra:
+      clusterName: {{ .Cluster.metadata.name }}
+    cloudControllerManager:
+      clusterCIDR: {{ .Cluster.spec.clusterNetwork.pods.cidrBlocks | join "," }}
+      logVerbosity: 4
+---
+apiVersion: addons.cluster.x-k8s.io/v1alpha1
+kind: HelmChartProxy
+metadata:
+  name: cloud-provider-azure-chart-ci
+  namespace: default
+spec:
+  chartName: cloud-provider-azure
+  clusterSelector:
+    matchLabels:
+      cloud-provider: azure-ci
+  releaseName: cloud-provider-azure
+  repoURL: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/helm/repo
+  valuesTemplate: |-
+    infra:
+      clusterName: {{ .Cluster.metadata.name }}
+    cloudControllerManager:
+      clusterCIDR: {{ .Cluster.spec.clusterNetwork.pods.cidrBlocks | join "," }}
+      imageName: ${CCM_IMAGE_NAME}
+      imageRepository: ${CCM_IMAGE_REGISTRY}
+      imageTag: ${IMAGE_TAG_CCM}
+      logVerbosity: 4
+    cloudNodeManager:
+      imageName: ${CNM_IMAGE_NAME}
+      imageRepository: ${CNM_IMAGE_REGISTRY}
+      imageTag: ${IMAGE_TAG_CCM}
 ---
 apiVersion: v1
 data:

--- a/templates/test/dev/cluster-template-custom-builds.yaml
+++ b/templates/test/dev/cluster-template-custom-builds.yaml
@@ -3,6 +3,7 @@ kind: Cluster
 metadata:
   labels:
     azuredisk-csi: "true"
+    cloud-provider: ${CLOUD_PROVIDER_AZURE_LABEL}
     cni: calico
     cni-windows: ${CLUSTER_NAME}-calico
     containerd-logger: enabled
@@ -678,6 +679,51 @@ spec:
       runOnControlPlane: true
     windows:
       useHostProcessContainers: {{ hasKey .Cluster.metadata.labels "cni-windows" }}
+---
+apiVersion: addons.cluster.x-k8s.io/v1alpha1
+kind: HelmChartProxy
+metadata:
+  name: cloud-provider-azure-chart
+  namespace: default
+spec:
+  chartName: cloud-provider-azure
+  clusterSelector:
+    matchLabels:
+      cloud-provider: azure
+  releaseName: cloud-provider-azure
+  repoURL: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/helm/repo
+  valuesTemplate: |-
+    infra:
+      clusterName: {{ .Cluster.metadata.name }}
+    cloudControllerManager:
+      clusterCIDR: {{ .Cluster.spec.clusterNetwork.pods.cidrBlocks | join "," }}
+      logVerbosity: 4
+---
+apiVersion: addons.cluster.x-k8s.io/v1alpha1
+kind: HelmChartProxy
+metadata:
+  name: cloud-provider-azure-chart-ci
+  namespace: default
+spec:
+  chartName: cloud-provider-azure
+  clusterSelector:
+    matchLabels:
+      cloud-provider: azure-ci
+  releaseName: cloud-provider-azure
+  repoURL: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/helm/repo
+  valuesTemplate: |-
+    infra:
+      clusterName: {{ .Cluster.metadata.name }}
+    cloudControllerManager:
+      clusterCIDR: {{ .Cluster.spec.clusterNetwork.pods.cidrBlocks | join "," }}
+      imageName: ${CCM_IMAGE_NAME}
+      imageRepository: ${CCM_IMAGE_REGISTRY}
+      imageTag: ${IMAGE_TAG_CCM}
+      logVerbosity: 4
+    cloudNodeManager:
+      imageName: ${CNM_IMAGE_NAME}
+      imageRepository: ${CNM_IMAGE_REGISTRY}
+      imageTag: ${IMAGE_TAG_CCM}
 ---
 apiVersion: v1
 data:

--- a/test/e2e/azure_selfhosted.go
+++ b/test/e2e/azure_selfhosted.go
@@ -98,6 +98,14 @@ func SelfHostedSpec(ctx context.Context, inputGetter func() SelfHostedSpecInput)
 		Expect(os.Setenv(ClusterIdentityNamespace, namespace.Name)).To(Succeed())
 		Expect(os.Setenv(ClusterIdentitySecretName, "cluster-identity-secret")).To(Succeed())
 		Expect(os.Setenv(ClusterIdentitySecretNamespace, namespace.Name)).To(Succeed())
+
+		cloudProviderAzureLabel := "azure"
+		fmt.Println("Value of useCIArtifacts is", useCIArtifacts)
+		if useCIArtifacts {
+			cloudProviderAzureLabel = "azure-ci"
+		}
+		os.Setenv("CLOUD_PROVIDER_AZURE_LABEL", cloudProviderAzureLabel)
+		setPlaceholderValuesForCCMEnvVars()
 	})
 
 	// Management clusters do not support Windows nodes because of cert manager

--- a/test/e2e/azure_test.go
+++ b/test/e2e/azure_test.go
@@ -77,6 +77,7 @@ var _ = Describe("Workload cluster creation", func() {
 			cloudProviderAzureLabel = "azure-ci"
 		}
 		os.Setenv("CLOUD_PROVIDER_AZURE_LABEL", cloudProviderAzureLabel)
+		setPlaceholderValuesForCCMEnvVars()
 
 		// Setup a Namespace where to host objects for this spec and create a watcher for the namespace events.
 		var err error

--- a/test/e2e/azure_test.go
+++ b/test/e2e/azure_test.go
@@ -71,6 +71,13 @@ var _ = Describe("Workload cluster creation", func() {
 			clusterNamePrefix = clusterNameSpace
 		}
 
+		cloudProviderAzureLabel := "azure"
+		fmt.Println("Value of useCIArtifacts is", useCIArtifacts)
+		if useCIArtifacts {
+			cloudProviderAzureLabel = "azure-ci"
+		}
+		os.Setenv("CLOUD_PROVIDER_AZURE_LABEL", cloudProviderAzureLabel)
+
 		// Setup a Namespace where to host objects for this spec and create a watcher for the namespace events.
 		var err error
 		namespace, cancelWatches, err = setupSpecNamespace(ctx, clusterNamePrefix, bootstrapClusterProxy, artifactFolder)

--- a/test/e2e/capi_test.go
+++ b/test/e2e/capi_test.go
@@ -86,6 +86,14 @@ var _ = Describe("Running the Cluster API E2E tests", func() {
 		Expect(os.Setenv(ClusterIdentitySecretName, IdentitySecretName)).To(Succeed())
 		Expect(os.Setenv(ClusterIdentitySecretNamespace, identityNamespace.Name)).To(Succeed())
 
+		cloudProviderAzureLabel := "azure"
+		fmt.Println("Value of useCIArtifacts is", useCIArtifacts)
+		if useCIArtifacts {
+			cloudProviderAzureLabel = "azure-ci"
+		}
+		os.Setenv("CLOUD_PROVIDER_AZURE_LABEL", cloudProviderAzureLabel)
+		setPlaceholderValuesForCCMEnvVars()
+
 		logCheckpoint(specTimes)
 	})
 

--- a/test/e2e/cloud-provider-azure.go
+++ b/test/e2e/cloud-provider-azure.go
@@ -38,34 +38,39 @@ const (
 	azureDiskCSIDriverHelmReleaseName = "azuredisk-csi-driver-oot"
 )
 
-// InstallCNIAndCloudProviderAzureHelmChart installs the official cloud-provider-azure helm chart
+// EnsureCNIAndCloudProviderAzureHelmChart installs the official cloud-provider-azure helm chart
 // and a CNI and validates that expected pods exist and are Ready.
-func InstallCNIAndCloudProviderAzureHelmChart(ctx context.Context, input clusterctl.ApplyCustomClusterTemplateAndWaitInput, installHelmChart bool, cidrBlocks []string, hasWindows bool) {
-	specName := "cloud-provider-azure-install"
-	By("Installing cloud-provider-azure components via helm")
-	options := &HelmOptions{
-		Values: []string{
-			fmt.Sprintf("infra.clusterName=%s", input.ClusterName),
-			"cloudControllerManager.logVerbosity=4",
-		},
-		StringValues: []string{fmt.Sprintf("cloudControllerManager.clusterCIDR=%s", strings.Join(cidrBlocks, `\,`))},
-	}
-	// If testing a CI version of Kubernetes, use CCM and CNM images built from source.
-	if useCIArtifacts || usePRArtifacts {
-		options.Values = append(options.Values, fmt.Sprintf("cloudControllerManager.imageName=%s", os.Getenv("CCM_IMAGE_NAME")))
-		options.Values = append(options.Values, fmt.Sprintf("cloudNodeManager.imageName=%s", os.Getenv("CNM_IMAGE_NAME")))
-		options.Values = append(options.Values, fmt.Sprintf("cloudControllerManager.imageRepository=%s", os.Getenv("IMAGE_REGISTRY")))
-		options.Values = append(options.Values, fmt.Sprintf("cloudNodeManager.imageRepository=%s", os.Getenv("IMAGE_REGISTRY")))
-		options.StringValues = append(options.StringValues, fmt.Sprintf("cloudControllerManager.imageTag=%s", os.Getenv("IMAGE_TAG_CCM")))
-		options.StringValues = append(options.StringValues, fmt.Sprintf("cloudNodeManager.imageTag=%s", os.Getenv("IMAGE_TAG_CNM")))
-	}
-
-	if strings.Contains(input.ClusterName, "flatcar") {
-		options.StringValues = append(options.StringValues, "cloudControllerManager.caCertDir=/usr/share/ca-certificates")
-	}
-
+func EnsureCNIAndCloudProviderAzureHelmChart(ctx context.Context, input clusterctl.ApplyCustomClusterTemplateAndWaitInput, installHelmChart bool, cidrBlocks []string, hasWindows bool) {
+	specName := "ensure-cloud-provider-azure"
 	clusterProxy := input.ClusterProxy.GetWorkloadCluster(ctx, input.Namespace, input.ClusterName)
-	InstallHelmChart(ctx, clusterProxy, defaultNamespace, cloudProviderAzureHelmRepoURL, cloudProviderAzureChartName, cloudProviderAzureHelmReleaseName, options, "")
+
+	if installHelmChart {
+		By("Installing cloud-provider-azure components via helm")
+		options := &HelmOptions{
+			Values: []string{
+				fmt.Sprintf("infra.clusterName=%s", input.ClusterName),
+				"cloudControllerManager.logVerbosity=4",
+			},
+			StringValues: []string{fmt.Sprintf("cloudControllerManager.clusterCIDR=%s", strings.Join(cidrBlocks, `\,`))},
+		}
+		// If testing a CI version of Kubernetes, use CCM and CNM images built from source.
+		if useCIArtifacts || usePRArtifacts {
+			options.Values = append(options.Values, fmt.Sprintf("cloudControllerManager.imageName=%s", os.Getenv("CCM_IMAGE_NAME")))
+			options.Values = append(options.Values, fmt.Sprintf("cloudNodeManager.imageName=%s", os.Getenv("CNM_IMAGE_NAME")))
+			options.Values = append(options.Values, fmt.Sprintf("cloudControllerManager.imageRepository=%s", os.Getenv("IMAGE_REGISTRY")))
+			options.Values = append(options.Values, fmt.Sprintf("cloudNodeManager.imageRepository=%s", os.Getenv("IMAGE_REGISTRY")))
+			options.StringValues = append(options.StringValues, fmt.Sprintf("cloudControllerManager.imageTag=%s", os.Getenv("IMAGE_TAG_CCM")))
+			options.StringValues = append(options.StringValues, fmt.Sprintf("cloudNodeManager.imageTag=%s", os.Getenv("IMAGE_TAG_CNM")))
+		}
+
+		if strings.Contains(input.ClusterName, "flatcar") {
+			options.StringValues = append(options.StringValues, "cloudControllerManager.caCertDir=/usr/share/ca-certificates")
+		}
+
+		InstallHelmChart(ctx, clusterProxy, defaultNamespace, cloudProviderAzureHelmRepoURL, cloudProviderAzureChartName, cloudProviderAzureHelmReleaseName, options, "")
+	} else {
+		By("Ensuring cloud-provider-azure is installed via CAAPH")
+	}
 
 	// We do this before waiting for the pods to be ready because there is a co-dependency between CNI (nodes ready) and cloud-provider being initialized.
 	EnsureCNI(ctx, input, installHelmChart, cidrBlocks, hasWindows)

--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -292,7 +292,7 @@ func ensureControlPlaneInitialized(ctx context.Context, input clusterctl.ApplyCu
 
 	if kubeadmControlPlane.Spec.KubeadmConfigSpec.ClusterConfiguration.ControllerManager.ExtraArgs["cloud-provider"] != infrav1.AzureNetworkPluginName {
 		// There is a co-dependency between cloud-provider and CNI so we install both together if cloud-provider is external.
-		InstallCNIAndCloudProviderAzureHelmChart(ctx, input, installHelmCharts, cluster.Spec.ClusterNetwork.Pods.CIDRBlocks, hasWindows)
+		EnsureCNIAndCloudProviderAzureHelmChart(ctx, input, installHelmCharts, cluster.Spec.ClusterNetwork.Pods.CIDRBlocks, hasWindows)
 	} else {
 		EnsureCNI(ctx, input, installHelmCharts, cluster.Spec.ClusterNetwork.Pods.CIDRBlocks, hasWindows)
 	}

--- a/test/e2e/conformance_test.go
+++ b/test/e2e/conformance_test.go
@@ -93,6 +93,14 @@ var _ = Describe("Conformance Tests", func() {
 		Expect(os.Setenv(ClusterIdentityNamespace, namespace.Name)).To(Succeed())
 		Expect(os.Setenv(ClusterIdentitySecretName, "cluster-identity-secret")).To(Succeed())
 		Expect(os.Setenv(ClusterIdentitySecretNamespace, namespace.Name)).To(Succeed())
+
+		cloudProviderAzureLabel := "azure"
+		fmt.Println("Value of useCIArtifacts is", useCIArtifacts)
+		if useCIArtifacts {
+			cloudProviderAzureLabel = "azure-ci"
+		}
+		os.Setenv("CLOUD_PROVIDER_AZURE_LABEL", cloudProviderAzureLabel)
+		setPlaceholderValuesForCCMEnvVars()
 	})
 
 	It(specName, func() {

--- a/test/e2e/data/infrastructure-azure/v1beta1/bases/cloud-provider-azure-ci.yaml
+++ b/test/e2e/data/infrastructure-azure/v1beta1/bases/cloud-provider-azure-ci.yaml
@@ -1,0 +1,24 @@
+apiVersion: addons.cluster.x-k8s.io/v1alpha1
+kind: HelmChartProxy
+metadata:
+  name: cloud-provider-azure-chart-ci
+spec:
+  clusterSelector:
+    matchLabels:
+      cloud-provider: "azure-ci"
+  repoURL: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/helm/repo
+  chartName: cloud-provider-azure
+  releaseName: cloud-provider-azure
+  valuesTemplate: |
+    infra:
+      clusterName: {{ .Cluster.metadata.name }}
+    cloudControllerManager:
+      clusterCIDR: {{ .Cluster.spec.clusterNetwork.pods.cidrBlocks | join "," }}
+      imageName: ${CCM_IMAGE_NAME}
+      imageRepository: ${CCM_IMAGE_REGISTRY}
+      imageTag: ${IMAGE_TAG_CCM}
+      logVerbosity: 4
+    cloudNodeManager:
+      imageName: ${CNM_IMAGE_NAME}
+      imageRepository: ${CNM_IMAGE_REGISTRY}
+      imageTag: ${IMAGE_TAG_CCM}

--- a/test/e2e/data/infrastructure-azure/v1beta1/bases/cloud-provider-azure.yaml
+++ b/test/e2e/data/infrastructure-azure/v1beta1/bases/cloud-provider-azure.yaml
@@ -1,0 +1,17 @@
+apiVersion: addons.cluster.x-k8s.io/v1alpha1
+kind: HelmChartProxy
+metadata:
+  name: cloud-provider-azure-chart
+spec:
+  clusterSelector:
+    matchLabels:
+      cloud-provider: "azure"
+  repoURL: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/helm/repo
+  chartName: cloud-provider-azure
+  releaseName: cloud-provider-azure
+  valuesTemplate: |
+    infra:
+      clusterName: {{ .Cluster.metadata.name }}
+    cloudControllerManager:
+      clusterCIDR: {{ .Cluster.spec.clusterNetwork.pods.cidrBlocks | join "," }}
+      logVerbosity: 4

--- a/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-kcp-remediation.yaml
+++ b/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-kcp-remediation.yaml
@@ -49,6 +49,49 @@ spec:
       image: mcr.microsoft.com/oss/calico/ctl
   version: ${CALICO_VERSION}
 ---
+apiVersion: addons.cluster.x-k8s.io/v1alpha1
+kind: HelmChartProxy
+metadata:
+  name: cloud-provider-azure-chart
+spec:
+  chartName: cloud-provider-azure
+  clusterSelector:
+    matchLabels:
+      cloud-provider: azure
+  releaseName: cloud-provider-azure
+  repoURL: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/helm/repo
+  valuesTemplate: |-
+    infra:
+      clusterName: {{ .Cluster.metadata.name }}
+    cloudControllerManager:
+      clusterCIDR: {{ .Cluster.spec.clusterNetwork.pods.cidrBlocks | join "," }}
+      logVerbosity: 4
+---
+apiVersion: addons.cluster.x-k8s.io/v1alpha1
+kind: HelmChartProxy
+metadata:
+  name: cloud-provider-azure-chart-ci
+spec:
+  chartName: cloud-provider-azure
+  clusterSelector:
+    matchLabels:
+      cloud-provider: azure-ci
+  releaseName: cloud-provider-azure
+  repoURL: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/helm/repo
+  valuesTemplate: |-
+    infra:
+      clusterName: {{ .Cluster.metadata.name }}
+    cloudControllerManager:
+      clusterCIDR: {{ .Cluster.spec.clusterNetwork.pods.cidrBlocks | join "," }}
+      imageName: ${CCM_IMAGE_NAME}
+      imageRepository: ${CCM_IMAGE_REGISTRY}
+      imageTag: ${IMAGE_TAG_CCM}
+      logVerbosity: 4
+    cloudNodeManager:
+      imageName: ${CNM_IMAGE_NAME}
+      imageRepository: ${CNM_IMAGE_REGISTRY}
+      imageTag: ${IMAGE_TAG_CCM}
+---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate
 metadata:

--- a/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-kcp-remediation/kustomization.yaml
+++ b/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-kcp-remediation/kustomization.yaml
@@ -1,12 +1,14 @@
 bases:
-  - ../bases/cluster-with-kcp.yaml
-  - ../bases/md.yaml
-  - mhc.yaml
-  - ../bases/azure-cluster-identity.yaml
-  - ../bases/calico.yaml
-  - ../bases/azuredisk-csi-driver.yaml
+- ../bases/cluster-with-kcp.yaml
+- ../bases/md.yaml
+- mhc.yaml
+- ../bases/azure-cluster-identity.yaml
+- ../bases/calico.yaml
+- ../bases/azuredisk-csi-driver.yaml
+- ../bases/cloud-provider-azure.yaml
+- ../bases/cloud-provider-azure-ci.yaml
 
 patchesStrategicMerge:
-  - ../patches/azurecluster-identity-ref.yaml
-  - ../patches/cluster-label-calico.yaml
-  - ../patches/cluster-label-azuredisk-csi-driver.yaml
+- ../patches/azurecluster-identity-ref.yaml
+- ../patches/cluster-label-calico.yaml
+- ../patches/cluster-label-azuredisk-csi-driver.yaml

--- a/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-kcp-scale-in.yaml
+++ b/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-kcp-scale-in.yaml
@@ -49,6 +49,49 @@ spec:
       image: mcr.microsoft.com/oss/calico/ctl
   version: ${CALICO_VERSION}
 ---
+apiVersion: addons.cluster.x-k8s.io/v1alpha1
+kind: HelmChartProxy
+metadata:
+  name: cloud-provider-azure-chart
+spec:
+  chartName: cloud-provider-azure
+  clusterSelector:
+    matchLabels:
+      cloud-provider: azure
+  releaseName: cloud-provider-azure
+  repoURL: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/helm/repo
+  valuesTemplate: |-
+    infra:
+      clusterName: {{ .Cluster.metadata.name }}
+    cloudControllerManager:
+      clusterCIDR: {{ .Cluster.spec.clusterNetwork.pods.cidrBlocks | join "," }}
+      logVerbosity: 4
+---
+apiVersion: addons.cluster.x-k8s.io/v1alpha1
+kind: HelmChartProxy
+metadata:
+  name: cloud-provider-azure-chart-ci
+spec:
+  chartName: cloud-provider-azure
+  clusterSelector:
+    matchLabels:
+      cloud-provider: azure-ci
+  releaseName: cloud-provider-azure
+  repoURL: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/helm/repo
+  valuesTemplate: |-
+    infra:
+      clusterName: {{ .Cluster.metadata.name }}
+    cloudControllerManager:
+      clusterCIDR: {{ .Cluster.spec.clusterNetwork.pods.cidrBlocks | join "," }}
+      imageName: ${CCM_IMAGE_NAME}
+      imageRepository: ${CCM_IMAGE_REGISTRY}
+      imageTag: ${IMAGE_TAG_CCM}
+      logVerbosity: 4
+    cloudNodeManager:
+      imageName: ${CNM_IMAGE_NAME}
+      imageRepository: ${CNM_IMAGE_REGISTRY}
+      imageTag: ${IMAGE_TAG_CCM}
+---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate
 metadata:
@@ -76,6 +119,7 @@ kind: Cluster
 metadata:
   labels:
     azuredisk-csi: "true"
+    cloud-provider: ${CLOUD_PROVIDER_AZURE_LABEL}
     cni: calico
   name: ${CLUSTER_NAME}
   namespace: default

--- a/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-kcp-scale-in/kustomization.yaml
+++ b/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-kcp-scale-in/kustomization.yaml
@@ -4,9 +4,12 @@ bases:
 - ../bases/azure-cluster-identity.yaml
 - ../bases/calico.yaml
 - ../bases/azuredisk-csi-driver.yaml
+- ../bases/cloud-provider-azure.yaml
+- ../bases/cloud-provider-azure-ci.yaml
 
 patchesStrategicMerge:
 - ./cluster-with-kcp.yaml
 - ../patches/azurecluster-identity-ref.yaml
 - ../patches/cluster-label-calico.yaml
 - ../patches/cluster-label-azuredisk-csi-driver.yaml
+- ../patches/cluster-label-cloud-provider-azure.yaml

--- a/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-machine-pool.yaml
+++ b/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-machine-pool.yaml
@@ -49,6 +49,49 @@ spec:
       image: mcr.microsoft.com/oss/calico/ctl
   version: ${CALICO_VERSION}
 ---
+apiVersion: addons.cluster.x-k8s.io/v1alpha1
+kind: HelmChartProxy
+metadata:
+  name: cloud-provider-azure-chart
+spec:
+  chartName: cloud-provider-azure
+  clusterSelector:
+    matchLabels:
+      cloud-provider: azure
+  releaseName: cloud-provider-azure
+  repoURL: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/helm/repo
+  valuesTemplate: |-
+    infra:
+      clusterName: {{ .Cluster.metadata.name }}
+    cloudControllerManager:
+      clusterCIDR: {{ .Cluster.spec.clusterNetwork.pods.cidrBlocks | join "," }}
+      logVerbosity: 4
+---
+apiVersion: addons.cluster.x-k8s.io/v1alpha1
+kind: HelmChartProxy
+metadata:
+  name: cloud-provider-azure-chart-ci
+spec:
+  chartName: cloud-provider-azure
+  clusterSelector:
+    matchLabels:
+      cloud-provider: azure-ci
+  releaseName: cloud-provider-azure
+  repoURL: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/helm/repo
+  valuesTemplate: |-
+    infra:
+      clusterName: {{ .Cluster.metadata.name }}
+    cloudControllerManager:
+      clusterCIDR: {{ .Cluster.spec.clusterNetwork.pods.cidrBlocks | join "," }}
+      imageName: ${CCM_IMAGE_NAME}
+      imageRepository: ${CCM_IMAGE_REGISTRY}
+      imageTag: ${IMAGE_TAG_CCM}
+      logVerbosity: 4
+    cloudNodeManager:
+      imageName: ${CNM_IMAGE_NAME}
+      imageRepository: ${CNM_IMAGE_REGISTRY}
+      imageTag: ${IMAGE_TAG_CCM}
+---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfig
 metadata:
@@ -75,6 +118,7 @@ kind: Cluster
 metadata:
   labels:
     azuredisk-csi: "true"
+    cloud-provider: ${CLOUD_PROVIDER_AZURE_LABEL}
     cni: calico
   name: ${CLUSTER_NAME}
   namespace: default

--- a/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-machine-pool/kustomization.yaml
+++ b/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-machine-pool/kustomization.yaml
@@ -1,11 +1,14 @@
 resources:
-  - ../bases/cluster-with-kcp.yaml
-  - ../bases/mp.yaml
-  - ../bases/azure-cluster-identity.yaml
-  - ../bases/calico.yaml
-  - ../bases/azuredisk-csi-driver.yaml
+- ../bases/cluster-with-kcp.yaml
+- ../bases/mp.yaml
+- ../bases/azure-cluster-identity.yaml
+- ../bases/calico.yaml
+- ../bases/azuredisk-csi-driver.yaml
+- ../bases/cloud-provider-azure.yaml
+- ../bases/cloud-provider-azure-ci.yaml
 
 patchesStrategicMerge:
-  - ../patches/azurecluster-identity-ref.yaml
-  - ../patches/cluster-label-calico.yaml
-  - ../patches/cluster-label-azuredisk-csi-driver.yaml
+- ../patches/azurecluster-identity-ref.yaml
+- ../patches/cluster-label-calico.yaml
+- ../patches/cluster-label-azuredisk-csi-driver.yaml
+- ../patches/cluster-label-cloud-provider-azure.yaml

--- a/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-md-remediation.yaml
+++ b/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-md-remediation.yaml
@@ -49,6 +49,49 @@ spec:
       image: mcr.microsoft.com/oss/calico/ctl
   version: ${CALICO_VERSION}
 ---
+apiVersion: addons.cluster.x-k8s.io/v1alpha1
+kind: HelmChartProxy
+metadata:
+  name: cloud-provider-azure-chart
+spec:
+  chartName: cloud-provider-azure
+  clusterSelector:
+    matchLabels:
+      cloud-provider: azure
+  releaseName: cloud-provider-azure
+  repoURL: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/helm/repo
+  valuesTemplate: |-
+    infra:
+      clusterName: {{ .Cluster.metadata.name }}
+    cloudControllerManager:
+      clusterCIDR: {{ .Cluster.spec.clusterNetwork.pods.cidrBlocks | join "," }}
+      logVerbosity: 4
+---
+apiVersion: addons.cluster.x-k8s.io/v1alpha1
+kind: HelmChartProxy
+metadata:
+  name: cloud-provider-azure-chart-ci
+spec:
+  chartName: cloud-provider-azure
+  clusterSelector:
+    matchLabels:
+      cloud-provider: azure-ci
+  releaseName: cloud-provider-azure
+  repoURL: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/helm/repo
+  valuesTemplate: |-
+    infra:
+      clusterName: {{ .Cluster.metadata.name }}
+    cloudControllerManager:
+      clusterCIDR: {{ .Cluster.spec.clusterNetwork.pods.cidrBlocks | join "," }}
+      imageName: ${CCM_IMAGE_NAME}
+      imageRepository: ${CCM_IMAGE_REGISTRY}
+      imageTag: ${IMAGE_TAG_CCM}
+      logVerbosity: 4
+    cloudNodeManager:
+      imageName: ${CNM_IMAGE_NAME}
+      imageRepository: ${CNM_IMAGE_REGISTRY}
+      imageTag: ${IMAGE_TAG_CCM}
+---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate
 metadata:
@@ -76,6 +119,7 @@ kind: Cluster
 metadata:
   labels:
     azuredisk-csi: "true"
+    cloud-provider: ${CLOUD_PROVIDER_AZURE_LABEL}
     cni: calico
   name: ${CLUSTER_NAME}
   namespace: default

--- a/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-md-remediation/kustomization.yaml
+++ b/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-md-remediation/kustomization.yaml
@@ -1,13 +1,16 @@
 bases:
-  - ../bases/cluster-with-kcp.yaml
-  - ../bases/md.yaml
-  - mhc.yaml
-  - ../bases/azure-cluster-identity.yaml
-  - ../bases/calico.yaml
-  - ../bases/azuredisk-csi-driver.yaml
+- ../bases/cluster-with-kcp.yaml
+- ../bases/md.yaml
+- mhc.yaml
+- ../bases/azure-cluster-identity.yaml
+- ../bases/calico.yaml
+- ../bases/azuredisk-csi-driver.yaml
+- ../bases/cloud-provider-azure.yaml
+- ../bases/cloud-provider-azure-ci.yaml
 
 patchesStrategicMerge:
 - ./md.yaml
 - ../patches/azurecluster-identity-ref.yaml
 - ../patches/cluster-label-calico.yaml
 - ../patches/cluster-label-azuredisk-csi-driver.yaml
+- ../patches/cluster-label-cloud-provider-azure.yaml

--- a/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-node-drain.yaml
+++ b/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-node-drain.yaml
@@ -49,6 +49,49 @@ spec:
       image: mcr.microsoft.com/oss/calico/ctl
   version: ${CALICO_VERSION}
 ---
+apiVersion: addons.cluster.x-k8s.io/v1alpha1
+kind: HelmChartProxy
+metadata:
+  name: cloud-provider-azure-chart
+spec:
+  chartName: cloud-provider-azure
+  clusterSelector:
+    matchLabels:
+      cloud-provider: azure
+  releaseName: cloud-provider-azure
+  repoURL: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/helm/repo
+  valuesTemplate: |-
+    infra:
+      clusterName: {{ .Cluster.metadata.name }}
+    cloudControllerManager:
+      clusterCIDR: {{ .Cluster.spec.clusterNetwork.pods.cidrBlocks | join "," }}
+      logVerbosity: 4
+---
+apiVersion: addons.cluster.x-k8s.io/v1alpha1
+kind: HelmChartProxy
+metadata:
+  name: cloud-provider-azure-chart-ci
+spec:
+  chartName: cloud-provider-azure
+  clusterSelector:
+    matchLabels:
+      cloud-provider: azure-ci
+  releaseName: cloud-provider-azure
+  repoURL: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/helm/repo
+  valuesTemplate: |-
+    infra:
+      clusterName: {{ .Cluster.metadata.name }}
+    cloudControllerManager:
+      clusterCIDR: {{ .Cluster.spec.clusterNetwork.pods.cidrBlocks | join "," }}
+      imageName: ${CCM_IMAGE_NAME}
+      imageRepository: ${CCM_IMAGE_REGISTRY}
+      imageTag: ${IMAGE_TAG_CCM}
+      logVerbosity: 4
+    cloudNodeManager:
+      imageName: ${CNM_IMAGE_NAME}
+      imageRepository: ${CNM_IMAGE_REGISTRY}
+      imageTag: ${IMAGE_TAG_CCM}
+---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate
 metadata:
@@ -76,6 +119,7 @@ kind: Cluster
 metadata:
   labels:
     azuredisk-csi: "true"
+    cloud-provider: ${CLOUD_PROVIDER_AZURE_LABEL}
     cni: calico
   name: ${CLUSTER_NAME}
   namespace: default

--- a/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-node-drain/kustomization.yaml
+++ b/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-node-drain/kustomization.yaml
@@ -4,6 +4,8 @@ bases:
 - ../bases/azure-cluster-identity.yaml
 - ../bases/calico.yaml
 - ../bases/azuredisk-csi-driver.yaml
+- ../bases/cloud-provider-azure.yaml
+- ../bases/cloud-provider-azure-ci.yaml
 
 patchesStrategicMerge:
 - ./md.yaml
@@ -11,3 +13,4 @@ patchesStrategicMerge:
 - ../patches/azurecluster-identity-ref.yaml
 - ../patches/cluster-label-calico.yaml
 - ../patches/cluster-label-azuredisk-csi-driver.yaml
+- ../patches/cluster-label-cloud-provider-azure.yaml

--- a/test/e2e/data/infrastructure-azure/v1beta1/cluster-template.yaml
+++ b/test/e2e/data/infrastructure-azure/v1beta1/cluster-template.yaml
@@ -49,6 +49,49 @@ spec:
       image: mcr.microsoft.com/oss/calico/ctl
   version: ${CALICO_VERSION}
 ---
+apiVersion: addons.cluster.x-k8s.io/v1alpha1
+kind: HelmChartProxy
+metadata:
+  name: cloud-provider-azure-chart
+spec:
+  chartName: cloud-provider-azure
+  clusterSelector:
+    matchLabels:
+      cloud-provider: azure
+  releaseName: cloud-provider-azure
+  repoURL: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/helm/repo
+  valuesTemplate: |-
+    infra:
+      clusterName: {{ .Cluster.metadata.name }}
+    cloudControllerManager:
+      clusterCIDR: {{ .Cluster.spec.clusterNetwork.pods.cidrBlocks | join "," }}
+      logVerbosity: 4
+---
+apiVersion: addons.cluster.x-k8s.io/v1alpha1
+kind: HelmChartProxy
+metadata:
+  name: cloud-provider-azure-chart-ci
+spec:
+  chartName: cloud-provider-azure
+  clusterSelector:
+    matchLabels:
+      cloud-provider: azure-ci
+  releaseName: cloud-provider-azure
+  repoURL: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/helm/repo
+  valuesTemplate: |-
+    infra:
+      clusterName: {{ .Cluster.metadata.name }}
+    cloudControllerManager:
+      clusterCIDR: {{ .Cluster.spec.clusterNetwork.pods.cidrBlocks | join "," }}
+      imageName: ${CCM_IMAGE_NAME}
+      imageRepository: ${CCM_IMAGE_REGISTRY}
+      imageTag: ${IMAGE_TAG_CCM}
+      logVerbosity: 4
+    cloudNodeManager:
+      imageName: ${CNM_IMAGE_NAME}
+      imageRepository: ${CNM_IMAGE_REGISTRY}
+      imageTag: ${IMAGE_TAG_CCM}
+---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate
 metadata:
@@ -76,6 +119,7 @@ kind: Cluster
 metadata:
   labels:
     azuredisk-csi: "true"
+    cloud-provider: ${CLOUD_PROVIDER_AZURE_LABEL}
     cni: calico
   name: ${CLUSTER_NAME}
   namespace: default

--- a/test/e2e/data/infrastructure-azure/v1beta1/cluster-template/kustomization.yaml
+++ b/test/e2e/data/infrastructure-azure/v1beta1/cluster-template/kustomization.yaml
@@ -4,8 +4,11 @@ bases:
 - ../bases/azure-cluster-identity.yaml
 - ../bases/calico.yaml
 - ../bases/azuredisk-csi-driver.yaml
+- ../bases/cloud-provider-azure.yaml
+- ../bases/cloud-provider-azure-ci.yaml
 
 patchesStrategicMerge:
 - ../patches/azurecluster-identity-ref.yaml
 - ../patches/cluster-label-calico.yaml
 - ../patches/cluster-label-azuredisk-csi-driver.yaml
+- ../patches/cluster-label-cloud-provider-azure.yaml

--- a/test/e2e/data/infrastructure-azure/v1beta1/patches/cluster-label-cloud-provider-azure.yaml
+++ b/test/e2e/data/infrastructure-azure/v1beta1/patches/cluster-label-cloud-provider-azure.yaml
@@ -1,0 +1,6 @@
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  name: ${CLUSTER_NAME}
+  labels:
+    cloud-provider: ${CLOUD_PROVIDER_AZURE_LABEL}

--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -942,3 +942,18 @@ func getSubscriptionID(g Gomega) string {
 	g.Expect(subscriptionID).NotTo(BeEmpty())
 	return subscriptionID
 }
+
+func setPlaceholderValuesForCCMEnvVars() {
+	Expect(setEnvVarIfNotSet("CCM_IMAGE_NAME", "ccm_image_name_placeholder")).To(Succeed())
+	Expect(setEnvVarIfNotSet("CCM_IMAGE_REGISTRY", "ccm_image_registry_placeholder")).To(Succeed())
+	Expect(setEnvVarIfNotSet("CNM_IMAGE_NAME", "cnm_image_name_placeholder")).To(Succeed())
+	Expect(setEnvVarIfNotSet("CNM_IMAGE_REGISTRY", "cnm_image_registry_placeholder")).To(Succeed())
+	Expect(setEnvVarIfNotSet("IMAGE_TAG_CCM", "image_tag_ccm_placeholder")).To(Succeed())
+}
+
+func setEnvVarIfNotSet(name string, defaultValue string) error {
+	if _, ok := os.LookupEnv(name); !ok {
+		return os.Setenv(name, defaultValue)
+	}
+	return nil
+}


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind feature

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**: Install cloud provider azure Helm chart with CAAPH in e2e tests.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3736

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Install cloud provider azure Helm chart with CAAPH
```
