### PR TITLE
[release-1.12] only consider spec in existing when reconciling ASO tags

### DIFF
--- a/azure/services/aso/aso.go
+++ b/azure/services/aso/aso.go
@@ -156,9 +156,6 @@ func (r *reconciler[T]) CreateOrUpdateResource(ctx context.Context, spec azure.A
 
 	if t, ok := spec.(TagsGetterSetter[T]); ok {
 		if err := reconcileTags(t, existing, resourceExists, parameters); err != nil {
-			if azure.IsOperationNotDoneError(err) && readyErr != nil {
-				return zero, readyErr
-			}
 			return zero, errors.Wrap(err, "failed to reconcile tags")
 		}
 	}

--- a/azure/services/aso/aso_test.go
+++ b/azure/services/aso/aso_test.go
@@ -727,7 +727,6 @@ func TestCreateOrUpdateResource(t *testing.T) {
 		})
 		specMock.MockASOResourceSpecGetter.EXPECT().WasManaged(gomock.Any()).Return(false)
 
-		specMock.MockTagsGetterSetter.EXPECT().GetActualTags(gomock.Any()).Return(nil)
 		specMock.MockTagsGetterSetter.EXPECT().GetAdditionalTags().Return(nil)
 		specMock.MockTagsGetterSetter.EXPECT().GetDesiredTags(gomock.Any()).Return(nil).Times(2)
 		specMock.MockTagsGetterSetter.EXPECT().SetTags(gomock.Any(), gomock.Any())
@@ -817,71 +816,6 @@ func TestCreateOrUpdateResource(t *testing.T) {
 		result, err := s.CreateOrUpdateResource(ctx, specMock, "service")
 		g.Expect(result).To(BeNil())
 		g.Expect(err.Error()).To(ContainSubstring("failed to reconcile tags"))
-	})
-
-	t.Run("with tags not done error and readyErr", func(t *testing.T) {
-		g := NewGomegaWithT(t)
-
-		sch := runtime.NewScheme()
-		g.Expect(asoresourcesv1.AddToScheme(sch)).To(Succeed())
-		c := fakeclient.NewClientBuilder().
-			WithScheme(sch).
-			Build()
-		s := New[*asoresourcesv1.ResourceGroup](c, clusterName)
-
-		mockCtrl := gomock.NewController(t)
-		specMock := struct {
-			*mock_azure.MockASOResourceSpecGetter[*asoresourcesv1.ResourceGroup]
-			*mock_aso.MockTagsGetterSetter[*asoresourcesv1.ResourceGroup]
-		}{
-			MockASOResourceSpecGetter: mock_azure.NewMockASOResourceSpecGetter[*asoresourcesv1.ResourceGroup](mockCtrl),
-			MockTagsGetterSetter:      mock_aso.NewMockTagsGetterSetter[*asoresourcesv1.ResourceGroup](mockCtrl),
-		}
-		specMock.MockASOResourceSpecGetter.EXPECT().ResourceRef().Return(&asoresourcesv1.ResourceGroup{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "name",
-				Namespace: "namespace",
-			},
-		})
-		specMock.MockASOResourceSpecGetter.EXPECT().Parameters(gomockinternal.AContext(), gomock.Any()).DoAndReturn(func(_ context.Context, group *asoresourcesv1.ResourceGroup) (*asoresourcesv1.ResourceGroup, error) {
-			return group, nil
-		})
-
-		existing := &asoresourcesv1.ResourceGroup{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "name",
-				Namespace: "namespace",
-				Labels: map[string]string{
-					infrav1.OwnedByClusterLabelKey: clusterName,
-				},
-				Annotations: map[string]string{
-					asoannotations.ReconcilePolicy: string(asoannotations.ReconcilePolicyManage),
-				},
-			},
-			Spec: asoresourcesv1.ResourceGroup_Spec{
-				Tags: map[string]string{"desired": "tags"},
-			},
-			Status: asoresourcesv1.ResourceGroup_STATUS{
-				Tags: map[string]string{"actual": "tags"},
-				Conditions: []conditions.Condition{
-					{
-						Type:    conditions.ConditionTypeReady,
-						Status:  metav1.ConditionFalse,
-						Message: "not ready :(",
-					},
-				},
-			},
-		}
-
-		specMock.MockTagsGetterSetter.EXPECT().GetActualTags(gomock.Any()).Return(existing.Status.Tags)
-		specMock.MockTagsGetterSetter.EXPECT().GetDesiredTags(gomock.Any()).Return(existing.Spec.Tags)
-
-		ctx := context.Background()
-		g.Expect(c.Create(ctx, existing)).To(Succeed())
-
-		result, err := s.CreateOrUpdateResource(ctx, specMock, "service")
-		g.Expect(result).To(BeNil())
-		g.Expect(err.Error()).To(ContainSubstring("not ready :("))
 	})
 
 	t.Run("reconcile policy annotation resets after un-pause", func(t *testing.T) {

--- a/azure/services/aso/interfaces.go
+++ b/azure/services/aso/interfaces.go
@@ -36,7 +36,6 @@ type Reconciler[T genruntime.MetaObject] interface {
 type TagsGetterSetter[T genruntime.MetaObject] interface {
 	GetAdditionalTags() infrav1.Tags
 	GetDesiredTags(resource T) infrav1.Tags
-	GetActualTags(resource T) infrav1.Tags
 	SetTags(resource T, tags infrav1.Tags)
 }
 

--- a/azure/services/aso/mock_aso/aso_mock.go
+++ b/azure/services/aso/mock_aso/aso_mock.go
@@ -125,20 +125,6 @@ func (m *MockTagsGetterSetter[T]) EXPECT() *MockTagsGetterSetterMockRecorder[T] 
 	return m.recorder
 }
 
-// GetActualTags mocks base method.
-func (m *MockTagsGetterSetter[T]) GetActualTags(resource T) v1beta1.Tags {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetActualTags", resource)
-	ret0, _ := ret[0].(v1beta1.Tags)
-	return ret0
-}
-
-// GetActualTags indicates an expected call of GetActualTags.
-func (mr *MockTagsGetterSetterMockRecorder[T]) GetActualTags(resource any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetActualTags", reflect.TypeOf((*MockTagsGetterSetter[T])(nil).GetActualTags), resource)
-}
-
 // GetAdditionalTags mocks base method.
 func (m *MockTagsGetterSetter[T]) GetAdditionalTags() v1beta1.Tags {
 	m.ctrl.T.Helper()

--- a/azure/services/aso/tags.go
+++ b/azure/services/aso/tags.go
@@ -18,13 +18,10 @@ package aso
 
 import (
 	"encoding/json"
-	"reflect"
 
-	asoannotations "github.com/Azure/azure-service-operator/v2/pkg/common/annotations"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	"github.com/pkg/errors"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
-	"sigs.k8s.io/cluster-api-provider-azure/azure"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/converters"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/services/tags"
 	"sigs.k8s.io/cluster-api-provider-azure/util/maps"
@@ -49,17 +46,7 @@ func reconcileTags[T genruntime.MetaObject](t TagsGetterSetter[T], existing T, r
 			}
 		}
 
-		existingTags = t.GetActualTags(existing)
-		// Wait for tags to converge so we know for sure which ones are deleted from additionalTags (and
-		// should be deleted) and which were added manually (and should be kept).
-		if !reflect.DeepEqual(t.GetDesiredTags(existing), existingTags) &&
-			existing.GetAnnotations()[asoannotations.ReconcilePolicy] == string(asoannotations.ReconcilePolicyManage) {
-			return azure.WithTransientError(azure.NewOperationNotDoneError(&infrav1.Future{
-				Type:          createOrUpdateFutureType,
-				ResourceGroup: existing.GetNamespace(),
-				Name:          existing.GetName(),
-			}), requeueInterval)
-		}
+		existingTags = t.GetDesiredTags(existing)
 	}
 
 	existingTagsMap := converters.TagsToMap(existingTags)

--- a/azure/services/groups/spec.go
+++ b/azure/services/groups/spec.go
@@ -86,11 +86,6 @@ func (*GroupSpec) GetDesiredTags(resource *asoresourcesv1.ResourceGroup) infrav1
 	return resource.Spec.Tags
 }
 
-// GetActualTags implements aso.TagsGetterSetter.
-func (*GroupSpec) GetActualTags(resource *asoresourcesv1.ResourceGroup) infrav1.Tags {
-	return resource.Status.Tags
-}
-
 // SetTags implements aso.TagsGetterSetter.
 func (*GroupSpec) SetTags(resource *asoresourcesv1.ResourceGroup, tags infrav1.Tags) {
 	resource.Spec.Tags = tags

--- a/azure/services/managedclusters/spec.go
+++ b/azure/services/managedclusters/spec.go
@@ -601,11 +601,6 @@ func (*ManagedClusterSpec) GetDesiredTags(resource *asocontainerservicev1.Manage
 	return resource.Spec.Tags
 }
 
-// GetActualTags implements aso.TagsGetterSetter.
-func (*ManagedClusterSpec) GetActualTags(resource *asocontainerservicev1.ManagedCluster) infrav1.Tags {
-	return resource.Status.Tags
-}
-
 // SetTags implements aso.TagsGetterSetter.
 func (*ManagedClusterSpec) SetTags(resource *asocontainerservicev1.ManagedCluster, tags infrav1.Tags) {
 	resource.Spec.Tags = tags


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

Manual cherry-pick of #4531:
> This PR offers an alternative fix to the issue addressed by #4149 which fixes the regression described by #4525. It eliminates CAPZ's use of ASO resources' `status.tags` from its reconciliation of tags in favor of only considering `spec.tags` which is easier to synchronize with CAPZ's extra bookkeeping in the `last-applied-tags` annotation.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixed a bug where tags applied by Azure Policy were keeping CAPZ from reconciling ASO ResourceGroups and ManagedClusters
```
