### PR TITLE
fix AKS to machine pool mapper

### DIFF
--- a/exp/controllers/azuremachinepool_controller.go
+++ b/exp/controllers/azuremachinepool_controller.go
@@ -103,7 +103,7 @@ func (ampr *AzureMachinePoolReconciler) SetupWithManager(ctx context.Context, mg
 	if err != nil {
 		return errors.Wrapf(err, "failed to create AzureCluster to AzureMachinePools mapper")
 	}
-	azureManagedClusterMapper, err := AzureManagedClusterToAzureMachinePoolsMapper(ctx, ampr.Client, mgr.GetScheme(), log)
+	azureManagedControlPlaneMapper, err := AzureManagedControlPlaneToAzureMachinePoolsMapper(ctx, ampr.Client, mgr.GetScheme(), log)
 	if err != nil {
 		return errors.Wrapf(err, "failed to create AzureManagedCluster to AzureMachinePools mapper")
 	}
@@ -125,7 +125,7 @@ func (ampr *AzureMachinePoolReconciler) SetupWithManager(ctx context.Context, mg
 		// watch for changes in AzureManagedControlPlane resources
 		Watches(
 			&infrav1.AzureManagedControlPlane{},
-			handler.EnqueueRequestsFromMapFunc(azureManagedClusterMapper),
+			handler.EnqueueRequestsFromMapFunc(azureManagedControlPlaneMapper),
 		).
 		// watch for changes in KubeadmConfig to sync bootstrap token
 		Watches(


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

Currently, the AzureMachinePool controller watches AzureManagedControlPlanes:
https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/8a09a423306b5aa0c0d94c371cb4c1da0697a0aa/exp/controllers/azuremachinepool_controller.go#L125-L129

But the map func assumes it receives an AzureManagedCluster: https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/8a09a423306b5aa0c0d94c371cb4c1da0697a0aa/exp/controllers/helpers.go#L113-L117

This PR updates the map func to operate on an AzureManagedControlPlane instead of an AzureCluster since the watch is used to notify the AzureMachinePool controller when an AzureManagedControlPlane is available: https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/8a09a423306b5aa0c0d94c371cb4c1da0697a0aa/controllers/helpers.go#L1103-L1107

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate <-- This original code doesn't exist on any release branch.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
