### PR TITLE
Fix: DNSPrefix error on existing tenant cluster

### DIFF
--- a/api/v1beta1/azuremanagedcontrolplane_default.go
+++ b/api/v1beta1/azuremanagedcontrolplane_default.go
@@ -19,6 +19,7 @@ package v1beta1
 import (
 	"encoding/base64"
 	"fmt"
+	"reflect"
 	"strings"
 
 	"golang.org/x/crypto/ssh"
@@ -194,7 +195,7 @@ func (m *AzureManagedControlPlane) setDefaultOIDCIssuerProfile() {
 }
 
 func (m *AzureManagedControlPlane) setDefaultDNSPrefix() {
-	if m.Spec.DNSPrefix == nil {
+	if reflect.ValueOf(m.Spec.DNSPrefix).IsZero() {
 		m.Spec.DNSPrefix = ptr.To(m.Name)
 	}
 }

--- a/api/v1beta1/azuremanagedcontrolplane_webhook.go
+++ b/api/v1beta1/azuremanagedcontrolplane_webhook.go
@@ -207,10 +207,20 @@ func (mw *azureManagedControlPlaneWebhook) ValidateUpdate(ctx context.Context, o
 		allErrs = append(allErrs, err)
 	}
 
+	oldDNSPrefix := old.Spec.DNSPrefix
+	newDNSPrefix := m.Spec.DNSPrefix
+	if reflect.ValueOf(oldDNSPrefix).IsZero() {
+		oldDNSPrefix = ptr.To(old.Name)
+	}
+
+	if reflect.ValueOf(newDNSPrefix).IsZero() {
+		newDNSPrefix = ptr.To(m.Name)
+	}
+
 	if err := webhookutils.ValidateImmutable(
 		field.NewPath("Spec", "DNSPrefix"),
-		m.Spec.DNSPrefix,
-		old.Spec.DNSPrefix,
+		oldDNSPrefix,
+		newDNSPrefix,
 	); err != nil {
 		allErrs = append(allErrs, err)
 	}


### PR DESCRIPTION


**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
On updating from capz v1.11.x to v1.12.0 the exisiting tenant clusters fail with this error 
```
is invalid: Spec.DNSPrefix: Invalid value: "null": field is immutable, unable to set an empty value if it was already set
```
Upon inspection found that the check of immutability was reversed. After fixing it found out that the old spec will always be null because the assignment was done deeper. The fix proposes to check if the dnsprefix is null and in that case it will compare it with the name of the cluster as this was the default assignment before https://github.com/kubernetes-sigs/cluster-api-provider-azure/commit/24c7651cec6d6a7268f50ebef30c4886259c7a57#diff-93244f1c63a059e09b47604787d4b3f353123bc6a26ac1a148e44fdf9e0532fcR168


**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:

```release-note
Fix: DNSPrefix error on existing tenant cluster
```
