### PR TITLE
clean up unreferenced ASO resources

### DIFF
--- a/azure/services/bastionhosts/bastionhosts.go
+++ b/azure/services/bastionhosts/bastionhosts.go
@@ -17,10 +17,14 @@ limitations under the License.
 package bastionhosts
 
 import (
+	"context"
+
 	asonetworkv1 "github.com/Azure/azure-service-operator/v2/api/network/v1api20220701"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/services/aso"
+	"sigs.k8s.io/cluster-api-provider-azure/util/slice"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const serviceName = "bastionhosts"
@@ -38,6 +42,13 @@ func New(scope BastionScope) *aso.Service[*asonetworkv1.BastionHost, BastionScop
 	if spec != nil {
 		svc.Specs = []azure.ASOResourceSpecGetter[*asonetworkv1.BastionHost]{spec}
 	}
+	svc.ListFunc = list
 	svc.ConditionType = infrav1.BastionHostReadyCondition
 	return svc
+}
+
+func list(ctx context.Context, client client.Client, opts ...client.ListOption) ([]*asonetworkv1.BastionHost, error) {
+	list := &asonetworkv1.BastionHostList{}
+	err := client.List(ctx, list, opts...)
+	return slice.ToPtrs(list.Items), err
 }

--- a/test/e2e/aks_fleets_member.go
+++ b/test/e2e/aks_fleets_member.go
@@ -138,11 +138,11 @@ func AKSFleetsMemberSpec(ctx context.Context, inputGetter func() AKSFleetsMember
 		g.Expect(aks.ManagedCluster.Properties.ProvisioningState).NotTo(Equal(ptr.To("Updating")))
 	}, input.WaitIntervals...).Should(Succeed())
 
-	By("Deleting the fleets member")
-	fleetsMemberPoller, err := fleetsMemberClient.BeginDelete(ctx, groupName, fleetName, input.Cluster.Name, nil)
-	Expect(err).NotTo(HaveOccurred())
-	_, err = fleetsMemberPoller.PollUntilDone(ctx, nil)
-	Expect(err).NotTo(HaveOccurred())
+	By("Waiting for the FleetsMember to be deleted")
+	Eventually(func(g Gomega) {
+		_, err := fleetsMemberClient.Get(ctx, groupName, fleetName, input.Cluster.Name, nil)
+		g.Expect(azure.ResourceNotFound(err)).To(BeTrue(), "expected err to be 'not found', got %v", err)
+	}, input.WaitIntervals...).Should(Succeed())
 
 	Logf("Deleting the fleet manager resource group %q", groupName)
 	grpPoller, err := groupClient.BeginDelete(ctx, groupName, nil)

--- a/util/slice/slice.go
+++ b/util/slice/slice.go
@@ -16,6 +16,8 @@ limitations under the License.
 
 package slice
 
+import "k8s.io/utils/ptr"
+
 // Contains tells whether a Contains x.
 func Contains(a []string, x string) bool {
 	for _, n := range a {
@@ -24,4 +26,16 @@ func Contains(a []string, x string) bool {
 		}
 	}
 	return false
+}
+
+// ToPtrs takes a slice of values and returns a slice of pointers to the same values.
+func ToPtrs[T any](in []T) []*T {
+	if in == nil {
+		return nil
+	}
+	ptrs := make([]*T, 0, len(in))
+	for i := range in {
+		ptrs = append(ptrs, ptr.To(in[i]))
+	}
+	return ptrs
 }


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

This PR makes it possible for CAPZ to delete ASO resources that used to be managed by CAPZ but no longer are because they were removed from a CAPZ spec by a user. e.g. a user removes one element from an AzureCluster's `spec.networkSpec.subnets`. This aims to accomplish the same thing as #3591 in a way that can easily be plugged in to every ASO service implementation.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4338

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate <-- Even though I called this a bug fix, this seems like a big enough change that I think we can live without it in the existing release series.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [ ] includes documentation
- [X] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
CAPZ now deletes ASO resources it manages if references to them are removed from CAPZ resource specs
```
