### PR TITLE
Revert "Temporarily pin Flatcar version to v1.26.10"

### DIFF
--- a/test/e2e/config/azure-dev.yaml
+++ b/test/e2e/config/azure-dev.yaml
@@ -170,7 +170,7 @@ variables:
   AKS_KUBERNETES_VERSION: "latest"
   AKS_KUBERNETES_VERSION_UPGRADE_FROM: "latest-1"
   KUBERNETES_VERSION: "${KUBERNETES_VERSION:-v1.26.6}" # temporarily pin to v1.26.6 to workaround Calico dual stack issues
-  FLATCAR_KUBERNETES_VERSION: "${FLATCAR_KUBERNETES_VERSION:-v1.26.10}" # temporarily pin to v1.26.10 to workaround Flatcar image issues
+  FLATCAR_KUBERNETES_VERSION: "${FLATCAR_KUBERNETES_VERSION:-stable-1.26}"
   FLATCAR_VERSION: "${FLATCAR_VERSION:-latest}"
   ETCD_VERSION_UPGRADE_TO: "3.5.4-0"
   COREDNS_VERSION_UPGRADE_TO: "v1.9.3"

--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -751,7 +751,7 @@ func resolveFlatcarVersion(config *clusterctl.E2EConfig, versions semver.Version
 
 	if version == "latest" {
 		semver.Sort(versions)
-		version = versions[0].String()
+		version = versions[len(versions)-1].String()
 	}
 
 	resolveVariable(config, varName, version)


### PR DESCRIPTION
Reverts kubernetes-sigs/cluster-api-provider-azure#4321.

This should no longer be necessary with Flatcar version 3602.2.3.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```