### PR TITLE
Fix scalesets status condition

### DIFF
--- a/azure/services/scalesets/scalesets.go
+++ b/azure/services/scalesets/scalesets.go
@@ -103,7 +103,7 @@ func (s *Service) Reconcile(ctx context.Context) (retErr error) {
 		scaleSetSpec.VMSSInstances, err = s.Client.ListInstances(ctx, spec.ResourceGroupName(), spec.ResourceName())
 		if err != nil {
 			err = errors.Wrapf(err, "failed to get existing VMSS instances")
-			s.Scope.UpdatePutStatus(infrav1.BootstrapSucceededCondition, serviceName, err)
+			s.Scope.UpdatePutStatus(infrav1.ScaleSetRunningCondition, serviceName, err)
 			return err
 		}
 	} else if !azure.ResourceNotFound(err) {
@@ -111,7 +111,7 @@ func (s *Service) Reconcile(ctx context.Context) (retErr error) {
 	}
 
 	result, err := s.CreateOrUpdateResource(ctx, scaleSetSpec, serviceName)
-	s.Scope.UpdatePutStatus(infrav1.BootstrapSucceededCondition, serviceName, err)
+	s.Scope.UpdatePutStatus(infrav1.ScaleSetRunningCondition, serviceName, err)
 
 	if err == nil && result != nil {
 		vmss, ok := result.(armcompute.VirtualMachineScaleSet)
@@ -160,7 +160,7 @@ func (s *Service) Delete(ctx context.Context) error {
 
 	err := s.DeleteResource(ctx, scaleSetSpec, serviceName)
 
-	s.Scope.UpdateDeleteStatus(infrav1.BootstrapSucceededCondition, serviceName, err)
+	s.Scope.UpdateDeleteStatus(infrav1.ScaleSetRunningCondition, serviceName, err)
 
 	return err
 }

--- a/azure/services/scalesets/scalesets_test.go
+++ b/azure/services/scalesets/scalesets_test.go
@@ -110,7 +110,7 @@ func TestReconcileVMSS(t *testing.T) {
 				m.Get(gomockinternal.AContext(), &defaultSpec).Return(&resultVMSS, nil)
 				m.ListInstances(gomockinternal.AContext(), defaultSpec.ResourceGroup, defaultSpec.Name).Return(defaultInstances, nil)
 				r.CreateOrUpdateResource(gomockinternal.AContext(), spec, serviceName).Return(getResultVMSS(), nil)
-				s.UpdatePutStatus(infrav1.BootstrapSucceededCondition, serviceName, nil)
+				s.UpdatePutStatus(infrav1.ScaleSetRunningCondition, serviceName, nil)
 
 				s.ReconcileReplicas(gomockinternal.AContext(), &fetchedVMSS).Return(nil)
 				s.SetProviderID(azureutil.ProviderIDPrefix + defaultVMSSID)
@@ -126,7 +126,7 @@ func TestReconcileVMSS(t *testing.T) {
 				s.ScaleSetSpec(gomockinternal.AContext()).Return(spec).AnyTimes()
 				m.Get(gomockinternal.AContext(), &defaultSpec).Return(nil, notFoundError)
 				r.CreateOrUpdateResource(gomockinternal.AContext(), spec, serviceName).Return(getResultVMSS(), nil)
-				s.UpdatePutStatus(infrav1.BootstrapSucceededCondition, serviceName, nil)
+				s.UpdatePutStatus(infrav1.ScaleSetRunningCondition, serviceName, nil)
 
 				s.ReconcileReplicas(gomockinternal.AContext(), &fetchedVMSS).Return(nil)
 				s.SetProviderID(azureutil.ProviderIDPrefix + defaultVMSSID)
@@ -152,7 +152,7 @@ func TestReconcileVMSS(t *testing.T) {
 				s.ScaleSetSpec(gomockinternal.AContext()).Return(spec).AnyTimes()
 				m.Get(gomockinternal.AContext(), &defaultSpec).Return(&resultVMSS, nil)
 				m.ListInstances(gomockinternal.AContext(), defaultSpec.ResourceGroup, defaultSpec.Name).Return(defaultInstances, internalError)
-				s.UpdatePutStatus(infrav1.BootstrapSucceededCondition, serviceName, gomockinternal.ErrStrEq("failed to get existing VMSS instances: #: Internal Server Error: StatusCode=500"))
+				s.UpdatePutStatus(infrav1.ScaleSetRunningCondition, serviceName, gomockinternal.ErrStrEq("failed to get existing VMSS instances: #: Internal Server Error: StatusCode=500"))
 			},
 		},
 		{
@@ -166,7 +166,7 @@ func TestReconcileVMSS(t *testing.T) {
 
 				r.CreateOrUpdateResource(gomockinternal.AContext(), spec, serviceName).
 					Return(nil, internalError)
-				s.UpdatePutStatus(infrav1.BootstrapSucceededCondition, serviceName, internalError)
+				s.UpdatePutStatus(infrav1.ScaleSetRunningCondition, serviceName, internalError)
 			},
 		},
 		{
@@ -179,7 +179,7 @@ func TestReconcileVMSS(t *testing.T) {
 				m.ListInstances(gomockinternal.AContext(), defaultSpec.ResourceGroup, defaultSpec.Name).Return(defaultInstances, nil)
 
 				r.CreateOrUpdateResource(gomockinternal.AContext(), spec, serviceName).Return(getResultVMSS(), nil)
-				s.UpdatePutStatus(infrav1.BootstrapSucceededCondition, serviceName, nil)
+				s.UpdatePutStatus(infrav1.ScaleSetRunningCondition, serviceName, nil)
 
 				s.ReconcileReplicas(gomockinternal.AContext(), &fetchedVMSS).Return(internalError)
 			},
@@ -336,7 +336,7 @@ func TestDeleteVMSS(t *testing.T) {
 			expect: func(s *mock_scalesets.MockScaleSetScopeMockRecorder, r *mock_async.MockReconcilerMockRecorder, m *mock_scalesets.MockClientMockRecorder) {
 				s.ScaleSetSpec(gomockinternal.AContext()).Return(&defaultSpec).AnyTimes()
 				r.DeleteResource(gomockinternal.AContext(), &defaultSpec, serviceName).Return(nil)
-				s.UpdateDeleteStatus(infrav1.BootstrapSucceededCondition, serviceName, nil)
+				s.UpdateDeleteStatus(infrav1.ScaleSetRunningCondition, serviceName, nil)
 
 				m.Get(gomockinternal.AContext(), &defaultSpec).Return(resultVMSS, nil)
 				m.ListInstances(gomockinternal.AContext(), defaultSpec.ResourceGroup, defaultSpec.Name).Return(defaultInstances, nil)
@@ -349,7 +349,7 @@ func TestDeleteVMSS(t *testing.T) {
 			expect: func(s *mock_scalesets.MockScaleSetScopeMockRecorder, r *mock_async.MockReconcilerMockRecorder, m *mock_scalesets.MockClientMockRecorder) {
 				s.ScaleSetSpec(gomockinternal.AContext()).Return(&defaultSpec).AnyTimes()
 				r.DeleteResource(gomockinternal.AContext(), &defaultSpec, serviceName).Return(nil)
-				s.UpdateDeleteStatus(infrav1.BootstrapSucceededCondition, serviceName, nil)
+				s.UpdateDeleteStatus(infrav1.ScaleSetRunningCondition, serviceName, nil)
 				m.Get(gomockinternal.AContext(), &defaultSpec).Return(armcompute.VirtualMachineScaleSet{}, notFoundError)
 			},
 		},
@@ -359,7 +359,7 @@ func TestDeleteVMSS(t *testing.T) {
 			expect: func(s *mock_scalesets.MockScaleSetScopeMockRecorder, r *mock_async.MockReconcilerMockRecorder, m *mock_scalesets.MockClientMockRecorder) {
 				s.ScaleSetSpec(gomockinternal.AContext()).Return(&defaultSpec).AnyTimes()
 				r.DeleteResource(gomockinternal.AContext(), &defaultSpec, serviceName).Return(internalError)
-				s.UpdateDeleteStatus(infrav1.BootstrapSucceededCondition, serviceName, internalError)
+				s.UpdateDeleteStatus(infrav1.ScaleSetRunningCondition, serviceName, internalError)
 				m.Get(gomockinternal.AContext(), &defaultSpec).Return(armcompute.VirtualMachineScaleSet{}, notFoundError)
 			},
 		},


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

/kind bug


<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**: We were setting the bootstrap succeeded condition too early when the scaleset is first created, even though the nodes might not be ready yet. We are setting the bootstrap succeeded condition later here: https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/azure/scope/machinepool.go#L563

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix scalesets status condition
```
