### PR TITLE
Add mdbook output files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,7 +38,8 @@ kubeconfig
 /out
 
 # Mdbook build directory
-bookout
+docs/book/bookout
+docs/book/src/reference/*.html
 
 # vscode
 .vscode


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Hides two generated documentation files:

```shell
% make -C docs/book build
% git st  
On branch main
Your branch is up to date with 'upstream/main'.

Untracked files:
  (use "git add <file>..." to include in what will be committed)
	docs/book/src/reference/v1beta1-api-raw.html
	docs/book/src/reference/v1beta1-exp-api-raw.html
```

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

- [ ] cherry-pick candidate

**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:

```release-note
NONE
```
