### PR TITLE
Revert "Use clusterctl move annotation on last systempool validation"

### DIFF
--- a/api/v1beta1/azuremanagedmachinepool_webhook.go
+++ b/api/v1beta1/azuremanagedmachinepool_webhook.go
@@ -34,7 +34,6 @@ import (
 	azureutil "sigs.k8s.io/cluster-api-provider-azure/util/azure"
 	webhookutils "sigs.k8s.io/cluster-api-provider-azure/util/webhook"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
-	clusterctlv1 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
 	capifeature "sigs.k8s.io/cluster-api/feature"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -337,8 +336,7 @@ func validateLastSystemNodePool(cli client.Client, labels map[string]string, nam
 		return nil
 	}
 
-	// checking if the Cluster is going to be deleted for clusterctl move operation
-	if _, found := ownerCluster.Annotations[clusterctlv1.DeleteForMoveAnnotation]; found {
+	if ownerCluster.Spec.Paused {
 		return nil
 	}
 


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
- This reverts commit cf1024138f260ea01715214aa383c684b7bb14e6 of the PR https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/3426
- With this PR `api/v1beta1/azuremanagedmachinepool_webhook.go` will use `ownerCluster.Spec.Paused` while performing clusterctl move.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Temporarily unblocks users facing https://github.com/kubernetes-sigs/cluster-api-provider-azure/issues/4341

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [x] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Revert 'Use clusterctl move annotation on last system pool validation'
```
