### PR TITLE
[release-1.12] Bump CAPI to v1.5.6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -301,7 +301,7 @@ create-management-cluster: $(KUSTOMIZE) $(ENVSUBST) $(KUBECTL) $(KIND) ## Create
 	./hack/create-custom-cloud-provider-config.sh
 
 	# Deploy CAPI
-	timeout --foreground 300 bash -c "until curl --retry $(CURL_RETRIES) -sSL https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.5.5/cluster-api-components.yaml | $(ENVSUBST) | $(KUBECTL) apply -f -; do sleep 5; done"
+	timeout --foreground 300 bash -c "until curl --retry $(CURL_RETRIES) -sSL https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.5.6/cluster-api-components.yaml | $(ENVSUBST) | $(KUBECTL) apply -f -; do sleep 5; done"
 
 	# Deploy CAAPH
 	timeout --foreground 300 bash -c "until curl --retry $(CURL_RETRIES) -sSL https://github.com/kubernetes-sigs/cluster-api-addon-provider-helm/releases/download/v0.1.0-alpha.10/addon-components.yaml | $(ENVSUBST) | $(KUBECTL) apply -f -; do sleep 5; done"

--- a/Tiltfile
+++ b/Tiltfile
@@ -19,7 +19,7 @@ settings = {
     "deploy_cert_manager": True,
     "preload_images_for_kind": True,
     "kind_cluster_name": "capz",
-    "capi_version": "v1.5.5",
+    "capi_version": "v1.5.6",
     "cert_manager_version": "v1.13.2",
     "kubernetes_version": "v1.28.0",
     "aks_kubernetes_version": "v1.26.3",

--- a/go.mod
+++ b/go.mod
@@ -54,8 +54,8 @@ require (
 	k8s.io/kubectl v0.27.2
 	k8s.io/utils v0.0.0-20230726121419-3b25d923346b
 	sigs.k8s.io/cloud-provider-azure v1.27.7
-	sigs.k8s.io/cluster-api v1.5.5
-	sigs.k8s.io/cluster-api/test v1.5.5
+	sigs.k8s.io/cluster-api v1.5.6
+	sigs.k8s.io/cluster-api/test v1.5.6
 	sigs.k8s.io/controller-runtime v0.16.3
 	sigs.k8s.io/kind v0.20.0
 )
@@ -214,7 +214,7 @@ require (
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
 
-replace sigs.k8s.io/cluster-api => sigs.k8s.io/cluster-api v1.5.5
+replace sigs.k8s.io/cluster-api => sigs.k8s.io/cluster-api v1.5.6
 
 // All of these below are necessary until CAPI is updated to v1.6.0.
 // After that, this kube-openapi one will still be necessary, replacing

--- a/go.sum
+++ b/go.sum
@@ -1138,10 +1138,10 @@ sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.1.2 h1:trsWhjU5jZrx6U
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.1.2/go.mod h1:+qG7ISXqCDVVcyO8hLn12AKVYYUjM7ftlqsqmrhMZE0=
 sigs.k8s.io/cloud-provider-azure v1.27.7 h1:X6DdOA1aUlnBfSffTdq1zGWph7L62VY6ZS1ErwR5bVY=
 sigs.k8s.io/cloud-provider-azure v1.27.7/go.mod h1:ytwtCpVGJFvIc+n9q6CB14QD+AiiuXnsqz3DkWG7bBI=
-sigs.k8s.io/cluster-api v1.5.5 h1:MmxTGE8bJvALrJzzuTA2YEP+qKPrpxg7u8AecU93fwc=
-sigs.k8s.io/cluster-api v1.5.5/go.mod h1:T50/vFznHz409V1XS74DIiPl9JDH4r2+xHiCYpYRTmc=
-sigs.k8s.io/cluster-api/test v1.5.5 h1:7paIrbvMM+CHlFTD9sMvuxV7NvEgujVuAkJkAM88taU=
-sigs.k8s.io/cluster-api/test v1.5.5/go.mod h1:aoUTgVdZhgZ0DSuEHK0yM1VP8OXc/XzgU9DcYbzs3aI=
+sigs.k8s.io/cluster-api v1.5.6 h1:gGaKnzBNNgExBk0jV/HTkTuo7R0NqOuk0EWDY/77B20=
+sigs.k8s.io/cluster-api v1.5.6/go.mod h1:T50/vFznHz409V1XS74DIiPl9JDH4r2+xHiCYpYRTmc=
+sigs.k8s.io/cluster-api/test v1.5.6 h1:LZDY/HGxmPoqsYMjM7lwx6GE18kRwKppKCOLJwVOP2U=
+sigs.k8s.io/cluster-api/test v1.5.6/go.mod h1:aoUTgVdZhgZ0DSuEHK0yM1VP8OXc/XzgU9DcYbzs3aI=
 sigs.k8s.io/controller-runtime v0.16.3 h1:2TuvuokmfXvDUamSx1SuAOO3eTyye+47mJCigwG62c4=
 sigs.k8s.io/controller-runtime v0.16.3/go.mod h1:j7bialYoSn142nv9sCOJmQgDXQXxnroFU4VnX/brVJ0=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd h1:EDPBXCAspyGV4jQlpZSudPeMmr1bNJefnuqLsRAsHZo=

--- a/test/e2e/capi_test.go
+++ b/test/e2e/capi_test.go
@@ -260,10 +260,10 @@ var _ = Describe("Running the Cluster API E2E tests", func() {
 							WaitForControlPlaneInitialized: EnsureControlPlaneInitialized,
 						},
 						InitWithKubernetesVersion:       "v1.26.12",
-						InitWithBinary:                  "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.5.5/clusterctl-{OS}-{ARCH}",
-						InitWithCoreProvider:            "cluster-api:v1.5.5",
-						InitWithBootstrapProviders:      []string{"kubeadm:v1.5.5"},
-						InitWithControlPlaneProviders:   []string{"kubeadm:v1.5.5"},
+						InitWithBinary:                  "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.5.6/clusterctl-{OS}-{ARCH}",
+						InitWithCoreProvider:            "cluster-api:v1.5.6",
+						InitWithBootstrapProviders:      []string{"kubeadm:v1.5.6"},
+						InitWithControlPlaneProviders:   []string{"kubeadm:v1.5.6"},
 						InitWithInfrastructureProviders: []string{"azure:v1.10.8"},
 					}
 				})

--- a/test/e2e/config/azure-dev.yaml
+++ b/test/e2e/config/azure-dev.yaml
@@ -16,8 +16,8 @@ providers:
   - name: cluster-api
     type: CoreProvider
     versions:
-    - name: v1.5.5 # latest patch of earliest minor in supported v1beta1 releases; this is used for v1beta1 old --> v1beta1 latest clusterctl upgrades test only.
-      value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.5.5/core-components.yaml"
+    - name: v1.5.6 # latest patch of earliest minor in supported v1beta1 releases; this is used for v1beta1 old --> v1beta1 latest clusterctl upgrades test only.
+      value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.5.6/core-components.yaml"
       type: "url"
       contract: v1beta1
       replacements:
@@ -39,8 +39,8 @@ providers:
   - name: kubeadm
     type: BootstrapProvider
     versions:
-    - name: v1.5.5 # latest patch of earliest minor in supported v1beta1 releases; this is used for v1beta1 old --> v1beta1 latest clusterctl upgrades test only.
-      value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.5.5/bootstrap-components.yaml"
+    - name: v1.5.6 # latest patch of earliest minor in supported v1beta1 releases; this is used for v1beta1 old --> v1beta1 latest clusterctl upgrades test only.
+      value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.5.6/bootstrap-components.yaml"
       type: "url"
       contract: v1beta1
       replacements:
@@ -61,8 +61,8 @@ providers:
   - name: kubeadm
     type: ControlPlaneProvider
     versions:
-    - name: v1.5.5 # latest patch of earliest minor in supported v1beta1 releases; this is used for v1beta1 old --> v1beta1 latest clusterctl upgrades test only.
-      value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.5.5/control-plane-components.yaml"
+    - name: v1.5.6 # latest patch of earliest minor in supported v1beta1 releases; this is used for v1beta1 old --> v1beta1 latest clusterctl upgrades test only.
+      value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.5.6/control-plane-components.yaml"
       type: "url"
       contract: v1beta1
       replacements:


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Updates CAPI to [v1.5.6](https://github.com/kubernetes-sigs/cluster-api/releases/tag/v1.5.6) and all that entails.

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

- [ ] cherry-pick candidate

**TODOs**:

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:

```release-note
Bump CAPI to v1.5.6
```
