### PR TITLE
Skip book output files in codespell verification

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -275,7 +275,7 @@ verify-tiltfile: ## Verify Tiltfile format.
 
 .PHONY: verify-codespell
 verify-codespell: codespell ## Verify codespell.
-	@$(CODESPELL) $(ROOT_DIR) --ignore-words=$(ROOT_DIR)/.codespellignore --skip="*.git,*_artifacts,*.sum,$(ROOT_DIR)/hack/tools/bin/codespell_dist"
+	@$(CODESPELL) $(ROOT_DIR) --ignore-words=$(ROOT_DIR)/.codespellignore --skip="*.git,*_artifacts,*.sum,$(ROOT_DIR)/docs/book/bookout,$(ROOT_DIR)/hack/tools/bin/codespell_dist"
 
 ## --------------------------------------
 ## Development


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

If you've built the CAPZ book locally, the `make verify-codespell` target will find many spelling errors in its JavaScript assets:

```shell
% make verify-codespell
/Users/matt/projects/cluster-api-provider-azure/docs/book/bookout/searcher.js:142: inbetween ==> between, in between
/Users/matt/projects/cluster-api-provider-azure/docs/book/bookout/highlight.js:6: inout ==> input, in out
/Users/matt/projects/cluster-api-provider-azure/docs/book/bookout/highlight.js:6: isnt ==> isn't
/Users/matt/projects/cluster-api-provider-azure/docs/book/bookout/highlight.js:6: inout ==> input, in out
/Users/matt/projects/cluster-api-provider-azure/docs/book/bookout/highlight.js:6: crate ==> create
/Users/matt/projects/cluster-api-provider-azure/docs/book/bookout/highlight.js:6: inout ==> input, in out
/Users/matt/projects/cluster-api-provider-azure/docs/book/bookout/highlight.js:6: aas ==> ass, as
/Users/matt/projects/cluster-api-provider-azure/docs/book/bookout/highlight.js:6: daa ==> data
/Users/matt/projects/cluster-api-provider-azure/docs/book/bookout/highlight.js:6: struc ==> struct
/Users/matt/projects/cluster-api-provider-azure/docs/book/bookout/highlight.js:6: te ==> the, be, we, to
/Users/matt/projects/cluster-api-provider-azure/docs/book/bookout/highlight.js:6: attribut ==> attribute
/Users/matt/projects/cluster-api-provider-azure/docs/book/bookout/highlight.js:6: colum ==> column
/Users/matt/projects/cluster-api-provider-azure/docs/book/bookout/highlight.js:6: connec ==> connect, conned
/Users/matt/projects/cluster-api-provider-azure/docs/book/bookout/highlight.js:6: defaul ==> default
/Users/matt/projects/cluster-api-provider-azure/docs/book/bookout/highlight.js:6: defin ==> define
/Users/matt/projects/cluster-api-provider-azure/docs/book/bookout/highlight.js:6: describ ==> describe
/Users/matt/projects/cluster-api-provider-azure/docs/book/bookout/highlight.js:6: execut ==> execute
/Users/matt/projects/cluster-api-provider-azure/docs/book/bookout/highlight.js:6: iif ==> if
/Users/matt/projects/cluster-api-provider-azure/docs/book/bookout/highlight.js:6: lenght ==> length
/Users/matt/projects/cluster-api-provider-azure/docs/book/bookout/highlight.js:6: numbe ==> number, numb
/Users/matt/projects/cluster-api-provider-azure/docs/book/bookout/highlight.js:6: variabl ==> variable
/Users/matt/projects/cluster-api-provider-azure/docs/book/bookout/elasticlunr.min.js:10: seperator ==> separator
/Users/matt/projects/cluster-api-provider-azure/docs/book/bookout/elasticlunr.min.js:10: seperator ==> separator
/Users/matt/projects/cluster-api-provider-azure/docs/book/bookout/elasticlunr.min.js:10: seperator ==> separator
/Users/matt/projects/cluster-api-provider-azure/docs/book/bookout/elasticlunr.min.js:10: seperator ==> separator
/Users/matt/projects/cluster-api-provider-azure/docs/book/bookout/elasticlunr.min.js:10: seperator ==> separator
/Users/matt/projects/cluster-api-provider-azure/docs/book/bookout/elasticlunr.min.js:10: seperator ==> separator
/Users/matt/projects/cluster-api-provider-azure/docs/book/bookout/elasticlunr.min.js:10: ative ==> active, native
/Users/matt/projects/cluster-api-provider-azure/docs/book/bookout/elasticlunr.min.js:10: ative ==> active, native
/Users/matt/projects/cluster-api-provider-azure/docs/book/bookout/elasticlunr.min.js:10: ment ==> meant
/Users/matt/projects/cluster-api-provider-azure/docs/book/bookout/book.js:81: crate ==> create
/Users/matt/projects/cluster-api-provider-azure/docs/book/bookout/book.js:83: crate ==> create
/Users/matt/projects/cluster-api-provider-azure/docs/book/bookout/FontAwesome/fonts/fontawesome-webfont.svg:1193: adn ==> and
```

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

- [ ] cherry-pick candidate

**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:

```release-note
NONE
```
