### PR TITLE
Revert "workaround ASO swallowing updates into ongoing operations"

### DIFF
--- a/azure/services/aso/aso.go
+++ b/azure/services/aso/aso.go
@@ -122,15 +122,11 @@ func (r *reconciler[T]) CreateOrUpdateResource(ctx context.Context, spec azure.A
 				// update instead of returning early.
 				adopt = true
 			case cond.Reason == conditions.ReasonReconciling.Name:
-				// Updating the spec of an ASO resource that is already being updated will swallow this update
-				// and ignore it until the next periodic ASO resync.
-				// ref: https://github.com/Azure/azure-service-operator/issues/3451
-				err := azure.NewOperationNotDoneError(&infrav1.Future{
+				readyErr = azure.NewOperationNotDoneError(&infrav1.Future{
 					Type:          createOrUpdateFutureType,
 					ResourceGroup: existing.GetNamespace(),
 					Name:          existing.GetName(),
 				})
-				return zero, azure.WithTransientError(err, requeueInterval)
 			default:
 				readyErr = fmt.Errorf("resource is not Ready: %s", conds[i].Message)
 			}

--- a/azure/services/aso/aso_test.go
+++ b/azure/services/aso/aso_test.go
@@ -230,6 +230,10 @@ func TestCreateOrUpdateResource(t *testing.T) {
 				Namespace: "namespace",
 			},
 		})
+		specMock.EXPECT().Parameters(gomockinternal.AContext(), gomock.Not(gomock.Nil())).DoAndReturn(func(_ context.Context, group *asoresourcesv1.ResourceGroup) (*asoresourcesv1.ResourceGroup, error) {
+			return group, nil
+		})
+		specMock.EXPECT().WasManaged(gomock.Any()).Return(false)
 
 		ctx := context.Background()
 		g.Expect(c.Create(ctx, &asoresourcesv1.ResourceGroup{


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind cleanup

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

This PR reverts #4158 which works around a bug in ASO now fixed in v2.4.0.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [ ] includes documentation
- [X] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
