### PR TITLE
Add support for Azure CNI Powered by Cilium

### DIFF
--- a/api/v1beta1/azuremanagedcontrolplane_types.go
+++ b/api/v1beta1/azuremanagedcontrolplane_types.go
@@ -105,6 +105,16 @@ const (
 	NetworkPluginModeOverlay NetworkPluginMode = "overlay"
 )
 
+// NetworkDataplaneType is the type of network dataplane to use.
+type NetworkDataplaneType string
+
+const (
+	// NetworkDataplaneTypeAzure is the Azure network dataplane type.
+	NetworkDataplaneTypeAzure NetworkDataplaneType = "azure"
+	// NetworkDataplaneTypeCilium is the Cilium network dataplane type.
+	NetworkDataplaneTypeCilium NetworkDataplaneType = "cilium"
+)
+
 const (
 	// LoadBalancerSKUStandard is the Standard load balancer SKU.
 	LoadBalancerSKUStandard = "Standard"

--- a/api/v1beta1/azuremanagedcontrolplanetemplate_webhook.go
+++ b/api/v1beta1/azuremanagedcontrolplanetemplate_webhook.go
@@ -124,6 +124,13 @@ func (mcpw *azureManagedControlPlaneTemplateWebhook) ValidateUpdate(ctx context.
 	}
 
 	if err := webhookutils.ValidateImmutable(
+		field.NewPath("Spec", "Template", "Spec", "NetworkDataplane"),
+		old.Spec.Template.Spec.NetworkDataplane,
+		mcp.Spec.Template.Spec.NetworkDataplane); err != nil {
+		allErrs = append(allErrs, err)
+	}
+
+	if err := webhookutils.ValidateImmutable(
 		field.NewPath("Spec", "Template", "Spec", "LoadBalancerSKU"),
 		old.Spec.Template.Spec.LoadBalancerSKU,
 		mcp.Spec.Template.Spec.LoadBalancerSKU); err != nil {
@@ -214,6 +221,10 @@ func (mcp *AzureManagedControlPlaneTemplate) validateManagedControlPlaneTemplate
 	allErrs = append(allErrs, validateAKSExtensions(mcp.Spec.Template.Spec.Extensions, field.NewPath("spec").Child("Extensions"))...)
 
 	allErrs = append(allErrs, mcp.Spec.Template.Spec.AzureManagedControlPlaneClassSpec.validateSecurityProfile()...)
+
+	allErrs = append(allErrs, validateNetworkPolicy(mcp.Spec.Template.Spec.NetworkPolicy, mcp.Spec.Template.Spec.NetworkDataplane, field.NewPath("spec").Child("template").Child("spec").Child("NetworkPolicy"))...)
+
+	allErrs = append(allErrs, validateNetworkDataplane(mcp.Spec.Template.Spec.NetworkDataplane, mcp.Spec.Template.Spec.NetworkPolicy, mcp.Spec.Template.Spec.NetworkPluginMode, field.NewPath("spec").Child("template").Child("spec").Child("NetworkDataplane"))...)
 
 	return allErrs.ToAggregate()
 }

--- a/api/v1beta1/azuremanagedcontrolplanetemplate_webhook_test.go
+++ b/api/v1beta1/azuremanagedcontrolplanetemplate_webhook_test.go
@@ -249,6 +249,16 @@ func TestControlPlaneTemplateUpdateWebhook(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "azuremanagedcontrolplanetemplate networkDataplane is immutable",
+			oldControlPlaneTemplate: getAzureManagedControlPlaneTemplate(func(cpt *AzureManagedControlPlaneTemplate) {
+				cpt.Spec.Template.Spec.NetworkDataplane = ptr.To(NetworkDataplaneTypeAzure)
+			}),
+			controlPlaneTemplate: getAzureManagedControlPlaneTemplate(func(cpt *AzureManagedControlPlaneTemplate) {
+				cpt.Spec.Template.Spec.NetworkDataplane = ptr.To(NetworkDataplaneTypeCilium)
+			}),
+			wantErr: true,
+		},
+		{
 			name: "AzureManagedControlPlane invalid version downgrade change",
 			oldControlPlaneTemplate: getAzureManagedControlPlaneTemplate(func(cpt *AzureManagedControlPlaneTemplate) {
 				cpt.Spec.Template.Spec.Version = "v1.18.0"

--- a/api/v1beta1/types_class.go
+++ b/api/v1beta1/types_class.go
@@ -120,9 +120,14 @@ type AzureManagedControlPlaneClassSpec struct {
 	NetworkPluginMode *NetworkPluginMode `json:"networkPluginMode,omitempty"`
 
 	// NetworkPolicy used for building Kubernetes network.
-	// +kubebuilder:validation:Enum=azure;calico
+	// +kubebuilder:validation:Enum=azure;calico;cilium
 	// +optional
 	NetworkPolicy *string `json:"networkPolicy,omitempty"`
+
+	// NetworkDataplane is the dataplane used for building the Kubernetes network.
+	// +kubebuilder:validation:Enum=azure;cilium
+	// +optional
+	NetworkDataplane *NetworkDataplaneType `json:"networkDataplane,omitempty"`
 
 	// Outbound configuration used by Nodes.
 	// +kubebuilder:validation:Enum=loadBalancer;managedNATGateway;userAssignedNATGateway;userDefinedRouting

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -1351,6 +1351,11 @@ func (in *AzureManagedControlPlaneClassSpec) DeepCopyInto(out *AzureManagedContr
 		*out = new(string)
 		**out = **in
 	}
+	if in.NetworkDataplane != nil {
+		in, out := &in.NetworkDataplane, &out.NetworkDataplane
+		*out = new(NetworkDataplaneType)
+		**out = **in
+	}
 	if in.OutboundType != nil {
 		in, out := &in.OutboundType, &out.OutboundType
 		*out = new(ManagedControlPlaneOutboundType)

--- a/azure/scope/managedcontrolplane.go
+++ b/azure/scope/managedcontrolplane.go
@@ -558,6 +558,9 @@ func (s *ManagedControlPlaneScope) ManagedClusterSpec() azure.ASOResourceSpecGet
 	if s.ControlPlane.Spec.NetworkPolicy != nil {
 		managedClusterSpec.NetworkPolicy = *s.ControlPlane.Spec.NetworkPolicy
 	}
+	if s.ControlPlane.Spec.NetworkDataplane != nil {
+		managedClusterSpec.NetworkDataplane = s.ControlPlane.Spec.NetworkDataplane
+	}
 	if s.ControlPlane.Spec.LoadBalancerSKU != nil {
 		// CAPZ accepts Standard/Basic, Azure accepts standard/basic
 		managedClusterSpec.LoadBalancerSKU = strings.ToLower(*s.ControlPlane.Spec.LoadBalancerSKU)

--- a/azure/services/managedclusters/spec.go
+++ b/azure/services/managedclusters/spec.go
@@ -72,8 +72,11 @@ type ManagedClusterSpec struct {
 	// NetworkPluginMode is the mode the network plugin should use.
 	NetworkPluginMode *infrav1.NetworkPluginMode
 
-	// NetworkPolicy used for building Kubernetes network. Possible values include: 'calico', 'azure'.
+	// NetworkPolicy used for building Kubernetes network. Possible values include: 'azure', 'calico', 'cilium'.
 	NetworkPolicy string
+
+	// NetworkDataplane used for building Kubernetes network. Possible values include: 'azure', 'cilium'.
+	NetworkDataplane *infrav1.NetworkDataplaneType
 
 	// OutboundType used for building Kubernetes network. Possible values include: 'loadBalancer', 'managedNATGateway', 'userAssignedNATGateway', 'userDefinedRouting'.
 	OutboundType *infrav1.ManagedControlPlaneOutboundType
@@ -422,6 +425,9 @@ func (s *ManagedClusterSpec) Parameters(ctx context.Context, existing *asocontai
 		NetworkPlugin:   azure.AliasOrNil[asocontainerservicev1.NetworkPlugin](&s.NetworkPlugin),
 		LoadBalancerSku: azure.AliasOrNil[asocontainerservicev1.ContainerServiceNetworkProfile_LoadBalancerSku](&s.LoadBalancerSKU),
 		NetworkPolicy:   azure.AliasOrNil[asocontainerservicev1.ContainerServiceNetworkProfile_NetworkPolicy](&s.NetworkPolicy),
+	}
+	if s.NetworkDataplane != nil {
+		managedCluster.Spec.NetworkProfile.NetworkDataplane = ptr.To(asocontainerservicev1.ContainerServiceNetworkProfile_NetworkDataplane(*s.NetworkDataplane))
 	}
 	managedCluster.Spec.AutoScalerProfile = buildAutoScalerProfile(s.AutoScalerProfile)
 

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremanagedcontrolplanes.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremanagedcontrolplanes.yaml
@@ -547,6 +547,13 @@ spec:
                   the AzureManagedControlPlaneTemplate, this field is used only to
                   fulfill the CAPI contract.
                 type: object
+              networkDataplane:
+                description: NetworkDataplane is the dataplane used for building the
+                  Kubernetes network.
+                enum:
+                - azure
+                - cilium
+                type: string
               networkPlugin:
                 description: NetworkPlugin used for building Kubernetes network.
                 enum:
@@ -565,6 +572,7 @@ spec:
                 enum:
                 - azure
                 - calico
+                - cilium
                 type: string
               nodeResourceGroupName:
                 description: NodeResourceGroupName is the name of the resource group

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremanagedcontrolplanetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremanagedcontrolplanetemplates.yaml
@@ -537,6 +537,13 @@ spec:
                           plane. For the AzureManagedControlPlaneTemplate, this field
                           is used only to fulfill the CAPI contract.
                         type: object
+                      networkDataplane:
+                        description: NetworkDataplane is the dataplane used for building
+                          the Kubernetes network.
+                        enum:
+                        - azure
+                        - cilium
+                        type: string
                       networkPlugin:
                         description: NetworkPlugin used for building Kubernetes network.
                         enum:
@@ -555,6 +562,7 @@ spec:
                         enum:
                         - azure
                         - calico
+                        - cilium
                         type: string
                       oidcIssuerProfile:
                         description: OIDCIssuerProfile is the OIDC issuer profile


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind feature

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
Add support for [Azure CNI Powered by Cilium](https://learn.microsoft.com/en-us/azure/aks/azure-cni-powered-by-cilium#option-2-assign-ip-addresses-from-a-virtual-network) on AKS managed clusters by enabling the `NetworkDataplane` for the ManagedClucster network profile to be configurable.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4167

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add support for Azure CNI Powered by Cilium
```
