### PR TITLE
Update subnet validation webhook regex

### DIFF
--- a/api/v1beta1/azuremanagedmachinepool_webhook.go
+++ b/api/v1beta1/azuremanagedmachinepool_webhook.go
@@ -477,7 +477,7 @@ func validateEnableNodePublicIP(enableNodePublicIP *bool, nodePublicIPPrefixID *
 
 func validateMPSubnetName(subnetName *string, fldPath *field.Path) error {
 	if subnetName != nil {
-		subnetRegex := "^[a-zA-Z0-9][a-zA-Z0-9-]{0,78}[a-zA-Z0-9]$"
+		subnetRegex := "^[a-zA-Z0-9][a-zA-Z0-9._-]{0,78}[a-zA-Z0-9]$"
 		regex := regexp.MustCompile(subnetRegex)
 		if success := regex.MatchString(ptr.Deref(subnetName, "")); !success {
 			return field.Invalid(fldPath, subnetName,

--- a/api/v1beta1/azuremanagedmachinepool_webhook_test.go
+++ b/api/v1beta1/azuremanagedmachinepool_webhook_test.go
@@ -736,11 +736,11 @@ func TestAzureManagedMachinePool_ValidateCreate(t *testing.T) {
 			errorLen: 1,
 		},
 		{
-			name: "invalid subnetname",
+			name: "invalid subnetname with versioning",
 			ammp: &AzureManagedMachinePool{
 				Spec: AzureManagedMachinePoolSpec{
 					AzureManagedMachinePoolClassSpec: AzureManagedMachinePoolClassSpec{
-						SubnetName: ptr.To("E-a_b-c"),
+						SubnetName: ptr.To("workload-ampt-v0.1.0."),
 					},
 				},
 			},
@@ -789,6 +789,17 @@ func TestAzureManagedMachinePool_ValidateCreate(t *testing.T) {
 				Spec: AzureManagedMachinePoolSpec{
 					AzureManagedMachinePoolClassSpec: AzureManagedMachinePoolClassSpec{
 						SubnetName: ptr.To("3DgIb8EZMkLs0KlyPaTcNxoJU9ufmW6jvXrweqz1hVp5nS4RtH2QY7AFOiC5nS4RtH2QY7AFOiC3DgIb"),
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid subnetname with versioning",
+			ammp: &AzureManagedMachinePool{
+				Spec: AzureManagedMachinePoolSpec{
+					AzureManagedMachinePoolClassSpec: AzureManagedMachinePoolClassSpec{
+						SubnetName: ptr.To("workload-ampt-v0.1.0"),
 					},
 				},
 			},


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This PR updates the AzureManagedMachinePool subnet Regex validation to make it be inline with the [official Azure subnet naming rules](https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules#microsoftnetwork). With this PR, it would be possible to use periods and underscores in the subnet name, without triggering the validation webhook.

Without this the AzureManagedMachinePool will fail if you use periods in the AzureManagedMachinePoolTemplate `metadata.name`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

No issues made, but It would fix a problem described in the cluster-api-azure slack channel:
https://kubernetes.slack.com/archives/CEX9HENG7/p1706097160653959


**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Correcting AzureManagedMachinePool subnet name validation webhook to match Azure subnet naming rules. 
```
