### PR TITLE
Updated uuid.Validate over uuid.Parse where appropriate

### DIFF
--- a/api/v1beta1/azuremachine_default_test.go
+++ b/api/v1beta1/azuremachine_default_test.go
@@ -115,7 +115,7 @@ func TestAzureMachineSpec_SetIdentityDefaults(t *testing.T) {
 
 	emptyTest.machine.Spec.SetIdentityDefaults(fakeSubscriptionID)
 	g.Expect(emptyTest.machine.Spec.SystemAssignedIdentityRole.Name).To(Not(BeEmpty()))
-	_, err := uuid.Parse(emptyTest.machine.Spec.SystemAssignedIdentityRole.Name)
+	_, err := uuid.Validate(emptyTest.machine.Spec.SystemAssignedIdentityRole.Name)
 	g.Expect(err).To(Not(HaveOccurred()))
 	g.Expect(emptyTest.machine.Spec.SystemAssignedIdentityRole.Scope).To(Equal(fmt.Sprintf("/subscriptions/%s/", fakeSubscriptionID)))
 	g.Expect(emptyTest.machine.Spec.SystemAssignedIdentityRole.DefinitionID).To(Equal(fmt.Sprintf("/subscriptions/%s/providers/Microsoft.Authorization/roleDefinitions/%s", fakeSubscriptionID, ContributorRoleID)))

--- a/api/v1beta1/azuremachine_validation.go
+++ b/api/v1beta1/azuremachine_validation.go
@@ -112,7 +112,7 @@ func ValidateSystemAssignedIdentity(identityType VMIdentity, oldIdentity, newIde
 	allErrs := field.ErrorList{}
 
 	if identityType == VMIdentitySystemAssigned {
-		if _, err := uuid.Parse(newIdentity); err != nil {
+		if _, err := uuid.Validate(newIdentity); err != nil {
 			allErrs = append(allErrs, field.Invalid(fldPath, newIdentity, "Role assignment name must be a valid GUID. It is optional and will be auto-generated when not specified."))
 		}
 		if oldIdentity != "" && oldIdentity != newIdentity {

--- a/exp/api/v1beta1/azuremachinepool_webhook_test.go
+++ b/exp/api/v1beta1/azuremachinepool_webhook_test.go
@@ -479,7 +479,7 @@ func TestAzureMachinePool_Default(t *testing.T) {
 	err = ampw.Default(context.Background(), emptyTest.amp)
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(emptyTest.amp.Spec.SystemAssignedIdentityRole.Name).To(Not(BeEmpty()))
-	_, err = guuid.Parse(emptyTest.amp.Spec.SystemAssignedIdentityRole.Name)
+	_, err = guuid.Validate(emptyTest.amp.Spec.SystemAssignedIdentityRole.Name)
 	g.Expect(err).To(Not(HaveOccurred()))
 	g.Expect(emptyTest.amp.Spec.SystemAssignedIdentityRole).To(Not(BeNil()))
 	g.Expect(emptyTest.amp.Spec.SystemAssignedIdentityRole.Scope).To(Equal(fmt.Sprintf("/subscriptions/%s/", fakeSubscriptionID)))


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
v1.5.0 of the [uuid](https://pkg.go.dev/github.com/google/uuid) package we use (https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/4397) introduced a Validate function which makes more sense to use than Parse when we only care if a string is a valid UUID.

Resolves #4403

<!--
Add one of the following kinds:
/kind cleanup
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [x] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

Fixed now

```
