### PR TITLE
Add missing kind constants for API

### DIFF
--- a/api/v1beta1/azureclustertemplate_webhook.go
+++ b/api/v1beta1/azureclustertemplate_webhook.go
@@ -67,7 +67,7 @@ func (c *AzureClusterTemplate) ValidateUpdate(oldRaw runtime.Object) (admission.
 	if len(allErrs) == 0 {
 		return nil, nil
 	}
-	return nil, apierrors.NewInvalid(GroupVersion.WithKind("AzureClusterTemplate").GroupKind(), c.Name, allErrs)
+	return nil, apierrors.NewInvalid(GroupVersion.WithKind(AzureClusterTemplateKind).GroupKind(), c.Name, allErrs)
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type.

--- a/api/v1beta1/azuremachine_webhook.go
+++ b/api/v1beta1/azuremachine_webhook.go
@@ -70,7 +70,7 @@ func (mw *azureMachineWebhook) ValidateCreate(ctx context.Context, obj runtime.O
 		return nil, nil
 	}
 
-	return nil, apierrors.NewInvalid(GroupVersion.WithKind("AzureMachine").GroupKind(), m.Name, allErrs)
+	return nil, apierrors.NewInvalid(GroupVersion.WithKind(AzureMachineKind).GroupKind(), m.Name, allErrs)
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
@@ -209,7 +209,7 @@ func (mw *azureMachineWebhook) ValidateUpdate(ctx context.Context, oldObj, newOb
 	if len(allErrs) == 0 {
 		return nil, nil
 	}
-	return nil, apierrors.NewInvalid(GroupVersion.WithKind("AzureMachine").GroupKind(), m.Name, allErrs)
+	return nil, apierrors.NewInvalid(GroupVersion.WithKind(AzureMachineKind).GroupKind(), m.Name, allErrs)
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type.

--- a/api/v1beta1/azuremachinetemplate_webhook.go
+++ b/api/v1beta1/azuremachinetemplate_webhook.go
@@ -89,7 +89,7 @@ func (r *AzureMachineTemplate) ValidateCreate(ctx context.Context, obj runtime.O
 		return nil, nil
 	}
 
-	return nil, apierrors.NewInvalid(GroupVersion.WithKind("AzureMachineTemplate").GroupKind(), t.Name, allErrs)
+	return nil, apierrors.NewInvalid(GroupVersion.WithKind(AzureMachineTemplateKind).GroupKind(), t.Name, allErrs)
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
@@ -133,7 +133,7 @@ func (r *AzureMachineTemplate) ValidateUpdate(ctx context.Context, oldRaw runtim
 	if len(allErrs) == 0 {
 		return nil, nil
 	}
-	return nil, apierrors.NewInvalid(GroupVersion.WithKind("AzureMachineTemplate").GroupKind(), t.Name, allErrs)
+	return nil, apierrors.NewInvalid(GroupVersion.WithKind(AzureMachineTemplateKind).GroupKind(), t.Name, allErrs)
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type.

--- a/api/v1beta1/azuremanagedcontrolplanetemplate_webhook.go
+++ b/api/v1beta1/azuremanagedcontrolplanetemplate_webhook.go
@@ -176,7 +176,7 @@ func (mcpw *azureManagedControlPlaneTemplateWebhook) ValidateUpdate(ctx context.
 		return nil, mcp.validateManagedControlPlaneTemplate(mcpw.Client)
 	}
 
-	return nil, apierrors.NewInvalid(GroupVersion.WithKind("AzureManagedControlPlaneTemplate").GroupKind(), mcp.Name, allErrs)
+	return nil, apierrors.NewInvalid(GroupVersion.WithKind(AzureManagedControlPlaneTemplateKind).GroupKind(), mcp.Name, allErrs)
 }
 
 // Validate the Azure Managed Control Plane Template and return an aggregate error.

--- a/api/v1beta1/azuremanagedmachinepool_webhook.go
+++ b/api/v1beta1/azuremanagedmachinepool_webhook.go
@@ -293,7 +293,7 @@ func (mw *azureManagedMachinePoolWebhook) ValidateUpdate(ctx context.Context, ol
 	}
 
 	if len(allErrs) != 0 {
-		return nil, apierrors.NewInvalid(GroupVersion.WithKind("AzureManagedMachinePool").GroupKind(), m.Name, allErrs)
+		return nil, apierrors.NewInvalid(GroupVersion.WithKind(AzureManagedMachinePoolKind).GroupKind(), m.Name, allErrs)
 	}
 
 	return nil, nil

--- a/api/v1beta1/azuremanagedmachinepooltemplate_webhook.go
+++ b/api/v1beta1/azuremanagedmachinepooltemplate_webhook.go
@@ -270,7 +270,7 @@ func (mpw *azureManagedMachinePoolTemplateWebhook) ValidateUpdate(ctx context.Co
 	if len(allErrs) == 0 {
 		return nil, nil
 	}
-	return nil, apierrors.NewInvalid(GroupVersion.WithKind("AzureManagedMachinePoolTemplate").GroupKind(), mp.Name, allErrs)
+	return nil, apierrors.NewInvalid(GroupVersion.WithKind(AzureManagedMachinePoolTemplateKind).GroupKind(), mp.Name, allErrs)
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type.

--- a/api/v1beta1/consts.go
+++ b/api/v1beta1/consts.go
@@ -160,16 +160,31 @@ const (
 )
 
 const (
+	// AzureNetworkPluginName is the name of the Azure network plugin.
+	AzureNetworkPluginName = "azure"
+)
+
+const (
 	// AzureClusterKind indicates the kind of an AzureCluster.
 	AzureClusterKind = "AzureCluster"
+	// AzureClusterTemplateKind indicates the kind of an AzureClusterTemplate.
+	AzureClusterTemplateKind = "AzureClusterTemplate"
+	// AzureMachineKind indicates the kind of an AzureMachine.
+	AzureMachineKind = "AzureMachine"
+	// AzureMachineTemplateKind indicates the kind of an AzureMachineTemplate.
+	AzureMachineTemplateKind = "AzureMachineTemplate"
 	// AzureMachinePoolKind indicates the kind of an AzureMachinePool.
 	AzureMachinePoolKind = "AzureMachinePool"
+	// AzureManagedMachinePoolKind indicates the kind of an AzureManagedMachinePool.
+	AzureManagedMachinePoolKind = "AzureManagedMachinePool"
 	// AzureManagedClusterKind indicates the kind of an AzureManagedCluster.
 	AzureManagedClusterKind = "AzureManagedCluster"
 	// AzureManagedControlPlaneKind indicates the kind of an AzureManagedControlPlane.
 	AzureManagedControlPlaneKind = "AzureManagedControlPlane"
+	// AzureManagedControlPlaneTemplateKind indicates the kind of an AzureManagedControlPlaneTemplate.
+	AzureManagedControlPlaneTemplateKind = "AzureManagedControlPlaneTemplate"
+	// AzureManagedMachinePoolTemplateKind indicates the kind of an AzureManagedMachinePoolTemplate.
+	AzureManagedMachinePoolTemplateKind = "AzureManagedMachinePoolTemplate"
 	// AzureClusterIdentityKind indicates the kind of an AzureClusterIdentity.
 	AzureClusterIdentityKind = "AzureClusterIdentity"
-	// AzureNetworkPluginName is the name of the Azure network plugin.
-	AzureNetworkPluginName = "azure"
 )

--- a/azure/scope/managedcontrolplane.go
+++ b/azure/scope/managedcontrolplane.go
@@ -701,7 +701,7 @@ func (s *ManagedControlPlaneScope) MakeClusterCA() *corev1.Secret {
 			Name:      secret.Name(s.Cluster.Name, secret.ClusterCA),
 			Namespace: s.Cluster.Namespace,
 			OwnerReferences: []metav1.OwnerReference{
-				*metav1.NewControllerRef(s.ControlPlane, infrav1.GroupVersion.WithKind("AzureManagedControlPlane")),
+				*metav1.NewControllerRef(s.ControlPlane, infrav1.GroupVersion.WithKind(infrav1.AzureManagedControlPlaneKind)),
 			},
 		},
 	}


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind cleanup

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
This PR is a follow up to #4155 that adds constants for kinds. Comment here: https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/4155#pullrequestreview-1735250845

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
