### PR TITLE
Fix support for AKS BYOCNI by allowing networkPlugin: none

### DIFF
--- a/api/v1beta1/types_class.go
+++ b/api/v1beta1/types_class.go
@@ -97,7 +97,7 @@ type AzureManagedControlPlaneClassSpec struct {
 	AdditionalTags Tags `json:"additionalTags,omitempty"`
 
 	// NetworkPlugin used for building Kubernetes network.
-	// +kubebuilder:validation:Enum=azure;kubenet
+	// +kubebuilder:validation:Enum=azure;kubenet;none
 	// +optional
 	NetworkPlugin *string `json:"networkPlugin,omitempty"`
 

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremanagedcontrolplanes.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremanagedcontrolplanes.yaml
@@ -384,6 +384,7 @@ spec:
                 enum:
                 - azure
                 - kubenet
+                - none
                 type: string
               networkPluginMode:
                 description: NetworkPluginMode is the mode the network plugin should

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremanagedcontrolplanetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremanagedcontrolplanetemplates.yaml
@@ -392,6 +392,7 @@ spec:
                         enum:
                         - azure
                         - kubenet
+                        - none
                         type: string
                       networkPluginMode:
                         description: NetworkPluginMode is the mode the network plugin


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Fix support for AKS [BYOCNI](https://learn.microsoft.com/en-us/azure/aks/use-byo-cni?tabs=azure-cli) by allowing `networkPlugin: none`

**Which issue(s) this PR fixes**
Fixes #4299 

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Support AKS BYOCNI by allowing networkPlugin: none
```
