### PR TITLE
Add unit tests to azuremanagedcontrolplane reconciler

### DIFF
--- a/azure/scope/managedcontrolplane.go
+++ b/azure/scope/managedcontrolplane.go
@@ -119,7 +119,7 @@ func NewManagedControlPlaneScope(ctx context.Context, params ManagedControlPlane
 		Cluster:             params.Cluster,
 		ControlPlane:        params.ControlPlane,
 		ManagedMachinePools: params.ManagedMachinePools,
-		patchHelper:         helper,
+		PatchHelper:         helper,
 		cache:               params.Cache,
 		VnetDescriber:       params.VnetDescriber,
 	}, nil
@@ -128,7 +128,7 @@ func NewManagedControlPlaneScope(ctx context.Context, params ManagedControlPlane
 // ManagedControlPlaneScope defines the basic context for an actuator to operate upon.
 type ManagedControlPlaneScope struct {
 	Client              client.Client
-	patchHelper         *patch.Helper
+	PatchHelper         *patch.Helper
 	adminKubeConfigData []byte
 	userKubeConfigData  []byte
 	cache               *ManagedControlPlaneCache
@@ -230,7 +230,7 @@ func (s *ManagedControlPlaneScope) PatchObject(ctx context.Context) error {
 
 	conditions.SetSummary(s.ControlPlane)
 
-	return s.patchHelper.Patch(
+	return s.PatchHelper.Patch(
 		ctx,
 		s.ControlPlane,
 		patch.WithOwnedConditions{Conditions: []clusterv1.ConditionType{


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

This will increase coverage around the controller/reconciler code.  
 
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4290 

**Special notes for your reviewer**:
This test is marked as an error happening for the following reasons.  When it hits the path to `StoreClusterInfo` it cannot create a remote client because that call is trying to reach out to do this.  This is expected and not meant to derail the effort around coverage.  However, this doesn't show the successful path around the `reconcileNormal`.  There are many functions/methods that I had to extract and refactor to become testable to reduce the level of abstraction around how nested the `New` funcs are within certain places where I can't inject but patch as done in a previous PR and as well as done here.   

I did create new mocks to test the clients that we export in the services package `AzureClient` which held azure-sdk-for-go clients and added coverage around this as well.  
I left the commits as a single point of reference if you want to review this within the context of the commits, however I can squash if this meets the satisfaction of the maintainers.  

Also, the test for `CreateOrUpdateAsync` end in error (not failing) because the poller that is returned is something that I cannot inject to `EXPECT` on the return value.  The call cannot be done because the return value for runtime.Poller[<pick your response>] is not something that the azure-sdk-defined and cannot make that interface return value a thing to utilize in the test.  

- [ ] cherry-pick candidate

**TODOs**:

- [ ] squashed commits
- [ ] includes documentation
- [x] adds unit tests

**Release note**:
```release-note
None
```
