### PR TITLE
Move CecileRobertMichon to emeritus

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -13,6 +13,7 @@ reviewers:
 emeritus_approvers:
   - alexeldeib
   - awesomenix
+  - CecileRobertMichon
   - justaugustus
   - nader-ziada
   - ncdc

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -7,16 +7,14 @@ aliases:
     - neolit123
     - timothysc
   cluster-api-admins:
-    - CecileRobertMichon
+    - fabriziopandini
     - vincepri
   cluster-api-maintainers:
-    - CecileRobertMichon
     - enxebre
     - fabriziopandini
     - sbueringer
     - vincepri
   cluster-api-azure-maintainers:
-    - CecileRobertMichon
     - jackfrancis
     - mboersma
     - nojnhuh


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**: Moving myself to emeritus. After 6+ years at Microsoft and the last 3+ years spent working with the Cluster API community, I've decided to try something new which means I'll have less time to dedicate to this project going forward. I am removing myself as an approver to make room for future approvers. I've learned so much from the folks in this community and am proud to see how far the project has come. I will still be around in the k8s slack, feel free to reach out! 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
