### PR TITLE
wait for provisioning state in AKS e2e tests

### DIFF
--- a/test/e2e/aks_autoscaler.go
+++ b/test/e2e/aks_autoscaler.go
@@ -111,6 +111,7 @@ func validateAKSAutoscaleDisabled(agentPoolGetter func() (armcontainerservice.Ag
 	Eventually(func(g Gomega) {
 		agentpool, err := agentPoolGetter()
 		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(agentpool.Properties.ProvisioningState).To(Equal(ptr.To("Succeeded")))
 		g.Expect(ptr.Deref(agentpool.Properties.EnableAutoScaling, false)).To(BeFalse())
 	}, inputGetter().WaitIntervals...).Should(Succeed())
 }
@@ -120,6 +121,7 @@ func validateAKSAutoscaleEnabled(agentPoolGetter func() (armcontainerservice.Age
 	Eventually(func(g Gomega) {
 		agentpool, err := agentPoolGetter()
 		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(agentpool.Properties.ProvisioningState).To(Equal(ptr.To("Succeeded")))
 		g.Expect(ptr.Deref(agentpool.Properties.EnableAutoScaling, false)).To(BeTrue())
 	}, inputGetter().WaitIntervals...).Should(Succeed())
 }

--- a/test/e2e/aks_azure_cluster_autoscaler.go
+++ b/test/e2e/aks_azure_cluster_autoscaler.go
@@ -61,6 +61,7 @@ func AKSAzureClusterAutoscalerSettingsSpec(ctx context.Context, inputGetter func
 
 		aks, err := containerserviceClient.Get(ctx, amcp.Spec.ResourceGroupName, amcp.Name, nil)
 		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(aks.Properties.ProvisioningState).To(Equal(ptr.To("Succeeded")))
 		aksInitialAutoScalerProfile := aks.Properties.AutoScalerProfile
 
 		// Conditional is based off of the actual AKS settings not the AzureManagedControlPlane
@@ -106,6 +107,7 @@ func AKSAzureClusterAutoscalerSettingsSpec(ctx context.Context, inputGetter func
 		// Check that the autoscaler settings have been sync'd to AKS
 		aks, err := containerserviceClient.Get(ctx, amcp.Spec.ResourceGroupName, amcp.Name, nil)
 		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(aks.Properties.ProvisioningState).To(Equal(ptr.To("Succeeded")))
 		g.Expect(aks.Properties.AutoScalerProfile).ToNot(BeNil())
 		g.Expect(aks.Properties.AutoScalerProfile.Expander).To(Equal(&expectedAksExpander))
 	}, input.WaitIntervals...).Should(Succeed())

--- a/test/e2e/aks_node_labels.go
+++ b/test/e2e/aks_node_labels.go
@@ -78,6 +78,7 @@ func AKSNodeLabelsSpec(ctx context.Context, inputGetter func() AKSNodeLabelsSpec
 			checkLabels := func(g Gomega) {
 				resp, err := agentpoolsClient.Get(ctx, infraControlPlane.Spec.ResourceGroupName, infraControlPlane.Name, *ammp.Spec.Name, nil)
 				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(resp.Properties.ProvisioningState).To(Equal(ptr.To("Succeeded")))
 
 				agentpool := resp.AgentPool
 				var actualLabels map[string]string

--- a/test/e2e/aks_node_taints.go
+++ b/test/e2e/aks_node_taints.go
@@ -89,6 +89,7 @@ func AKSNodeTaintsSpec(ctx context.Context, inputGetter func() AKSNodeTaintsSpec
 
 				resp, err := agentpoolsClient.Get(ctx, infraControlPlane.Spec.ResourceGroupName, infraControlPlane.Name, *ammp.Spec.Name, nil)
 				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(resp.Properties.ProvisioningState).To(Equal(ptr.To("Succeeded")))
 				actualTaintStrs := resp.AgentPool.Properties.NodeTaints
 				if expectedTaintStrs == nil {
 					g.Expect(actualTaintStrs).To(BeNil())

--- a/test/e2e/aks_tags.go
+++ b/test/e2e/aks_tags.go
@@ -28,6 +28,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/converters"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
@@ -83,6 +84,7 @@ func AKSAdditionalTagsSpec(ctx context.Context, inputGetter func() AKSAdditional
 		checkTags := func(g Gomega) {
 			resp, err := managedclustersClient.Get(ctx, infraControlPlane.Spec.ResourceGroupName, infraControlPlane.Name, nil)
 			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(resp.Properties.ProvisioningState).To(Equal(ptr.To("Succeeded")))
 			actualTags := converters.MapToTags(resp.ManagedCluster.Tags)
 			// Ignore tags not originally specified in spec.additionalTags
 			for k := range nonAdditionalTagKeys {
@@ -167,6 +169,7 @@ func AKSAdditionalTagsSpec(ctx context.Context, inputGetter func() AKSAdditional
 			checkTags := func(g Gomega) {
 				resp, err := agentpoolsClient.Get(ctx, infraControlPlane.Spec.ResourceGroupName, infraControlPlane.Name, *ammp.Spec.Name, nil)
 				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(resp.Properties.ProvisioningState).To(Equal(ptr.To("Succeeded")))
 				actualTags := converters.MapToTags(resp.AgentPool.Properties.Tags)
 				// Ignore tags not originally specified in spec.additionalTags
 				for k := range nonAdditionalTagKeys {

--- a/test/e2e/aks_upgrade.go
+++ b/test/e2e/aks_upgrade.go
@@ -26,6 +26,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v4"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	expv1 "sigs.k8s.io/cluster-api/exp/api/v1beta1"
@@ -65,6 +66,7 @@ func AKSUpgradeSpec(ctx context.Context, inputGetter func() AKSUpgradeSpecInput)
 	Eventually(func(g Gomega) {
 		resp, err := managedClustersClient.Get(ctx, infraControlPlane.Spec.ResourceGroupName, infraControlPlane.Name, nil)
 		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(resp.Properties.ProvisioningState).To(Equal(ptr.To("Succeeded")))
 		aksCluster := resp.ManagedCluster
 		g.Expect(aksCluster.Properties).NotTo(BeNil())
 		g.Expect(aksCluster.Properties.KubernetesVersion).NotTo(BeNil())


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind flake

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

Many of the e2e test specs for managed clusters make some update to a CAPZ resource and then wait for that change to be reflected in Azure. Until now, this wait hasn't taken into account the `provisioningState` of the resource in Azure, which changes from "Updating" to "Succeeded" when the operation is done. Anecdotally, I tend to observe updates in the Azure API to apply a noticeable amount of time before operations finish. I have a hypothesis that the current behavior is causing the tests to progress too quickly and cause issues like #3955 and https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/4069#issuecomment-1773158364.

This PR inserts checks that the provisioning state of the AKS resources is Succeeded alongside the existing checks that the other relevant API fields have been updated to ensure the cluster is in a successful state and not actively being updated before moving on.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3955

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [X] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
