### PR TITLE
[release-1.11] ASO: Return readyErr over not done err when tags fail

### DIFF
--- a/azure/services/aso/aso_test.go
+++ b/azure/services/aso/aso_test.go
@@ -822,6 +822,71 @@ func TestCreateOrUpdateResource(t *testing.T) {
 		g.Expect(err.Error()).To(ContainSubstring("failed to reconcile tags"))
 	})
 
+	t.Run("with tags not done error and readyErr", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+
+		sch := runtime.NewScheme()
+		g.Expect(asoresourcesv1.AddToScheme(sch)).To(Succeed())
+		c := fakeclient.NewClientBuilder().
+			WithScheme(sch).
+			Build()
+		s := New(c, clusterName)
+
+		mockCtrl := gomock.NewController(t)
+		specMock := struct {
+			*mock_azure.MockASOResourceSpecGetter
+			*mock_aso.MockTagsGetterSetter
+		}{
+			MockASOResourceSpecGetter: mock_azure.NewMockASOResourceSpecGetter(mockCtrl),
+			MockTagsGetterSetter:      mock_aso.NewMockTagsGetterSetter(mockCtrl),
+		}
+		specMock.MockASOResourceSpecGetter.EXPECT().ResourceRef().Return(&asoresourcesv1.ResourceGroup{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "name",
+				Namespace: "namespace",
+			},
+		})
+		specMock.MockASOResourceSpecGetter.EXPECT().Parameters(gomockinternal.AContext(), gomock.Any()).DoAndReturn(func(_ context.Context, group *asoresourcesv1.ResourceGroup) (*asoresourcesv1.ResourceGroup, error) {
+			return group, nil
+		})
+
+		existing := &asoresourcesv1.ResourceGroup{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "name",
+				Namespace: "namespace",
+				Labels: map[string]string{
+					infrav1.OwnedByClusterLabelKey: clusterName,
+				},
+				Annotations: map[string]string{
+					asoannotations.ReconcilePolicy: string(asoannotations.ReconcilePolicyManage),
+				},
+			},
+			Spec: asoresourcesv1.ResourceGroup_Spec{
+				Tags: map[string]string{"desired": "tags"},
+			},
+			Status: asoresourcesv1.ResourceGroup_STATUS{
+				Tags: map[string]string{"actual": "tags"},
+				Conditions: []conditions.Condition{
+					{
+						Type:    conditions.ConditionTypeReady,
+						Status:  metav1.ConditionFalse,
+						Message: "not ready :(",
+					},
+				},
+			},
+		}
+
+		specMock.MockTagsGetterSetter.EXPECT().GetActualTags(gomock.Any()).Return(existing.Status.Tags, nil)
+		specMock.MockTagsGetterSetter.EXPECT().GetDesiredTags(gomock.Any()).Return(existing.Spec.Tags, nil)
+
+		ctx := context.Background()
+		g.Expect(c.Create(ctx, existing)).To(Succeed())
+
+		result, err := s.CreateOrUpdateResource(ctx, specMock, "service")
+		g.Expect(result).To(BeNil())
+		g.Expect(err.Error()).To(ContainSubstring("not ready :("))
+	})
+
 	t.Run("reconcile policy annotation resets after un-pause", func(t *testing.T) {
 		g := NewGomegaWithT(t)
 


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

Manual cherry-pick of #4371:

> When tags are reconciled for ASO resources, CAPZ waits for the spec and status of the ASO resource's tags to match (#4149). In cases where that convergence will never happen because there is a different issue preventing ASO from reconciling the resource reflected in its `Ready` condition, a not-very-helpful "not done" error is bubbled up into the CAPZ resource status because the spec and status of the ASO resource do not match.
> 
> This PR instead bubbles up the error matching what's in the ASO resource's `Ready` condition instead when reconciling tags fails because the spec and status do not match, since that is closer to the root of the problem.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [ ] includes documentation
- [X] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Propagate error affecting ASO resources' `Ready` conditions when tags cannot yet be reconciled.
```
