### PR TITLE
fix subnet test check by ignoring order

### DIFF
--- a/api/v1beta1/azurecluster_validation_test.go
+++ b/api/v1beta1/azurecluster_validation_test.go
@@ -553,7 +553,7 @@ func TestClusterSubnetsValid(t *testing.T) {
 			g := NewWithT(t)
 			errs := validateSubnets(tc.subnets, createValidVnet(),
 				field.NewPath("spec").Child("networkSpec").Child("subnets"))
-			g.Expect(errs).To(Equal(tc.err))
+			g.Expect(errs).To(ConsistOf(tc.err))
 		})
 	}
 }


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind flake

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

This PR updates a check in a unit test against a slice to ignore the order of elements since that is not deterministic because the slice is constructed by iterating over a map.

Running the test 100 times is enough to get it to fail every time for me:
```
go test ./api/v1beta1 -run TestClusterSubnetsValid/no_subnet -count 100 -failfast
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [X] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
