### PR TITLE
label Cluster for azuredisk-csi HelmChartProxy at E2E runtime

### DIFF
--- a/templates/test/ci/cluster-template-prow-azure-cni-v1.yaml
+++ b/templates/test/ci/cluster-template-prow-azure-cni-v1.yaml
@@ -1,8 +1,6 @@
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster
 metadata:
-  labels:
-    azuredisk-csi: "true"
   name: ${CLUSTER_NAME}
   namespace: default
 spec:

--- a/templates/test/ci/cluster-template-prow-ci-version-dual-stack.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version-dual-stack.yaml
@@ -2,7 +2,6 @@ apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster
 metadata:
   labels:
-    azuredisk-csi: "true"
     cni: calico-dual-stack
     cni-windows: ${CLUSTER_NAME}-calico
     containerd-logger: disabled

--- a/templates/test/ci/cluster-template-prow-ci-version-ipv6.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version-ipv6.yaml
@@ -2,7 +2,6 @@ apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster
 metadata:
   labels:
-    azuredisk-csi: "true"
     cni: calico-ipv6
     cni-windows: ${CLUSTER_NAME}-calico
     containerd-logger: disabled

--- a/templates/test/ci/cluster-template-prow-ci-version.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version.yaml
@@ -2,7 +2,6 @@ apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster
 metadata:
   labels:
-    azuredisk-csi: "true"
     cni: calico
     cni-windows: ${CLUSTER_NAME}-calico
     containerd-logger: enabled

--- a/templates/test/ci/cluster-template-prow-custom-vnet.yaml
+++ b/templates/test/ci/cluster-template-prow-custom-vnet.yaml
@@ -2,7 +2,6 @@ apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster
 metadata:
   labels:
-    azuredisk-csi: "true"
     cni: calico
   name: ${CLUSTER_NAME}
   namespace: default

--- a/templates/test/ci/cluster-template-prow-dual-stack.yaml
+++ b/templates/test/ci/cluster-template-prow-dual-stack.yaml
@@ -2,7 +2,6 @@ apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster
 metadata:
   labels:
-    azuredisk-csi: "true"
     cni: calico-dual-stack
   name: ${CLUSTER_NAME}
   namespace: default

--- a/templates/test/ci/cluster-template-prow-edgezone.yaml
+++ b/templates/test/ci/cluster-template-prow-edgezone.yaml
@@ -2,7 +2,6 @@ apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster
 metadata:
   labels:
-    azuredisk-csi: "true"
     cni: calico
   name: ${CLUSTER_NAME}
   namespace: default

--- a/templates/test/ci/cluster-template-prow-flatcar.yaml
+++ b/templates/test/ci/cluster-template-prow-flatcar.yaml
@@ -2,7 +2,6 @@ apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster
 metadata:
   labels:
-    azuredisk-csi: "true"
     cni: calico
   name: ${CLUSTER_NAME}
   namespace: default

--- a/templates/test/ci/cluster-template-prow-intree-cloud-provider-machine-pool.yaml
+++ b/templates/test/ci/cluster-template-prow-intree-cloud-provider-machine-pool.yaml
@@ -2,7 +2,6 @@ apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster
 metadata:
   labels:
-    azuredisk-csi: "true"
     cni: calico
     cni-windows: ${CLUSTER_NAME}-calico
     containerd-logger: enabled

--- a/templates/test/ci/cluster-template-prow-intree-cloud-provider.yaml
+++ b/templates/test/ci/cluster-template-prow-intree-cloud-provider.yaml
@@ -2,7 +2,6 @@ apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster
 metadata:
   labels:
-    azuredisk-csi: "true"
     cni: calico
     cni-windows: ${CLUSTER_NAME}-calico
     containerd-logger: enabled

--- a/templates/test/ci/cluster-template-prow-ipv6.yaml
+++ b/templates/test/ci/cluster-template-prow-ipv6.yaml
@@ -2,7 +2,6 @@ apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster
 metadata:
   labels:
-    azuredisk-csi: "true"
     cni: calico-ipv6
   name: ${CLUSTER_NAME}
   namespace: default

--- a/templates/test/ci/cluster-template-prow-machine-pool-ci-version.yaml
+++ b/templates/test/ci/cluster-template-prow-machine-pool-ci-version.yaml
@@ -2,7 +2,6 @@ apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster
 metadata:
   labels:
-    azuredisk-csi: "true"
     cni: calico
     cni-windows: ${CLUSTER_NAME}-calico
     containerd-logger: enabled

--- a/templates/test/ci/cluster-template-prow-machine-pool-flex.yaml
+++ b/templates/test/ci/cluster-template-prow-machine-pool-flex.yaml
@@ -2,7 +2,6 @@ apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster
 metadata:
   labels:
-    azuredisk-csi: "true"
     cni: calico
     cni-windows: ${CLUSTER_NAME}-calico
     containerd-logger: enabled

--- a/templates/test/ci/cluster-template-prow-machine-pool.yaml
+++ b/templates/test/ci/cluster-template-prow-machine-pool.yaml
@@ -2,7 +2,6 @@ apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster
 metadata:
   labels:
-    azuredisk-csi: "true"
     cni: calico
     cni-windows: ${CLUSTER_NAME}-calico
     containerd-logger: enabled

--- a/templates/test/ci/cluster-template-prow-nvidia-gpu.yaml
+++ b/templates/test/ci/cluster-template-prow-nvidia-gpu.yaml
@@ -2,7 +2,6 @@ apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster
 metadata:
   labels:
-    azuredisk-csi: "true"
     cni: calico
   name: ${CLUSTER_NAME}
   namespace: default

--- a/templates/test/ci/cluster-template-prow-private.yaml
+++ b/templates/test/ci/cluster-template-prow-private.yaml
@@ -2,7 +2,6 @@ apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster
 metadata:
   labels:
-    azuredisk-csi: "true"
     cni: calico
   name: ${CLUSTER_NAME}
   namespace: default

--- a/templates/test/ci/cluster-template-prow-topology.yaml
+++ b/templates/test/ci/cluster-template-prow-topology.yaml
@@ -2,7 +2,6 @@ apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster
 metadata:
   labels:
-    azuredisk-csi: "true"
     cni: calico
     cni-windows: ${CLUSTER_NAME}-calico
     containerd-logger: enabled

--- a/templates/test/ci/cluster-template-prow-workload-identity.yaml
+++ b/templates/test/ci/cluster-template-prow-workload-identity.yaml
@@ -2,7 +2,6 @@ apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster
 metadata:
   labels:
-    azuredisk-csi: "true"
     cni: calico
   name: ${CLUSTER_NAME}
   namespace: default

--- a/templates/test/ci/cluster-template-prow.yaml
+++ b/templates/test/ci/cluster-template-prow.yaml
@@ -2,7 +2,6 @@ apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster
 metadata:
   labels:
-    azuredisk-csi: "true"
     cni: calico
     cni-windows: ${CLUSTER_NAME}-calico
     containerd-logger: enabled

--- a/templates/test/ci/patches/cluster-label-azuredisk-csi-driver.yaml
+++ b/templates/test/ci/patches/cluster-label-azuredisk-csi-driver.yaml
@@ -1,6 +1,0 @@
-apiVersion: cluster.x-k8s.io/v1beta1
-kind: Cluster
-metadata:
-  name: ${CLUSTER_NAME}
-  labels:
-    azuredisk-csi: "true"

--- a/templates/test/ci/prow-azure-cni-v1/kustomization.yaml
+++ b/templates/test/ci/prow-azure-cni-v1/kustomization.yaml
@@ -7,4 +7,3 @@ resources:
 patchesStrategicMerge:
   - ../patches/tags.yaml
   - ../patches/controller-manager.yaml
-  - ../patches/cluster-label-azuredisk-csi-driver.yaml

--- a/templates/test/ci/prow-custom-vnet/kustomization.yaml
+++ b/templates/test/ci/prow-custom-vnet/kustomization.yaml
@@ -14,4 +14,3 @@ patchesStrategicMerge:
   - ../patches/uami-md-0.yaml
   - ../patches/uami-control-plane.yaml
   - ../patches/cluster-label-calico.yaml
-  - ../patches/cluster-label-azuredisk-csi-driver.yaml

--- a/templates/test/ci/prow-dual-stack/kustomization.yaml
+++ b/templates/test/ci/prow-dual-stack/kustomization.yaml
@@ -12,4 +12,3 @@ patchesStrategicMerge:
   - patches/azure-machine-template-control-plane.yaml
   - patches/azure-machine-template.yaml
   - patches/cluster-label-calico-dual-stack.yaml
-  - ../patches/cluster-label-azuredisk-csi-driver.yaml

--- a/templates/test/ci/prow-edgezone/kustomization.yaml
+++ b/templates/test/ci/prow-edgezone/kustomization.yaml
@@ -16,4 +16,3 @@ patchesStrategicMerge:
   - patches/machine-type.yaml
   - patches/kubernetes-version.yaml
   - ../patches/cluster-label-calico.yaml
-  - ../patches/cluster-label-azuredisk-csi-driver.yaml

--- a/templates/test/ci/prow-flatcar/kustomization.yaml
+++ b/templates/test/ci/prow-flatcar/kustomization.yaml
@@ -9,4 +9,3 @@ patchesStrategicMerge:
   - ../patches/tags.yaml
   - ../patches/controller-manager.yaml
   - ../patches/cluster-label-calico.yaml
-  - ../patches/cluster-label-azuredisk-csi-driver.yaml

--- a/templates/test/ci/prow-ipv6/kustomization.yaml
+++ b/templates/test/ci/prow-ipv6/kustomization.yaml
@@ -10,5 +10,3 @@ patchesStrategicMerge:
   - ../patches/tags.yaml
   - ../patches/controller-manager.yaml
   - patches/cluster-label-calico-ipv6.yaml
-  - ../patches/cluster-label-azuredisk-csi-driver.yaml
-

--- a/templates/test/ci/prow-machine-pool/kustomization.yaml
+++ b/templates/test/ci/prow-machine-pool/kustomization.yaml
@@ -15,7 +15,6 @@ patchesStrategicMerge:
   - ../patches/machine-pool-worker-counts.yaml
   - ../patches/windows-containerd-labels.yaml
   - ../patches/cluster-label-calico.yaml
-  - ../patches/cluster-label-azuredisk-csi-driver.yaml
 configMapGenerator:
   - name: cni-${CLUSTER_NAME}-calico-windows
     files:

--- a/templates/test/ci/prow-nvidia-gpu/kustomization.yaml
+++ b/templates/test/ci/prow-nvidia-gpu/kustomization.yaml
@@ -10,7 +10,6 @@ patchesStrategicMerge:
   - ../patches/controller-manager.yaml
   - ../patches/azurecluster-gpu.yaml
   - ../patches/cluster-label-calico.yaml
-  - ../patches/cluster-label-azuredisk-csi-driver.yaml
 patches:
 - path: patches/node-storage-type.yaml
   target:

--- a/templates/test/ci/prow-private/kustomization.yaml
+++ b/templates/test/ci/prow-private/kustomization.yaml
@@ -16,7 +16,6 @@ patchesStrategicMerge:
   - ../prow-intree-cloud-provider/patches/intree-cp.yaml # TODO: remove once CAPI supports Helm addons
   - ../prow-intree-cloud-provider/patches/intree-md-0.yaml # TODO: remove once CAPI supports Helm addons
   - ../patches/cluster-label-calico.yaml
-  - ../patches/cluster-label-azuredisk-csi-driver.yaml
 patches:
   - path: patches/user-assigned.yaml
     target:

--- a/templates/test/ci/prow-topology/kustomization.yaml
+++ b/templates/test/ci/prow-topology/kustomization.yaml
@@ -11,7 +11,6 @@ patchesStrategicMerge:
   - ../patches/windows-containerd-labels.yaml
   - cluster.yaml
   - ../patches/cluster-label-calico.yaml
-  - ../patches/cluster-label-azuredisk-csi-driver.yaml
 configMapGenerator:
   - name: cni-${CLUSTER_NAME}-calico-windows
     files:

--- a/templates/test/ci/prow-workload-identity/kustomization.yaml
+++ b/templates/test/ci/prow-workload-identity/kustomization.yaml
@@ -13,4 +13,3 @@ patchesStrategicMerge:
   - ../patches/uami-md-0.yaml
   - ../patches/uami-control-plane.yaml
   - ../patches/cluster-label-calico.yaml
-  - ../patches/cluster-label-azuredisk-csi-driver.yaml

--- a/templates/test/ci/prow/kustomization.yaml
+++ b/templates/test/ci/prow/kustomization.yaml
@@ -23,7 +23,6 @@ patchesStrategicMerge:
   - ../patches/windows-containerd-labels.yaml
   - ../patches/windows-server-version.yaml
   - ../patches/cluster-label-calico.yaml
-  - ../patches/cluster-label-azuredisk-csi-driver.yaml
 patches:
 - target:
     group: bootstrap.cluster.x-k8s.io

--- a/templates/test/dev/cluster-template-custom-builds-machine-pool.yaml
+++ b/templates/test/dev/cluster-template-custom-builds-machine-pool.yaml
@@ -2,7 +2,6 @@ apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster
 metadata:
   labels:
-    azuredisk-csi: "true"
     cni: calico
     cni-windows: ${CLUSTER_NAME}-calico
     containerd-logger: enabled

--- a/templates/test/dev/cluster-template-custom-builds.yaml
+++ b/templates/test/dev/cluster-template-custom-builds.yaml
@@ -2,7 +2,6 @@ apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster
 metadata:
   labels:
-    azuredisk-csi: "true"
     cni: calico
     cni-windows: ${CLUSTER_NAME}-calico
     containerd-logger: enabled

--- a/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-kcp-remediation.yaml
+++ b/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-kcp-remediation.yaml
@@ -75,7 +75,6 @@ apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster
 metadata:
   labels:
-    azuredisk-csi: "true"
     cni: calico
   name: ${CLUSTER_NAME}
   namespace: default

--- a/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-kcp-remediation/kustomization.yaml
+++ b/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-kcp-remediation/kustomization.yaml
@@ -9,4 +9,3 @@ bases:
 patchesStrategicMerge:
   - ../patches/azurecluster-identity-ref.yaml
   - ../patches/cluster-label-calico.yaml
-  - ../patches/cluster-label-azuredisk-csi-driver.yaml

--- a/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-kcp-scale-in.yaml
+++ b/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-kcp-scale-in.yaml
@@ -75,7 +75,6 @@ apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster
 metadata:
   labels:
-    azuredisk-csi: "true"
     cni: calico
   name: ${CLUSTER_NAME}
   namespace: default

--- a/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-kcp-scale-in/kustomization.yaml
+++ b/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-kcp-scale-in/kustomization.yaml
@@ -9,4 +9,3 @@ patchesStrategicMerge:
 - ./cluster-with-kcp.yaml
 - ../patches/azurecluster-identity-ref.yaml
 - ../patches/cluster-label-calico.yaml
-- ../patches/cluster-label-azuredisk-csi-driver.yaml

--- a/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-machine-pool.yaml
+++ b/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-machine-pool.yaml
@@ -74,7 +74,6 @@ apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster
 metadata:
   labels:
-    azuredisk-csi: "true"
     cni: calico
   name: ${CLUSTER_NAME}
   namespace: default

--- a/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-machine-pool/kustomization.yaml
+++ b/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-machine-pool/kustomization.yaml
@@ -8,4 +8,3 @@ resources:
 patchesStrategicMerge:
   - ../patches/azurecluster-identity-ref.yaml
   - ../patches/cluster-label-calico.yaml
-  - ../patches/cluster-label-azuredisk-csi-driver.yaml

--- a/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-md-remediation.yaml
+++ b/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-md-remediation.yaml
@@ -75,7 +75,6 @@ apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster
 metadata:
   labels:
-    azuredisk-csi: "true"
     cni: calico
   name: ${CLUSTER_NAME}
   namespace: default

--- a/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-md-remediation/kustomization.yaml
+++ b/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-md-remediation/kustomization.yaml
@@ -10,4 +10,3 @@ patchesStrategicMerge:
 - ./md.yaml
 - ../patches/azurecluster-identity-ref.yaml
 - ../patches/cluster-label-calico.yaml
-- ../patches/cluster-label-azuredisk-csi-driver.yaml

--- a/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-node-drain.yaml
+++ b/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-node-drain.yaml
@@ -75,7 +75,6 @@ apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster
 metadata:
   labels:
-    azuredisk-csi: "true"
     cni: calico
   name: ${CLUSTER_NAME}
   namespace: default

--- a/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-node-drain/kustomization.yaml
+++ b/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-node-drain/kustomization.yaml
@@ -10,4 +10,3 @@ patchesStrategicMerge:
 - ./cluster-with-kcp.yaml
 - ../patches/azurecluster-identity-ref.yaml
 - ../patches/cluster-label-calico.yaml
-- ../patches/cluster-label-azuredisk-csi-driver.yaml

--- a/test/e2e/data/infrastructure-azure/v1beta1/cluster-template.yaml
+++ b/test/e2e/data/infrastructure-azure/v1beta1/cluster-template.yaml
@@ -75,7 +75,6 @@ apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster
 metadata:
   labels:
-    azuredisk-csi: "true"
     cni: calico
   name: ${CLUSTER_NAME}
   namespace: default

--- a/test/e2e/data/infrastructure-azure/v1beta1/cluster-template/kustomization.yaml
+++ b/test/e2e/data/infrastructure-azure/v1beta1/cluster-template/kustomization.yaml
@@ -8,4 +8,3 @@ bases:
 patchesStrategicMerge:
 - ../patches/azurecluster-identity-ref.yaml
 - ../patches/cluster-label-calico.yaml
-- ../patches/cluster-label-azuredisk-csi-driver.yaml

--- a/test/e2e/data/infrastructure-azure/v1beta1/patches/cluster-label-azuredisk-csi-driver.yaml
+++ b/test/e2e/data/infrastructure-azure/v1beta1/patches/cluster-label-azuredisk-csi-driver.yaml
@@ -1,6 +1,0 @@
-apiVersion: cluster.x-k8s.io/v1beta1
-kind: Cluster
-metadata:
-  name: ${CLUSTER_NAME}
-  labels:
-    azuredisk-csi: "true"


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

/kind failing-test

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

This PR removes the in-template installation of azuredisk-csi drivers. Instead, we install the relevant HelmChartProxy as part of the cluster template, and then add the cluster label later during E2E if we want to install and test azuredisk-csi during our own test flow.

Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
