### PR TITLE
fix HTTP 409 flake in AKS Cluster Class test

### DIFF
--- a/test/e2e/aks_clusterclass.go
+++ b/test/e2e/aks_clusterclass.go
@@ -31,6 +31,7 @@ import (
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	expv1 "sigs.k8s.io/cluster-api/exp/api/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type AKSClusterClassInput struct {
@@ -106,6 +107,8 @@ func AKSClusterClassSpec(ctx context.Context, inputGetter func() AKSClusterClass
 
 	By("Upgrading the cluster topology version")
 	Eventually(func(g Gomega) {
+		err := mgmtClient.Get(ctx, client.ObjectKeyFromObject(input.Cluster), input.Cluster)
+		g.Expect(err).NotTo(HaveOccurred())
 		input.Cluster.Spec.Topology.Version = input.KubernetesVersionUpgradeTo
 		g.Expect(mgmtClient.Update(ctx, input.Cluster)).To(Succeed())
 	}, inputGetter().WaitIntervals...).Should(Succeed())


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind flake

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**: This PR fixes a flake in the AKS e2e test where the Cluster Class test can get stuck trying to update an out-of-date version of the Cluster object and continuously hitting HTTP 409 errors by adding a GET in the retry loop before the update.

Here's one instance of the flake: https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/periodic-cluster-api-provider-azure-e2e-aks-main/1743360260954918912

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [X] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
