### PR TITLE
Work around mdbook installation on Apple Silicon

### DIFF
--- a/docs/book/install-and-build.sh
+++ b/docs/book/install-and-build.sh
@@ -44,6 +44,7 @@ case ${os} in
         ;;
     darwin)
         target="apple-darwin"
+        arch="x86_64" # mdbook isn't packaged for arm64 darwin yet
         ;;
     linux)
         # works for linux, too


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

Defaults to `x86_64` architecture when installing the `mdbook` utility on a Mac, since an `arm64` package isn't available. (The `x86_64` binary runs fine, assuming [Rosetta 2](https://support.apple.com/en-us/HT211861) is installed.)

**Which issue(s) this PR fixes**:

Refs #4275

**Special notes for your reviewer**:

- [ ] cherry-pick candidate

**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:

```release-note
NONE
```
