### PR TITLE
Support deploying an azure infra cluster using a single subnet for both  control plane and worker nodes.

### DIFF
--- a/api/v1beta1/azurecluster_default_test.go
+++ b/api/v1beta1/azurecluster_default_test.go
@@ -480,6 +480,108 @@ func TestSubnetDefaults(t *testing.T) {
 			},
 		},
 		{
+			name: "cluster subnet with custom attributes",
+			cluster: &AzureCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cluster-test",
+				},
+				Spec: AzureClusterSpec{
+					NetworkSpec: NetworkSpec{
+						Subnets: Subnets{
+							{
+								SubnetClassSpec: SubnetClassSpec{
+									Role:       SubnetCluster,
+									CIDRBlocks: []string{"10.0.0.16/24"},
+									Name:       "my-subnet",
+								},
+								NatGateway: NatGateway{
+									NatGatewayClassSpec: NatGatewayClassSpec{
+										Name: "foo-natgw",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			output: &AzureCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cluster-test",
+				},
+				Spec: AzureClusterSpec{
+					NetworkSpec: NetworkSpec{
+						Subnets: Subnets{
+							{
+								SubnetClassSpec: SubnetClassSpec{
+									Role:       SubnetCluster,
+									CIDRBlocks: []string{"10.0.0.16/24"},
+									Name:       "my-subnet",
+								},
+								SecurityGroup: SecurityGroup{Name: "cluster-test-nsg"},
+								RouteTable:    RouteTable{Name: "cluster-test-routetable"},
+								NatGateway: NatGateway{
+									NatGatewayClassSpec: NatGatewayClassSpec{
+										Name: "foo-natgw",
+									},
+									NatGatewayIP: PublicIPSpec{
+										Name: "pip-foo-natgw",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "cluster subnet with subnets specified",
+			cluster: &AzureCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cluster-test",
+				},
+				Spec: AzureClusterSpec{
+					NetworkSpec: NetworkSpec{
+						Subnets: Subnets{
+							{
+								SubnetClassSpec: SubnetClassSpec{
+									Role: SubnetCluster,
+									Name: "cluster-test-subnet",
+								},
+							},
+						},
+					},
+				},
+			},
+			output: &AzureCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cluster-test",
+				},
+				Spec: AzureClusterSpec{
+					NetworkSpec: NetworkSpec{
+						Subnets: Subnets{
+							{
+								SubnetClassSpec: SubnetClassSpec{
+									Role:       SubnetCluster,
+									CIDRBlocks: []string{DefaultClusterSubnetCIDR},
+									Name:       "cluster-test-subnet",
+								},
+								SecurityGroup: SecurityGroup{Name: "cluster-test-nsg"},
+								RouteTable:    RouteTable{Name: "cluster-test-routetable"},
+								NatGateway: NatGateway{
+									NatGatewayClassSpec: NatGatewayClassSpec{
+										Name: "cluster-test-natgw",
+									},
+									NatGatewayIP: PublicIPSpec{
+										Name: "pip-cluster-test-natgw",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "subnets route tables specified",
 			cluster: &AzureCluster{
 				ObjectMeta: metav1.ObjectMeta{

--- a/api/v1beta1/azureclustertemplate_default_test.go
+++ b/api/v1beta1/azureclustertemplate_default_test.go
@@ -442,6 +442,99 @@ func TestSubnetsTemplateDefaults(t *testing.T) {
 			},
 		},
 		{
+			name: "cluster subnet with custom attributes",
+			clusterTemplate: &AzureClusterTemplate{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-cluster-template",
+				},
+				Spec: AzureClusterTemplateSpec{
+					Template: AzureClusterTemplateResource{
+						Spec: AzureClusterTemplateResourceSpec{
+							NetworkSpec: NetworkTemplateSpec{
+								Subnets: SubnetTemplatesSpec{
+									{
+										SubnetClassSpec: SubnetClassSpec{
+											Role:       SubnetCluster,
+											CIDRBlocks: []string{"10.1.0.16/24"},
+										},
+										NatGateway: NatGatewayClassSpec{
+											Name: "foo-natgw",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			outputTemplate: &AzureClusterTemplate{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-cluster-template",
+				},
+				Spec: AzureClusterTemplateSpec{
+					Template: AzureClusterTemplateResource{
+						Spec: AzureClusterTemplateResourceSpec{
+							NetworkSpec: NetworkTemplateSpec{
+								Subnets: SubnetTemplatesSpec{
+									{
+										SubnetClassSpec: SubnetClassSpec{
+											Role:       SubnetCluster,
+											CIDRBlocks: []string{"10.1.0.16/24"},
+										},
+										NatGateway: NatGatewayClassSpec{Name: "foo-natgw"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "subnets specified",
+			clusterTemplate: &AzureClusterTemplate{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-cluster-template",
+				},
+				Spec: AzureClusterTemplateSpec{
+					Template: AzureClusterTemplateResource{
+						Spec: AzureClusterTemplateResourceSpec{
+							NetworkSpec: NetworkTemplateSpec{
+								Subnets: SubnetTemplatesSpec{
+									{
+										SubnetClassSpec: SubnetClassSpec{
+											Role: SubnetCluster,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			outputTemplate: &AzureClusterTemplate{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-cluster-template",
+				},
+				Spec: AzureClusterTemplateSpec{
+					Template: AzureClusterTemplateResource{
+						Spec: AzureClusterTemplateResourceSpec{
+							NetworkSpec: NetworkTemplateSpec{
+								Subnets: SubnetTemplatesSpec{
+									{
+										SubnetClassSpec: SubnetClassSpec{
+											Role:       SubnetCluster,
+											CIDRBlocks: []string{DefaultClusterSubnetCIDR},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "only node subnet specified",
 			clusterTemplate: &AzureClusterTemplate{
 				ObjectMeta: metav1.ObjectMeta{

--- a/api/v1beta1/types_class.go
+++ b/api/v1beta1/types_class.go
@@ -432,7 +432,7 @@ type SubnetClassSpec struct {
 	Name string `json:"name"`
 
 	// Role defines the subnet role (eg. Node, ControlPlane)
-	// +kubebuilder:validation:Enum=node;control-plane;bastion
+	// +kubebuilder:validation:Enum=node;control-plane;bastion;all
 	Role SubnetRole `json:"role"`
 
 	// CIDRBlocks defines the subnet's address space, specified as one or more address prefixes in CIDR notation.

--- a/api/v1beta1/types_template.go
+++ b/api/v1beta1/types_template.go
@@ -77,20 +77,20 @@ type NetworkTemplateSpec struct {
 	ControlPlaneOutboundLB *LoadBalancerClassSpec `json:"controlPlaneOutboundLB,omitempty"`
 }
 
-// GetControlPlaneSubnetTemplate returns the cluster control plane subnet template.
-func (n *NetworkTemplateSpec) GetControlPlaneSubnetTemplate() (SubnetTemplateSpec, error) {
+// GetSubnetTemplate returns the subnet template based on the subnet role.
+func (n *NetworkTemplateSpec) GetSubnetTemplate(role SubnetRole) (SubnetTemplateSpec, error) {
 	for _, sn := range n.Subnets {
-		if sn.Role == SubnetControlPlane {
+		if sn.Role == role {
 			return sn, nil
 		}
 	}
-	return SubnetTemplateSpec{}, errors.Errorf("no subnet template found with role %s", SubnetControlPlane)
+	return SubnetTemplateSpec{}, errors.Errorf("no subnet template found with role %s", role)
 }
 
-// UpdateControlPlaneSubnetTemplate updates the cluster control plane subnet template.
-func (n *NetworkTemplateSpec) UpdateControlPlaneSubnetTemplate(subnet SubnetTemplateSpec) {
+// UpdateSubnetTemplate updates the subnet template based on subnet role.
+func (n *NetworkTemplateSpec) UpdateSubnetTemplate(subnet SubnetTemplateSpec, role SubnetRole) {
 	for i, sn := range n.Subnets {
-		if sn.Role == SubnetControlPlane {
+		if sn.Role == role {
 			n.Subnets[i] = subnet
 		}
 	}

--- a/azure/scope/cluster.go
+++ b/azure/scope/cluster.go
@@ -610,7 +610,7 @@ func (s *ClusterScope) ControlPlaneSubnet() infrav1.SubnetSpec {
 func (s *ClusterScope) NodeSubnets() []infrav1.SubnetSpec {
 	subnets := []infrav1.SubnetSpec{}
 	for _, subnet := range s.AzureCluster.Spec.NetworkSpec.Subnets {
-		if subnet.Role == infrav1.SubnetNode {
+		if subnet.Role == infrav1.SubnetNode || subnet.Role == infrav1.SubnetCluster {
 			subnets = append(subnets, subnet)
 		}
 	}

--- a/azure/scope/machine.go
+++ b/azure/scope/machine.go
@@ -726,12 +726,22 @@ func (m *MachineScope) SetSubnetName() error {
 		subnetName := ""
 		subnets := m.Subnets()
 		var subnetCount int
+		clusterSubnetName := ""
 		for _, subnet := range subnets {
 			if string(subnet.Role) == m.Role() {
 				subnetCount++
 				subnetName = subnet.Name
 			}
+			if subnet.Role == infrav1.SubnetCluster {
+				clusterSubnetName = subnet.Name
+			}
 		}
+
+		if subnetName == "" && clusterSubnetName != "" {
+			subnetName = clusterSubnetName
+			subnetCount = 1
+		}
+
 		if subnetCount == 0 || subnetCount > 1 || subnetName == "" {
 			return errors.New("a subnet name must be specified when no subnets are specified or more than 1 subnet of the same role exist")
 		}

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azureclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azureclusters.yaml
@@ -291,6 +291,7 @@ spec:
                             - node
                             - control-plane
                             - bastion
+                            - all
                             type: string
                           routeTable:
                             description: RouteTable defines the route table that should
@@ -1033,6 +1034,7 @@ spec:
                           - node
                           - control-plane
                           - bastion
+                          - all
                           type: string
                         routeTable:
                           description: RouteTable defines the route table that should

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azureclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azureclustertemplates.yaml
@@ -194,6 +194,7 @@ spec:
                                     - node
                                     - control-plane
                                     - bastion
+                                    - all
                                     type: string
                                   securityGroup:
                                     description: SecurityGroup defines the NSG (network
@@ -692,6 +693,7 @@ spec:
                                   - node
                                   - control-plane
                                   - bastion
+                                  - all
                                   type: string
                                 securityGroup:
                                   description: SecurityGroup defines the NSG (network

--- a/controllers/helpers.go
+++ b/controllers/helpers.go
@@ -318,7 +318,7 @@ func newCloudProviderConfig(d azure.ClusterScoper) (controlPlaneConfig *CloudPro
 // getOneNodeSubnet returns one of the subnets for the node role.
 func getOneNodeSubnet(d azure.ClusterScoper) infrav1.SubnetSpec {
 	for _, subnet := range d.Subnets() {
-		if subnet.Role == infrav1.SubnetNode {
+		if subnet.Role == infrav1.SubnetNode || subnet.Role == infrav1.SubnetCluster {
 			return subnet
 		}
 	}


### PR DESCRIPTION
…ure infra clusters.

 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
Allows user to create azure infra clusters with a single subnet 


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2202

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Support to deploy infra clusters using a single subnet for both control plane and worker nodes.
```
