### PR TITLE
wait for cluster to be Ready before hitting API server

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -349,7 +349,7 @@ create-workload-cluster: $(ENVSUBST) $(KUBECTL) ## Create a workload cluster.
 	timeout --foreground 300 bash -c "while ! $(KUBECTL) get secrets | grep $(CLUSTER_NAME)-kubeconfig; do sleep 1; done"
 	# Get kubeconfig and store it locally.
 	$(KUBECTL) get secrets $(CLUSTER_NAME)-kubeconfig -o json | jq -r .data.value | base64 --decode > ./kubeconfig
-	timeout --foreground 600 bash -c "while ! $(KUBECTL) --kubeconfig=./kubeconfig get nodes | grep control-plane; do sleep 1; done"
+	$(KUBECTL) wait --for=condition=Ready --timeout=10m cluster "$(CLUSTER_NAME)"
 
 	@echo 'run "$(KUBECTL) --kubeconfig=./kubeconfig ..." to work with the new target cluster'
 


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind cleanup

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

This PR changes the workload cluster creation flow invoked by ci-entrypoint.sh to wait for the Cluster to be Ready before finishing instead of querying the workload cluster API server which is expected to fail for a period of time. This eliminates errors from logs like this as the control plane is coming online which seemed to start appearing after #4461:

```
E0219 14:13:58.386781   70553 memcache.go:265] couldn't get current server API group list: Get "https://capz-6th1am-c35b5ef9.uksouth.cloudapp.azure.com:6443/api?timeout=32s": dial tcp 4.158.170.189:6443: i/o timeout
E0219 14:14:28.388293   70553 memcache.go:265] couldn't get current server API group list: Get "https://capz-6th1am-c35b5ef9.uksouth.cloudapp.azure.com:6443/api?timeout=32s": dial tcp 4.158.170.189:6443: i/o timeout
E0219 14:14:58.389239   70553 memcache.go:265] couldn't get current server API group list: Get "https://capz-6th1am-c35b5ef9.uksouth.cloudapp.azure.com:6443/api?timeout=32s": dial tcp 4.158.170.189:6443: i/o timeout
E0219 14:15:28.390241   70553 memcache.go:265] couldn't get current server API group list: Get "https://capz-6th1am-c35b5ef9.uksouth.cloudapp.azure.com:6443/api?timeout=32s": dial tcp 4.158.170.189:6443: i/o timeout
E0219 14:15:58.391214   70553 memcache.go:265] couldn't get current server API group list: Get "https://capz-6th1am-c35b5ef9.uksouth.cloudapp.azure.com:6443/api?timeout=32s": dial tcp 4.158.170.189:6443: i/o timeout
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4583

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [X] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
