### PR TITLE
Update metrics address flag in Tilt

### DIFF
--- a/hack/observability/opentelemetry/controller-manager-patch.yaml
+++ b/hack/observability/opentelemetry/controller-manager-patch.yaml
@@ -9,7 +9,8 @@ spec:
       containers:
         - name: manager
           args:
-            - "--metrics-bind-addr=:8080"
+            - "--diagnostics-address=:8080"
+            - "--insecure-diagnostics"
             - "--leader-elect"
             - "--feature-gates=MachinePool=${EXP_MACHINE_POOL:=false},AKSResourceHealth=${EXP_AKS_RESOURCE_HEALTH:=false},EdgeZone=${EXP_EDGEZONE:=false}"
             - "--enable-tracing"


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Updates a controller-manager patch file to use the newer metrics flags to avoid this deprecation warning in Tilt:

```
Flag --metrics-bind-addr has been deprecated,
Please use --diagnostics-address instead.
To continue to serve metrics via http and without 
authentication/authorization set --insecure-diagnostics as well.
```

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

This was an oversight; it should have been updated in #4182 with the other instances of this flag.

- [ ] cherry-pick candidate

**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:

```release-note
NONE
```
