### PR TITLE
Set PlatformFaultDomainCount if VMSS flex is enabled

### DIFF
--- a/azure/services/scalesets/spec.go
+++ b/azure/services/scalesets/spec.go
@@ -214,6 +214,7 @@ func (s *ScaleSetSpec) Parameters(ctx context.Context, existing interface{}) (pa
 	case armcompute.OrchestrationModeFlexible: // VMSS Flex, VMs are treated as individual virtual machines
 		vmss.Properties.VirtualMachineProfile.NetworkProfile.NetworkAPIVersion =
 			ptr.To(armcompute.NetworkAPIVersionTwoThousandTwenty1101)
+		vmss.Properties.PlatformFaultDomainCount = ptr.To[int32](1)
 	}
 
 	if s.PlatformFaultDomainCount != nil {


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind failing-test

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
This PR fixes an issue that broke the [VMSS e2e test](https://testgrid.k8s.io/sig-cluster-lifecycle-cluster-api-provider-azure#capz-periodic-e2e-main) that originated here: https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/4554/files#diff-1c3a6255d04d392f77db2ebb95d67e705ee50a6f374884f02cf10ce5ed0639eeL215

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
