### PR TITLE
Restore AMMP-converges-to-failed-ready test spec

### DIFF
--- a/test/e2e/aks_public_ip_prefix.go
+++ b/test/e2e/aks_public_ip_prefix.go
@@ -83,7 +83,7 @@ func AKSPublicIPPrefixSpec(ctx context.Context, inputGetter func() AKSPublicIPPr
 		publicIPPrefix = resp.PublicIPPrefix
 	}, input.WaitIntervals...).Should(Succeed(), "failed to create public IP prefix")
 
-	By("Creating node pool with 2 nodes")
+	By("Creating node pool with 3 nodes")
 	infraMachinePool := &infrav1.AzureManagedMachinePool{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "pool3",
@@ -108,7 +108,7 @@ func AKSPublicIPPrefixSpec(ctx context.Context, inputGetter func() AKSPublicIPPr
 		},
 		Spec: expv1.MachinePoolSpec{
 			ClusterName: input.Cluster.Name,
-			Replicas:    ptr.To[int32](2),
+			Replicas:    ptr.To[int32](3),
 			Template: clusterv1.MachineTemplateSpec{
 				Spec: clusterv1.MachineSpec{
 					Bootstrap: clusterv1.Bootstrap{
@@ -143,6 +143,27 @@ func AKSPublicIPPrefixSpec(ctx context.Context, inputGetter func() AKSPublicIPPr
 			g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
 		}, input.WaitIntervals...).Should(Succeed(), "Deleted AzureManagedMachinePool %s/%s still exists", infraMachinePool.Namespace, infraMachinePool.Name)
 	}()
+
+	By("Verifying the AzureManagedMachinePool converges to a failed ready status")
+	Eventually(func(g Gomega) {
+		infraMachinePool := &infrav1.AzureManagedMachinePool{}
+		err := mgmtClient.Get(ctx, client.ObjectKeyFromObject(machinePool), infraMachinePool)
+		g.Expect(err).NotTo(HaveOccurred())
+		cond := conditions.Get(infraMachinePool, infrav1.AgentPoolsReadyCondition)
+		g.Expect(cond).NotTo(BeNil())
+		g.Expect(cond.Status).To(Equal(corev1.ConditionFalse))
+		g.Expect(cond.Reason).To(Equal(infrav1.FailedReason))
+		g.Expect(cond.Message).To(ContainSubstring("PublicIpPrefixOutOfIpAddressesForVMScaleSet"))
+	}, input.WaitIntervals...).Should(Succeed())
+
+	By("Scaling the MachinePool to 2 nodes")
+	Eventually(func(g Gomega) {
+		err = mgmtClient.Get(ctx, client.ObjectKeyFromObject(machinePool), machinePool)
+		g.Expect(err).NotTo(HaveOccurred())
+		machinePool.Spec.Replicas = ptr.To[int32](2)
+		err = mgmtClient.Update(ctx, machinePool)
+		g.Expect(err).NotTo(HaveOccurred())
+	}, input.WaitIntervals...).Should(Succeed())
 
 	By("Verifying the AzureManagedMachinePool becomes ready")
 	Eventually(func(g Gomega) {


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
This PR restores the AMMP-converges-to-failed-ready test spec that was removed in #3857.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3893 

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
