### PR TITLE
allow adding pre-existing privateDNSZone to AKS clusters

### DIFF
--- a/api/v1beta1/azuremanagedcontrolplanetemplate_webhook.go
+++ b/api/v1beta1/azuremanagedcontrolplanetemplate_webhook.go
@@ -226,6 +226,8 @@ func (mcp *AzureManagedControlPlaneTemplate) validateManagedControlPlaneTemplate
 
 	allErrs = append(allErrs, validateNetworkDataplane(mcp.Spec.Template.Spec.NetworkDataplane, mcp.Spec.Template.Spec.NetworkPolicy, mcp.Spec.Template.Spec.NetworkPluginMode, field.NewPath("spec").Child("template").Child("spec").Child("NetworkDataplane"))...)
 
+	allErrs = append(allErrs, validateAPIServerAccessProfile(mcp.Spec.Template.Spec.APIServerAccessProfile, field.NewPath("spec").Child("template").Child("spec").Child("APIServerAccessProfile"))...)
+
 	return allErrs.ToAggregate()
 }
 

--- a/api/v1beta1/types_class.go
+++ b/api/v1beta1/types_class.go
@@ -410,7 +410,6 @@ type APIServerAccessProfileClassSpec struct {
 	EnablePrivateCluster *bool `json:"enablePrivateCluster,omitempty"`
 
 	// PrivateDNSZone enables private dns zone mode for private cluster.
-	// +kubebuilder:validation:Enum=System;None
 	// +optional
 	PrivateDNSZone *string `json:"privateDNSZone,omitempty"`
 

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremanagedcontrolplanes.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremanagedcontrolplanes.yaml
@@ -128,9 +128,6 @@ spec:
                   privateDNSZone:
                     description: PrivateDNSZone enables private dns zone mode for
                       private cluster.
-                    enum:
-                    - System
-                    - None
                     type: string
                 type: object
               autoUpgradeProfile:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremanagedcontrolplanetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremanagedcontrolplanetemplates.yaml
@@ -119,9 +119,6 @@ spec:
                           privateDNSZone:
                             description: PrivateDNSZone enables private dns zone mode
                               for private cluster.
-                            enum:
-                            - System
-                            - None
                             type: string
                         type: object
                       autoUpgradeProfile:


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:

/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
- Adds support to pre-existing privateDNSZone to AKS clusters.
  - Removes the earlier kubebuilder's validation on `APIServerAccessProfileClassSpec.PrivateDNSZone`.
  - Adds validation for `PrivateDNSZone` being either
    - `System`
    - `None`
    - resource ID ending with `privatelink.<region>.azmk8s.io`
    - resource ID ending with `<subzone>.privatelink.<region>.azmk8s.io`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4566 

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [x] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
allow adding pre-existing privateDNSZone to AKS clusters
```
