### PR TITLE
return from ASO reconcile early for no specs

### DIFF
--- a/azure/services/aso/service.go
+++ b/azure/services/aso/service.go
@@ -63,6 +63,10 @@ func (s *Service[T, S]) Reconcile(ctx context.Context) error {
 	ctx, cancel := context.WithTimeout(ctx, reconcilerutil.DefaultAzureServiceReconcileTimeout)
 	defer cancel()
 
+	if len(s.Specs) == 0 {
+		return nil
+	}
+
 	// We go through the list of Specs to reconcile each one, independently of the result of the previous one.
 	// If multiple errors occur, we return the most pressing one.
 	// Order of precedence (highest -> lowest) is:
@@ -94,6 +98,10 @@ func (s *Service[T, S]) Delete(ctx context.Context) error {
 
 	ctx, cancel := context.WithTimeout(ctx, reconcilerutil.DefaultAzureServiceReconcileTimeout)
 	defer cancel()
+
+	if len(s.Specs) == 0 {
+		return nil
+	}
 
 	// We go through the list of Specs to delete each one, independently of the resultErr of the previous one.
 	// If multiple errors occur, we return the most pressing one.


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind cleanup

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**: This PR aligns the generic `aso.Service` with existing implementations by returning from `Reconcile` early when no specs are defined. The main tangible difference this makes is that when a service like bastionhosts reconciles no resources, AzureCluster will not set the `BastionHostReady` status condition. This is how CAPZ behaved before ASO.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [ ] includes documentation
- [X] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
