### PR TITLE
fix log flags

### DIFF
--- a/main.go
+++ b/main.go
@@ -41,7 +41,6 @@ import (
 	cgrecord "k8s.io/client-go/tools/record"
 	"k8s.io/component-base/logs"
 	"k8s.io/klog/v2"
-	"k8s.io/klog/v2/textlogger"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/controllers"
 	infrav1exp "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1beta1"
@@ -117,11 +116,10 @@ var (
 	diagnosticsOptions                 = DiagnosticsOptions{}
 	reconcileTimeout                   time.Duration
 	enableTracing                      bool
-	logConfig                          = textlogger.NewConfig()
 )
 
 // InitFlags initializes all command-line flags.
-func InitFlags(fs *pflag.FlagSet, gofs *flag.FlagSet) {
+func InitFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(
 		&enableLeaderElection,
 		"leader-elect",
@@ -241,7 +239,6 @@ func InitFlags(fs *pflag.FlagSet, gofs *flag.FlagSet) {
 	)
 
 	AddDiagnosticsOptions(fs, &diagnosticsOptions)
-	logConfig.AddFlags(gofs)
 
 	feature.MutableGates.AddFlag(fs)
 }
@@ -251,7 +248,8 @@ func InitFlags(fs *pflag.FlagSet, gofs *flag.FlagSet) {
 // +kubebuilder:rbac:groups=authorization.k8s.io,resources=subjectaccessreviews,verbs=create
 
 func main() {
-	InitFlags(pflag.CommandLine, flag.CommandLine)
+	InitFlags(pflag.CommandLine)
+	klog.InitFlags(flag.CommandLine)
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 	pflag.Parse()
 


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

This PR fixes a regression by #4274 where the command line flag configuration from main.go was no longer matching the logging implementation being set up, so flags like `-v` were no longer having any effect. This PR removes the `textlogger.Config` from main.go and instead sets up command line flags with `klog.InitFlags`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate <-- this bug doesn't exist on any release branch

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
^ this bug has never affected any users of published releases.