### PR TITLE
remove unneeded embedded interfaces from ASO services

### DIFF
--- a/azure/services/agentpools/agentpools.go
+++ b/azure/services/agentpools/agentpools.go
@@ -31,7 +31,6 @@ const serviceName = "agentpools"
 
 // AgentPoolScope defines the scope interface for an agent pool.
 type AgentPoolScope interface {
-	azure.ClusterDescriber
 	aso.Scope
 
 	Name() string

--- a/azure/services/agentpools/mock_agentpools/agentpools_mock.go
+++ b/azure/services/agentpools/mock_agentpools/agentpools_mock.go
@@ -29,7 +29,6 @@ import (
 	reflect "reflect"
 	time "time"
 
-	azcore "github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	v1api20231001 "github.com/Azure/azure-service-operator/v2/api/containerservice/v1api20231001"
 	gomock "go.uber.org/mock/gomock"
 	v1beta1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
@@ -61,20 +60,6 @@ func (m *MockAgentPoolScope) EXPECT() *MockAgentPoolScopeMockRecorder {
 	return m.recorder
 }
 
-// AdditionalTags mocks base method.
-func (m *MockAgentPoolScope) AdditionalTags() v1beta1.Tags {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AdditionalTags")
-	ret0, _ := ret[0].(v1beta1.Tags)
-	return ret0
-}
-
-// AdditionalTags indicates an expected call of AdditionalTags.
-func (mr *MockAgentPoolScopeMockRecorder) AdditionalTags() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AdditionalTags", reflect.TypeOf((*MockAgentPoolScope)(nil).AdditionalTags))
-}
-
 // AgentPoolSpec mocks base method.
 func (m *MockAgentPoolScope) AgentPoolSpec() azure.ASOResourceSpecGetter[*v1api20231001.ManagedClustersAgentPool] {
 	m.ctrl.T.Helper()
@@ -87,90 +72,6 @@ func (m *MockAgentPoolScope) AgentPoolSpec() azure.ASOResourceSpecGetter[*v1api2
 func (mr *MockAgentPoolScopeMockRecorder) AgentPoolSpec() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AgentPoolSpec", reflect.TypeOf((*MockAgentPoolScope)(nil).AgentPoolSpec))
-}
-
-// AvailabilitySetEnabled mocks base method.
-func (m *MockAgentPoolScope) AvailabilitySetEnabled() bool {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AvailabilitySetEnabled")
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-// AvailabilitySetEnabled indicates an expected call of AvailabilitySetEnabled.
-func (mr *MockAgentPoolScopeMockRecorder) AvailabilitySetEnabled() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AvailabilitySetEnabled", reflect.TypeOf((*MockAgentPoolScope)(nil).AvailabilitySetEnabled))
-}
-
-// BaseURI mocks base method.
-func (m *MockAgentPoolScope) BaseURI() string {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BaseURI")
-	ret0, _ := ret[0].(string)
-	return ret0
-}
-
-// BaseURI indicates an expected call of BaseURI.
-func (mr *MockAgentPoolScopeMockRecorder) BaseURI() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BaseURI", reflect.TypeOf((*MockAgentPoolScope)(nil).BaseURI))
-}
-
-// ClientID mocks base method.
-func (m *MockAgentPoolScope) ClientID() string {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ClientID")
-	ret0, _ := ret[0].(string)
-	return ret0
-}
-
-// ClientID indicates an expected call of ClientID.
-func (mr *MockAgentPoolScopeMockRecorder) ClientID() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClientID", reflect.TypeOf((*MockAgentPoolScope)(nil).ClientID))
-}
-
-// ClientSecret mocks base method.
-func (m *MockAgentPoolScope) ClientSecret() string {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ClientSecret")
-	ret0, _ := ret[0].(string)
-	return ret0
-}
-
-// ClientSecret indicates an expected call of ClientSecret.
-func (mr *MockAgentPoolScopeMockRecorder) ClientSecret() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClientSecret", reflect.TypeOf((*MockAgentPoolScope)(nil).ClientSecret))
-}
-
-// CloudEnvironment mocks base method.
-func (m *MockAgentPoolScope) CloudEnvironment() string {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CloudEnvironment")
-	ret0, _ := ret[0].(string)
-	return ret0
-}
-
-// CloudEnvironment indicates an expected call of CloudEnvironment.
-func (mr *MockAgentPoolScopeMockRecorder) CloudEnvironment() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CloudEnvironment", reflect.TypeOf((*MockAgentPoolScope)(nil).CloudEnvironment))
-}
-
-// CloudProviderConfigOverrides mocks base method.
-func (m *MockAgentPoolScope) CloudProviderConfigOverrides() *v1beta1.CloudProviderConfigOverrides {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CloudProviderConfigOverrides")
-	ret0, _ := ret[0].(*v1beta1.CloudProviderConfigOverrides)
-	return ret0
-}
-
-// CloudProviderConfigOverrides indicates an expected call of CloudProviderConfigOverrides.
-func (mr *MockAgentPoolScopeMockRecorder) CloudProviderConfigOverrides() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CloudProviderConfigOverrides", reflect.TypeOf((*MockAgentPoolScope)(nil).CloudProviderConfigOverrides))
 }
 
 // ClusterName mocks base method.
@@ -241,62 +142,6 @@ func (mr *MockAgentPoolScopeMockRecorder) DeleteLongRunningOperationState(arg0, 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteLongRunningOperationState", reflect.TypeOf((*MockAgentPoolScope)(nil).DeleteLongRunningOperationState), arg0, arg1, arg2)
 }
 
-// ExtendedLocation mocks base method.
-func (m *MockAgentPoolScope) ExtendedLocation() *v1beta1.ExtendedLocationSpec {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ExtendedLocation")
-	ret0, _ := ret[0].(*v1beta1.ExtendedLocationSpec)
-	return ret0
-}
-
-// ExtendedLocation indicates an expected call of ExtendedLocation.
-func (mr *MockAgentPoolScopeMockRecorder) ExtendedLocation() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExtendedLocation", reflect.TypeOf((*MockAgentPoolScope)(nil).ExtendedLocation))
-}
-
-// ExtendedLocationName mocks base method.
-func (m *MockAgentPoolScope) ExtendedLocationName() string {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ExtendedLocationName")
-	ret0, _ := ret[0].(string)
-	return ret0
-}
-
-// ExtendedLocationName indicates an expected call of ExtendedLocationName.
-func (mr *MockAgentPoolScopeMockRecorder) ExtendedLocationName() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExtendedLocationName", reflect.TypeOf((*MockAgentPoolScope)(nil).ExtendedLocationName))
-}
-
-// ExtendedLocationType mocks base method.
-func (m *MockAgentPoolScope) ExtendedLocationType() string {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ExtendedLocationType")
-	ret0, _ := ret[0].(string)
-	return ret0
-}
-
-// ExtendedLocationType indicates an expected call of ExtendedLocationType.
-func (mr *MockAgentPoolScopeMockRecorder) ExtendedLocationType() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExtendedLocationType", reflect.TypeOf((*MockAgentPoolScope)(nil).ExtendedLocationType))
-}
-
-// FailureDomains mocks base method.
-func (m *MockAgentPoolScope) FailureDomains() []*string {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FailureDomains")
-	ret0, _ := ret[0].([]*string)
-	return ret0
-}
-
-// FailureDomains indicates an expected call of FailureDomains.
-func (mr *MockAgentPoolScopeMockRecorder) FailureDomains() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FailureDomains", reflect.TypeOf((*MockAgentPoolScope)(nil).FailureDomains))
-}
-
 // GetClient mocks base method.
 func (m *MockAgentPoolScope) GetClient() client.Client {
 	m.ctrl.T.Helper()
@@ -323,34 +168,6 @@ func (m *MockAgentPoolScope) GetLongRunningOperationState(arg0, arg1, arg2 strin
 func (mr *MockAgentPoolScopeMockRecorder) GetLongRunningOperationState(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLongRunningOperationState", reflect.TypeOf((*MockAgentPoolScope)(nil).GetLongRunningOperationState), arg0, arg1, arg2)
-}
-
-// HashKey mocks base method.
-func (m *MockAgentPoolScope) HashKey() string {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "HashKey")
-	ret0, _ := ret[0].(string)
-	return ret0
-}
-
-// HashKey indicates an expected call of HashKey.
-func (mr *MockAgentPoolScopeMockRecorder) HashKey() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HashKey", reflect.TypeOf((*MockAgentPoolScope)(nil).HashKey))
-}
-
-// Location mocks base method.
-func (m *MockAgentPoolScope) Location() string {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Location")
-	ret0, _ := ret[0].(string)
-	return ret0
-}
-
-// Location indicates an expected call of Location.
-func (mr *MockAgentPoolScopeMockRecorder) Location() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Location", reflect.TypeOf((*MockAgentPoolScope)(nil).Location))
 }
 
 // Name mocks base method.
@@ -391,20 +208,6 @@ func (m *MockAgentPoolScope) RemoveCAPIMachinePoolAnnotation(key string) {
 func (mr *MockAgentPoolScopeMockRecorder) RemoveCAPIMachinePoolAnnotation(key any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveCAPIMachinePoolAnnotation", reflect.TypeOf((*MockAgentPoolScope)(nil).RemoveCAPIMachinePoolAnnotation), key)
-}
-
-// ResourceGroup mocks base method.
-func (m *MockAgentPoolScope) ResourceGroup() string {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ResourceGroup")
-	ret0, _ := ret[0].(string)
-	return ret0
-}
-
-// ResourceGroup indicates an expected call of ResourceGroup.
-func (mr *MockAgentPoolScopeMockRecorder) ResourceGroup() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResourceGroup", reflect.TypeOf((*MockAgentPoolScope)(nil).ResourceGroup))
 }
 
 // SetAgentPoolProviderIDList mocks base method.
@@ -489,48 +292,6 @@ func (m *MockAgentPoolScope) SetSubnetName() {
 func (mr *MockAgentPoolScopeMockRecorder) SetSubnetName() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetSubnetName", reflect.TypeOf((*MockAgentPoolScope)(nil).SetSubnetName))
-}
-
-// SubscriptionID mocks base method.
-func (m *MockAgentPoolScope) SubscriptionID() string {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SubscriptionID")
-	ret0, _ := ret[0].(string)
-	return ret0
-}
-
-// SubscriptionID indicates an expected call of SubscriptionID.
-func (mr *MockAgentPoolScopeMockRecorder) SubscriptionID() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SubscriptionID", reflect.TypeOf((*MockAgentPoolScope)(nil).SubscriptionID))
-}
-
-// TenantID mocks base method.
-func (m *MockAgentPoolScope) TenantID() string {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "TenantID")
-	ret0, _ := ret[0].(string)
-	return ret0
-}
-
-// TenantID indicates an expected call of TenantID.
-func (mr *MockAgentPoolScopeMockRecorder) TenantID() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TenantID", reflect.TypeOf((*MockAgentPoolScope)(nil).TenantID))
-}
-
-// Token mocks base method.
-func (m *MockAgentPoolScope) Token() azcore.TokenCredential {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Token")
-	ret0, _ := ret[0].(azcore.TokenCredential)
-	return ret0
-}
-
-// Token indicates an expected call of Token.
-func (mr *MockAgentPoolScopeMockRecorder) Token() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Token", reflect.TypeOf((*MockAgentPoolScope)(nil).Token))
 }
 
 // UpdateDeleteStatus mocks base method.

--- a/azure/services/bastionhosts/bastionhosts.go
+++ b/azure/services/bastionhosts/bastionhosts.go
@@ -27,7 +27,6 @@ const serviceName = "bastionhosts"
 
 // BastionScope defines the scope interface for a bastion host service.
 type BastionScope interface {
-	azure.ClusterScoper
 	aso.Scope
 	AzureBastionSpec() azure.ASOResourceSpecGetter[*asonetworkv1.BastionHost]
 }

--- a/azure/services/natgateways/mock_natgateways/natgateways_mock.go
+++ b/azure/services/natgateways/mock_natgateways/natgateways_mock.go
@@ -29,10 +29,8 @@ import (
 	reflect "reflect"
 	time "time"
 
-	azcore "github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	v1api20220701 "github.com/Azure/azure-service-operator/v2/api/network/v1api20220701"
 	gomock "go.uber.org/mock/gomock"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1beta1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	azure "sigs.k8s.io/cluster-api-provider-azure/azure"
 	v1beta10 "sigs.k8s.io/cluster-api/api/v1beta1"
@@ -62,146 +60,6 @@ func (m *MockNatGatewayScope) EXPECT() *MockNatGatewayScopeMockRecorder {
 	return m.recorder
 }
 
-// APIServerLB mocks base method.
-func (m *MockNatGatewayScope) APIServerLB() *v1beta1.LoadBalancerSpec {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "APIServerLB")
-	ret0, _ := ret[0].(*v1beta1.LoadBalancerSpec)
-	return ret0
-}
-
-// APIServerLB indicates an expected call of APIServerLB.
-func (mr *MockNatGatewayScopeMockRecorder) APIServerLB() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "APIServerLB", reflect.TypeOf((*MockNatGatewayScope)(nil).APIServerLB))
-}
-
-// APIServerLBName mocks base method.
-func (m *MockNatGatewayScope) APIServerLBName() string {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "APIServerLBName")
-	ret0, _ := ret[0].(string)
-	return ret0
-}
-
-// APIServerLBName indicates an expected call of APIServerLBName.
-func (mr *MockNatGatewayScopeMockRecorder) APIServerLBName() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "APIServerLBName", reflect.TypeOf((*MockNatGatewayScope)(nil).APIServerLBName))
-}
-
-// APIServerLBPoolName mocks base method.
-func (m *MockNatGatewayScope) APIServerLBPoolName() string {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "APIServerLBPoolName")
-	ret0, _ := ret[0].(string)
-	return ret0
-}
-
-// APIServerLBPoolName indicates an expected call of APIServerLBPoolName.
-func (mr *MockNatGatewayScopeMockRecorder) APIServerLBPoolName() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "APIServerLBPoolName", reflect.TypeOf((*MockNatGatewayScope)(nil).APIServerLBPoolName))
-}
-
-// AdditionalTags mocks base method.
-func (m *MockNatGatewayScope) AdditionalTags() v1beta1.Tags {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AdditionalTags")
-	ret0, _ := ret[0].(v1beta1.Tags)
-	return ret0
-}
-
-// AdditionalTags indicates an expected call of AdditionalTags.
-func (mr *MockNatGatewayScopeMockRecorder) AdditionalTags() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AdditionalTags", reflect.TypeOf((*MockNatGatewayScope)(nil).AdditionalTags))
-}
-
-// AvailabilitySetEnabled mocks base method.
-func (m *MockNatGatewayScope) AvailabilitySetEnabled() bool {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AvailabilitySetEnabled")
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-// AvailabilitySetEnabled indicates an expected call of AvailabilitySetEnabled.
-func (mr *MockNatGatewayScopeMockRecorder) AvailabilitySetEnabled() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AvailabilitySetEnabled", reflect.TypeOf((*MockNatGatewayScope)(nil).AvailabilitySetEnabled))
-}
-
-// BaseURI mocks base method.
-func (m *MockNatGatewayScope) BaseURI() string {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BaseURI")
-	ret0, _ := ret[0].(string)
-	return ret0
-}
-
-// BaseURI indicates an expected call of BaseURI.
-func (mr *MockNatGatewayScopeMockRecorder) BaseURI() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BaseURI", reflect.TypeOf((*MockNatGatewayScope)(nil).BaseURI))
-}
-
-// ClientID mocks base method.
-func (m *MockNatGatewayScope) ClientID() string {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ClientID")
-	ret0, _ := ret[0].(string)
-	return ret0
-}
-
-// ClientID indicates an expected call of ClientID.
-func (mr *MockNatGatewayScopeMockRecorder) ClientID() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClientID", reflect.TypeOf((*MockNatGatewayScope)(nil).ClientID))
-}
-
-// ClientSecret mocks base method.
-func (m *MockNatGatewayScope) ClientSecret() string {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ClientSecret")
-	ret0, _ := ret[0].(string)
-	return ret0
-}
-
-// ClientSecret indicates an expected call of ClientSecret.
-func (mr *MockNatGatewayScopeMockRecorder) ClientSecret() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClientSecret", reflect.TypeOf((*MockNatGatewayScope)(nil).ClientSecret))
-}
-
-// CloudEnvironment mocks base method.
-func (m *MockNatGatewayScope) CloudEnvironment() string {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CloudEnvironment")
-	ret0, _ := ret[0].(string)
-	return ret0
-}
-
-// CloudEnvironment indicates an expected call of CloudEnvironment.
-func (mr *MockNatGatewayScopeMockRecorder) CloudEnvironment() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CloudEnvironment", reflect.TypeOf((*MockNatGatewayScope)(nil).CloudEnvironment))
-}
-
-// CloudProviderConfigOverrides mocks base method.
-func (m *MockNatGatewayScope) CloudProviderConfigOverrides() *v1beta1.CloudProviderConfigOverrides {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CloudProviderConfigOverrides")
-	ret0, _ := ret[0].(*v1beta1.CloudProviderConfigOverrides)
-	return ret0
-}
-
-// CloudProviderConfigOverrides indicates an expected call of CloudProviderConfigOverrides.
-func (mr *MockNatGatewayScopeMockRecorder) CloudProviderConfigOverrides() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CloudProviderConfigOverrides", reflect.TypeOf((*MockNatGatewayScope)(nil).CloudProviderConfigOverrides))
-}
-
 // ClusterName mocks base method.
 func (m *MockNatGatewayScope) ClusterName() string {
 	m.ctrl.T.Helper()
@@ -214,34 +72,6 @@ func (m *MockNatGatewayScope) ClusterName() string {
 func (mr *MockNatGatewayScopeMockRecorder) ClusterName() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClusterName", reflect.TypeOf((*MockNatGatewayScope)(nil).ClusterName))
-}
-
-// ControlPlaneRouteTable mocks base method.
-func (m *MockNatGatewayScope) ControlPlaneRouteTable() v1beta1.RouteTable {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ControlPlaneRouteTable")
-	ret0, _ := ret[0].(v1beta1.RouteTable)
-	return ret0
-}
-
-// ControlPlaneRouteTable indicates an expected call of ControlPlaneRouteTable.
-func (mr *MockNatGatewayScopeMockRecorder) ControlPlaneRouteTable() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ControlPlaneRouteTable", reflect.TypeOf((*MockNatGatewayScope)(nil).ControlPlaneRouteTable))
-}
-
-// ControlPlaneSubnet mocks base method.
-func (m *MockNatGatewayScope) ControlPlaneSubnet() v1beta1.SubnetSpec {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ControlPlaneSubnet")
-	ret0, _ := ret[0].(v1beta1.SubnetSpec)
-	return ret0
-}
-
-// ControlPlaneSubnet indicates an expected call of ControlPlaneSubnet.
-func (mr *MockNatGatewayScopeMockRecorder) ControlPlaneSubnet() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ControlPlaneSubnet", reflect.TypeOf((*MockNatGatewayScope)(nil).ControlPlaneSubnet))
 }
 
 // DefaultedAzureCallTimeout mocks base method.
@@ -298,62 +128,6 @@ func (mr *MockNatGatewayScopeMockRecorder) DeleteLongRunningOperationState(arg0,
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteLongRunningOperationState", reflect.TypeOf((*MockNatGatewayScope)(nil).DeleteLongRunningOperationState), arg0, arg1, arg2)
 }
 
-// ExtendedLocation mocks base method.
-func (m *MockNatGatewayScope) ExtendedLocation() *v1beta1.ExtendedLocationSpec {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ExtendedLocation")
-	ret0, _ := ret[0].(*v1beta1.ExtendedLocationSpec)
-	return ret0
-}
-
-// ExtendedLocation indicates an expected call of ExtendedLocation.
-func (mr *MockNatGatewayScopeMockRecorder) ExtendedLocation() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExtendedLocation", reflect.TypeOf((*MockNatGatewayScope)(nil).ExtendedLocation))
-}
-
-// ExtendedLocationName mocks base method.
-func (m *MockNatGatewayScope) ExtendedLocationName() string {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ExtendedLocationName")
-	ret0, _ := ret[0].(string)
-	return ret0
-}
-
-// ExtendedLocationName indicates an expected call of ExtendedLocationName.
-func (mr *MockNatGatewayScopeMockRecorder) ExtendedLocationName() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExtendedLocationName", reflect.TypeOf((*MockNatGatewayScope)(nil).ExtendedLocationName))
-}
-
-// ExtendedLocationType mocks base method.
-func (m *MockNatGatewayScope) ExtendedLocationType() string {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ExtendedLocationType")
-	ret0, _ := ret[0].(string)
-	return ret0
-}
-
-// ExtendedLocationType indicates an expected call of ExtendedLocationType.
-func (mr *MockNatGatewayScopeMockRecorder) ExtendedLocationType() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExtendedLocationType", reflect.TypeOf((*MockNatGatewayScope)(nil).ExtendedLocationType))
-}
-
-// FailureDomains mocks base method.
-func (m *MockNatGatewayScope) FailureDomains() []*string {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FailureDomains")
-	ret0, _ := ret[0].([]*string)
-	return ret0
-}
-
-// FailureDomains indicates an expected call of FailureDomains.
-func (mr *MockNatGatewayScopeMockRecorder) FailureDomains() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FailureDomains", reflect.TypeOf((*MockNatGatewayScope)(nil).FailureDomains))
-}
-
 // GetClient mocks base method.
 func (m *MockNatGatewayScope) GetClient() client.Client {
 	m.ctrl.T.Helper()
@@ -366,20 +140,6 @@ func (m *MockNatGatewayScope) GetClient() client.Client {
 func (mr *MockNatGatewayScopeMockRecorder) GetClient() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetClient", reflect.TypeOf((*MockNatGatewayScope)(nil).GetClient))
-}
-
-// GetDeletionTimestamp mocks base method.
-func (m *MockNatGatewayScope) GetDeletionTimestamp() *v1.Time {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetDeletionTimestamp")
-	ret0, _ := ret[0].(*v1.Time)
-	return ret0
-}
-
-// GetDeletionTimestamp indicates an expected call of GetDeletionTimestamp.
-func (mr *MockNatGatewayScopeMockRecorder) GetDeletionTimestamp() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDeletionTimestamp", reflect.TypeOf((*MockNatGatewayScope)(nil).GetDeletionTimestamp))
 }
 
 // GetLongRunningOperationState mocks base method.
@@ -396,90 +156,6 @@ func (mr *MockNatGatewayScopeMockRecorder) GetLongRunningOperationState(arg0, ar
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLongRunningOperationState", reflect.TypeOf((*MockNatGatewayScope)(nil).GetLongRunningOperationState), arg0, arg1, arg2)
 }
 
-// GetPrivateDNSZoneName mocks base method.
-func (m *MockNatGatewayScope) GetPrivateDNSZoneName() string {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetPrivateDNSZoneName")
-	ret0, _ := ret[0].(string)
-	return ret0
-}
-
-// GetPrivateDNSZoneName indicates an expected call of GetPrivateDNSZoneName.
-func (mr *MockNatGatewayScopeMockRecorder) GetPrivateDNSZoneName() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPrivateDNSZoneName", reflect.TypeOf((*MockNatGatewayScope)(nil).GetPrivateDNSZoneName))
-}
-
-// HashKey mocks base method.
-func (m *MockNatGatewayScope) HashKey() string {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "HashKey")
-	ret0, _ := ret[0].(string)
-	return ret0
-}
-
-// HashKey indicates an expected call of HashKey.
-func (mr *MockNatGatewayScopeMockRecorder) HashKey() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HashKey", reflect.TypeOf((*MockNatGatewayScope)(nil).HashKey))
-}
-
-// IsAPIServerPrivate mocks base method.
-func (m *MockNatGatewayScope) IsAPIServerPrivate() bool {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsAPIServerPrivate")
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-// IsAPIServerPrivate indicates an expected call of IsAPIServerPrivate.
-func (mr *MockNatGatewayScopeMockRecorder) IsAPIServerPrivate() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsAPIServerPrivate", reflect.TypeOf((*MockNatGatewayScope)(nil).IsAPIServerPrivate))
-}
-
-// IsIPv6Enabled mocks base method.
-func (m *MockNatGatewayScope) IsIPv6Enabled() bool {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsIPv6Enabled")
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-// IsIPv6Enabled indicates an expected call of IsIPv6Enabled.
-func (mr *MockNatGatewayScopeMockRecorder) IsIPv6Enabled() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsIPv6Enabled", reflect.TypeOf((*MockNatGatewayScope)(nil).IsIPv6Enabled))
-}
-
-// IsVnetManaged mocks base method.
-func (m *MockNatGatewayScope) IsVnetManaged() bool {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsVnetManaged")
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-// IsVnetManaged indicates an expected call of IsVnetManaged.
-func (mr *MockNatGatewayScopeMockRecorder) IsVnetManaged() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsVnetManaged", reflect.TypeOf((*MockNatGatewayScope)(nil).IsVnetManaged))
-}
-
-// Location mocks base method.
-func (m *MockNatGatewayScope) Location() string {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Location")
-	ret0, _ := ret[0].(string)
-	return ret0
-}
-
-// Location indicates an expected call of Location.
-func (mr *MockNatGatewayScopeMockRecorder) Location() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Location", reflect.TypeOf((*MockNatGatewayScope)(nil).Location))
-}
-
 // NatGatewaySpecs mocks base method.
 func (m *MockNatGatewayScope) NatGatewaySpecs() []azure.ASOResourceSpecGetter[*v1api20220701.NatGateway] {
 	m.ctrl.T.Helper()
@@ -492,76 +168,6 @@ func (m *MockNatGatewayScope) NatGatewaySpecs() []azure.ASOResourceSpecGetter[*v
 func (mr *MockNatGatewayScopeMockRecorder) NatGatewaySpecs() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NatGatewaySpecs", reflect.TypeOf((*MockNatGatewayScope)(nil).NatGatewaySpecs))
-}
-
-// NodeResourceGroup mocks base method.
-func (m *MockNatGatewayScope) NodeResourceGroup() string {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "NodeResourceGroup")
-	ret0, _ := ret[0].(string)
-	return ret0
-}
-
-// NodeResourceGroup indicates an expected call of NodeResourceGroup.
-func (mr *MockNatGatewayScopeMockRecorder) NodeResourceGroup() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NodeResourceGroup", reflect.TypeOf((*MockNatGatewayScope)(nil).NodeResourceGroup))
-}
-
-// NodeSubnets mocks base method.
-func (m *MockNatGatewayScope) NodeSubnets() []v1beta1.SubnetSpec {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "NodeSubnets")
-	ret0, _ := ret[0].([]v1beta1.SubnetSpec)
-	return ret0
-}
-
-// NodeSubnets indicates an expected call of NodeSubnets.
-func (mr *MockNatGatewayScopeMockRecorder) NodeSubnets() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NodeSubnets", reflect.TypeOf((*MockNatGatewayScope)(nil).NodeSubnets))
-}
-
-// OutboundLBName mocks base method.
-func (m *MockNatGatewayScope) OutboundLBName(arg0 string) string {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "OutboundLBName", arg0)
-	ret0, _ := ret[0].(string)
-	return ret0
-}
-
-// OutboundLBName indicates an expected call of OutboundLBName.
-func (mr *MockNatGatewayScopeMockRecorder) OutboundLBName(arg0 any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OutboundLBName", reflect.TypeOf((*MockNatGatewayScope)(nil).OutboundLBName), arg0)
-}
-
-// OutboundPoolName mocks base method.
-func (m *MockNatGatewayScope) OutboundPoolName(arg0 string) string {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "OutboundPoolName", arg0)
-	ret0, _ := ret[0].(string)
-	return ret0
-}
-
-// OutboundPoolName indicates an expected call of OutboundPoolName.
-func (mr *MockNatGatewayScopeMockRecorder) OutboundPoolName(arg0 any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OutboundPoolName", reflect.TypeOf((*MockNatGatewayScope)(nil).OutboundPoolName), arg0)
-}
-
-// ResourceGroup mocks base method.
-func (m *MockNatGatewayScope) ResourceGroup() string {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ResourceGroup")
-	ret0, _ := ret[0].(string)
-	return ret0
-}
-
-// ResourceGroup indicates an expected call of ResourceGroup.
-func (mr *MockNatGatewayScopeMockRecorder) ResourceGroup() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResourceGroup", reflect.TypeOf((*MockNatGatewayScope)(nil).ResourceGroup))
 }
 
 // SetLongRunningOperationState mocks base method.
@@ -586,88 +192,6 @@ func (m *MockNatGatewayScope) SetNatGatewayIDInSubnets(natGatewayName, natGatewa
 func (mr *MockNatGatewayScopeMockRecorder) SetNatGatewayIDInSubnets(natGatewayName, natGatewayID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetNatGatewayIDInSubnets", reflect.TypeOf((*MockNatGatewayScope)(nil).SetNatGatewayIDInSubnets), natGatewayName, natGatewayID)
-}
-
-// SetSubnet mocks base method.
-func (m *MockNatGatewayScope) SetSubnet(arg0 v1beta1.SubnetSpec) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SetSubnet", arg0)
-}
-
-// SetSubnet indicates an expected call of SetSubnet.
-func (mr *MockNatGatewayScopeMockRecorder) SetSubnet(arg0 any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetSubnet", reflect.TypeOf((*MockNatGatewayScope)(nil).SetSubnet), arg0)
-}
-
-// Subnet mocks base method.
-func (m *MockNatGatewayScope) Subnet(arg0 string) v1beta1.SubnetSpec {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Subnet", arg0)
-	ret0, _ := ret[0].(v1beta1.SubnetSpec)
-	return ret0
-}
-
-// Subnet indicates an expected call of Subnet.
-func (mr *MockNatGatewayScopeMockRecorder) Subnet(arg0 any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Subnet", reflect.TypeOf((*MockNatGatewayScope)(nil).Subnet), arg0)
-}
-
-// Subnets mocks base method.
-func (m *MockNatGatewayScope) Subnets() v1beta1.Subnets {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Subnets")
-	ret0, _ := ret[0].(v1beta1.Subnets)
-	return ret0
-}
-
-// Subnets indicates an expected call of Subnets.
-func (mr *MockNatGatewayScopeMockRecorder) Subnets() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Subnets", reflect.TypeOf((*MockNatGatewayScope)(nil).Subnets))
-}
-
-// SubscriptionID mocks base method.
-func (m *MockNatGatewayScope) SubscriptionID() string {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SubscriptionID")
-	ret0, _ := ret[0].(string)
-	return ret0
-}
-
-// SubscriptionID indicates an expected call of SubscriptionID.
-func (mr *MockNatGatewayScopeMockRecorder) SubscriptionID() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SubscriptionID", reflect.TypeOf((*MockNatGatewayScope)(nil).SubscriptionID))
-}
-
-// TenantID mocks base method.
-func (m *MockNatGatewayScope) TenantID() string {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "TenantID")
-	ret0, _ := ret[0].(string)
-	return ret0
-}
-
-// TenantID indicates an expected call of TenantID.
-func (mr *MockNatGatewayScopeMockRecorder) TenantID() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TenantID", reflect.TypeOf((*MockNatGatewayScope)(nil).TenantID))
-}
-
-// Token mocks base method.
-func (m *MockNatGatewayScope) Token() azcore.TokenCredential {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Token")
-	ret0, _ := ret[0].(azcore.TokenCredential)
-	return ret0
-}
-
-// Token indicates an expected call of Token.
-func (mr *MockNatGatewayScopeMockRecorder) Token() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Token", reflect.TypeOf((*MockNatGatewayScope)(nil).Token))
 }
 
 // UpdateDeleteStatus mocks base method.
@@ -704,18 +228,4 @@ func (m *MockNatGatewayScope) UpdatePutStatus(arg0 v1beta10.ConditionType, arg1 
 func (mr *MockNatGatewayScopeMockRecorder) UpdatePutStatus(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdatePutStatus", reflect.TypeOf((*MockNatGatewayScope)(nil).UpdatePutStatus), arg0, arg1, arg2)
-}
-
-// Vnet mocks base method.
-func (m *MockNatGatewayScope) Vnet() *v1beta1.VnetSpec {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Vnet")
-	ret0, _ := ret[0].(*v1beta1.VnetSpec)
-	return ret0
-}
-
-// Vnet indicates an expected call of Vnet.
-func (mr *MockNatGatewayScopeMockRecorder) Vnet() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Vnet", reflect.TypeOf((*MockNatGatewayScope)(nil).Vnet))
 }

--- a/azure/services/natgateways/natgateways.go
+++ b/azure/services/natgateways/natgateways.go
@@ -29,7 +29,6 @@ const serviceName = "natgateways"
 
 // NatGatewayScope defines the scope interface for NAT gateway service.
 type NatGatewayScope interface {
-	azure.ClusterScoper
 	aso.Scope
 	SetNatGatewayIDInSubnets(natGatewayName string, natGatewayID string)
 	NatGatewaySpecs() []azure.ASOResourceSpecGetter[*asonetworkv1.NatGateway]


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind cleanup

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**: This PR removes the `azure.ClusterScoper` interface from a few of the ASO services' `Scope` types since it's not needed.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```