### PR TITLE
feat(aso): add azure workload identity label to pod template

### DIFF
--- a/config/aso/kustomization.yaml
+++ b/config/aso/kustomization.yaml
@@ -22,6 +22,15 @@ patches:
       version: v1
       kind: Deployment
       name: azureserviceoperator-controller-manager
+  - patch: |- # Add label for Azure workload identity webhook
+      - op: add
+        path: "/spec/template/metadata/labels/azure.workload.identity~1use"
+        value: "true"
+    target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: azureserviceoperator-controller-manager
   - patch: |- # remove permissions to manage CRDs
       $patch: delete
       apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->
/kind feature
**What this PR does / why we need it**:

Add the label `azure.workload.identity/use: "true"` to ASO deployment pod template so credentials can be injected using the Azure Workload Identity webhook.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
