### PR TITLE
Skip AvailabilitySet creation for Spot instances

### DIFF
--- a/azure/scope/machine.go
+++ b/azure/scope/machine.go
@@ -499,7 +499,8 @@ func (m *MachineScope) AvailabilitySetSpec() azure.ResourceSpecGetter {
 // AvailabilitySet returns the availability set for this machine if available.
 func (m *MachineScope) AvailabilitySet() (string, bool) {
 	// AvailabilitySet service is not supported on EdgeZone currently.
-	if !m.AvailabilitySetEnabled() || m.ExtendedLocation() != nil {
+	// AvailabilitySet cannot be used with Spot instances.
+	if !m.AvailabilitySetEnabled() || m.AzureMachine.Spec.SpotVMOptions != nil || m.ExtendedLocation() != nil {
 		return "", false
 	}
 


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Availability set are not supported when using spot instances, but the capi provider still creates the availability set and attempts to use it. Causing the machines to fail to provision with error from azure, "Azure Spot Virtual Machine is not supported in Availability Set."

This PR disables AvailabilitySet creation when a machine has `spotVMOptions` set.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4432 

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [x] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix: Spot machines failing to provision on regions without availability zones due to use of AvailabilitySets 
```
