### PR TITLE
Remove deprecated kubelet credential provider flag

### DIFF
--- a/docs/book/src/topics/managedcluster.md
+++ b/docs/book/src/topics/managedcluster.md
@@ -455,7 +455,6 @@ spec:
         kubeConfigPath: /etc/kubernetes/admin.conf
     nodeRegistration:
       kubeletExtraArgs:
-        azure-container-registry-config: /etc/kubernetes/azure.json
         cloud-provider: external
       name: '{{ ds.meta_data["local_hostname"] }}'
   preKubeadmCommands:

--- a/templates/cluster-template-aad.yaml
+++ b/templates/cluster-template-aad.yaml
@@ -193,7 +193,6 @@ spec:
       joinConfiguration:
         nodeRegistration:
           kubeletExtraArgs:
-            azure-container-registry-config: /etc/kubernetes/azure.json
             cloud-provider: external
           name: '{{ ds.meta_data["local_hostname"] }}'
 ---

--- a/templates/cluster-template-azure-bastion.yaml
+++ b/templates/cluster-template-azure-bastion.yaml
@@ -188,7 +188,6 @@ spec:
       joinConfiguration:
         nodeRegistration:
           kubeletExtraArgs:
-            azure-container-registry-config: /etc/kubernetes/azure.json
             cloud-provider: external
           name: '{{ ds.meta_data["local_hostname"] }}'
       preKubeadmCommands: []

--- a/templates/cluster-template-azure-cni-v1.yaml
+++ b/templates/cluster-template-azure-cni-v1.yaml
@@ -194,7 +194,6 @@ spec:
       joinConfiguration:
         nodeRegistration:
           kubeletExtraArgs:
-            azure-container-registry-config: /etc/kubernetes/azure.json
             cloud-provider: external
             max-pods: "110"
           name: '{{ ds.meta_data["local_hostname"] }}'

--- a/templates/cluster-template-clusterclass.yaml
+++ b/templates/cluster-template-clusterclass.yaml
@@ -186,13 +186,11 @@ spec:
         initConfiguration:
           nodeRegistration:
             kubeletExtraArgs:
-              azure-container-registry-config: /etc/kubernetes/azure.json
               cloud-provider: external
             name: '{{ ds.meta_data["local_hostname"] }}'
         joinConfiguration:
           nodeRegistration:
             kubeletExtraArgs:
-              azure-container-registry-config: /etc/kubernetes/azure.json
               cloud-provider: external
             name: '{{ ds.meta_data["local_hostname"] }}'
         mounts:
@@ -220,7 +218,6 @@ spec:
       joinConfiguration:
         nodeRegistration:
           kubeletExtraArgs:
-            azure-container-registry-config: /etc/kubernetes/azure.json
             cloud-provider: external
           name: '{{ ds.meta_data["local_hostname"] }}'
       preKubeadmCommands: []

--- a/templates/cluster-template-dual-stack.yaml
+++ b/templates/cluster-template-dual-stack.yaml
@@ -229,6 +229,5 @@ spec:
       joinConfiguration:
         nodeRegistration:
           kubeletExtraArgs:
-            azure-container-registry-config: /etc/kubernetes/azure.json
             cloud-provider: external
           name: '{{ ds.meta_data["local_hostname"] }}'

--- a/templates/cluster-template-edgezone.yaml
+++ b/templates/cluster-template-edgezone.yaml
@@ -189,7 +189,6 @@ spec:
       joinConfiguration:
         nodeRegistration:
           kubeletExtraArgs:
-            azure-container-registry-config: /etc/kubernetes/azure.json
             cloud-provider: external
           name: '{{ ds.meta_data["local_hostname"] }}'
       preKubeadmCommands: []

--- a/templates/cluster-template-ephemeral.yaml
+++ b/templates/cluster-template-ephemeral.yaml
@@ -192,7 +192,6 @@ spec:
       joinConfiguration:
         nodeRegistration:
           kubeletExtraArgs:
-            azure-container-registry-config: /etc/kubernetes/azure.json
             cloud-provider: external
           name: '{{ ds.meta_data["local_hostname"] }}'
       preKubeadmCommands: []

--- a/templates/cluster-template-flatcar.yaml
+++ b/templates/cluster-template-flatcar.yaml
@@ -225,7 +225,6 @@ spec:
       joinConfiguration:
         nodeRegistration:
           kubeletExtraArgs:
-            azure-container-registry-config: /etc/kubernetes/azure.json
             cloud-provider: external
           name: '@@HOSTNAME@@'
       postKubeadmCommands: []

--- a/templates/cluster-template-intree-cloud-provider.yaml
+++ b/templates/cluster-template-intree-cloud-provider.yaml
@@ -206,7 +206,6 @@ spec:
       joinConfiguration:
         nodeRegistration:
           kubeletExtraArgs:
-            azure-container-registry-config: /etc/kubernetes/azure.json
             cloud-config: /etc/kubernetes/azure.json
             cloud-provider: azure
             feature-gates: CSIMigrationAzureDisk=true

--- a/templates/cluster-template-ipv6.yaml
+++ b/templates/cluster-template-ipv6.yaml
@@ -244,7 +244,6 @@ spec:
       joinConfiguration:
         nodeRegistration:
           kubeletExtraArgs:
-            azure-container-registry-config: /etc/kubernetes/azure.json
             cloud-provider: external
             cluster-dns: '[fd00::10]'
           name: '{{ ds.meta_data["local_hostname"] }}'

--- a/templates/cluster-template-nvidia-gpu.yaml
+++ b/templates/cluster-template-nvidia-gpu.yaml
@@ -204,6 +204,5 @@ spec:
       joinConfiguration:
         nodeRegistration:
           kubeletExtraArgs:
-            azure-container-registry-config: /etc/kubernetes/azure.json
             cloud-provider: external
           name: '{{ ds.meta_data["local_hostname"] }}'

--- a/templates/cluster-template-private.yaml
+++ b/templates/cluster-template-private.yaml
@@ -200,7 +200,6 @@ spec:
       joinConfiguration:
         nodeRegistration:
           kubeletExtraArgs:
-            azure-container-registry-config: /etc/kubernetes/azure.json
             cloud-provider: external
           name: '{{ ds.meta_data["local_hostname"] }}'
       preKubeadmCommands: []

--- a/templates/cluster-template-windows.yaml
+++ b/templates/cluster-template-windows.yaml
@@ -190,7 +190,6 @@ spec:
       joinConfiguration:
         nodeRegistration:
           kubeletExtraArgs:
-            azure-container-registry-config: /etc/kubernetes/azure.json
             cloud-provider: external
           name: '{{ ds.meta_data["local_hostname"] }}'
       preKubeadmCommands: []

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -186,7 +186,6 @@ spec:
       joinConfiguration:
         nodeRegistration:
           kubeletExtraArgs:
-            azure-container-registry-config: /etc/kubernetes/azure.json
             cloud-provider: external
           name: '{{ ds.meta_data["local_hostname"] }}'
       preKubeadmCommands: []

--- a/templates/flavors/aad/machine-deployment.yaml
+++ b/templates/flavors/aad/machine-deployment.yaml
@@ -48,7 +48,6 @@ spec:
         nodeRegistration:
           name: '{{ ds.meta_data["local_hostname"] }}'
           kubeletExtraArgs:
-            azure-container-registry-config: /etc/kubernetes/azure.json
             cloud-provider: external
       files:
       - contentFrom:

--- a/templates/flavors/clusterclass/kubeadm-config-template.yaml
+++ b/templates/flavors/clusterclass/kubeadm-config-template.yaml
@@ -17,7 +17,6 @@ spec:
       joinConfiguration:
         nodeRegistration:
           kubeletExtraArgs:
-            azure-container-registry-config: /etc/kubernetes/azure.json
             cloud-provider: external
           name: '{{ ds.meta_data["local_hostname"] }}'
       preKubeadmCommands: []

--- a/templates/flavors/clusterclass/kubeadm-controlplane-template.yaml
+++ b/templates/flavors/clusterclass/kubeadm-controlplane-template.yaml
@@ -50,13 +50,11 @@ spec:
         initConfiguration:
           nodeRegistration:
             kubeletExtraArgs:
-              azure-container-registry-config: /etc/kubernetes/azure.json
               cloud-provider: external
             name: '{{ ds.meta_data["local_hostname"] }}'
         joinConfiguration:
           nodeRegistration:
             kubeletExtraArgs:
-              azure-container-registry-config: /etc/kubernetes/azure.json
               cloud-provider: external
             name: '{{ ds.meta_data["local_hostname"] }}'
         mounts:

--- a/templates/flavors/default/machine-deployment.yaml
+++ b/templates/flavors/default/machine-deployment.yaml
@@ -47,7 +47,6 @@ spec:
         nodeRegistration:
           name: '{{ ds.meta_data["local_hostname"] }}'
           kubeletExtraArgs:
-            azure-container-registry-config: /etc/kubernetes/azure.json
             cloud-provider: external
       files:
       - contentFrom:

--- a/templates/flavors/dual-stack/machine-deployment.yaml
+++ b/templates/flavors/dual-stack/machine-deployment.yaml
@@ -49,7 +49,6 @@ spec:
         nodeRegistration:
           name: '{{ ds.meta_data["local_hostname"] }}'
           kubeletExtraArgs:
-            azure-container-registry-config: /etc/kubernetes/azure.json
             cloud-provider: external
       files:
       - contentFrom:

--- a/templates/flavors/flatcar/machine-deployment.yaml
+++ b/templates/flavors/flatcar/machine-deployment.yaml
@@ -72,7 +72,6 @@ spec:
       joinConfiguration:
         nodeRegistration:
           kubeletExtraArgs:
-            azure-container-registry-config: /etc/kubernetes/azure.json
             cloud-provider: external
           name: '@@HOSTNAME@@'
       postKubeadmCommands: []

--- a/templates/flavors/ipv6/machine-deployment.yaml
+++ b/templates/flavors/ipv6/machine-deployment.yaml
@@ -49,7 +49,6 @@ spec:
         nodeRegistration:
           name: '{{ ds.meta_data["local_hostname"] }}'
           kubeletExtraArgs:
-            azure-container-registry-config: /etc/kubernetes/azure.json
             cloud-provider: external
             cluster-dns: "[fd00::10]"
       clusterConfiguration:

--- a/templates/flavors/nvidia-gpu/machine-deployment.yaml
+++ b/templates/flavors/nvidia-gpu/machine-deployment.yaml
@@ -48,7 +48,6 @@ spec:
         nodeRegistration:
           name: '{{ ds.meta_data["local_hostname"] }}'
           kubeletExtraArgs:
-            azure-container-registry-config: /etc/kubernetes/azure.json
             cloud-provider: external
       files:
         - contentFrom:

--- a/templates/test/ci/cluster-template-prow-aks-clusterclass.yaml
+++ b/templates/test/ci/cluster-template-prow-aks-clusterclass.yaml
@@ -221,7 +221,6 @@ spec:
       joinConfiguration:
         nodeRegistration:
           kubeletExtraArgs:
-            azure-container-registry-config: /etc/kubernetes/azure.json
             cloud-provider: external
           name: '{{ ds.meta_data["local_hostname"] }}'
       preKubeadmCommands: []
@@ -245,7 +244,6 @@ spec:
       joinConfiguration:
         nodeRegistration:
           kubeletExtraArgs:
-            azure-container-registry-config: /etc/kubernetes/azure.json
             cloud-provider: external
           name: '{{ ds.meta_data["local_hostname"] }}'
       preKubeadmCommands: []

--- a/templates/test/ci/cluster-template-prow-azure-cni-v1.yaml
+++ b/templates/test/ci/cluster-template-prow-azure-cni-v1.yaml
@@ -199,7 +199,6 @@ spec:
       joinConfiguration:
         nodeRegistration:
           kubeletExtraArgs:
-            azure-container-registry-config: /etc/kubernetes/azure.json
             cloud-provider: external
             max-pods: "110"
           name: '{{ ds.meta_data["local_hostname"] }}'

--- a/templates/test/ci/cluster-template-prow-ci-version-dual-stack.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version-dual-stack.yaml
@@ -415,7 +415,6 @@ spec:
       joinConfiguration:
         nodeRegistration:
           kubeletExtraArgs:
-            azure-container-registry-config: /etc/kubernetes/azure.json
             cloud-provider: external
             image-credential-provider-bin-dir: /var/lib/kubelet/credential-provider
             image-credential-provider-config: /var/lib/kubelet/credential-provider-config.yaml

--- a/templates/test/ci/cluster-template-prow-ci-version-ipv6.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version-ipv6.yaml
@@ -432,7 +432,6 @@ spec:
       joinConfiguration:
         nodeRegistration:
           kubeletExtraArgs:
-            azure-container-registry-config: /etc/kubernetes/azure.json
             cloud-provider: external
             cluster-dns: '[fd00::10]'
             image-credential-provider-bin-dir: /var/lib/kubelet/credential-provider

--- a/templates/test/ci/cluster-template-prow-ci-version.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version.yaml
@@ -392,7 +392,6 @@ spec:
       joinConfiguration:
         nodeRegistration:
           kubeletExtraArgs:
-            azure-container-registry-config: /etc/kubernetes/azure.json
             cloud-provider: external
             image-credential-provider-bin-dir: /var/lib/kubelet/credential-provider
             image-credential-provider-config: /var/lib/kubelet/credential-provider-config.yaml

--- a/templates/test/ci/cluster-template-prow-clusterclass-ci-default.yaml
+++ b/templates/test/ci/cluster-template-prow-clusterclass-ci-default.yaml
@@ -420,13 +420,11 @@ spec:
         initConfiguration:
           nodeRegistration:
             kubeletExtraArgs:
-              azure-container-registry-config: /etc/kubernetes/azure.json
               cloud-provider: external
             name: '{{ ds.meta_data["local_hostname"] }}'
         joinConfiguration:
           nodeRegistration:
             kubeletExtraArgs:
-              azure-container-registry-config: /etc/kubernetes/azure.json
               cloud-provider: external
             name: '{{ ds.meta_data["local_hostname"] }}'
         mounts:
@@ -497,7 +495,6 @@ spec:
       joinConfiguration:
         nodeRegistration:
           kubeletExtraArgs:
-            azure-container-registry-config: /etc/kubernetes/azure.json
             cloud-provider: external
           name: '{{ ds.meta_data["local_hostname"] }}'
       preKubeadmCommands: []
@@ -541,7 +538,6 @@ spec:
         nodeRegistration:
           criSocket: npipe:////./pipe/containerd-containerd
           kubeletExtraArgs:
-            azure-container-registry-config: c:/k/azure.json
             cloud-provider: external
             v: "2"
             windows-priorityclass: ABOVE_NORMAL_PRIORITY_CLASS

--- a/templates/test/ci/cluster-template-prow-custom-vnet.yaml
+++ b/templates/test/ci/cluster-template-prow-custom-vnet.yaml
@@ -208,7 +208,6 @@ spec:
       joinConfiguration:
         nodeRegistration:
           kubeletExtraArgs:
-            azure-container-registry-config: /etc/kubernetes/azure.json
             cloud-provider: external
           name: '{{ ds.meta_data["local_hostname"] }}'
       preKubeadmCommands: []

--- a/templates/test/ci/cluster-template-prow-dual-stack.yaml
+++ b/templates/test/ci/cluster-template-prow-dual-stack.yaml
@@ -240,7 +240,6 @@ spec:
       joinConfiguration:
         nodeRegistration:
           kubeletExtraArgs:
-            azure-container-registry-config: /etc/kubernetes/azure.json
             cloud-provider: external
           name: '{{ ds.meta_data["local_hostname"] }}'
 ---

--- a/templates/test/ci/cluster-template-prow-edgezone.yaml
+++ b/templates/test/ci/cluster-template-prow-edgezone.yaml
@@ -208,7 +208,6 @@ spec:
       joinConfiguration:
         nodeRegistration:
           kubeletExtraArgs:
-            azure-container-registry-config: /etc/kubernetes/azure.json
             cloud-provider: external
           name: '{{ ds.meta_data["local_hostname"] }}'
       preKubeadmCommands: []

--- a/templates/test/ci/cluster-template-prow-flatcar.yaml
+++ b/templates/test/ci/cluster-template-prow-flatcar.yaml
@@ -232,7 +232,6 @@ spec:
       joinConfiguration:
         nodeRegistration:
           kubeletExtraArgs:
-            azure-container-registry-config: /etc/kubernetes/azure.json
             cloud-provider: external
           name: '@@HOSTNAME@@'
       postKubeadmCommands: []

--- a/templates/test/ci/cluster-template-prow-intree-cloud-provider.yaml
+++ b/templates/test/ci/cluster-template-prow-intree-cloud-provider.yaml
@@ -222,7 +222,6 @@ spec:
       joinConfiguration:
         nodeRegistration:
           kubeletExtraArgs:
-            azure-container-registry-config: /etc/kubernetes/azure.json
             cloud-config: /etc/kubernetes/azure.json
             cloud-provider: azure
           name: '{{ ds.meta_data["local_hostname"] }}'

--- a/templates/test/ci/cluster-template-prow-ipv6.yaml
+++ b/templates/test/ci/cluster-template-prow-ipv6.yaml
@@ -251,7 +251,6 @@ spec:
       joinConfiguration:
         nodeRegistration:
           kubeletExtraArgs:
-            azure-container-registry-config: /etc/kubernetes/azure.json
             cloud-provider: external
             cluster-dns: '[fd00::10]'
           name: '{{ ds.meta_data["local_hostname"] }}'

--- a/templates/test/ci/cluster-template-prow-nvidia-gpu.yaml
+++ b/templates/test/ci/cluster-template-prow-nvidia-gpu.yaml
@@ -211,7 +211,6 @@ spec:
       joinConfiguration:
         nodeRegistration:
           kubeletExtraArgs:
-            azure-container-registry-config: /etc/kubernetes/azure.json
             cloud-provider: external
           name: '{{ ds.meta_data["local_hostname"] }}'
 ---

--- a/templates/test/ci/cluster-template-prow-private.yaml
+++ b/templates/test/ci/cluster-template-prow-private.yaml
@@ -249,7 +249,6 @@ spec:
       joinConfiguration:
         nodeRegistration:
           kubeletExtraArgs:
-            azure-container-registry-config: /etc/kubernetes/azure.json
             cloud-config: /etc/kubernetes/azure.json
             cloud-provider: azure
           name: '{{ ds.meta_data["local_hostname"] }}'

--- a/templates/test/ci/cluster-template-prow-workload-identity.yaml
+++ b/templates/test/ci/cluster-template-prow-workload-identity.yaml
@@ -200,7 +200,6 @@ spec:
       joinConfiguration:
         nodeRegistration:
           kubeletExtraArgs:
-            azure-container-registry-config: /etc/kubernetes/azure.json
             cloud-provider: external
           name: '{{ ds.meta_data["local_hostname"] }}'
       preKubeadmCommands: []

--- a/templates/test/ci/cluster-template-prow.yaml
+++ b/templates/test/ci/cluster-template-prow.yaml
@@ -208,7 +208,6 @@ spec:
       joinConfiguration:
         nodeRegistration:
           kubeletExtraArgs:
-            azure-container-registry-config: /etc/kubernetes/azure.json
             cloud-provider: external
           name: '{{ ds.meta_data["local_hostname"] }}'
       preKubeadmCommands: []

--- a/templates/test/ci/patches/azurediskcsi-migration-off.yaml
+++ b/templates/test/ci/patches/azurediskcsi-migration-off.yaml
@@ -42,4 +42,3 @@ spec:
         nodeRegistration:
           kubeletExtraArgs:
             feature-gates: CSIMigrationAzureDisk=false
-            azure-container-registry-config: /etc/kubernetes/azure.json

--- a/templates/test/ci/prow-aks-clusterclass/patches/kubeadm-config-template.yaml
+++ b/templates/test/ci/prow-aks-clusterclass/patches/kubeadm-config-template.yaml
@@ -16,7 +16,6 @@ spec:
       joinConfiguration:
         nodeRegistration:
           kubeletExtraArgs:
-            azure-container-registry-config: /etc/kubernetes/azure.json
             cloud-provider: external
           name: '{{ ds.meta_data["local_hostname"] }}'
       preKubeadmCommands: []
@@ -39,7 +38,6 @@ spec:
       joinConfiguration:
         nodeRegistration:
           kubeletExtraArgs:
-            azure-container-registry-config: /etc/kubernetes/azure.json
             cloud-provider: external
           name: '{{ ds.meta_data["local_hostname"] }}'
       preKubeadmCommands: []

--- a/templates/test/ci/prow-ci-version-ipv6/patches/machine-deployment.yaml
+++ b/templates/test/ci/prow-ci-version-ipv6/patches/machine-deployment.yaml
@@ -9,7 +9,6 @@ spec:
         nodeRegistration:
           name: '{{ ds.meta_data["local_hostname"] }}'
           kubeletExtraArgs:
-            azure-container-registry-config: /etc/kubernetes/azure.json
             cloud-provider: external
             cluster-dns: "[fd00::10]"
       clusterConfiguration:

--- a/templates/test/ci/prow-clusterclass-ci-default/kubeadm-config-template.yaml
+++ b/templates/test/ci/prow-clusterclass-ci-default/kubeadm-config-template.yaml
@@ -17,7 +17,6 @@ spec:
       joinConfiguration:
         nodeRegistration:
           kubeletExtraArgs:
-            azure-container-registry-config: /etc/kubernetes/azure.json
             cloud-provider: external
           name: '{{ ds.meta_data["local_hostname"] }}'
       preKubeadmCommands: []

--- a/templates/test/ci/prow-clusterclass-ci-default/windows.yaml
+++ b/templates/test/ci/prow-clusterclass-ci-default/windows.yaml
@@ -28,7 +28,6 @@ spec:
           criSocket: npipe:////./pipe/containerd-containerd
           kubeletExtraArgs:
             cloud-provider: external
-            azure-container-registry-config: 'c:/k/azure.json'
             v: "2"
             windows-priorityclass: "ABOVE_NORMAL_PRIORITY_CLASS"
       files:

--- a/templates/test/ci/prow-intree-cloud-provider/patches/intree-md-0.yaml
+++ b/templates/test/ci/prow-intree-cloud-provider/patches/intree-md-0.yaml
@@ -9,6 +9,5 @@ spec:
       joinConfiguration:
         nodeRegistration:
           kubeletExtraArgs:
-            azure-container-registry-config: /etc/kubernetes/azure.json
             cloud-config: /etc/kubernetes/azure.json
             cloud-provider: azure

--- a/templates/test/ci/prow-machine-pool-ci-version/patches/machine-pool-ci-version.yaml
+++ b/templates/test/ci/prow-machine-pool-ci-version/patches/machine-pool-ci-version.yaml
@@ -6,7 +6,6 @@ spec:
   joinConfiguration:
     nodeRegistration:
       kubeletExtraArgs:
-        azure-container-registry-config: /etc/kubernetes/azure.json
         cloud-provider: external
         image-credential-provider-bin-dir: /var/lib/kubelet/credential-provider
         image-credential-provider-config: /var/lib/kubelet/credential-provider-config.yaml

--- a/templates/test/dev/cluster-template-custom-builds.yaml
+++ b/templates/test/dev/cluster-template-custom-builds.yaml
@@ -348,7 +348,6 @@ spec:
       joinConfiguration:
         nodeRegistration:
           kubeletExtraArgs:
-            azure-container-registry-config: /etc/kubernetes/azure.json
             cloud-provider: external
             image-credential-provider-bin-dir: /var/lib/kubelet/credential-provider
             image-credential-provider-config: /var/lib/kubelet/credential-provider-config.yaml

--- a/templates/test/dev/custom-builds-machine-pool/patches/custom-builds.yaml
+++ b/templates/test/dev/custom-builds-machine-pool/patches/custom-builds.yaml
@@ -6,7 +6,6 @@ spec:
   joinConfiguration:
     nodeRegistration:
       kubeletExtraArgs:
-        azure-container-registry-config: /etc/kubernetes/azure.json
         cloud-provider: external
         image-credential-provider-bin-dir: /var/lib/kubelet/credential-provider
         image-credential-provider-config: /var/lib/kubelet/credential-provider-config.yaml

--- a/test/e2e/aks_byo_node.go
+++ b/test/e2e/aks_byo_node.go
@@ -109,8 +109,7 @@ func AKSBYONodeSpec(ctx context.Context, inputGetter func() AKSBYONodeSpecInput)
 				NodeRegistration: bootstrapv1.NodeRegistrationOptions{
 					Name: "{{ ds.meta_data[\"local_hostname\"] }}",
 					KubeletExtraArgs: map[string]string{
-						"cloud-provider":                  "external",
-						"azure-container-registry-config": "/etc/kubernetes/azure.json",
+						"cloud-provider": "external",
 					},
 				},
 			},

--- a/test/e2e/data/infrastructure-azure/v1.0.2/cluster-template-prow.yaml
+++ b/test/e2e/data/infrastructure-azure/v1.0.2/cluster-template-prow.yaml
@@ -212,7 +212,6 @@ spec:
       joinConfiguration:
         nodeRegistration:
           kubeletExtraArgs:
-            azure-container-registry-config: /etc/kubernetes/azure.json
             cloud-config: /etc/kubernetes/azure.json
             cloud-provider: azure
           name: '{{ ds.meta_data["local_hostname"] }}'

--- a/test/e2e/data/infrastructure-azure/v1beta1/bases/mp.yaml
+++ b/test/e2e/data/infrastructure-azure/v1beta1/bases/mp.yaml
@@ -58,6 +58,5 @@ spec:
   joinConfiguration:
     nodeRegistration:
       kubeletExtraArgs:
-        azure-container-registry-config: /etc/kubernetes/azure.json
         cloud-provider: external
       name: '{{ ds.meta_data["local_hostname"] }}'

--- a/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-machine-pool.yaml
+++ b/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-machine-pool.yaml
@@ -66,7 +66,6 @@ spec:
   joinConfiguration:
     nodeRegistration:
       kubeletExtraArgs:
-        azure-container-registry-config: /etc/kubernetes/azure.json
         cloud-provider: external
       name: '{{ ds.meta_data["local_hostname"] }}'
 ---

--- a/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-upgrades.yaml
+++ b/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-upgrades.yaml
@@ -15,7 +15,6 @@ spec:
   joinConfiguration:
     nodeRegistration:
       kubeletExtraArgs:
-        azure-container-registry-config: /etc/kubernetes/azure.json
         cloud-provider: external
       name: '{{ ds.meta_data["local_hostname"] }}'
 ---


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

/kind cleanup

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**: In-tree credential kubelet providers are deprecated and will be removed soon. See https://github.com/kubernetes/kubernetes/pull/122595.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Remove deprecated kubelet credential provider flag
```
