### PR TITLE
simplify aso.Reconciler interface

### DIFF
--- a/azure/services/aso/interfaces.go
+++ b/azure/services/aso/interfaces.go
@@ -28,8 +28,8 @@ import (
 // Reconciler is a generic interface used to perform reconciliation of Azure resources backed by ASO.
 type Reconciler[T genruntime.MetaObject] interface {
 	CreateOrUpdateResource(ctx context.Context, spec azure.ASOResourceSpecGetter[T], serviceName string) (result T, err error)
-	DeleteResource(ctx context.Context, spec azure.ASOResourceSpecGetter[T], serviceName string) (err error)
-	PauseResource(ctx context.Context, spec azure.ASOResourceSpecGetter[T], serviceName string) (err error)
+	DeleteResource(ctx context.Context, resource T, serviceName string) (err error)
+	PauseResource(ctx context.Context, resource T, serviceName string) (err error)
 }
 
 // TagsGetterSetter represents an object that supports tags.

--- a/azure/services/aso/mock_aso/aso_mock.go
+++ b/azure/services/aso/mock_aso/aso_mock.go
@@ -77,31 +77,31 @@ func (mr *MockReconcilerMockRecorder[T]) CreateOrUpdateResource(ctx, spec, servi
 }
 
 // DeleteResource mocks base method.
-func (m *MockReconciler[T]) DeleteResource(ctx context.Context, spec azure.ASOResourceSpecGetter[T], serviceName string) error {
+func (m *MockReconciler[T]) DeleteResource(ctx context.Context, resource T, serviceName string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteResource", ctx, spec, serviceName)
+	ret := m.ctrl.Call(m, "DeleteResource", ctx, resource, serviceName)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteResource indicates an expected call of DeleteResource.
-func (mr *MockReconcilerMockRecorder[T]) DeleteResource(ctx, spec, serviceName any) *gomock.Call {
+func (mr *MockReconcilerMockRecorder[T]) DeleteResource(ctx, resource, serviceName any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteResource", reflect.TypeOf((*MockReconciler[T])(nil).DeleteResource), ctx, spec, serviceName)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteResource", reflect.TypeOf((*MockReconciler[T])(nil).DeleteResource), ctx, resource, serviceName)
 }
 
 // PauseResource mocks base method.
-func (m *MockReconciler[T]) PauseResource(ctx context.Context, spec azure.ASOResourceSpecGetter[T], serviceName string) error {
+func (m *MockReconciler[T]) PauseResource(ctx context.Context, resource T, serviceName string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PauseResource", ctx, spec, serviceName)
+	ret := m.ctrl.Call(m, "PauseResource", ctx, resource, serviceName)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // PauseResource indicates an expected call of PauseResource.
-func (mr *MockReconcilerMockRecorder[T]) PauseResource(ctx, spec, serviceName any) *gomock.Call {
+func (mr *MockReconcilerMockRecorder[T]) PauseResource(ctx, resource, serviceName any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PauseResource", reflect.TypeOf((*MockReconciler[T])(nil).PauseResource), ctx, spec, serviceName)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PauseResource", reflect.TypeOf((*MockReconciler[T])(nil).PauseResource), ctx, resource, serviceName)
 }
 
 // MockTagsGetterSetter is a mock of TagsGetterSetter interface.

--- a/azure/services/aso/service.go
+++ b/azure/services/aso/service.go
@@ -110,7 +110,7 @@ func (s *Service[T, S]) Delete(ctx context.Context) error {
 	//   - no error (i.e. deleted)
 	var resultErr error
 	for _, spec := range s.Specs {
-		err := s.DeleteResource(ctx, spec, s.Name())
+		err := s.DeleteResource(ctx, spec.ResourceRef(), s.Name())
 		if err != nil && (!azure.IsOperationNotDoneError(err) || resultErr == nil) {
 			resultErr = err
 		}
@@ -131,8 +131,8 @@ func (s *Service[T, S]) Pause(ctx context.Context) error {
 	defer done()
 
 	for _, spec := range s.Specs {
-		if err := s.PauseResource(ctx, spec, s.Name()); err != nil {
-			ref := spec.ResourceRef()
+		ref := spec.ResourceRef()
+		if err := s.PauseResource(ctx, ref, s.Name()); err != nil {
 			return errors.Wrapf(err, "failed to pause ASO resource %s %s/%s", ref.GetObjectKind().GroupVersionKind(), ref.GetNamespace(), ref.GetName())
 		}
 	}

--- a/azure/services/aso/service_test.go
+++ b/azure/services/aso/service_test.go
@@ -263,12 +263,12 @@ func TestServiceDelete(t *testing.T) {
 
 		scope := mock_aso.NewMockScope(mockCtrl)
 		specs := []azure.ASOResourceSpecGetter[*asoresourcesv1.ResourceGroup]{
-			mock_azure.NewMockASOResourceSpecGetter[*asoresourcesv1.ResourceGroup](mockCtrl),
+			mockSpecExpectingResourceRef(mockCtrl, &asoresourcesv1.ResourceGroup{}),
 		}
 
 		deleteErr := errors.New("DeleteResource error")
 		reconciler := mock_aso.NewMockReconciler[*asoresourcesv1.ResourceGroup](mockCtrl)
-		reconciler.EXPECT().DeleteResource(gomockinternal.AContext(), specs[0], serviceName).Return(deleteErr)
+		reconciler.EXPECT().DeleteResource(gomockinternal.AContext(), specs[0].ResourceRef(), serviceName).Return(deleteErr)
 		scope.EXPECT().UpdateDeleteStatus(conditionType, serviceName, deleteErr)
 		scope.EXPECT().DefaultedAzureServiceReconcileTimeout().Return(reconcilerutils.DefaultAzureServiceReconcileTimeout)
 
@@ -291,15 +291,15 @@ func TestServiceDelete(t *testing.T) {
 
 		scope := mock_aso.NewMockScope(mockCtrl)
 		specs := []azure.ASOResourceSpecGetter[*asoresourcesv1.ResourceGroup]{
-			mock_azure.NewMockASOResourceSpecGetter[*asoresourcesv1.ResourceGroup](mockCtrl),
-			mock_azure.NewMockASOResourceSpecGetter[*asoresourcesv1.ResourceGroup](mockCtrl),
-			mock_azure.NewMockASOResourceSpecGetter[*asoresourcesv1.ResourceGroup](mockCtrl),
+			mockSpecExpectingResourceRef(mockCtrl, &asoresourcesv1.ResourceGroup{}),
+			mockSpecExpectingResourceRef(mockCtrl, &asoresourcesv1.ResourceGroup{}),
+			mockSpecExpectingResourceRef(mockCtrl, &asoresourcesv1.ResourceGroup{}),
 		}
 
 		reconciler := mock_aso.NewMockReconciler[*asoresourcesv1.ResourceGroup](mockCtrl)
-		reconciler.EXPECT().DeleteResource(gomockinternal.AContext(), specs[0], serviceName).Return(nil)
-		reconciler.EXPECT().DeleteResource(gomockinternal.AContext(), specs[1], serviceName).Return(nil)
-		reconciler.EXPECT().DeleteResource(gomockinternal.AContext(), specs[2], serviceName).Return(nil)
+		reconciler.EXPECT().DeleteResource(gomockinternal.AContext(), specs[0].ResourceRef(), serviceName).Return(nil)
+		reconciler.EXPECT().DeleteResource(gomockinternal.AContext(), specs[1].ResourceRef(), serviceName).Return(nil)
+		reconciler.EXPECT().DeleteResource(gomockinternal.AContext(), specs[2].ResourceRef(), serviceName).Return(nil)
 		scope.EXPECT().UpdateDeleteStatus(conditionType, serviceName, nil)
 		scope.EXPECT().DefaultedAzureServiceReconcileTimeout().Return(reconcilerutils.DefaultAzureServiceReconcileTimeout)
 
@@ -322,16 +322,16 @@ func TestServiceDelete(t *testing.T) {
 
 		scope := mock_aso.NewMockScope(mockCtrl)
 		specs := []azure.ASOResourceSpecGetter[*asoresourcesv1.ResourceGroup]{
-			mock_azure.NewMockASOResourceSpecGetter[*asoresourcesv1.ResourceGroup](mockCtrl),
-			mock_azure.NewMockASOResourceSpecGetter[*asoresourcesv1.ResourceGroup](mockCtrl),
-			mock_azure.NewMockASOResourceSpecGetter[*asoresourcesv1.ResourceGroup](mockCtrl),
+			mockSpecExpectingResourceRef(mockCtrl, &asoresourcesv1.ResourceGroup{}),
+			mockSpecExpectingResourceRef(mockCtrl, &asoresourcesv1.ResourceGroup{}),
+			mockSpecExpectingResourceRef(mockCtrl, &asoresourcesv1.ResourceGroup{}),
 		}
 
 		deleteErr := azure.NewOperationNotDoneError(&infrav1.Future{})
 		reconciler := mock_aso.NewMockReconciler[*asoresourcesv1.ResourceGroup](mockCtrl)
-		reconciler.EXPECT().DeleteResource(gomockinternal.AContext(), specs[0], serviceName).Return(nil)
-		reconciler.EXPECT().DeleteResource(gomockinternal.AContext(), specs[1], serviceName).Return(deleteErr)
-		reconciler.EXPECT().DeleteResource(gomockinternal.AContext(), specs[2], serviceName).Return(nil)
+		reconciler.EXPECT().DeleteResource(gomockinternal.AContext(), specs[0].ResourceRef(), serviceName).Return(nil)
+		reconciler.EXPECT().DeleteResource(gomockinternal.AContext(), specs[1].ResourceRef(), serviceName).Return(deleteErr)
+		reconciler.EXPECT().DeleteResource(gomockinternal.AContext(), specs[2].ResourceRef(), serviceName).Return(nil)
 		scope.EXPECT().UpdateDeleteStatus(conditionType, serviceName, deleteErr)
 		scope.EXPECT().DefaultedAzureServiceReconcileTimeout().Return(reconcilerutils.DefaultAzureServiceReconcileTimeout)
 
@@ -354,16 +354,16 @@ func TestServiceDelete(t *testing.T) {
 
 		scope := mock_aso.NewMockScope(mockCtrl)
 		specs := []azure.ASOResourceSpecGetter[*asoresourcesv1.ResourceGroup]{
-			mock_azure.NewMockASOResourceSpecGetter[*asoresourcesv1.ResourceGroup](mockCtrl),
-			mock_azure.NewMockASOResourceSpecGetter[*asoresourcesv1.ResourceGroup](mockCtrl),
-			mock_azure.NewMockASOResourceSpecGetter[*asoresourcesv1.ResourceGroup](mockCtrl),
+			mockSpecExpectingResourceRef(mockCtrl, &asoresourcesv1.ResourceGroup{}),
+			mockSpecExpectingResourceRef(mockCtrl, &asoresourcesv1.ResourceGroup{}),
+			mockSpecExpectingResourceRef(mockCtrl, &asoresourcesv1.ResourceGroup{}),
 		}
 
 		deleteErr := errors.New("non-not done error")
 		reconciler := mock_aso.NewMockReconciler[*asoresourcesv1.ResourceGroup](mockCtrl)
-		reconciler.EXPECT().DeleteResource(gomockinternal.AContext(), specs[0], serviceName).Return(azure.NewOperationNotDoneError(&infrav1.Future{}))
-		reconciler.EXPECT().DeleteResource(gomockinternal.AContext(), specs[1], serviceName).Return(deleteErr)
-		reconciler.EXPECT().DeleteResource(gomockinternal.AContext(), specs[2], serviceName).Return(azure.NewOperationNotDoneError(&infrav1.Future{}))
+		reconciler.EXPECT().DeleteResource(gomockinternal.AContext(), specs[0].ResourceRef(), serviceName).Return(azure.NewOperationNotDoneError(&infrav1.Future{}))
+		reconciler.EXPECT().DeleteResource(gomockinternal.AContext(), specs[1].ResourceRef(), serviceName).Return(deleteErr)
+		reconciler.EXPECT().DeleteResource(gomockinternal.AContext(), specs[2].ResourceRef(), serviceName).Return(azure.NewOperationNotDoneError(&infrav1.Future{}))
 		scope.EXPECT().UpdateDeleteStatus(conditionType, serviceName, deleteErr)
 		scope.EXPECT().DefaultedAzureServiceReconcileTimeout().Return(reconcilerutils.DefaultAzureServiceReconcileTimeout)
 
@@ -386,13 +386,13 @@ func TestServiceDelete(t *testing.T) {
 
 		scope := mock_aso.NewMockScope(mockCtrl)
 		specs := []azure.ASOResourceSpecGetter[*asoresourcesv1.ResourceGroup]{
-			mock_azure.NewMockASOResourceSpecGetter[*asoresourcesv1.ResourceGroup](mockCtrl),
+			mockSpecExpectingResourceRef(mockCtrl, &asoresourcesv1.ResourceGroup{}),
 		}
 
 		deleteErr := errors.New("DeleteResource error")
 		postErr := errors.New("PostDeleteHook error")
 		reconciler := mock_aso.NewMockReconciler[*asoresourcesv1.ResourceGroup](mockCtrl)
-		reconciler.EXPECT().DeleteResource(gomockinternal.AContext(), specs[0], serviceName).Return(deleteErr)
+		reconciler.EXPECT().DeleteResource(gomockinternal.AContext(), specs[0].ResourceRef(), serviceName).Return(deleteErr)
 		scope.EXPECT().UpdateDeleteStatus(conditionType, serviceName, postErr)
 		scope.EXPECT().DefaultedAzureServiceReconcileTimeout().Return(reconcilerutils.DefaultAzureServiceReconcileTimeout)
 
@@ -422,15 +422,15 @@ func TestServicePause(t *testing.T) {
 
 		scope := mock_aso.NewMockScope(mockCtrl)
 		specs := []azure.ASOResourceSpecGetter[*asoresourcesv1.ResourceGroup]{
-			mock_azure.NewMockASOResourceSpecGetter[*asoresourcesv1.ResourceGroup](mockCtrl),
-			mock_azure.NewMockASOResourceSpecGetter[*asoresourcesv1.ResourceGroup](mockCtrl),
-			mock_azure.NewMockASOResourceSpecGetter[*asoresourcesv1.ResourceGroup](mockCtrl),
+			mockSpecExpectingResourceRef(mockCtrl, &asoresourcesv1.ResourceGroup{}),
+			mockSpecExpectingResourceRef(mockCtrl, &asoresourcesv1.ResourceGroup{}),
+			mockSpecExpectingResourceRef(mockCtrl, &asoresourcesv1.ResourceGroup{}),
 		}
 
 		reconciler := mock_aso.NewMockReconciler[*asoresourcesv1.ResourceGroup](mockCtrl)
-		reconciler.EXPECT().PauseResource(gomockinternal.AContext(), specs[0], serviceName).Return(nil)
-		reconciler.EXPECT().PauseResource(gomockinternal.AContext(), specs[1], serviceName).Return(nil)
-		reconciler.EXPECT().PauseResource(gomockinternal.AContext(), specs[2], serviceName).Return(nil)
+		reconciler.EXPECT().PauseResource(gomockinternal.AContext(), specs[0].ResourceRef(), serviceName).Return(nil)
+		reconciler.EXPECT().PauseResource(gomockinternal.AContext(), specs[1].ResourceRef(), serviceName).Return(nil)
+		reconciler.EXPECT().PauseResource(gomockinternal.AContext(), specs[2].ResourceRef(), serviceName).Return(nil)
 
 		s := &Service[*asoresourcesv1.ResourceGroup, *mock_aso.MockScope]{
 			Reconciler:    reconciler,
@@ -450,23 +450,21 @@ func TestServicePause(t *testing.T) {
 		mockCtrl := gomock.NewController(t)
 
 		scope := mock_aso.NewMockScope(mockCtrl)
-		failSpec := mock_azure.NewMockASOResourceSpecGetter[*asoresourcesv1.ResourceGroup](mockCtrl)
-		failSpec.EXPECT().ResourceRef().Return(&asoresourcesv1.ResourceGroup{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "name",
-				Namespace: "namespace",
-			},
-		})
 		specs := []azure.ASOResourceSpecGetter[*asoresourcesv1.ResourceGroup]{
-			mock_azure.NewMockASOResourceSpecGetter[*asoresourcesv1.ResourceGroup](mockCtrl),
-			failSpec,
-			mock_azure.NewMockASOResourceSpecGetter[*asoresourcesv1.ResourceGroup](mockCtrl),
+			mockSpecExpectingResourceRef(mockCtrl, &asoresourcesv1.ResourceGroup{}),
+			mockSpecExpectingResourceRef(mockCtrl, &asoresourcesv1.ResourceGroup{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "name",
+					Namespace: "namespace",
+				},
+			}),
+			mockSpecExpectingResourceRef(mockCtrl, &asoresourcesv1.ResourceGroup{}),
 		}
 
 		pauseErr := errors.New("Pause error")
 		reconciler := mock_aso.NewMockReconciler[*asoresourcesv1.ResourceGroup](mockCtrl)
-		reconciler.EXPECT().PauseResource(gomockinternal.AContext(), specs[0], serviceName).Return(nil)
-		reconciler.EXPECT().PauseResource(gomockinternal.AContext(), specs[1], serviceName).Return(pauseErr)
+		reconciler.EXPECT().PauseResource(gomockinternal.AContext(), specs[0].ResourceRef(), serviceName).Return(nil)
+		reconciler.EXPECT().PauseResource(gomockinternal.AContext(), specs[1].ResourceRef(), serviceName).Return(pauseErr)
 
 		s := &Service[*asoresourcesv1.ResourceGroup, *mock_aso.MockScope]{
 			Reconciler:    reconciler,
@@ -479,4 +477,10 @@ func TestServicePause(t *testing.T) {
 		err := s.Pause(context.Background())
 		g.Expect(err).To(MatchError(pauseErr))
 	})
+}
+
+func mockSpecExpectingResourceRef(ctrl *gomock.Controller, resource *asoresourcesv1.ResourceGroup) azure.ASOResourceSpecGetter[*asoresourcesv1.ResourceGroup] {
+	spec := mock_azure.NewMockASOResourceSpecGetter[*asoresourcesv1.ResourceGroup](ctrl)
+	spec.EXPECT().ResourceRef().Return(resource).AnyTimes()
+	return spec
 }

--- a/azure/services/groups/groups.go
+++ b/azure/services/groups/groups.go
@@ -59,7 +59,7 @@ func New(scope GroupScope) *Service {
 func (s *Service) IsManaged(ctx context.Context) (bool, error) {
 	// Unless all resource groups are managed by CAPZ and reconciled by ASO, resources need to be deleted individually.
 	for _, spec := range s.Specs {
-		managed, err := aso.IsManaged(ctx, s.Scope.GetClient(), spec, s.Scope.ClusterName())
+		managed, err := aso.IsManaged(ctx, s.Scope.GetClient(), spec.ResourceRef(), s.Scope.ClusterName())
 		if err != nil || !managed {
 			return managed, err
 		}


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind cleanup

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

This PR simplifies the `aso.Reconciler` interface to make the `DeleteResource` and `PauseResource` methods only require an ASO object vs. an entire `azure.ASOResourceSpecGetter` since those methods don't require any other parts of an `azure.ASOResourceSpecGetter` besides the ASO object reference. I'm planning to reuse this `DeleteResource` method for #4338 and this makes that quite a bit easier.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
