### PR TITLE
Bump pre-commit pylint to v3.0.2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
   - id: end-of-file-fixer
   - id: trailing-whitespace
 - repo: https://github.com/pylint-dev/pylint
-  rev: v2.17.2
+  rev: v3.0.2
   hooks:
   - id: pylint
     exclude: ^hack/boilerplate/boilerplate.py$


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Updates the `pylint` used by the git pre-commit hook to [v3.0.2](https://github.com/pylint-dev/pylint/releases/tag/v3.0.2).

This fixes a [well-known problem](https://stackoverflow.com/questions/77364550/attributeerror-module-pkgutil-has-no-attribute-impimporter-did-you-mean) I've seen locally on macOS Sonoma with Python 3.12 installed by `brew`:

```shell
% git commit -m "test" --allow-empty
[INFO] Installing environment for https://github.com/pylint-dev/pylint.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
An unexpected error has occurred: CalledProcessError: command: ('/Users/matt/.cache/pre-commit/repokorf215l/py_env-python3.12/bin/python', '-mpip', 'install', '.')
return code: 1
stdout:
    Processing /Users/matt/.cache/pre-commit/repokorf215l
      Installing build dependencies: started
      Installing build dependencies: finished with status 'done'
      Getting requirements to build wheel: started
      Getting requirements to build wheel: finished with status 'error'
stderr:
      error: subprocess-exited-with-error
      
      × Getting requirements to build wheel did not run successfully.
      │ exit code: 1

 <snip>

              register_finder(pkgutil.ImpImporter, find_on_path)
                              ^^^^^^^^^^^^^^^^^^^
          AttributeError: module 'pkgutil' has no attribute 'ImpImporter'. Did you mean: 'zipimporter'?
          [end of output]
      
      note: This error originates from a subprocess, and is likely not a problem with pip.
    error: subprocess-exited-with-error
    
    × Getting requirements to build wheel did not run successfully.
    │ exit code: 1
    ╰─> See above for output.
    
    note: This error originates from a subprocess, and is likely not a problem with pip.
Check the log at /Users/matt/.cache/pre-commit/pre-commit.log
```


**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:

```release-note
NONE
```
