### PR TITLE
Create test to cover path of azureMachinePool.Spec.UserAssignedIdenti…

### DIFF
--- a/azure/services/identities/client.go
+++ b/azure/services/identities/client.go
@@ -39,7 +39,7 @@ type AzureClient struct {
 }
 
 // NewClient creates a new MSI client from an authorizer.
-func NewClient(auth azure.Authorizer) (*AzureClient, error) {
+func NewClient(auth azure.Authorizer) (Client, error) {
 	opts, err := azure.ARMClientOptions(auth.CloudEnvironment())
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create identities client options")

--- a/controllers/azurejson_machinepool_controller.go
+++ b/controllers/azurejson_machinepool_controller.go
@@ -149,7 +149,7 @@ func (r *AzureJSONMachinePoolReconciler) Reconcile(ctx context.Context, req ctrl
 	// Construct secret for this machine
 	userAssignedIdentityIfExists := ""
 	if len(azureMachinePool.Spec.UserAssignedIdentities) > 0 {
-		idsClient, err := identities.NewClient(clusterScope)
+		idsClient, err := getClient(clusterScope)
 		if err != nil {
 			return reconcile.Result{}, errors.Wrap(err, "failed to create identities client")
 		}
@@ -194,3 +194,5 @@ func (r *AzureJSONMachinePoolReconciler) Reconcile(ctx context.Context, req ctrl
 
 	return ctrl.Result{}, nil
 }
+
+var getClient = identities.NewClient


### PR DESCRIPTION

**What type of PR is this?**
/kind cleanup 

**What this PR does / why we need it**:
Adds testing to the `controllers` package 

- [x] Add unit test for controller azurejson
- [x] Create func to monkey patch during testing
- [x] Export interface instead of concrete type for testing 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #https://github.com/kubernetes-sigs/cluster-api-provider-azure/issues/4277
Partially fixes: https://github.com/kubernetes-sigs/cluster-api-provider-azure/issues/3649

**Special notes for your reviewer**:

_I had to change the return value to an interface _(which the return type implements)_ to allow the patch to ensure mocking can take place.  The mocking will use the generated mocks and the EXPECT() to allow to hit that code path while testing._ 


- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests

**Release note**:
```release-note
NONE
```
