### PR TITLE
Add test, comment, cleanup for DNSPrefix webhook fix

### DIFF
--- a/api/v1beta1/azuremanagedcontrolplane_default.go
+++ b/api/v1beta1/azuremanagedcontrolplane_default.go
@@ -19,7 +19,6 @@ package v1beta1
 import (
 	"encoding/base64"
 	"fmt"
-	"reflect"
 	"strings"
 
 	"golang.org/x/crypto/ssh"
@@ -195,7 +194,7 @@ func (m *AzureManagedControlPlane) setDefaultOIDCIssuerProfile() {
 }
 
 func (m *AzureManagedControlPlane) setDefaultDNSPrefix() {
-	if reflect.ValueOf(m.Spec.DNSPrefix).IsZero() {
+	if m.Spec.DNSPrefix == nil {
 		m.Spec.DNSPrefix = ptr.To(m.Name)
 	}
 }

--- a/api/v1beta1/azuremanagedcontrolplane_webhook_test.go
+++ b/api/v1beta1/azuremanagedcontrolplane_webhook_test.go
@@ -2560,6 +2560,29 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "AzureManagedControlPlane DNSPrefix can be updated from nil when resource name matches",
+			oldAMCP: &AzureManagedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "capz-aks",
+				},
+				Spec: AzureManagedControlPlaneSpec{
+					DNSPrefix: nil,
+					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+						Version: "v1.18.0",
+					},
+				},
+			},
+			amcp: &AzureManagedControlPlane{
+				Spec: AzureManagedControlPlaneSpec{
+					DNSPrefix: ptr.To("capz-aks"),
+					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+						Version: "v1.18.0",
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
 			name: "DisableLocalAccounts cannot be set for non AAD clusters",
 			oldAMCP: &AzureManagedControlPlane{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind cleanup

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

This PR follows up from #4308 to address outstanding comments.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [X] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [ ] includes documentation
- [X] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
