### PR TITLE
chore: update AzCNI to new installer image

### DIFF
--- a/templates/addons/azure-cni-v1.yaml
+++ b/templates/addons/azure-cni-v1.yaml
@@ -50,7 +50,7 @@ spec:
         - /etc/cni/net.d/10-azure.conflist
         command:
         - /dropgz
-        image: mcr.microsoft.com/containernetworking/cni-dropgz:v0.0.4
+        image: mcr.microsoft.com/containernetworking/azure-cni:v1.5.16
         imagePullPolicy: Always
         name: azure-cni
         volumeMounts:

--- a/templates/addons/azure-cni-v1/kustomization.yaml
+++ b/templates/addons/azure-cni-v1/kustomization.yaml
@@ -2,5 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - https://raw.githubusercontent.com/Azure/azure-container-networking/v1.5.3/hack/manifests/cni-installer-v1.yaml
-
+  - https://raw.githubusercontent.com/Azure/azure-container-networking/4034aad0d7085f2a9e96cce6d2b50b81ea9ec900/hack/manifests/cni-installer-v1.yaml


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind cleanup

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**: Migrates to new installer image for AzCNI. Incidentally upgrades the AzCNI version.

See https://github.com/Azure/azure-container-networking/issues/2333

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->



**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Update AzCNI to v1.5.16
```
