### PR TITLE
Set specific token permissions in GH actions

### DIFF
--- a/.github/workflows/dependabot-code-gen.yml
+++ b/.github/workflows/dependabot-code-gen.yml
@@ -9,11 +9,13 @@ on:
       - dependabot/**
   workflow_dispatch:
 
-permissions:
-  contents: write # Allow to update the PR.
+permissions:  # added using https://github.com/step-security/secure-repo
+  contents: read
 
 jobs:
   build:
+    permissions:
+      contents: write  # for EndBug/add-and-commit
     name: Build
     runs-on: ubuntu-latest
     steps:
@@ -21,7 +23,6 @@ jobs:
       uses: step-security/harden-runner@eb238b55efaa70779f274895e782ed17c84f2895 # v2.6.1
       with:
         egress-policy: audit
-
     - name: Set up Go 1.x
       uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
       with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,11 +7,14 @@ on:
     paths:
       - 'CHANGELOG/*.md'
 
-permissions:
-  contents: write # Allow to push a tag, create a release branch and publish a draft release.
+permissions:  # added using https://github.com/step-security/secure-repo
+  contents: read
 
 jobs:
   push_release_tag:
+    permissions:
+      pull-requests: read  # for tj-actions/changed-files
+      contents: write  # for "Create Release Tag" step
     runs-on: ubuntu-latest
     outputs:
       release_tag: ${{ steps.release-version.outputs.release_version }}
@@ -20,7 +23,7 @@ jobs:
         uses: step-security/harden-runner@eb238b55efaa70779f274895e782ed17c84f2895 # v2.6.1
         with:
           egress-policy: audit
-      - name: Checkout code 
+      - name: Checkout code
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # tag=v4.1.1
         with:
           fetch-depth: 0
@@ -80,6 +83,8 @@ jobs:
           git push origin ${RELEASE_VERSION}
           echo "Created tag $RELEASE_VERSION"
   release:
+    permissions:
+      contents: write  # for softprops/action-gh-release to create GitHub release
     name: create draft release
     runs-on: ubuntu-latest
     needs: push_release_tag


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Removes the top-level `write` permission in two GitHub actions, in favor of giving more specific permissions to jobs that require it.

**Which issue(s) this PR fixes**:

N/A, but maintainers please see https://github.com/kubernetes-sigs/cluster-api-provider-azure/security/code-scanning/4 and https://github.com/kubernetes-sigs/cluster-api-provider-azure/security/code-scanning/12

**Special notes for your reviewer**:

- [x] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:

```release-note
NONE
```

