### PR TITLE
fix ever-growing log messages with overlapping fields

### DIFF
--- a/controllers/asosecret_controller.go
+++ b/controllers/asosecret_controller.go
@@ -116,7 +116,7 @@ func (asos *ASOSecretReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	)
 	defer done()
 
-	log = log.WithValues("namespace", req.Namespace, "AzureCluster", req.Name)
+	log = log.WithValues("namespace", req.Namespace)
 
 	// asoSecretOwner is the resource that created the identity. This could be either an AzureCluster or AzureManagedControlPlane (if AKS is enabled).
 	// check for AzureCluster first and if it is not found, check for AzureManagedControlPlane.

--- a/controllers/azureidentity_controller.go
+++ b/controllers/azureidentity_controller.go
@@ -151,8 +151,6 @@ func (r *AzureIdentityReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 
 	var bindingsToDelete []aadpodv1.AzureIdentityBinding
 	for _, b := range bindings.Items {
-		log = log.WithValues("azureidentitybinding", b.Name)
-
 		binding := b
 		clusterName := binding.ObjectMeta.Labels[clusterv1.ClusterNameLabel]
 		clusterNamespace := binding.ObjectMeta.Labels[infrav1.ClusterLabelNamespace]

--- a/controllers/helpers.go
+++ b/controllers/helpers.go
@@ -103,7 +103,7 @@ func AzureClusterToAzureMachinesMapper(ctx context.Context, c client.Client, obj
 			return nil
 		}
 
-		log = log.WithValues("AzureCluster", azCluster.Name, "Namespace", azCluster.Namespace)
+		log := log.WithValues("AzureCluster", azCluster.Name, "Namespace", azCluster.Namespace)
 
 		// Don't handle deleted AzureClusters
 		if !azCluster.ObjectMeta.DeletionTimestamp.IsZero() {
@@ -750,7 +750,7 @@ func AzureManagedClusterToAzureManagedMachinePoolsMapper(ctx context.Context, c 
 			return nil
 		}
 
-		log = log.WithValues("AzureManagedCluster", azCluster.Name, "Namespace", azCluster.Namespace)
+		log := log.WithValues("AzureManagedCluster", azCluster.Name, "Namespace", azCluster.Namespace)
 
 		// Don't handle deleted AzureManagedClusters
 		if !azCluster.ObjectMeta.DeletionTimestamp.IsZero() {
@@ -803,7 +803,7 @@ func AzureManagedControlPlaneToAzureManagedMachinePoolsMapper(ctx context.Contex
 			return nil
 		}
 
-		log = log.WithValues("AzureManagedControlPlane", azControlPlane.Name, "Namespace", azControlPlane.Namespace)
+		log := log.WithValues("AzureManagedControlPlane", azControlPlane.Name, "Namespace", azControlPlane.Namespace)
 
 		// Don't handle deleted AzureManagedControlPlanes
 		if !azControlPlane.ObjectMeta.DeletionTimestamp.IsZero() {
@@ -850,7 +850,7 @@ func AzureManagedClusterToAzureManagedControlPlaneMapper(ctx context.Context, c 
 			return nil
 		}
 
-		log = log.WithValues("AzureManagedCluster", azCluster.Name, "Namespace", azCluster.Namespace)
+		log := log.WithValues("AzureManagedCluster", azCluster.Name, "Namespace", azCluster.Namespace)
 
 		// Don't handle deleted AzureManagedClusters
 		if !azCluster.ObjectMeta.DeletionTimestamp.IsZero() {
@@ -899,7 +899,7 @@ func AzureManagedControlPlaneToAzureManagedClusterMapper(ctx context.Context, c 
 			return nil
 		}
 
-		log = log.WithValues("AzureManagedControlPlane", azManagedControlPlane.Name, "Namespace", azManagedControlPlane.Namespace)
+		log := log.WithValues("AzureManagedControlPlane", azManagedControlPlane.Name, "Namespace", azManagedControlPlane.Namespace)
 
 		// Don't handle deleted AzureManagedControlPlanes
 		if !azManagedControlPlane.ObjectMeta.DeletionTimestamp.IsZero() {

--- a/exp/controllers/helpers.go
+++ b/exp/controllers/helpers.go
@@ -63,7 +63,7 @@ func AzureClusterToAzureMachinePoolsMapper(ctx context.Context, c client.Client,
 			return nil
 		}
 
-		log = log.WithValues("AzureCluster", azCluster.Name, "Namespace", azCluster.Namespace)
+		log := log.WithValues("AzureCluster", azCluster.Name, "Namespace", azCluster.Namespace)
 
 		// Don't handle deleted AzureClusters
 		if !azCluster.ObjectMeta.DeletionTimestamp.IsZero() {
@@ -116,7 +116,7 @@ func AzureManagedControlPlaneToAzureMachinePoolsMapper(ctx context.Context, c cl
 			return nil
 		}
 
-		log = log.WithValues("AzureManagedControlPlane", azControlPlane.Name, "Namespace", azControlPlane.Namespace)
+		log := log.WithValues("AzureManagedControlPlane", azControlPlane.Name, "Namespace", azControlPlane.Namespace)
 
 		// Don't handle deleted AzureManagedControlPlane
 		if !azControlPlane.ObjectMeta.DeletionTimestamp.IsZero() {
@@ -165,7 +165,7 @@ func AzureMachinePoolMachineMapper(scheme *runtime.Scheme, log logr.Logger) hand
 			return nil
 		}
 
-		log = log.WithValues("AzureMachinePoolMachine", azureMachinePoolMachine.Name, "Namespace", azureMachinePoolMachine.Namespace)
+		log := log.WithValues("AzureMachinePoolMachine", azureMachinePoolMachine.Name, "Namespace", azureMachinePoolMachine.Namespace)
 		for _, ref := range azureMachinePoolMachine.OwnerReferences {
 			if ref.Kind != gvk.Kind {
 				continue


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind cleanup

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

The primary change here is to create new loggers (`:=` vs `=`) when adding key-value pairs to prevent those pairs from persisting longer than they should, leading to messages with an ever-growing set of redundant and mismatched values. A couple of other related minor changes also snuck into this PR.

Prevents log messages like:
`I1121 02:04:56.879702       1 helpers.go:116] "unable to get the owner cluster" logger="controllers.AzureMachineReconciler.SetupWithManager" controller="AzureMachine" x-ms-correlation-request-id="53f02e71-85d8-45cc-9220-d6fa3c85d019" AzureCluster="capz-e2e-tc4fvl-edgezone" Namespace="capz-e2e-tc4fvl" AzureCluster="capz-e2e-20z64k-dual-stack" Namespace="capz-e2e-20z64k" AzureCluster="capz-e2e-lmw5qj-intree" Namespace="capz-e2e-lmw5qj" AzureCluster="capz-e2e-gl561r-flex" Namespace="capz-e2e-gl561r" AzureCluster="capz-e2e-jl3vsc-flatcar" Namespace="capz-e2e-jl3vsc" AzureCluster="capz-e2e-gqwffh-azwi" Namespace="capz-e2e-gqwffh" AzureCluster="capz-e2e-m20fqa-gpu" Namespace="capz-e2e-m20fqa" AzureCluster="capz-e2e-20z64k-dual-stack" Namespace="capz-e2e-20z64k" AzureCluster="capz-e2e-20z64k-dual-stack" Namespace="capz-e2e-20z64k" AzureCluster="capz-e2e-m20fqa-gpu" Namespace="capz-e2e-m20fqa" AzureCluster="capz-e2e-m20fqa-gpu" Namespace="capz-e2e-m20fqa" AzureCluster="capz-e2e-tc4fvl-edgezone" Namespace="capz-e2e-tc4fvl" AzureCluster="capz-e2e-tc4fvl-edgezone" Namespace="capz-e2e-tc4fvl" AzureCluster="capz-e2e-lmw5qj-intree" Namespace="capz-e2e-lmw5qj" AzureCluster="capz-e2e-lmw5qj-intree" Namespace="capz-e2e-lmw5qj" AzureCluster="capz-e2e-gl561r-flex" Namespace="capz-e2e-gl561r" AzureCluster="capz-e2e-gl561r-flex" Namespace="capz-e2e-gl561r" AzureCluster="capz-e2e-jl3vsc-flatcar" Namespace="capz-e2e-jl3vsc" AzureCluster="capz-e2e-jl3vsc-flatcar" Namespace="capz-e2e-jl3vsc" AzureCluster="capz-e2e-gqwffh-azwi" Namespace="capz-e2e-gqwffh" AzureCluster="capz-e2e-gqwffh-azwi" Namespace="capz-e2e-gqwffh" AzureCluster="capz-e2e-ode3dx-cc-vwfnf" Namespace="capz-e2e-ode3dx" AzureCluster="capz-e2e-ode3dx-cc-vwfnf" Namespace="capz-e2e-ode3dx" AzureCluster="capz-e2e-ode3dx-cc-vwfnf" Namespace="capz-e2e-ode3dx" AzureCluster="capz-e2e-ode3dx-cc-vwfnf" Namespace="capz-e2e-ode3dx" AzureCluster="capz-e2e-ode3dx-cc-vwfnf" Namespace="capz-e2e-ode3dx" AzureCluster="capz-e2e-gl561r-flex" Namespace="capz-e2e-gl561r" AzureCluster="capz-e2e-gl561r-flex" Namespace="capz-e2e-gl561r" AzureCluster="capz-e2e-20z64k-dual-stack" Namespace="capz-e2e-20z64k" AzureCluster="capz-e2e-20z64k-dual-stack" Namespace="capz-e2e-20z64k" AzureCluster="capz-e2e-tc4fvl-edgezone" Namespace="capz-e2e-tc4fvl" AzureCluster="capz-e2e-tc4fvl-edgezone" Namespace="capz-e2e-tc4fvl" AzureCluster="capz-e2e-lmw5qj-intree" Namespace="capz-e2e-lmw5qj" AzureCluster="capz-e2e-lmw5qj-intree" Namespace="capz-e2e-lmw5qj" AzureCluster="capz-e2e-gqwffh-azwi" Namespace="capz-e2e-gqwffh" AzureCluster="capz-e2e-gqwffh-azwi" Namespace="capz-e2e-gqwffh" AzureCluster="capz-e2e-jl3vsc-flatcar" Namespace="capz-e2e-jl3vsc" AzureCluster="capz-e2e-jl3vsc-flatcar" Namespace="capz-e2e-jl3vsc" AzureCluster="capz-e2e-m20fqa-gpu" Namespace="capz-e2e-m20fqa" AzureCluster="capz-e2e-m20fqa-gpu" Namespace="capz-e2e-m20fqa" AzureCluster="capz-e2e-tc4fvl-edgezone" Namespace="capz-e2e-tc4fvl" AzureCluster="capz-e2e-tc4fvl-edgezone" Namespace="capz-e2e-tc4fvl" AzureCluster="capz-e2e-tc4fvl-edgezone" Namespace="capz-e2e-tc4fvl" AzureCluster="capz-e2e-tc4fvl-edgezone" Namespace="capz-e2e-tc4fvl" AzureCluster="capz-e2e-20z64k-dual-stack" Namespace="capz-e2e-20z64k" AzureCluster="capz-e2e-20z64k-dual-stack" Namespace="capz-e2e-20z64k" AzureCluster="capz-e2e-gqwffh-azwi" Namespace="capz-e2e-gqwffh" AzureCluster="capz-e2e-gqwffh-azwi" Namespace="capz-e2e-gqwffh" AzureCluster="capz-e2e-lmw5qj-intree" Namespace="capz-e2e-lmw5qj" AzureCluster="capz-e2e-lmw5qj-intree" Namespace="capz-e2e-lmw5qj" AzureCluster="capz-e2e-20z64k-dual-stack" Namespace="capz-e2e-20z64k" AzureCluster="capz-e2e-20z64k-dual-stack" Namespace="capz-e2e-20z64k" AzureCluster="capz-e2e-gqwffh-azwi" Namespace="capz-e2e-gqwffh" AzureCluster="capz-e2e-gqwffh-azwi" Namespace="capz-e2e-gqwffh" AzureCluster="capz-e2e-lmw5qj-intree" Namespace="capz-e2e-lmw5qj" AzureCluster="capz-e2e-lmw5qj-intree" Namespace="capz-e2e-lmw5qj" AzureCluster="capz-e2e-20z64k-dual-stack" Namespace="capz-e2e-20z64k" AzureCluster="capz-e2e-20z64k-dual-stack" Namespace="capz-e2e-20z64k" AzureCluster="capz-e2e-lmw5qj-intree" Namespace="capz-e2e-lmw5qj" AzureCluster="capz-e2e-lmw5qj-intree" Namespace="capz-e2e-lmw5qj" AzureCluster="capz-e2e-gqwffh-azwi" Namespace="capz-e2e-gqwffh" AzureCluster="capz-e2e-gqwffh-azwi" Namespace="capz-e2e-gqwffh" AzureCluster="capz-e2e-jl3vsc-flatcar" Namespace="capz-e2e-jl3vsc" AzureCluster="capz-e2e-jl3vsc-flatcar" Namespace="capz-e2e-jl3vsc" AzureCluster="capz-e2e-gl561r-flex" Namespace="capz-e2e-gl561r" AzureCluster="capz-e2e-gl561r-flex" Namespace="capz-e2e-gl561r" AzureCluster="capz-e2e-jl3vsc-flatcar" Namespace="capz-e2e-jl3vsc" AzureCluster="capz-e2e-jl3vsc-flatcar" Namespace="capz-e2e-jl3vsc" AzureCluster="capz-e2e-gl561r-flex" Namespace="capz-e2e-gl561r" AzureCluster="capz-e2e-gl561r-flex" Namespace="capz-e2e-gl561r" AzureCluster="capz-e2e-jl3vsc-flatcar" Namespace="capz-e2e-jl3vsc" AzureCluster="capz-e2e-jl3vsc-flatcar" Namespace="capz-e2e-jl3vsc" AzureCluster="capz-e2e-gl561r-flex" Namespace="capz-e2e-gl561r" AzureCluster="capz-e2e-gl561r-flex" Namespace="capz-e2e-gl561r" AzureCluster="capz-e2e-m20fqa-gpu" Namespace="capz-e2e-m20fqa" AzureCluster="capz-e2e-m20fqa-gpu" Namespace="capz-e2e-m20fqa" AzureCluster="capz-e2e-m20fqa-gpu" Namespace="capz-e2e-m20fqa" AzureCluster="capz-e2e-m20fqa-gpu" Namespace="capz-e2e-m20fqa" AzureCluster="capz-e2e-m20fqa-gpu" Namespace="capz-e2e-m20fqa" AzureCluster="capz-e2e-m20fqa-gpu" Namespace="capz-e2e-m20fqa" AzureCluster="capz-e2e-a314xj-public-custom-vnet" Namespace="capz-e2e-a314xj" AzureCluster="capz-e2e-a314xj-public-custom-vnet" Namespace="capz-e2e-a314xj"`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [X] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
