### PR TITLE
test deleting all tags, node labels, and node taints in AKS e2e

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,6 +40,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.20.0
 	go.uber.org/mock v0.3.0
 	golang.org/x/crypto v0.15.0
+	golang.org/x/exp v0.0.0-20231006140011-7918f672742d
 	golang.org/x/mod v0.14.0
 	golang.org/x/text v0.14.0
 	gopkg.in/yaml.v3 v3.0.1
@@ -182,7 +183,6 @@ require (
 	go.starlark.net v0.0.0-20200306205701-8dd3e2ee1dd5 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.25.0 // indirect
-	golang.org/x/exp v0.0.0-20231006140011-7918f672742d // indirect
 	golang.org/x/net v0.17.0 // indirect
 	golang.org/x/oauth2 v0.13.0 // indirect
 	golang.org/x/sync v0.4.0 // indirect

--- a/test/e2e/aks_node_taints.go
+++ b/test/e2e/aks_node_taints.go
@@ -98,6 +98,15 @@ func AKSNodeTaintsSpec(ctx context.Context, inputGetter func() AKSNodeTaintsSpec
 				}
 			}
 
+			Byf("Deleting all node taints for machine pool %s", mp.Name)
+			expectedTaints = nil
+			Eventually(func(g Gomega) {
+				g.Expect(mgmtClient.Get(ctx, client.ObjectKeyFromObject(ammp), ammp)).To(Succeed())
+				ammp.Spec.Taints = expectedTaints
+				g.Expect(mgmtClient.Update(ctx, ammp)).To(Succeed())
+			}, inputGetter().WaitForUpdate...).Should(Succeed())
+			Eventually(checkTaints, input.WaitForUpdate...).Should(Succeed())
+
 			Byf("Creating taints for machine pool %s", mp.Name)
 			expectedTaints = infrav1.Taints{
 				{
@@ -127,16 +136,14 @@ func AKSNodeTaintsSpec(ctx context.Context, inputGetter func() AKSNodeTaintsSpec
 			}, input.WaitForUpdate...).Should(Succeed())
 			Eventually(checkTaints, input.WaitForUpdate...).Should(Succeed())
 
-			if initialTaints != nil {
-				Byf("Restoring initial taints for machine pool %s", mp.Name)
-				expectedTaints = initialTaints
-				Eventually(func(g Gomega) {
-					g.Expect(mgmtClient.Get(ctx, client.ObjectKeyFromObject(ammp), ammp)).To(Succeed())
-					ammp.Spec.Taints = expectedTaints
-					g.Expect(mgmtClient.Update(ctx, ammp)).To(Succeed())
-				}, input.WaitForUpdate...).Should(Succeed())
-				Eventually(checkTaints, input.WaitForUpdate...).Should(Succeed())
-			}
+			Byf("Restoring initial taints for machine pool %s", mp.Name)
+			expectedTaints = initialTaints
+			Eventually(func(g Gomega) {
+				g.Expect(mgmtClient.Get(ctx, client.ObjectKeyFromObject(ammp), ammp)).To(Succeed())
+				ammp.Spec.Taints = expectedTaints
+				g.Expect(mgmtClient.Update(ctx, ammp)).To(Succeed())
+			}, input.WaitForUpdate...).Should(Succeed())
+			Eventually(checkTaints, input.WaitForUpdate...).Should(Succeed())
 		}(mp)
 	}
 


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind cleanup

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

This PR adds tests that remove all defined tags, node labels, and node taints on AKS resources. Deleting all tags had been previously tested but was removed in #4069 due to an ASO limitation at the time that has since been lifted. Deleting all node labels and taints was first made possible in #4122 and has never been tested in e2e before.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4266

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [X] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
