### PR TITLE
Replace most usage of go-autorest in unit tests

### DIFF
--- a/azure/scope/managedcontrolplane_test.go
+++ b/azure/scope/managedcontrolplane_test.go
@@ -24,7 +24,6 @@ import (
 	aadpodv1 "github.com/Azure/aad-pod-identity/pkg/apis/aadpodidentity/v1"
 	asocontainerservicev1 "github.com/Azure/azure-service-operator/v2/api/containerservice/v1api20231001"
 	asonetworkv1 "github.com/Azure/azure-service-operator/v2/api/network/v1api20220701"
-	"github.com/Azure/go-autorest/autorest"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -1291,9 +1290,6 @@ func TestManagedControlPlaneScope_PrivateEndpointSpecs(t *testing.T) {
 		{
 			Name: "returns empty private endpoints list if no subnets are specified",
 			Input: ManagedControlPlaneScopeParams{
-				AzureClients: AzureClients{
-					Authorizer: autorest.NullAuthorizer{},
-				},
 				Cluster: &clusterv1.Cluster{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "cluster1",
@@ -1318,9 +1314,6 @@ func TestManagedControlPlaneScope_PrivateEndpointSpecs(t *testing.T) {
 		{
 			Name: "returns empty private endpoints list if no private endpoints are specified",
 			Input: ManagedControlPlaneScopeParams{
-				AzureClients: AzureClients{
-					Authorizer: autorest.NullAuthorizer{},
-				},
 				Cluster: &clusterv1.Cluster{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "cluster1",
@@ -1351,9 +1344,6 @@ func TestManagedControlPlaneScope_PrivateEndpointSpecs(t *testing.T) {
 		{
 			Name: "returns list of private endpoint specs if private endpoints are specified",
 			Input: ManagedControlPlaneScopeParams{
-				AzureClients: AzureClients{
-					Authorizer: autorest.NullAuthorizer{},
-				},
 				Cluster: &clusterv1.Cluster{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "my-cluster",

--- a/azure/services/networkinterfaces/networkinterfaces_test.go
+++ b/azure/services/networkinterfaces/networkinterfaces_test.go
@@ -19,10 +19,12 @@ package networkinterfaces
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
+	"strings"
 	"testing"
 
-	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/google/go-cmp/cmp"
 	. "github.com/onsi/gomega"
 	"go.uber.org/mock/gomock"
@@ -71,7 +73,12 @@ var (
 		SKU:                   &fakeSku,
 		IPConfigs:             []IPConfig{{}, {}},
 	}
-	internalError = autorest.NewErrorWithResponse("", "", &http.Response{StatusCode: http.StatusInternalServerError}, "Internal Server Error")
+	internalError = &azcore.ResponseError{
+		RawResponse: &http.Response{
+			Body:       io.NopCloser(strings.NewReader("#: Internal Server Error: StatusCode=500")),
+			StatusCode: http.StatusInternalServerError,
+		},
+	}
 )
 
 func TestReconcileNetworkInterface(t *testing.T) {

--- a/azure/services/privatedns/privatedns_test.go
+++ b/azure/services/privatedns/privatedns_test.go
@@ -18,10 +18,11 @@ package privatedns
 
 import (
 	"context"
+	"net/http"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
-	"github.com/Azure/go-autorest/autorest"
 	. "github.com/onsi/gomega"
 	"github.com/pkg/errors"
 	"go.uber.org/mock/gomock"
@@ -92,7 +93,7 @@ var (
 
 	notDoneError  = azure.NewOperationNotDoneError(&infrav1.Future{Type: "resourceType", ResourceGroup: resourceGroup, Name: "resourceName"})
 	errFake       = errors.New("this is an error")
-	notFoundError = autorest.DetailedError{StatusCode: 404}
+	notFoundError = &azcore.ResponseError{StatusCode: http.StatusNotFound}
 )
 
 func TestReconcilePrivateDNS(t *testing.T) {

--- a/azure/services/publicips/publicips_test.go
+++ b/azure/services/publicips/publicips_test.go
@@ -18,11 +18,13 @@ package publicips
 
 import (
 	"context"
+	"io"
 	"net/http"
+	"strings"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
-	"github.com/Azure/go-autorest/autorest"
 	. "github.com/onsi/gomega"
 	"go.uber.org/mock/gomock"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -113,7 +115,12 @@ var (
 		},
 	}
 
-	internalError = autorest.NewErrorWithResponse("", "", &http.Response{StatusCode: http.StatusInternalServerError}, "Internal Server Error")
+	internalError = &azcore.ResponseError{
+		RawResponse: &http.Response{
+			Body:       io.NopCloser(strings.NewReader("#: Internal Server Error: StatusCode=500")),
+			StatusCode: http.StatusInternalServerError,
+		},
+	}
 )
 
 func TestReconcilePublicIP(t *testing.T) {

--- a/azure/services/roleassignments/roleassignments_test.go
+++ b/azure/services/roleassignments/roleassignments_test.go
@@ -19,11 +19,13 @@ package roleassignments
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
+	"strings"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
-	"github.com/Azure/go-autorest/autorest"
 	. "github.com/onsi/gomega"
 	"go.uber.org/mock/gomock"
 	"k8s.io/utils/ptr"
@@ -63,6 +65,15 @@ var (
 	}
 )
 
+func internalError() *azcore.ResponseError {
+	return &azcore.ResponseError{
+		RawResponse: &http.Response{
+			Body:       io.NopCloser(strings.NewReader("#: Internal Server Error: StatusCode=500")),
+			StatusCode: http.StatusInternalServerError,
+		},
+	}
+}
+
 func TestReconcileRoleAssignmentsVM(t *testing.T) {
 	testcases := []struct {
 		name          string
@@ -92,7 +103,7 @@ func TestReconcileRoleAssignmentsVM(t *testing.T) {
 		},
 		{
 			name:          "error getting VM",
-			expectedError: "failed to assign role to system assigned identity: failed to get principal ID for VM: #: Internal Server Error: StatusCode=500",
+			expectedError: "failed to assign role to system assigned identity: failed to get principal ID for VM:.*#: Internal Server Error: StatusCode=500",
 			expect: func(s *mock_roleassignments.MockRoleAssignmentScopeMockRecorder,
 				m *mock_async.MockGetterMockRecorder,
 				r *mock_async.MockReconcilerMockRecorder) {
@@ -102,12 +113,12 @@ func TestReconcileRoleAssignmentsVM(t *testing.T) {
 				s.Name().Return(fakeRoleAssignment1.MachineName)
 				s.HasSystemAssignedIdentity().Return(true)
 				s.RoleAssignmentResourceType().Return("VirtualMachine")
-				m.Get(gomockinternal.AContext(), &fakeVMSpec).Return(armcompute.VirtualMachine{}, autorest.NewErrorWithResponse("", "", &http.Response{StatusCode: http.StatusInternalServerError}, "Internal Server Error"))
+				m.Get(gomockinternal.AContext(), &fakeVMSpec).Return(armcompute.VirtualMachine{}, internalError())
 			},
 		},
 		{
 			name:          "return error when creating a role assignment",
-			expectedError: "cannot assign role to VirtualMachine system assigned identity: #: Internal Server Error: StatusCode=500",
+			expectedError: "cannot assign role to VirtualMachine system assigned identity:.*#: Internal Server Error: StatusCode=500",
 			expect: func(s *mock_roleassignments.MockRoleAssignmentScopeMockRecorder,
 				m *mock_async.MockGetterMockRecorder,
 				r *mock_async.MockReconcilerMockRecorder) {
@@ -124,7 +135,7 @@ func TestReconcileRoleAssignmentsVM(t *testing.T) {
 					},
 				}, nil)
 				r.CreateOrUpdateResource(gomockinternal.AContext(), &fakeRoleAssignment1, serviceName).Return(&RoleAssignmentSpec{},
-					autorest.NewErrorWithResponse("", "", &http.Response{StatusCode: http.StatusInternalServerError}, "Internal Server Error"))
+					internalError())
 			},
 		},
 	}
@@ -151,7 +162,7 @@ func TestReconcileRoleAssignmentsVM(t *testing.T) {
 			err := s.Reconcile(context.TODO())
 			if tc.expectedError != "" {
 				g.Expect(err).To(HaveOccurred())
-				g.Expect(err).To(MatchError(tc.expectedError))
+				g.Expect(strings.ReplaceAll(err.Error(), "\n", "")).To(MatchRegexp(tc.expectedError))
 			} else {
 				g.Expect(err).NotTo(HaveOccurred())
 			}
@@ -188,7 +199,7 @@ func TestReconcileRoleAssignmentsVMSS(t *testing.T) {
 		},
 		{
 			name:          "error getting VMSS",
-			expectedError: "failed to assign role to system assigned identity: failed to get principal ID for VMSS: #: Internal Server Error: StatusCode=500",
+			expectedError: "failed to assign role to system assigned identity: failed to get principal ID for VMSS:.*#: Internal Server Error: StatusCode=500",
 			expect: func(s *mock_roleassignments.MockRoleAssignmentScopeMockRecorder,
 				r *mock_async.MockReconcilerMockRecorder,
 				mvmss *mock_scalesets.MockClientMockRecorder) {
@@ -198,12 +209,12 @@ func TestReconcileRoleAssignmentsVMSS(t *testing.T) {
 				s.Name().Return("test-vmss")
 				s.HasSystemAssignedIdentity().Return(true)
 				mvmss.Get(gomockinternal.AContext(), &fakeVMSSSpec).Return(armcompute.VirtualMachineScaleSet{},
-					autorest.NewErrorWithResponse("", "", &http.Response{StatusCode: http.StatusInternalServerError}, "Internal Server Error"))
+					internalError())
 			},
 		},
 		{
 			name:          "return error when creating a role assignment",
-			expectedError: fmt.Sprintf("cannot assign role to %s system assigned identity: #: Internal Server Error: StatusCode=500", azure.VirtualMachineScaleSet),
+			expectedError: fmt.Sprintf("cannot assign role to %s system assigned identity:.*#: Internal Server Error: StatusCode=500", azure.VirtualMachineScaleSet),
 			expect: func(s *mock_roleassignments.MockRoleAssignmentScopeMockRecorder,
 				r *mock_async.MockReconcilerMockRecorder,
 				mvmss *mock_scalesets.MockClientMockRecorder) {
@@ -219,7 +230,7 @@ func TestReconcileRoleAssignmentsVMSS(t *testing.T) {
 					},
 				}, nil)
 				r.CreateOrUpdateResource(gomockinternal.AContext(), &fakeRoleAssignment2, serviceName).Return(&RoleAssignmentSpec{},
-					autorest.NewErrorWithResponse("", "", &http.Response{StatusCode: http.StatusInternalServerError}, "Internal Server Error"))
+					internalError())
 			},
 		},
 	}
@@ -246,7 +257,7 @@ func TestReconcileRoleAssignmentsVMSS(t *testing.T) {
 			err := s.Reconcile(context.TODO())
 			if tc.expectedError != "" {
 				g.Expect(err).To(HaveOccurred())
-				g.Expect(err).To(MatchError(tc.expectedError))
+				g.Expect(strings.ReplaceAll(err.Error(), "\n", "")).To(MatchRegexp(tc.expectedError))
 			} else {
 				g.Expect(err).NotTo(HaveOccurred())
 			}

--- a/azure/services/virtualmachines/virtualmachines_test.go
+++ b/azure/services/virtualmachines/virtualmachines_test.go
@@ -18,12 +18,14 @@ package virtualmachines
 
 import (
 	"context"
+	"io"
 	"net/http"
+	"strings"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v4"
-	"github.com/Azure/go-autorest/autorest"
 	. "github.com/onsi/gomega"
 	"github.com/pkg/errors"
 	"go.uber.org/mock/gomock"
@@ -117,8 +119,16 @@ var (
 	fakeUserAssignedIdentity2 = infrav1.UserAssignedIdentity{
 		ProviderID: "fake-provider-id-2",
 	}
-	internalError = autorest.NewErrorWithResponse("", "", &http.Response{StatusCode: http.StatusInternalServerError}, "Internal Server Error")
 )
+
+func internalError() *azcore.ResponseError {
+	return &azcore.ResponseError{
+		RawResponse: &http.Response{
+			Body:       io.NopCloser(strings.NewReader("#: Internal Server Error: StatusCode=500")),
+			StatusCode: http.StatusInternalServerError,
+		},
+	}
+}
 
 func TestReconcileVM(t *testing.T) {
 	testcases := []struct {
@@ -157,14 +167,14 @@ func TestReconcileVM(t *testing.T) {
 			expect: func(s *mock_virtualmachines.MockVMScopeMockRecorder, mnic *mock_async.MockGetterMockRecorder, mpip *mock_async.MockGetterMockRecorder, r *mock_async.MockReconcilerMockRecorder) {
 				s.DefaultedAzureServiceReconcileTimeout().Return(reconciler.DefaultAzureServiceReconcileTimeout)
 				s.VMSpec().Return(&fakeVMSpec)
-				r.CreateOrUpdateResource(gomockinternal.AContext(), &fakeVMSpec, serviceName).Return(nil, internalError)
-				s.UpdatePutStatus(infrav1.VMRunningCondition, serviceName, internalError)
-				s.UpdatePutStatus(infrav1.DisksReadyCondition, serviceName, internalError)
+				r.CreateOrUpdateResource(gomockinternal.AContext(), &fakeVMSpec, serviceName).Return(nil, internalError())
+				s.UpdatePutStatus(infrav1.VMRunningCondition, serviceName, internalError())
+				s.UpdatePutStatus(infrav1.DisksReadyCondition, serviceName, internalError())
 			},
 		},
 		{
 			name:          "create vm succeeds but failed to get network interfaces",
-			expectedError: "failed to fetch VM addresses: #: Internal Server Error: StatusCode=500",
+			expectedError: "failed to fetch VM addresses:.*#: Internal Server Error: StatusCode=500",
 			expect: func(s *mock_virtualmachines.MockVMScopeMockRecorder, mnic *mock_async.MockGetterMockRecorder, mpip *mock_async.MockGetterMockRecorder, r *mock_async.MockReconcilerMockRecorder) {
 				s.DefaultedAzureServiceReconcileTimeout().Return(reconciler.DefaultAzureServiceReconcileTimeout)
 				s.VMSpec().Return(&fakeVMSpec)
@@ -173,12 +183,12 @@ func TestReconcileVM(t *testing.T) {
 				s.UpdatePutStatus(infrav1.DisksReadyCondition, serviceName, nil)
 				s.SetProviderID("azure://subscriptions/123/resourceGroups/my_resource_group/providers/Microsoft.Compute/virtualMachines/my-vm")
 				s.SetAnnotation("cluster-api-provider-azure", "true")
-				mnic.Get(gomockinternal.AContext(), &fakeNetworkInterfaceGetterSpec).Return(armnetwork.Interface{}, internalError)
+				mnic.Get(gomockinternal.AContext(), &fakeNetworkInterfaceGetterSpec).Return(armnetwork.Interface{}, internalError())
 			},
 		},
 		{
 			name:          "create vm succeeds but failed to get public IPs",
-			expectedError: "failed to fetch VM addresses: #: Internal Server Error: StatusCode=500",
+			expectedError: "failed to fetch VM addresses:.*#: Internal Server Error: StatusCode=500",
 			expect: func(s *mock_virtualmachines.MockVMScopeMockRecorder, mnic *mock_async.MockGetterMockRecorder, mpip *mock_async.MockGetterMockRecorder, r *mock_async.MockReconcilerMockRecorder) {
 				s.DefaultedAzureServiceReconcileTimeout().Return(reconciler.DefaultAzureServiceReconcileTimeout)
 				s.VMSpec().Return(&fakeVMSpec)
@@ -188,7 +198,7 @@ func TestReconcileVM(t *testing.T) {
 				s.SetProviderID("azure://subscriptions/123/resourceGroups/my_resource_group/providers/Microsoft.Compute/virtualMachines/my-vm")
 				s.SetAnnotation("cluster-api-provider-azure", "true")
 				mnic.Get(gomockinternal.AContext(), &fakeNetworkInterfaceGetterSpec).Return(fakeNetworkInterface, nil)
-				mpip.Get(gomockinternal.AContext(), &fakePublicIPSpec).Return(armnetwork.PublicIPAddress{}, internalError)
+				mpip.Get(gomockinternal.AContext(), &fakePublicIPSpec).Return(armnetwork.PublicIPAddress{}, internalError())
 			},
 		},
 	}
@@ -218,7 +228,7 @@ func TestReconcileVM(t *testing.T) {
 			err := s.Reconcile(context.TODO())
 			if tc.expectedError != "" {
 				g.Expect(err).To(HaveOccurred())
-				g.Expect(err).To(MatchError(tc.expectedError))
+				g.Expect(strings.ReplaceAll(err.Error(), "\n", "")).To(MatchRegexp(tc.expectedError))
 			} else {
 				g.Expect(err).NotTo(HaveOccurred())
 			}
@@ -257,9 +267,9 @@ func TestDeleteVM(t *testing.T) {
 			expect: func(s *mock_virtualmachines.MockVMScopeMockRecorder, r *mock_async.MockReconcilerMockRecorder) {
 				s.DefaultedAzureServiceReconcileTimeout().Return(reconciler.DefaultAzureServiceReconcileTimeout)
 				s.VMSpec().AnyTimes().Return(&fakeVMSpec)
-				r.DeleteResource(gomockinternal.AContext(), &fakeVMSpec, serviceName).Return(internalError)
+				r.DeleteResource(gomockinternal.AContext(), &fakeVMSpec, serviceName).Return(internalError())
 				s.SetVMState(infrav1.Deleting)
-				s.UpdateDeleteStatus(infrav1.VMRunningCondition, serviceName, internalError)
+				s.UpdateDeleteStatus(infrav1.VMRunningCondition, serviceName, internalError())
 			},
 		},
 		{
@@ -295,7 +305,7 @@ func TestDeleteVM(t *testing.T) {
 			err := s.Delete(context.TODO())
 			if tc.expectedError != "" {
 				g.Expect(err).To(HaveOccurred())
-				g.Expect(err).To(MatchError(tc.expectedError))
+				g.Expect(err.Error()).To(ContainSubstring(tc.expectedError))
 			} else {
 				g.Expect(err).NotTo(HaveOccurred())
 			}

--- a/controllers/asosecret_controller_test.go
+++ b/controllers/asosecret_controller_test.go
@@ -22,7 +22,6 @@ import (
 	"testing"
 
 	aadpodv1 "github.com/Azure/aad-pod-identity/pkg/apis/aadpodidentity/v1"
-	"github.com/Azure/go-autorest/autorest/azure/auth"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -39,10 +38,10 @@ import (
 )
 
 func TestASOSecretReconcile(t *testing.T) {
-	os.Setenv(auth.ClientID, "fooClient")
-	os.Setenv(auth.ClientSecret, "fooSecret")
-	os.Setenv(auth.TenantID, "fooTenant")
-	os.Setenv(auth.SubscriptionID, "fooSubscription")
+	os.Setenv("AZURE_CLIENT_ID", "fooClient")
+	os.Setenv("AZURE_CLIENT_SECRET", "fooSecret")
+	os.Setenv("AZURE_TENANT_ID", "fooTenant")
+	os.Setenv("AZURE_SUBSCRIPTION_ID", "fooSubscription")
 
 	scheme := runtime.NewScheme()
 	_ = clusterv1.AddToScheme(scheme)

--- a/controllers/azurejson_machine_controller_test.go
+++ b/controllers/azurejson_machine_controller_test.go
@@ -18,11 +18,9 @@ package controllers
 
 import (
 	"context"
-	"os"
 	"testing"
 
 	aadpodv1 "github.com/Azure/aad-pod-identity/pkg/apis/aadpodidentity/v1"
-	"github.com/Azure/go-autorest/autorest/azure/auth"
 	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -226,10 +224,6 @@ func TestAzureJSONMachineReconciler(t *testing.T) {
 			fail: false,
 		},
 	}
-
-	os.Setenv(auth.ClientID, "fooClient")
-	os.Setenv(auth.ClientSecret, "fooSecret")
-	os.Setenv(auth.TenantID, "fooTenant")
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {

--- a/controllers/azurejson_machinepool_controller_test.go
+++ b/controllers/azurejson_machinepool_controller_test.go
@@ -22,7 +22,6 @@ import (
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
-	"github.com/Azure/go-autorest/autorest/azure/auth"
 	"github.com/google/go-cmp/cmp"
 	. "github.com/onsi/gomega"
 	"go.uber.org/mock/gomock"
@@ -211,9 +210,9 @@ func TestAzureJSONPoolReconciler(t *testing.T) {
 		},
 	}
 
-	t.Setenv(auth.ClientID, "fooClient")
-	t.Setenv(auth.ClientSecret, "fooSecret")
-	t.Setenv(auth.TenantID, "fooTenant")
+	t.Setenv("AZURE_CLIENT_ID", "fooClient")
+	t.Setenv("AZURE_CLIENT_SECRET", "fooSecret")
+	t.Setenv("AZURE_TENANT_ID", "fooTenant")
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {

--- a/controllers/azurejson_machinetemplate_controller_test.go
+++ b/controllers/azurejson_machinetemplate_controller_test.go
@@ -18,10 +18,8 @@ package controllers
 
 import (
 	"context"
-	"os"
 	"testing"
 
-	"github.com/Azure/go-autorest/autorest/azure/auth"
 	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -157,10 +155,6 @@ func TestAzureJSONTemplateReconciler(t *testing.T) {
 			fail: false,
 		},
 	}
-
-	os.Setenv(auth.ClientID, "fooClient")
-	os.Setenv(auth.ClientSecret, "fooSecret")
-	os.Setenv(auth.TenantID, "fooTenant")
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {

--- a/controllers/azuremanagedmachinepool_controller_test.go
+++ b/controllers/azuremanagedmachinepool_controller_test.go
@@ -18,13 +18,11 @@ package controllers
 
 import (
 	"context"
-	"os"
 	"testing"
 	"time"
 
 	aadpodv1 "github.com/Azure/aad-pod-identity/pkg/apis/aadpodidentity/v1"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
-	"github.com/Azure/go-autorest/autorest/azure/auth"
 	. "github.com/onsi/gomega"
 	"github.com/pkg/errors"
 	"go.uber.org/mock/gomock"
@@ -53,11 +51,6 @@ func TestAzureManagedMachinePoolReconcile(t *testing.T) {
 		*mock_azure.MockReconciler
 		*mock_azure.MockPauser
 	}
-
-	os.Setenv(auth.ClientID, "fooClient")
-	os.Setenv(auth.ClientSecret, "fooSecret")
-	os.Setenv(auth.TenantID, "fooTenant")
-	os.Setenv(auth.SubscriptionID, "fooSubscription")
 
 	cases := []struct {
 		name   string

--- a/controllers/helpers_test.go
+++ b/controllers/helpers_test.go
@@ -24,7 +24,6 @@ import (
 	"testing"
 
 	aadpodv1 "github.com/Azure/aad-pod-identity/pkg/apis/aadpodidentity/v1"
-	"github.com/Azure/go-autorest/autorest/azure/auth"
 	"github.com/go-logr/logr"
 	"github.com/google/go-cmp/cmp"
 	. "github.com/onsi/gomega"
@@ -170,9 +169,9 @@ func TestGetCloudProviderConfig(t *testing.T) {
 		},
 	}
 
-	os.Setenv(auth.ClientID, "fooClient")
-	os.Setenv(auth.ClientSecret, "fooSecret")
-	os.Setenv(auth.TenantID, "fooTenant")
+	os.Setenv("AZURE_CLIENT_ID", "fooClient")
+	os.Setenv("AZURE_CLIENT_SECRET", "fooSecret")
+	os.Setenv("AZURE_TENANT_ID", "fooTenant")
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {

--- a/exp/controllers/azuremachinepoolmachine_controller_test.go
+++ b/exp/controllers/azuremachinepoolmachine_controller_test.go
@@ -18,12 +18,10 @@ package controllers
 
 import (
 	"context"
-	"os"
 	"testing"
 	"time"
 
 	aadpodv1 "github.com/Azure/aad-pod-identity/pkg/apis/aadpodidentity/v1"
-	"github.com/Azure/go-autorest/autorest/azure/auth"
 	. "github.com/onsi/gomega"
 	"go.uber.org/mock/gomock"
 	corev1 "k8s.io/api/core/v1"
@@ -73,10 +71,6 @@ func TestAzureMachinePoolMachineReconciler_Reconcile(t *testing.T) {
 			},
 		},
 	}
-
-	os.Setenv(auth.ClientID, "fooClient")
-	os.Setenv(auth.ClientSecret, "fooSecret")
-	os.Setenv(auth.TenantID, "fooTenant")
 
 	for _, c := range cases {
 		c := c


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Removes most of the remaining usages of the deprecated `go-autorest` package in unit tests.

**Which issue(s) this PR fixes**:

Refs #2974

**Special notes for your reviewer**:

This leaves only the somewhat trickier use of `autorest.Environment` in the codebase, which we can address separately.

- [ ] cherry-pick candidate

**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:

```release-note
NONE
```
