### PR TITLE
use owner refs to determine ownership for ASO resources

### DIFF
--- a/api/v1beta1/consts.go
+++ b/api/v1beta1/consts.go
@@ -158,6 +158,8 @@ const (
 	// OwnedByClusterLabelKey communicates CAPZ's ownership of an ASO resource
 	// independently of its ownership of the underlying Azure resource. The
 	// value for the label is the CAPI Cluster Name.
+	//
+	// Deprecated: OwnerReferences now determine ownership.
 	OwnedByClusterLabelKey = NameAzureProviderPrefix + string(ResourceLifecycleOwned)
 )
 

--- a/azure/interfaces.go
+++ b/azure/interfaces.go
@@ -152,8 +152,9 @@ type ResourceSpecGetterWithHeaders interface {
 
 // ASOResourceSpecGetter is an interface for getting all the required information to create/update/delete an Azure resource.
 type ASOResourceSpecGetter[T genruntime.MetaObject] interface {
-	// ResourceRef returns a concrete, named (and namespaced if applicable) ASO
-	// resource type to facilitate a strongly-typed GET.
+	// ResourceRef returns a concrete, named ASO resource type to facilitate a
+	// strongly-typed GET. Namespace is not read if set here and is instead
+	// derived from OwnerReferences.
 	ResourceRef() T
 	// Parameters returns a modified object if it points to a non-nil resource.
 	// Otherwise it returns an unmodified object if no updates are needed.

--- a/azure/scope/cluster.go
+++ b/azure/scope/cluster.go
@@ -138,6 +138,11 @@ func (s *ClusterScope) GetDeletionTimestamp() *metav1.Time {
 	return s.Cluster.DeletionTimestamp
 }
 
+// ASOOwner implements aso.Scope.
+func (s *ClusterScope) ASOOwner() client.Object {
+	return s.AzureCluster
+}
+
 // PublicIPSpecs returns the public IP specs.
 func (s *ClusterScope) PublicIPSpecs() []azure.ResourceSpecGetter {
 	var publicIPSpecs []azure.ResourceSpecGetter
@@ -334,7 +339,6 @@ func (s *ClusterScope) NatGatewaySpecs() []azure.ASOResourceSpecGetter[*asonetwo
 				natGatewaySet[subnet.NatGateway.Name] = struct{}{} // empty struct to represent hash set
 				natGateways = append(natGateways, &natgateways.NatGatewaySpec{
 					Name:           subnet.NatGateway.Name,
-					Namespace:      s.Namespace(),
 					ResourceGroup:  s.ResourceGroup(),
 					SubscriptionID: s.SubscriptionID(),
 					Location:       s.Location(),
@@ -383,7 +387,6 @@ func (s *ClusterScope) SubnetSpecs() []azure.ASOResourceSpecGetter[*asonetworkv1
 	for _, subnet := range s.AzureCluster.Spec.NetworkSpec.Subnets {
 		subnetSpec := &subnets.SubnetSpec{
 			Name:              subnet.Name,
-			Namespace:         s.Namespace(),
 			ResourceGroup:     s.ResourceGroup(),
 			SubscriptionID:    s.SubscriptionID(),
 			CIDRs:             subnet.CIDRBlocks,
@@ -402,7 +405,6 @@ func (s *ClusterScope) SubnetSpecs() []azure.ASOResourceSpecGetter[*asonetworkv1
 		azureBastionSubnet := s.AzureCluster.Spec.BastionSpec.AzureBastion.Subnet
 		subnetSpecs = append(subnetSpecs, &subnets.SubnetSpec{
 			Name:              azureBastionSubnet.Name,
-			Namespace:         s.Namespace(),
 			ResourceGroup:     s.ResourceGroup(),
 			SubscriptionID:    s.SubscriptionID(),
 			CIDRs:             azureBastionSubnet.CIDRBlocks,
@@ -420,25 +422,20 @@ func (s *ClusterScope) SubnetSpecs() []azure.ASOResourceSpecGetter[*asonetworkv1
 
 // GroupSpecs returns the resource group spec.
 func (s *ClusterScope) GroupSpecs() []azure.ASOResourceSpecGetter[*asoresourcesv1.ResourceGroup] {
-	owner := *metav1.NewControllerRef(s.AzureCluster, infrav1.GroupVersion.WithKind(infrav1.AzureClusterKind))
 	specs := []azure.ASOResourceSpecGetter[*asoresourcesv1.ResourceGroup]{
 		&groups.GroupSpec{
 			Name:           s.ResourceGroup(),
-			Namespace:      s.Namespace(),
 			Location:       s.Location(),
 			ClusterName:    s.ClusterName(),
 			AdditionalTags: s.AdditionalTags(),
-			Owner:          owner,
 		},
 	}
 	if s.Vnet().ResourceGroup != s.ResourceGroup() {
 		specs = append(specs, &groups.GroupSpec{
 			Name:           s.Vnet().ResourceGroup,
-			Namespace:      s.Namespace(),
 			Location:       s.Location(),
 			ClusterName:    s.ClusterName(),
 			AdditionalTags: s.AdditionalTags(),
-			Owner:          owner,
 		})
 	}
 	return specs
@@ -484,7 +481,6 @@ func (s *ClusterScope) VNetSpec() azure.ASOResourceSpecGetter[*asonetworkv1api20
 	return &virtualnetworks.VNetSpec{
 		ResourceGroup:    s.Vnet().ResourceGroup,
 		Name:             s.Vnet().Name,
-		Namespace:        s.Namespace(),
 		CIDRs:            s.Vnet().CIDRBlocks,
 		ExtendedLocation: s.ExtendedLocation(),
 		Location:         s.Location(),
@@ -561,7 +557,6 @@ func (s *ClusterScope) AzureBastionSpec() azure.ASOResourceSpecGetter[*asonetwor
 
 		return &bastionhosts.AzureBastionSpec{
 			Name:            s.AzureBastion().Name,
-			Namespace:       s.Namespace(),
 			ResourceGroup:   s.ResourceGroup(),
 			Location:        s.Location(),
 			ClusterName:     s.ClusterName(),
@@ -1100,7 +1095,6 @@ func (s *ClusterScope) PrivateEndpointSpecs() []azure.ASOResourceSpecGetter[*aso
 		for _, privateEndpoint := range subnet.PrivateEndpoints {
 			privateEndpointSpec := &privateendpoints.PrivateEndpointSpec{
 				Name:                       privateEndpoint.Name,
-				Namespace:                  s.Namespace(),
 				ResourceGroup:              s.ResourceGroup(),
 				Location:                   privateEndpoint.Location,
 				CustomNetworkInterfaceName: privateEndpoint.CustomNetworkInterfaceName,

--- a/azure/scope/cluster_test.go
+++ b/azure/scope/cluster_test.go
@@ -3820,7 +3820,6 @@ func TestPrivateEndpointSpecs(t *testing.T) {
 			want: []azure.ASOResourceSpecGetter[*asonetworkv1api20220701.PrivateEndpoint]{
 				&privateendpoints.PrivateEndpointSpec{
 					Name:                       "my-private-endpoint",
-					Namespace:                  "dummy-ns",
 					ResourceGroup:              "dummy-rg",
 					Location:                   "westus2",
 					CustomNetworkInterfaceName: "my-custom-nic",
@@ -3848,7 +3847,6 @@ func TestPrivateEndpointSpecs(t *testing.T) {
 				},
 				&privateendpoints.PrivateEndpointSpec{
 					Name:                       "my-private-endpoint-2",
-					Namespace:                  "dummy-ns",
 					ResourceGroup:              "dummy-rg",
 					Location:                   "westus2",
 					CustomNetworkInterfaceName: "my-custom-nic-2",
@@ -3876,7 +3874,6 @@ func TestPrivateEndpointSpecs(t *testing.T) {
 				},
 				&privateendpoints.PrivateEndpointSpec{
 					Name:                       "my-private-endpoint-3",
-					Namespace:                  "dummy-ns",
 					ResourceGroup:              "dummy-rg",
 					Location:                   "westus2",
 					CustomNetworkInterfaceName: "my-custom-nic-3",

--- a/azure/scope/managedcontrolplane_test.go
+++ b/azure/scope/managedcontrolplane_test.go
@@ -176,7 +176,6 @@ func TestManagedControlPlaneScope_PoolVersion(t *testing.T) {
 				&agentpools.AgentPoolSpec{
 					Name:         "pool0",
 					AzureName:    "pool0",
-					Namespace:    "default",
 					SKU:          "Standard_D2s_v3",
 					Replicas:     1,
 					Mode:         "System",
@@ -222,7 +221,6 @@ func TestManagedControlPlaneScope_PoolVersion(t *testing.T) {
 				&agentpools.AgentPoolSpec{
 					Name:         "pool0",
 					AzureName:    "pool0",
-					Namespace:    "default",
 					SKU:          "Standard_D2s_v3",
 					Mode:         "System",
 					Replicas:     1,
@@ -474,7 +472,6 @@ func TestManagedControlPlaneScope_OSType(t *testing.T) {
 				&agentpools.AgentPoolSpec{
 					Name:         "pool0",
 					AzureName:    "pool0",
-					Namespace:    "default",
 					SKU:          "Standard_D2s_v3",
 					Mode:         "System",
 					Replicas:     1,
@@ -484,7 +481,6 @@ func TestManagedControlPlaneScope_OSType(t *testing.T) {
 				&agentpools.AgentPoolSpec{
 					Name:         "pool1",
 					AzureName:    "pool1",
-					Namespace:    "default",
 					SKU:          "Standard_D2s_v3",
 					Mode:         "User",
 					Replicas:     1,
@@ -495,7 +491,6 @@ func TestManagedControlPlaneScope_OSType(t *testing.T) {
 				&agentpools.AgentPoolSpec{
 					Name:         "pool2",
 					AzureName:    "pool2",
-					Namespace:    "default",
 					SKU:          "Standard_D2s_v3",
 					Mode:         "User",
 					Replicas:     1,
@@ -1390,7 +1385,6 @@ func TestManagedControlPlaneScope_PrivateEndpointSpecs(t *testing.T) {
 			Expected: []azure.ASOResourceSpecGetter[*asonetworkv1.PrivateEndpoint]{
 				&privateendpoints.PrivateEndpointSpec{
 					Name:                       "my-private-endpoint",
-					Namespace:                  "dummy-ns",
 					ResourceGroup:              "dummy-rg",
 					Location:                   "westus2",
 					CustomNetworkInterfaceName: "my-custom-nic",

--- a/azure/scope/managedmachinepool.go
+++ b/azure/scope/managedmachinepool.go
@@ -129,6 +129,11 @@ func (s *ManagedMachinePoolScope) GetClient() client.Client {
 	return s.Client
 }
 
+// ASOOwner implements aso.Scope.
+func (s *ManagedMachinePoolScope) ASOOwner() client.Object {
+	return s.InfraMachinePool
+}
+
 // Name returns the name of the infra machine pool.
 func (s *ManagedMachinePoolScope) Name() string {
 	return s.InfraMachinePool.Name
@@ -167,7 +172,6 @@ func buildAgentPoolSpec(managedControlPlane *infrav1.AzureManagedControlPlane,
 
 	agentPoolSpec := &agentpools.AgentPoolSpec{
 		Name:          managedMachinePool.Name,
-		Namespace:     managedMachinePool.Namespace,
 		AzureName:     ptr.Deref(managedMachinePool.Spec.Name, ""),
 		ResourceGroup: managedControlPlane.Spec.ResourceGroupName,
 		Cluster:       managedControlPlane.Name,

--- a/azure/scope/managedmachinepool_test.go
+++ b/azure/scope/managedmachinepool_test.go
@@ -74,7 +74,6 @@ func TestManagedMachinePoolScope_Autoscaling(t *testing.T) {
 
 				Name:         "pool0",
 				AzureName:    "pool0",
-				Namespace:    "default",
 				SKU:          "Standard_D2s_v3",
 				Replicas:     1,
 				Mode:         "System",
@@ -110,7 +109,6 @@ func TestManagedMachinePoolScope_Autoscaling(t *testing.T) {
 			Expected: &agentpools.AgentPoolSpec{
 				Name:              "pool1",
 				AzureName:         "pool1",
-				Namespace:         "default",
 				SKU:               "Standard_D2s_v3",
 				Mode:              "User",
 				Cluster:           "cluster1",
@@ -177,7 +175,6 @@ func TestManagedMachinePoolScope_NodeLabels(t *testing.T) {
 			Expected: &agentpools.AgentPoolSpec{
 				Name:         "pool0",
 				AzureName:    "pool0",
-				Namespace:    "default",
 				SKU:          "Standard_D2s_v3",
 				Replicas:     1,
 				Mode:         "System",
@@ -215,7 +212,6 @@ func TestManagedMachinePoolScope_NodeLabels(t *testing.T) {
 			Expected: &agentpools.AgentPoolSpec{
 				Name:      "pool1",
 				AzureName: "pool1",
-				Namespace: "default",
 				SKU:       "Standard_D2s_v3",
 				Mode:      "System",
 				Cluster:   "cluster1",
@@ -282,7 +278,6 @@ func TestManagedMachinePoolScope_AdditionalTags(t *testing.T) {
 			Expected: &agentpools.AgentPoolSpec{
 				Name:         "pool0",
 				AzureName:    "pool0",
-				Namespace:    "default",
 				SKU:          "Standard_D2s_v3",
 				Replicas:     1,
 				Mode:         "System",
@@ -320,7 +315,6 @@ func TestManagedMachinePoolScope_AdditionalTags(t *testing.T) {
 			Expected: &agentpools.AgentPoolSpec{
 				Name:      "pool1",
 				AzureName: "pool1",
-				Namespace: "default",
 				SKU:       "Standard_D2s_v3",
 				Mode:      "System",
 				Cluster:   "cluster1",
@@ -387,7 +381,6 @@ func TestManagedMachinePoolScope_MaxPods(t *testing.T) {
 			Expected: &agentpools.AgentPoolSpec{
 				Name:         "pool0",
 				AzureName:    "pool0",
-				Namespace:    "default",
 				SKU:          "Standard_D2s_v3",
 				Replicas:     1,
 				Mode:         "System",
@@ -423,7 +416,6 @@ func TestManagedMachinePoolScope_MaxPods(t *testing.T) {
 			Expected: &agentpools.AgentPoolSpec{
 				Name:         "pool1",
 				AzureName:    "pool1",
-				Namespace:    "default",
 				SKU:          "Standard_D2s_v3",
 				Mode:         "System",
 				Cluster:      "cluster1",
@@ -489,7 +481,6 @@ func TestManagedMachinePoolScope_Taints(t *testing.T) {
 
 				Name:         "pool0",
 				AzureName:    "pool0",
-				Namespace:    "default",
 				SKU:          "Standard_D2s_v3",
 				Replicas:     1,
 				Mode:         "System",
@@ -531,7 +522,6 @@ func TestManagedMachinePoolScope_Taints(t *testing.T) {
 			Expected: &agentpools.AgentPoolSpec{
 				Name:         "pool1",
 				AzureName:    "pool1",
-				Namespace:    "default",
 				SKU:          "Standard_D2s_v3",
 				Mode:         "User",
 				Cluster:      "cluster1",
@@ -596,7 +586,6 @@ func TestManagedMachinePoolScope_OSDiskType(t *testing.T) {
 			Expected: &agentpools.AgentPoolSpec{
 				Name:         "pool0",
 				AzureName:    "pool0",
-				Namespace:    "default",
 				SKU:          "Standard_D2s_v3",
 				Replicas:     1,
 				Mode:         "System",
@@ -632,7 +621,6 @@ func TestManagedMachinePoolScope_OSDiskType(t *testing.T) {
 			Expected: &agentpools.AgentPoolSpec{
 				Name:         "pool1",
 				AzureName:    "pool1",
-				Namespace:    "default",
 				SKU:          "Standard_D2s_v3",
 				Mode:         "User",
 				Cluster:      "cluster1",
@@ -697,7 +685,6 @@ func TestManagedMachinePoolScope_SubnetName(t *testing.T) {
 			Expected: &agentpools.AgentPoolSpec{
 				Name:         "pool0",
 				AzureName:    "pool0",
-				Namespace:    "default",
 				SKU:          "Standard_D2s_v3",
 				Replicas:     1,
 				Mode:         "System",
@@ -742,7 +729,6 @@ func TestManagedMachinePoolScope_SubnetName(t *testing.T) {
 			Expected: &agentpools.AgentPoolSpec{
 				Name:         "pool1",
 				AzureName:    "pool1",
-				Namespace:    "default",
 				SKU:          "Standard_D2s_v3",
 				Mode:         "User",
 				Cluster:      "cluster1",
@@ -787,7 +773,6 @@ func TestManagedMachinePoolScope_SubnetName(t *testing.T) {
 			Expected: &agentpools.AgentPoolSpec{
 				Name:         "pool1",
 				AzureName:    "pool1",
-				Namespace:    "default",
 				SKU:          "Standard_D2s_v3",
 				Mode:         "User",
 				Cluster:      "cluster1",
@@ -852,7 +837,6 @@ func TestManagedMachinePoolScope_KubeletDiskType(t *testing.T) {
 			Expected: &agentpools.AgentPoolSpec{
 				Name:         "pool0",
 				AzureName:    "pool0",
-				Namespace:    "default",
 				SKU:          "Standard_D2s_v3",
 				Replicas:     1,
 				Mode:         "System",
@@ -888,7 +872,6 @@ func TestManagedMachinePoolScope_KubeletDiskType(t *testing.T) {
 			Expected: &agentpools.AgentPoolSpec{
 				Name:            "pool1",
 				AzureName:       "pool1",
-				Namespace:       "default",
 				SKU:             "Standard_D2s_v3",
 				Mode:            "User",
 				Cluster:         "cluster1",

--- a/azure/services/agentpools/mock_agentpools/agentpools_mock.go
+++ b/azure/services/agentpools/mock_agentpools/agentpools_mock.go
@@ -60,6 +60,20 @@ func (m *MockAgentPoolScope) EXPECT() *MockAgentPoolScopeMockRecorder {
 	return m.recorder
 }
 
+// ASOOwner mocks base method.
+func (m *MockAgentPoolScope) ASOOwner() client.Object {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ASOOwner")
+	ret0, _ := ret[0].(client.Object)
+	return ret0
+}
+
+// ASOOwner indicates an expected call of ASOOwner.
+func (mr *MockAgentPoolScopeMockRecorder) ASOOwner() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ASOOwner", reflect.TypeOf((*MockAgentPoolScope)(nil).ASOOwner))
+}
+
 // AgentPoolSpec mocks base method.
 func (m *MockAgentPoolScope) AgentPoolSpec() azure.ASOResourceSpecGetter[*v1api20231001.ManagedClustersAgentPool] {
 	m.ctrl.T.Helper()

--- a/azure/services/agentpools/spec.go
+++ b/azure/services/agentpools/spec.go
@@ -60,9 +60,6 @@ type AgentPoolSpec struct {
 	// Name is the name of the ASO ManagedClustersAgentPool resource.
 	Name string
 
-	// Namespace is the namespace of the ASO ManagedClustersAgentPool resource.
-	Namespace string
-
 	// AzureName is the name of the agentpool resource in Azure.
 	AzureName string
 
@@ -158,8 +155,7 @@ type AgentPoolSpec struct {
 func (s *AgentPoolSpec) ResourceRef() *asocontainerservicev1.ManagedClustersAgentPool {
 	return &asocontainerservicev1.ManagedClustersAgentPool{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      s.Name,
-			Namespace: s.Namespace,
+			Name: s.Name,
 		},
 	}
 }

--- a/azure/services/agentpools/spec_test.go
+++ b/azure/services/agentpools/spec_test.go
@@ -35,7 +35,6 @@ func TestParameters(t *testing.T) {
 
 		spec := &AgentPoolSpec{
 			Name:                 "name",
-			Namespace:            "namespace",
 			AzureName:            "azure name",
 			ResourceGroup:        "rg",
 			Cluster:              "cluster",

--- a/azure/services/aso/interfaces.go
+++ b/azure/services/aso/interfaces.go
@@ -45,4 +45,5 @@ type Scope interface {
 	azure.AsyncStatusUpdater
 	GetClient() client.Client
 	ClusterName() string
+	ASOOwner() client.Object
 }

--- a/azure/services/aso/mock_aso/aso_mock.go
+++ b/azure/services/aso/mock_aso/aso_mock.go
@@ -204,6 +204,20 @@ func (m *MockScope) EXPECT() *MockScopeMockRecorder {
 	return m.recorder
 }
 
+// ASOOwner mocks base method.
+func (m *MockScope) ASOOwner() client.Object {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ASOOwner")
+	ret0, _ := ret[0].(client.Object)
+	return ret0
+}
+
+// ASOOwner indicates an expected call of ASOOwner.
+func (mr *MockScopeMockRecorder) ASOOwner() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ASOOwner", reflect.TypeOf((*MockScope)(nil).ASOOwner))
+}
+
 // ClusterName mocks base method.
 func (m *MockScope) ClusterName() string {
 	m.ctrl.T.Helper()

--- a/azure/services/aso/service.go
+++ b/azure/services/aso/service.go
@@ -43,7 +43,7 @@ type Service[T deepCopier[T], S Scope] struct {
 // NewService creates a new Service.
 func NewService[T deepCopier[T], S Scope](name string, scope S) *Service[T, S] {
 	return &Service[T, S]{
-		Reconciler: New[T](scope.GetClient(), scope.ClusterName()),
+		Reconciler: New[T](scope.GetClient(), scope.ClusterName(), scope.ASOOwner()),
 		Scope:      scope,
 		name:       name,
 	}
@@ -133,7 +133,7 @@ func (s *Service[T, S]) Pause(ctx context.Context) error {
 	for _, spec := range s.Specs {
 		ref := spec.ResourceRef()
 		if err := s.PauseResource(ctx, ref, s.Name()); err != nil {
-			return errors.Wrapf(err, "failed to pause ASO resource %s %s/%s", ref.GetObjectKind().GroupVersionKind(), ref.GetNamespace(), ref.GetName())
+			return errors.Wrapf(err, "failed to pause ASO resource %s %s/%s", ref.GetObjectKind().GroupVersionKind(), s.Scope.ASOOwner().GetNamespace(), ref.GetName())
 		}
 	}
 

--- a/azure/services/aso/service_test.go
+++ b/azure/services/aso/service_test.go
@@ -460,6 +460,7 @@ func TestServicePause(t *testing.T) {
 			}),
 			mockSpecExpectingResourceRef(mockCtrl, &asoresourcesv1.ResourceGroup{}),
 		}
+		scope.EXPECT().ASOOwner().Return(&asoresourcesv1.ResourceGroup{})
 
 		pauseErr := errors.New("Pause error")
 		reconciler := mock_aso.NewMockReconciler[*asoresourcesv1.ResourceGroup](mockCtrl)

--- a/azure/services/bastionhosts/spec.go
+++ b/azure/services/bastionhosts/spec.go
@@ -31,7 +31,6 @@ import (
 // AzureBastionSpec defines the specification for azure bastion feature.
 type AzureBastionSpec struct {
 	Name            string
-	Namespace       string
 	ResourceGroup   string
 	Location        string
 	ClusterName     string
@@ -45,8 +44,7 @@ type AzureBastionSpec struct {
 func (s *AzureBastionSpec) ResourceRef() *asonetworkv1.BastionHost {
 	return &asonetworkv1.BastionHost{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      s.Name,
-			Namespace: s.Namespace,
+			Name: s.Name,
 		},
 	}
 }

--- a/azure/services/bastionhosts/spec_test.go
+++ b/azure/services/bastionhosts/spec_test.go
@@ -62,7 +62,6 @@ var (
 	}
 	fakeAzureBastionSpec1 = AzureBastionSpec{
 		Name:            "my-bastion-host",
-		Namespace:       "default",
 		ClusterName:     "cluster",
 		Location:        "westus",
 		SubnetID:        "my-subnet-id",

--- a/azure/services/fleetsmembers/spec.go
+++ b/azure/services/fleetsmembers/spec.go
@@ -29,7 +29,6 @@ import (
 // AzureFleetsMemberSpec defines the specification for an Azure Fleets Member.
 type AzureFleetsMemberSpec struct {
 	Name                 string
-	Namespace            string
 	ClusterName          string
 	ClusterResourceGroup string
 	Group                string
@@ -42,8 +41,7 @@ type AzureFleetsMemberSpec struct {
 func (s *AzureFleetsMemberSpec) ResourceRef() *asocontainerservicev1.FleetsMember {
 	return &asocontainerservicev1.FleetsMember{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      s.Name,
-			Namespace: s.Namespace,
+			Name: s.Name,
 		},
 	}
 }

--- a/azure/services/fleetsmembers/spec_test.go
+++ b/azure/services/fleetsmembers/spec_test.go
@@ -43,7 +43,6 @@ var (
 	}
 	fakeAzureFleetsMemberSpec = AzureFleetsMemberSpec{
 		Name:                 "fake-name",
-		Namespace:            "fake-namespace",
 		ClusterName:          "fake-cluster-name",
 		ClusterResourceGroup: "fake-cluster-resource-group",
 		Group:                "fake-group",

--- a/azure/services/groups/mock_groups/groups_mock.go
+++ b/azure/services/groups/mock_groups/groups_mock.go
@@ -60,6 +60,20 @@ func (m *MockGroupScope) EXPECT() *MockGroupScopeMockRecorder {
 	return m.recorder
 }
 
+// ASOOwner mocks base method.
+func (m *MockGroupScope) ASOOwner() client.Object {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ASOOwner")
+	ret0, _ := ret[0].(client.Object)
+	return ret0
+}
+
+// ASOOwner indicates an expected call of ASOOwner.
+func (mr *MockGroupScopeMockRecorder) ASOOwner() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ASOOwner", reflect.TypeOf((*MockGroupScope)(nil).ASOOwner))
+}
+
 // ClusterName mocks base method.
 func (m *MockGroupScope) ClusterName() string {
 	m.ctrl.T.Helper()

--- a/azure/services/groups/spec.go
+++ b/azure/services/groups/spec.go
@@ -29,19 +29,16 @@ import (
 // GroupSpec defines the specification for a Resource Group.
 type GroupSpec struct {
 	Name           string
-	Namespace      string
 	Location       string
 	ClusterName    string
 	AdditionalTags infrav1.Tags
-	Owner          metav1.OwnerReference
 }
 
 // ResourceRef implements aso.ResourceSpecGetter.
 func (s *GroupSpec) ResourceRef() *asoresourcesv1.ResourceGroup {
 	return &asoresourcesv1.ResourceGroup{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      s.Name,
-			Namespace: s.Namespace,
+			Name: s.Name,
 		},
 	}
 }
@@ -53,9 +50,6 @@ func (s *GroupSpec) Parameters(ctx context.Context, existing *asoresourcesv1.Res
 	}
 
 	return &asoresourcesv1.ResourceGroup{
-		ObjectMeta: metav1.ObjectMeta{
-			OwnerReferences: []metav1.OwnerReference{s.Owner},
-		},
 		Spec: asoresourcesv1.ResourceGroup_Spec{
 			Location: ptr.To(s.Location),
 			Tags: infrav1.Build(infrav1.BuildParams{

--- a/azure/services/groups/spec_test.go
+++ b/azure/services/groups/spec_test.go
@@ -41,20 +41,9 @@ func TestParameters(t *testing.T) {
 				Location:       "location",
 				ClusterName:    "cluster",
 				AdditionalTags: infrav1.Tags{"some": "tags"},
-				Namespace:      "namespace",
-				Owner: metav1.OwnerReference{
-					Kind: "kind",
-				},
 			},
 			existing: nil,
 			expected: &asoresourcesv1.ResourceGroup{
-				ObjectMeta: metav1.ObjectMeta{
-					OwnerReferences: []metav1.OwnerReference{
-						{
-							Kind: "kind",
-						},
-					},
-				},
 				Spec: asoresourcesv1.ResourceGroup_Spec{
 					Location: ptr.To("location"),
 					Tags: map[string]string{

--- a/azure/services/managedclusters/mock_managedclusters/managedclusters_mock.go
+++ b/azure/services/managedclusters/mock_managedclusters/managedclusters_mock.go
@@ -63,6 +63,20 @@ func (m *MockManagedClusterScope) EXPECT() *MockManagedClusterScopeMockRecorder 
 	return m.recorder
 }
 
+// ASOOwner mocks base method.
+func (m *MockManagedClusterScope) ASOOwner() client.Object {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ASOOwner")
+	ret0, _ := ret[0].(client.Object)
+	return ret0
+}
+
+// ASOOwner indicates an expected call of ASOOwner.
+func (mr *MockManagedClusterScopeMockRecorder) ASOOwner() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ASOOwner", reflect.TypeOf((*MockManagedClusterScope)(nil).ASOOwner))
+}
+
 // AreLocalAccountsDisabled mocks base method.
 func (m *MockManagedClusterScope) AreLocalAccountsDisabled() bool {
 	m.ctrl.T.Helper()

--- a/azure/services/managedclusters/spec.go
+++ b/azure/services/managedclusters/spec.go
@@ -41,9 +41,6 @@ type ManagedClusterSpec struct {
 	// Name is the name of this AKS Cluster.
 	Name string
 
-	// Namespace is the namespace of the ASO ManagedCluster.
-	Namespace string
-
 	// ResourceGroup is the name of the Azure resource group for this AKS Cluster.
 	ResourceGroup string
 
@@ -255,8 +252,7 @@ type OIDCIssuerProfile struct {
 func (s *ManagedClusterSpec) ResourceRef() *asocontainerservicev1.ManagedCluster {
 	return &asocontainerservicev1.ManagedCluster{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      s.Name,
-			Namespace: s.Namespace,
+			Name: s.Name,
 		},
 	}
 }

--- a/azure/services/managedclusters/spec_test.go
+++ b/azure/services/managedclusters/spec_test.go
@@ -38,7 +38,6 @@ func TestParameters(t *testing.T) {
 
 		spec := &ManagedClusterSpec{
 			Name:              "name",
-			Namespace:         "namespace",
 			ResourceGroup:     "rg",
 			NodeResourceGroup: "node rg",
 			ClusterName:       "cluster",

--- a/azure/services/natgateways/mock_natgateways/natgateways_mock.go
+++ b/azure/services/natgateways/mock_natgateways/natgateways_mock.go
@@ -60,6 +60,20 @@ func (m *MockNatGatewayScope) EXPECT() *MockNatGatewayScopeMockRecorder {
 	return m.recorder
 }
 
+// ASOOwner mocks base method.
+func (m *MockNatGatewayScope) ASOOwner() client.Object {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ASOOwner")
+	ret0, _ := ret[0].(client.Object)
+	return ret0
+}
+
+// ASOOwner indicates an expected call of ASOOwner.
+func (mr *MockNatGatewayScopeMockRecorder) ASOOwner() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ASOOwner", reflect.TypeOf((*MockNatGatewayScope)(nil).ASOOwner))
+}
+
 // ClusterName mocks base method.
 func (m *MockNatGatewayScope) ClusterName() string {
 	m.ctrl.T.Helper()

--- a/azure/services/natgateways/spec.go
+++ b/azure/services/natgateways/spec.go
@@ -30,7 +30,6 @@ import (
 // NatGatewaySpec defines the specification for a NAT gateway.
 type NatGatewaySpec struct {
 	Name           string
-	Namespace      string
 	ResourceGroup  string
 	SubscriptionID string
 	Location       string
@@ -44,8 +43,7 @@ type NatGatewaySpec struct {
 func (s *NatGatewaySpec) ResourceRef() *asonetworkv1.NatGateway {
 	return &asonetworkv1.NatGateway{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      s.Name,
-			Namespace: s.Namespace,
+			Name: s.Name,
 		},
 	}
 }

--- a/azure/services/natgateways/spec_test.go
+++ b/azure/services/natgateways/spec_test.go
@@ -32,7 +32,6 @@ import (
 var (
 	fakeNatGatewaySpec = &NatGatewaySpec{
 		Name:           "my-natgateway",
-		Namespace:      "dummy-ns",
 		ResourceGroup:  "my-rg",
 		SubscriptionID: "123",
 		Location:       "eastus",

--- a/azure/services/privateendpoints/mock_privateendpoints/privateendpoints_mock.go
+++ b/azure/services/privateendpoints/mock_privateendpoints/privateendpoints_mock.go
@@ -60,6 +60,20 @@ func (m *MockPrivateEndpointScope) EXPECT() *MockPrivateEndpointScopeMockRecorde
 	return m.recorder
 }
 
+// ASOOwner mocks base method.
+func (m *MockPrivateEndpointScope) ASOOwner() client.Object {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ASOOwner")
+	ret0, _ := ret[0].(client.Object)
+	return ret0
+}
+
+// ASOOwner indicates an expected call of ASOOwner.
+func (mr *MockPrivateEndpointScopeMockRecorder) ASOOwner() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ASOOwner", reflect.TypeOf((*MockPrivateEndpointScope)(nil).ASOOwner))
+}
+
 // ClusterName mocks base method.
 func (m *MockPrivateEndpointScope) ClusterName() string {
 	m.ctrl.T.Helper()

--- a/azure/services/privateendpoints/spec.go
+++ b/azure/services/privateendpoints/spec.go
@@ -38,7 +38,6 @@ type PrivateLinkServiceConnection struct {
 // PrivateEndpointSpec defines the specification for a private endpoint.
 type PrivateEndpointSpec struct {
 	Name                          string
-	Namespace                     string
 	ResourceGroup                 string
 	Location                      string
 	CustomNetworkInterfaceName    string
@@ -55,8 +54,7 @@ type PrivateEndpointSpec struct {
 func (s *PrivateEndpointSpec) ResourceRef() *asonetworkv1.PrivateEndpoint {
 	return &asonetworkv1.PrivateEndpoint{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      s.Name,
-			Namespace: s.Namespace,
+			Name: s.Name,
 		},
 	}
 }

--- a/azure/services/privateendpoints/spec_test.go
+++ b/azure/services/privateendpoints/spec_test.go
@@ -31,7 +31,6 @@ import (
 var (
 	fakePrivateEndpoint = PrivateEndpointSpec{
 		Name:                       "test_private_endpoint_1",
-		Namespace:                  "test_ns",
 		ResourceGroup:              "test_rg",
 		Location:                   "test_location",
 		CustomNetworkInterfaceName: "test_if_name",
@@ -57,8 +56,7 @@ var (
 
 	fakeASOPrivateEndpoint = asonetworkv1.PrivateEndpoint{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fakePrivateEndpoint.Name,
-			Namespace: fakePrivateEndpoint.Namespace,
+			Name: fakePrivateEndpoint.Name,
 		},
 		Spec: asonetworkv1.PrivateEndpoint_Spec{
 			ApplicationSecurityGroups: []asonetworkv1.ApplicationSecurityGroupSpec_PrivateEndpoint_SubResourceEmbedded{

--- a/azure/services/subnets/mock_subnets/subnets_mock.go
+++ b/azure/services/subnets/mock_subnets/subnets_mock.go
@@ -60,6 +60,20 @@ func (m *MockSubnetScope) EXPECT() *MockSubnetScopeMockRecorder {
 	return m.recorder
 }
 
+// ASOOwner mocks base method.
+func (m *MockSubnetScope) ASOOwner() client.Object {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ASOOwner")
+	ret0, _ := ret[0].(client.Object)
+	return ret0
+}
+
+// ASOOwner indicates an expected call of ASOOwner.
+func (mr *MockSubnetScopeMockRecorder) ASOOwner() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ASOOwner", reflect.TypeOf((*MockSubnetScope)(nil).ASOOwner))
+}
+
 // ClusterName mocks base method.
 func (m *MockSubnetScope) ClusterName() string {
 	m.ctrl.T.Helper()

--- a/azure/services/subnets/spec.go
+++ b/azure/services/subnets/spec.go
@@ -31,7 +31,6 @@ import (
 // SubnetSpec defines the specification for a Subnet.
 type SubnetSpec struct {
 	Name              string
-	Namespace         string
 	ResourceGroup     string
 	SubscriptionID    string
 	CIDRs             []string
@@ -50,8 +49,7 @@ func (s *SubnetSpec) ResourceRef() *asonetworkv1.VirtualNetworksSubnet {
 		ObjectMeta: metav1.ObjectMeta{
 			// s.Name isn't unique per-cluster, so combine with vnet name to avoid collisions.
 			// ToLower makes the name compatible with standard Kubernetes name requirements.
-			Name:      s.VNetName + "-" + strings.ToLower(s.Name),
-			Namespace: s.Namespace,
+			Name: s.VNetName + "-" + strings.ToLower(s.Name),
 		},
 	}
 }

--- a/azure/services/virtualnetworks/mock_virtualnetworks/virtualnetworks_mock.go
+++ b/azure/services/virtualnetworks/mock_virtualnetworks/virtualnetworks_mock.go
@@ -60,6 +60,20 @@ func (m *MockVNetScope) EXPECT() *MockVNetScopeMockRecorder {
 	return m.recorder
 }
 
+// ASOOwner mocks base method.
+func (m *MockVNetScope) ASOOwner() client.Object {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ASOOwner")
+	ret0, _ := ret[0].(client.Object)
+	return ret0
+}
+
+// ASOOwner indicates an expected call of ASOOwner.
+func (mr *MockVNetScopeMockRecorder) ASOOwner() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ASOOwner", reflect.TypeOf((*MockVNetScope)(nil).ASOOwner))
+}
+
 // ClusterName mocks base method.
 func (m *MockVNetScope) ClusterName() string {
 	m.ctrl.T.Helper()

--- a/azure/services/virtualnetworks/spec.go
+++ b/azure/services/virtualnetworks/spec.go
@@ -31,7 +31,6 @@ import (
 type VNetSpec struct {
 	ResourceGroup    string
 	Name             string
-	Namespace        string
 	CIDRs            []string
 	Location         string
 	ExtendedLocation *infrav1.ExtendedLocationSpec
@@ -43,8 +42,7 @@ type VNetSpec struct {
 func (s *VNetSpec) ResourceRef() *asonetworkv1.VirtualNetwork {
 	return &asonetworkv1.VirtualNetwork{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      s.Name,
-			Namespace: s.Namespace,
+			Name: s.Name,
 		},
 	}
 }

--- a/azure/services/virtualnetworks/spec_test.go
+++ b/azure/services/virtualnetworks/spec_test.go
@@ -40,7 +40,6 @@ func TestParameters(t *testing.T) {
 			spec: VNetSpec{
 				ResourceGroup: "rg",
 				Name:          "name",
-				Namespace:     "namespace",
 				CIDRs:         []string{"cidr"},
 				Location:      "location",
 				ExtendedLocation: &infrav1.ExtendedLocationSpec{
@@ -78,7 +77,6 @@ func TestParameters(t *testing.T) {
 			spec: VNetSpec{
 				ResourceGroup: "rg",
 				Name:          "name",
-				Namespace:     "namespace",
 				CIDRs:         []string{"cidr"},
 				Location:      "location",
 				ExtendedLocation: &infrav1.ExtendedLocationSpec{


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind feature

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

This PR makes CAPZ add an OwnerReference to each ASO resource it controls (i.e. any ASO resource not pre-created by a user). This is used instead of the `sigs.k8s.io_cluster-api-provider-azure_owned` label that's currently used. This better enables #4338 by tracking ownership more granularly than only by Cluster (such as per-AzureMachine or per-AzureManagedMachinePool) and #4339. More motivation is spelled out in #4340.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4340

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [ ] includes documentation
- [X] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
CAPZ now uses `metadata.ownerReferences` instead of the `sigs.k8s.io_cluster-api-provider-azure_owned` label to track ownership of ASO resources
```
