### PR TITLE
include *_test.go files for lint rules already ignored in test/

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -132,13 +132,13 @@ issues:
       text: "use underscores in Go names|receiver name (.+) should be consistent|methods on the same type should have the same receiver name"
     - path: 'mock(\w+)/doc.go$'
       text: "use underscores in package names|don't use an underscore in package name"
-    - path: ^test/
+    - path: (^test/|_test.go$)
       linters:
         - dogsled
         - goconst
         - godot
         - prealloc
-    - path: ^test/
+    - path: (^test/|_test.go$)
       text: exported (.+) should have comment( \(or a comment on this block\))? or be unexported
     # Need to use the deprecated module "github.com/Azure/azure-sdk-for-go/services" till issue #2670 is addressed.
     - linters:

--- a/internal/test/env/env_test.go
+++ b/internal/test/env/env_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func TestGetFilePathToCAPICRDs(t *testing.T) {
-	_, filename, _, _ := goruntime.Caller(0) //nolint:dogsled // Ignore "declaration has 3 blank identifiers" check.
+	_, filename, _, _ := goruntime.Caller(0)
 	root := path.Join(path.Dir(filename), "..", "..", "..")
 	g := gomega.NewWithT(t)
 	g.Expect(getFilePathToCAPICRDs(root)).To(gomega.MatchRegexp(`(.+)/pkg/mod/sigs\.k8s\.io/cluster-api@v(.+)/config/crd/bases`))


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind cleanup

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

CAPZ's lint config already ignores a few of the more annoying linter rules for test code that lives under `test/`. This PR updates the lint config to ignore the same rules in `*_test.go` files.

In particular, `goconst` is very annoying in unit tests where test cases may happen to share a common value, but that value doesn't necessarily make sense to explicitly share between cases with a single variable, e.g. the namespace of a resource.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
