### PR TITLE
Bump golangci-lint to 1.55.2

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,17 +9,20 @@ linters:
   enable:
     - asasalint
     - asciicheck
+    - bidichk
     - bodyclose
     - containedctx
     - decorder
-    - depguard
     - dogsled
+    - dupword
+    - durationcheck
     - errcheck
     - errchkjson
     - errorlint
     - execinquery
     - exportloopref
     - gci
+    - ginkgolinter
     - goconst
     - gocritic
     - gocyclo
@@ -32,6 +35,7 @@ linters:
     - govet
     - importas
     - ineffassign
+    - loggercheck
     - misspell
     - nakedret
     - nilerr

--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ ENVSUBST_VER := $(shell go list -m -f '{{.Version}}' github.com/drone/envsubst/v
 ENVSUBST_BIN := envsubst
 ENVSUBST := $(TOOLS_BIN_DIR)/$(ENVSUBST_BIN)-$(ENVSUBST_VER)
 
-GOLANGCI_LINT_VER := v1.52.1
+GOLANGCI_LINT_VER := v1.55.2
 GOLANGCI_LINT_BIN := golangci-lint
 GOLANGCI_LINT := $(TOOLS_BIN_DIR)/$(GOLANGCI_LINT_BIN)-$(GOLANGCI_LINT_VER)
 

--- a/api/v1beta1/azurecluster_validation_test.go
+++ b/api/v1beta1/azurecluster_validation_test.go
@@ -121,7 +121,7 @@ func TestClusterWithPreexistingVnetValid(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			g := NewWithT(t)
 			_, err := tc.cluster.validateCluster(nil)
-			g.Expect(err).To(BeNil())
+			g.Expect(err).NotTo(HaveOccurred())
 		})
 	}
 }
@@ -148,7 +148,7 @@ func TestClusterWithPreexistingVnetInvalid(t *testing.T) {
 	t.Run(testCase.name, func(t *testing.T) {
 		g := NewWithT(t)
 		_, err := testCase.cluster.validateCluster(nil)
-		g.Expect(err).NotTo(BeNil())
+		g.Expect(err).To(HaveOccurred())
 	})
 }
 
@@ -176,7 +176,7 @@ func TestClusterWithoutPreexistingVnetValid(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			g := NewWithT(t)
 			_, err := tc.cluster.validateCluster(nil)
-			g.Expect(err).To(BeNil())
+			g.Expect(err).NotTo(HaveOccurred())
 		})
 	}
 }
@@ -228,7 +228,7 @@ func TestClusterSpecWithPreexistingVnetInvalid(t *testing.T) {
 	t.Run(testCase.name, func(t *testing.T) {
 		g := NewWithT(t)
 		errs := testCase.cluster.validateClusterSpec(nil)
-		g.Expect(len(errs)).To(BeNumerically(">", 0))
+		g.Expect(errs).NotTo(BeEmpty())
 	})
 }
 
@@ -271,7 +271,7 @@ func TestClusterSpecWithoutIdentityRefInvalid(t *testing.T) {
 	t.Run(testCase.name, func(t *testing.T) {
 		g := NewWithT(t)
 		errs := testCase.cluster.validateClusterSpec(nil)
-		g.Expect(len(errs)).To(BeNumerically(">", 0))
+		g.Expect(errs).NotTo(BeEmpty())
 	})
 }
 
@@ -292,7 +292,7 @@ func TestClusterSpecWithWrongKindInvalid(t *testing.T) {
 	t.Run(testCase.name, func(t *testing.T) {
 		g := NewWithT(t)
 		errs := testCase.cluster.validateClusterSpec(nil)
-		g.Expect(len(errs)).To(BeNumerically(">", 0))
+		g.Expect(errs).NotTo(BeEmpty())
 	})
 }
 
@@ -404,7 +404,7 @@ func TestResourceGroupValid(t *testing.T) {
 		g := NewWithT(t)
 		err := validateResourceGroup(testCase.resourceGroup,
 			field.NewPath("spec").Child("networkSpec").Child("vnet").Child("resourceGroup"))
-		g.Expect(err).To(BeNil())
+		g.Expect(err).NotTo(HaveOccurred())
 	})
 }
 
@@ -664,7 +664,7 @@ func TestSubnetNameValid(t *testing.T) {
 		g := NewWithT(t)
 		err := validateSubnetName(testCase.subnetName,
 			field.NewPath("spec").Child("networkSpec").Child("subnets").Index(0).Child("name"))
-		g.Expect(err).To(BeNil())
+		g.Expect(err).NotTo(HaveOccurred())
 	})
 }
 
@@ -815,16 +815,16 @@ func TestValidateSecurityRule(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 			g := NewWithT(t)
-			err := validateSecurityRule(
+			errs := validateSecurityRule(
 				testCase.validRule,
 				field.NewPath("spec").Child("networkSpec").Child("subnets").Index(0).Child("securityGroup").Child("securityRules").Index(0),
 			)
 			if testCase.wantErr {
-				g.Expect(err).NotTo(BeNil())
-				g.Expect(len(err)).To(Equal(1))
+				g.Expect(errs).NotTo(BeNil())
+				g.Expect(errs).To(HaveLen(1))
 			} else {
-				g.Expect(err).To(BeNil())
-				g.Expect(len(err)).To(Equal(0))
+				g.Expect(errs).To(BeNil())
+				g.Expect(errs).To(BeEmpty())
 			}
 		})
 	}

--- a/api/v1beta1/azuremachine_default_test.go
+++ b/api/v1beta1/azuremachine_default_test.go
@@ -46,11 +46,11 @@ func TestAzureMachineSpec_SetDefaultSSHPublicKey(t *testing.T) {
 	publicKeyNotExistTest := test{machine: createMachineWithSSHPublicKey("")}
 
 	err := publicKeyExistTest.machine.Spec.SetDefaultSSHPublicKey()
-	g.Expect(err).To(BeNil())
+	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(publicKeyExistTest.machine.Spec.SSHPublicKey).To(Equal(existingPublicKey))
 
 	err = publicKeyNotExistTest.machine.Spec.SetDefaultSSHPublicKey()
-	g.Expect(err).To(BeNil())
+	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(publicKeyNotExistTest.machine.Spec.SSHPublicKey).To(Not(BeEmpty()))
 }
 

--- a/api/v1beta1/azuremachine_validation_test.go
+++ b/api/v1beta1/azuremachine_validation_test.go
@@ -922,7 +922,7 @@ func TestAzureMachine_ValidateNetwork(t *testing.T) {
 			g := NewWithT(t)
 			err := ValidateNetwork(test.subnetName, test.acceleratedNetworking, test.networkInterfaces, field.NewPath("networkInterfaces"))
 			if test.wantErr {
-				g.Expect(err).ToNot(BeEmpty())
+				g.Expect(err).NotTo(BeEmpty())
 			} else {
 				g.Expect(err).To(BeEmpty())
 			}

--- a/api/v1beta1/azuremanagedcontrolplane_default_test.go
+++ b/api/v1beta1/azuremanagedcontrolplane_default_test.go
@@ -35,11 +35,11 @@ func TestAzureManagedControlPlane_SetDefaultSSHPublicKey(t *testing.T) {
 	publicKeyNotExistTest := test{m: createAzureManagedControlPlaneWithSSHPublicKey("")}
 
 	err := publicKeyExistTest.m.setDefaultSSHPublicKey()
-	g.Expect(err).To(BeNil())
+	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(*publicKeyExistTest.m.Spec.SSHPublicKey).To(Equal(existingPublicKey))
 
 	err = publicKeyNotExistTest.m.setDefaultSSHPublicKey()
-	g.Expect(err).To(BeNil())
+	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(*publicKeyNotExistTest.m.Spec.SSHPublicKey).NotTo(BeEmpty())
 }
 

--- a/api/v1beta1/azuremanagedcontrolplane_webhook_test.go
+++ b/api/v1beta1/azuremanagedcontrolplane_webhook_test.go
@@ -74,7 +74,7 @@ func TestDefaultingWebhook(t *testing.T) {
 	g.Expect(amcp.Spec.SKU.Tier).To(Equal(FreeManagedControlPlaneTier))
 	g.Expect(amcp.Spec.Identity.Type).To(Equal(ManagedControlPlaneIdentityTypeSystemAssigned))
 	g.Expect(*amcp.Spec.OIDCIssuerProfile.Enabled).To(BeFalse())
-	g.Expect(amcp.Spec.DNSPrefix).ToNot(BeNil())
+	g.Expect(amcp.Spec.DNSPrefix).NotTo(BeNil())
 	g.Expect(*amcp.Spec.DNSPrefix).To(Equal(amcp.Name))
 	g.Expect(amcp.Spec.Extensions[0].Plan.Name).To(Equal("fooName-test-product"))
 
@@ -118,16 +118,16 @@ func TestDefaultingWebhook(t *testing.T) {
 	g.Expect(amcp.Spec.VirtualNetwork.Subnet.Name).To(Equal("fooSubnetName"))
 	g.Expect(amcp.Spec.SKU.Tier).To(Equal(StandardManagedControlPlaneTier))
 	g.Expect(*amcp.Spec.OIDCIssuerProfile.Enabled).To(BeTrue())
-	g.Expect(amcp.Spec.DNSPrefix).ToNot(BeNil())
+	g.Expect(amcp.Spec.DNSPrefix).NotTo(BeNil())
 	g.Expect(*amcp.Spec.DNSPrefix).To(Equal("test-prefix"))
 	g.Expect(amcp.Spec.FleetsMember.Name).To(Equal("fooCluster"))
-	g.Expect(amcp.Spec.AutoUpgradeProfile).ToNot(BeNil())
-	g.Expect(amcp.Spec.AutoUpgradeProfile.UpgradeChannel).ToNot(BeNil())
+	g.Expect(amcp.Spec.AutoUpgradeProfile).NotTo(BeNil())
+	g.Expect(amcp.Spec.AutoUpgradeProfile.UpgradeChannel).NotTo(BeNil())
 	g.Expect(*amcp.Spec.AutoUpgradeProfile.UpgradeChannel).To(Equal(UpgradeChannelPatch))
-	g.Expect(amcp.Spec.SecurityProfile).ToNot(BeNil())
-	g.Expect(amcp.Spec.SecurityProfile.AzureKeyVaultKms).ToNot(BeNil())
-	g.Expect(amcp.Spec.SecurityProfile.ImageCleaner).ToNot(BeNil())
-	g.Expect(amcp.Spec.SecurityProfile.ImageCleaner.IntervalHours).ToNot(BeNil())
+	g.Expect(amcp.Spec.SecurityProfile).NotTo(BeNil())
+	g.Expect(amcp.Spec.SecurityProfile.AzureKeyVaultKms).NotTo(BeNil())
+	g.Expect(amcp.Spec.SecurityProfile.ImageCleaner).NotTo(BeNil())
+	g.Expect(amcp.Spec.SecurityProfile.ImageCleaner.IntervalHours).NotTo(BeNil())
 	g.Expect(*amcp.Spec.SecurityProfile.ImageCleaner.IntervalHours).To(Equal(48))
 
 	t.Logf("Testing amcp defaulting webhook with overlay")
@@ -163,8 +163,8 @@ func TestDefaultingWebhook(t *testing.T) {
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(amcp.Spec.VirtualNetwork.CIDRBlock).To(Equal(defaultAKSVnetCIDRForOverlay))
 	g.Expect(amcp.Spec.VirtualNetwork.Subnet.CIDRBlock).To(Equal(defaultAKSNodeSubnetCIDRForOverlay))
-	g.Expect(amcp.Spec.AutoUpgradeProfile).ToNot(BeNil())
-	g.Expect(amcp.Spec.AutoUpgradeProfile.UpgradeChannel).ToNot(BeNil())
+	g.Expect(amcp.Spec.AutoUpgradeProfile).NotTo(BeNil())
+	g.Expect(amcp.Spec.AutoUpgradeProfile.UpgradeChannel).NotTo(BeNil())
 	g.Expect(*amcp.Spec.AutoUpgradeProfile.UpgradeChannel).To(Equal(UpgradeChannelRapid))
 }
 
@@ -3994,11 +3994,11 @@ func TestValidateAPIServerAccessProfile(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			g := NewWithT(t)
-			err := validateAPIServerAccessProfile(tc.profile, field.NewPath("profile"))
+			errs := validateAPIServerAccessProfile(tc.profile, field.NewPath("profile"))
 			if tc.expectErr {
-				g.Expect(len(err)).To(BeNumerically("==", 1))
+				g.Expect(errs).To(HaveLen(1))
 			} else {
-				g.Expect(err).To(BeNil())
+				g.Expect(errs).To(BeEmpty())
 			}
 		})
 	}

--- a/azure/converters/identity_test.go
+++ b/azure/converters/identity_test.go
@@ -60,7 +60,7 @@ func Test_VMIdentityToVMSDK(t *testing.T) {
 			Name:         "Should return a system assigned identity when identity is system assigned",
 			identityType: infrav1.VMIdentitySystemAssigned,
 			Expect: func(g *GomegaWithT, m *armcompute.VirtualMachineIdentity, err error) {
-				g.Expect(err).Should(BeNil())
+				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(m).Should(Equal(&armcompute.VirtualMachineIdentity{
 					Type: ptr.To(armcompute.ResourceIdentityTypeSystemAssigned),
 				}))
@@ -71,7 +71,7 @@ func Test_VMIdentityToVMSDK(t *testing.T) {
 			identityType: infrav1.VMIdentityUserAssigned,
 			uami:         []infrav1.UserAssignedIdentity{{ProviderID: "my-uami-1"}, {ProviderID: "my-uami-2"}},
 			Expect: func(g *GomegaWithT, m *armcompute.VirtualMachineIdentity, err error) {
-				g.Expect(err).Should(BeNil())
+				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(m).Should(Equal(&armcompute.VirtualMachineIdentity{
 					Type: ptr.To(armcompute.ResourceIdentityTypeUserAssigned),
 					UserAssignedIdentities: map[string]*armcompute.UserAssignedIdentitiesValue{
@@ -93,7 +93,7 @@ func Test_VMIdentityToVMSDK(t *testing.T) {
 			Name:         "Should return nil if no known identity is specified",
 			identityType: "",
 			Expect: func(g *GomegaWithT, m *armcompute.VirtualMachineIdentity, err error) {
-				g.Expect(err).Should(BeNil())
+				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(m).Should(BeNil())
 			},
 		},
@@ -120,7 +120,7 @@ func Test_UserAssignedIdentitiesToVMSDK(t *testing.T) {
 			Name:           "ShouldPopulateWithData",
 			SubjectFactory: sampleSubjectFactory,
 			Expect: func(g *GomegaWithT, m map[string]*armcompute.UserAssignedIdentitiesValue, err error) {
-				g.Expect(err).Should(BeNil())
+				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(m).Should(Equal(expectedVMSDKObject))
 			},
 		},
@@ -155,7 +155,7 @@ func Test_UserAssignedIdentitiesToVMSSSDK(t *testing.T) {
 			Name:           "ShouldPopulateWithData",
 			SubjectFactory: sampleSubjectFactory,
 			Expect: func(g *GomegaWithT, m map[string]*armcompute.UserAssignedIdentitiesValue, err error) {
-				g.Expect(err).Should(BeNil())
+				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(m).Should(Equal(expectedVMSSSDKObject))
 			},
 		},

--- a/azure/converters/image_test.go
+++ b/azure/converters/image_test.go
@@ -165,7 +165,7 @@ func Test_ComputeImageToSDK(t *testing.T) {
 				},
 			},
 			expect: func(g *GomegaWithT, result *armcompute.ImageReference, err error) {
-				g.Expect(err).Should(BeNil())
+				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(result).To(Equal(&armcompute.ImageReference{
 					ID: ptr.To("/subscriptions/my-subscription-id/resourceGroups/my-resourcegroup/providers/Microsoft.Compute/galleries/my-gallery/images/my-image/versions/my-version"),
 				}))
@@ -183,7 +183,7 @@ func Test_ComputeImageToSDK(t *testing.T) {
 				},
 			},
 			expect: func(g *GomegaWithT, result *armcompute.ImageReference, err error) {
-				g.Expect(err).Should(BeNil())
+				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(result).To(Equal(&armcompute.ImageReference{
 					ID: ptr.To("/subscriptions/my-subscription-id/resourceGroups/my-resourcegroup/providers/Microsoft.Compute/galleries/my-gallery/images/my-image/versions/my-version"),
 				}))
@@ -199,7 +199,7 @@ func Test_ComputeImageToSDK(t *testing.T) {
 				},
 			},
 			expect: func(g *GomegaWithT, result *armcompute.ImageReference, err error) {
-				g.Expect(err).Should(BeNil())
+				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(result).To(Equal(&armcompute.ImageReference{
 					CommunityGalleryImageID: ptr.To("/CommunityGalleries/my-gallery/Images/my-image/Versions/my-version"),
 				}))
@@ -212,7 +212,7 @@ func Test_ComputeImageToSDK(t *testing.T) {
 				SharedGallery:  nil,
 			},
 			expect: func(g *GomegaWithT, result *armcompute.ImageReference, err error) {
-				g.Expect(err).ShouldNot(BeNil())
+				g.Expect(err).Should(HaveOccurred())
 			},
 		},
 	}
@@ -246,7 +246,7 @@ func Test_ImageToSDK(t *testing.T) {
 				},
 			},
 			expect: func(g *GomegaWithT, result *armcompute.ImageReference, err error) {
-				g.Expect(err).Should(BeNil())
+				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(result).To(Equal(&armcompute.ImageReference{
 					ID: ptr.To("/subscriptions/my-subscription-id/resourceGroups/my-resourcegroup/providers/Microsoft.Compute/galleries/my-gallery/images/my-image/versions/my-version"),
 				}))
@@ -264,7 +264,7 @@ func Test_ImageToSDK(t *testing.T) {
 				},
 			},
 			expect: func(g *GomegaWithT, result *armcompute.ImageReference, err error) {
-				g.Expect(err).Should(BeNil())
+				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(result).To(Equal(&armcompute.ImageReference{
 					ID: ptr.To("/subscriptions/my-subscription-id/resourceGroups/my-resourcegroup/providers/Microsoft.Compute/galleries/my-gallery/images/my-image/versions/my-version"),
 				}))
@@ -280,7 +280,7 @@ func Test_ImageToSDK(t *testing.T) {
 				},
 			},
 			expect: func(g *GomegaWithT, result *armcompute.ImageReference, err error) {
-				g.Expect(err).Should(BeNil())
+				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(result).To(Equal(&armcompute.ImageReference{
 					CommunityGalleryImageID: ptr.To("/CommunityGalleries/my-gallery/Images/my-image/Versions/my-version"),
 				}))
@@ -293,7 +293,7 @@ func Test_ImageToSDK(t *testing.T) {
 				SharedGallery:  nil,
 			},
 			expect: func(g *GomegaWithT, result *armcompute.ImageReference, err error) {
-				g.Expect(err).ShouldNot(BeNil())
+				g.Expect(err).Should(HaveOccurred())
 			},
 		},
 		{
@@ -302,7 +302,7 @@ func Test_ImageToSDK(t *testing.T) {
 				ID: ptr.To("my-image-id"),
 			},
 			expect: func(g *GomegaWithT, result *armcompute.ImageReference, err error) {
-				g.Expect(err).Should(BeNil())
+				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(result).To(Equal(&armcompute.ImageReference{
 					ID: ptr.To("my-image-id"),
 				}))
@@ -321,7 +321,7 @@ func Test_ImageToSDK(t *testing.T) {
 				},
 			},
 			expect: func(g *GomegaWithT, result *armcompute.ImageReference, err error) {
-				g.Expect(err).Should(BeNil())
+				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(result).To(Equal(&armcompute.ImageReference{
 					Offer:     ptr.To("my-offer"),
 					Publisher: ptr.To("my-publisher"),

--- a/azure/converters/spotinstances_test.go
+++ b/azure/converters/spotinstances_test.go
@@ -118,7 +118,7 @@ func TestGetSpotVMOptions(t *testing.T) {
 			g.Expect(result.vmPriorityTypes).To(Equal(tt.want.vmPriorityTypes), fmt.Sprintf("got: %v, want: %v", result.vmPriorityTypes, tt.want.vmPriorityTypes))
 			g.Expect(result.vmEvictionPolicyTypes).To(Equal(tt.want.vmEvictionPolicyTypes), fmt.Sprintf("got: %v, want: %v", result.vmEvictionPolicyTypes, tt.want.vmEvictionPolicyTypes))
 			g.Expect(result.billingProfile).To(Equal(tt.want.billingProfile), fmt.Sprintf("got: %v, want: %v", result.billingProfile, tt.want.billingProfile))
-			g.Expect(err).To(BeNil())
+			g.Expect(err).NotTo(HaveOccurred())
 		})
 	}
 }

--- a/azure/scope/cluster_test.go
+++ b/azure/scope/cluster_test.go
@@ -160,6 +160,7 @@ func TestAPIServerHost(t *testing.T) {
 	}
 
 	for _, tc := range tests {
+		tc := tc
 		g := NewWithT(t)
 		scheme := runtime.NewScheme()
 		_ = clusterv1.AddToScheme(scheme)
@@ -277,7 +278,7 @@ func TestGettingSecurityRules(t *testing.T) {
 
 	subnet, err := clusterScope.AzureCluster.Spec.NetworkSpec.GetControlPlaneSubnet()
 	g.Expect(err).NotTo(HaveOccurred())
-	g.Expect(len(subnet.SecurityGroup.SecurityRules)).To(Equal(2))
+	g.Expect(subnet.SecurityGroup.SecurityRules).To(HaveLen(2))
 }
 
 func TestPublicIPSpecs(t *testing.T) {
@@ -2482,7 +2483,7 @@ func TestBackendPoolName(t *testing.T) {
 			clusterScope.AzureCluster.SetBackendPoolNameDefault()
 			g.Expect(err).NotTo(HaveOccurred())
 			got := clusterScope.LBSpecs()
-			g.Expect(len(got)).To(Equal(3))
+			g.Expect(got).To(HaveLen(3))
 
 			// API server backend pool name
 			apiServerLBSpec := got[0].(*loadbalancers.LBSpec)

--- a/azure/scope/machinepool_test.go
+++ b/azure/scope/machinepool_test.go
@@ -1326,6 +1326,7 @@ func TestMachinePoolScope_SetInfrastructureMachineKind(t *testing.T) {
 	}
 
 	for _, tt := range testcases {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
 
@@ -1378,7 +1379,7 @@ func TestMachinePoolScope_applyAzureMachinePoolMachines(t *testing.T) {
 				g.Expect(err).NotTo(HaveOccurred())
 				list := clusterv1.MachineList{}
 				g.Expect(c.List(ctx, &list)).NotTo(HaveOccurred())
-				g.Expect(len(list.Items)).Should(Equal(2))
+				g.Expect(list.Items).Should(HaveLen(2))
 			},
 		},
 		{
@@ -1407,7 +1408,7 @@ func TestMachinePoolScope_applyAzureMachinePoolMachines(t *testing.T) {
 				g.Expect(err).NotTo(HaveOccurred())
 				list := clusterv1.MachineList{}
 				g.Expect(c.List(ctx, &list)).NotTo(HaveOccurred())
-				g.Expect(len(list.Items)).Should(Equal(1))
+				g.Expect(list.Items).Should(HaveLen(1))
 			},
 		},
 		{
@@ -1426,7 +1427,7 @@ func TestMachinePoolScope_applyAzureMachinePoolMachines(t *testing.T) {
 				g.Expect(err).NotTo(HaveOccurred())
 				list := infrav1exp.AzureMachinePoolMachineList{}
 				g.Expect(c.List(ctx, &list)).NotTo(HaveOccurred())
-				g.Expect(len(list.Items)).Should(Equal(1))
+				g.Expect(list.Items).Should(HaveLen(1))
 			},
 		},
 		{

--- a/azure/scope/machinepoolmachine_test.go
+++ b/azure/scope/machinepoolmachine_test.go
@@ -306,6 +306,7 @@ func TestMachineScope_updateDeleteMachineAnnotation(t *testing.T) {
 	}
 
 	for _, c := range cases {
+		c := c
 		t.Run(c.name, func(t *testing.T) {
 			g := NewWithT(t)
 
@@ -349,7 +350,7 @@ func TestMachineScope_UpdateNodeStatus(t *testing.T) {
 				return nil, ampm
 			},
 			Verify: func(g *WithT, scope *MachinePoolMachineScope) {
-				g.Expect(scope.AzureMachinePoolMachine.Status.Ready).To(Equal(true))
+				g.Expect(scope.AzureMachinePoolMachine.Status.Ready).To(BeTrue())
 				g.Expect(scope.AzureMachinePoolMachine.Status.Version).To(Equal("1.2.3"))
 				g.Expect(scope.AzureMachinePoolMachine.Status.NodeRef).To(Equal(&corev1.ObjectReference{
 					Name: "node1",
@@ -364,7 +365,7 @@ func TestMachineScope_UpdateNodeStatus(t *testing.T) {
 				return nil, ampm
 			},
 			Verify: func(g *WithT, scope *MachinePoolMachineScope) {
-				g.Expect(scope.AzureMachinePoolMachine.Status.Ready).To(Equal(false))
+				g.Expect(scope.AzureMachinePoolMachine.Status.Ready).To(BeFalse())
 				g.Expect(scope.AzureMachinePoolMachine.Status.Version).To(Equal("1.2.3"))
 				g.Expect(scope.AzureMachinePoolMachine.Status.NodeRef).To(Equal(&corev1.ObjectReference{
 					Name: "node1",
@@ -401,7 +402,7 @@ func TestMachineScope_UpdateNodeStatus(t *testing.T) {
 				return nil, ampm
 			},
 			Verify: func(g *WithT, scope *MachinePoolMachineScope) {
-				g.Expect(scope.AzureMachinePoolMachine.Status.Ready).To(Equal(true))
+				g.Expect(scope.AzureMachinePoolMachine.Status.Ready).To(BeTrue())
 				g.Expect(scope.AzureMachinePoolMachine.Status.Version).To(Equal("1.2.3"))
 				g.Expect(scope.AzureMachinePoolMachine.Status.NodeRef).To(Equal(&corev1.ObjectReference{
 					Name: "node1",

--- a/azure/scope/strategies/machinepool_deployments/machinepool_deployment_strategy_test.go
+++ b/azure/scope/strategies/machinepool_deployments/machinepool_deployment_strategy_test.go
@@ -299,7 +299,7 @@ func TestMachinePoolRollingUpdateStrategy_SelectMachinesToDelete(t *testing.T) {
 			}),
 		},
 		{
-			name:            "if over-provisioned and has delete machine annotation, select those machines machines first followed by newest",
+			name:            "if over-provisioned and has delete machine annotation, select those machines first followed by newest",
 			strategy:        makeRollingUpdateStrategy(infrav1exp.MachineRollingUpdateDeployment{DeletePolicy: infrav1exp.NewestDeletePolicyType}),
 			desiredReplicas: 2,
 			input: map[string]infrav1exp.AzureMachinePoolMachine{

--- a/azure/services/agentpools/spec_test.go
+++ b/azure/services/agentpools/spec_test.go
@@ -153,7 +153,7 @@ func TestParameters(t *testing.T) {
 		g.Expect(actual.Spec.AzureName).To(Equal("managed by CAPZ"))
 		g.Expect(actual.Spec.Count).To(Equal(ptr.To(1212)))
 		g.Expect(actual.Spec.PowerState.Code).To(Equal(ptr.To(asocontainerservicev1.PowerState_Code("set by the user"))))
-		g.Expect(actual.Spec.OrchestratorVersion).ToNot(BeNil())
+		g.Expect(actual.Spec.OrchestratorVersion).NotTo(BeNil())
 		g.Expect(*actual.Spec.OrchestratorVersion).To(Equal("1.27.2"))
 	})
 }

--- a/azure/services/aso/aso_test.go
+++ b/azure/services/aso/aso_test.go
@@ -128,7 +128,7 @@ func TestCreateOrUpdateResource(t *testing.T) {
 
 		result, err := s.CreateOrUpdateResource(ctx, specMock, "service")
 		g.Expect(result).To(BeNil())
-		g.Expect(err).NotTo(BeNil())
+		g.Expect(err).To(HaveOccurred())
 		g.Expect(err.Error()).To(ContainSubstring("ready status unknown"))
 	})
 
@@ -158,7 +158,7 @@ func TestCreateOrUpdateResource(t *testing.T) {
 		ctx := context.Background()
 		result, err := s.CreateOrUpdateResource(ctx, specMock, "service")
 		g.Expect(result).To(BeNil())
-		g.Expect(err).NotTo(BeNil())
+		g.Expect(err).To(HaveOccurred())
 		g.Expect(azure.IsOperationNotDoneError(err)).To(BeTrue())
 		var recerr azure.ReconcileError
 		g.Expect(errors.As(err, &recerr)).To(BeTrue())
@@ -223,7 +223,7 @@ func TestCreateOrUpdateResource(t *testing.T) {
 
 		result, err := s.CreateOrUpdateResource(ctx, specMock, "service")
 		g.Expect(result).To(BeNil())
-		g.Expect(err).NotTo(BeNil())
+		g.Expect(err).To(HaveOccurred())
 		g.Expect(err.Error()).To(ContainSubstring("resource is not Ready"))
 		var recerr azure.ReconcileError
 		g.Expect(errors.As(err, &recerr)).To(BeTrue())
@@ -325,7 +325,7 @@ func TestCreateOrUpdateResource(t *testing.T) {
 
 		result, err := s.CreateOrUpdateResource(ctx, specMock, "service")
 		g.Expect(result).To(BeNil())
-		g.Expect(err).NotTo(BeNil())
+		g.Expect(err).To(HaveOccurred())
 		g.Expect(err.Error()).To(ContainSubstring("resource is not Ready"))
 		var recerr azure.ReconcileError
 		g.Expect(errors.As(err, &recerr)).To(BeTrue())
@@ -354,7 +354,7 @@ func TestCreateOrUpdateResource(t *testing.T) {
 		ctx := context.Background()
 		result, err := s.CreateOrUpdateResource(ctx, specMock, "service")
 		g.Expect(result).To(BeNil())
-		g.Expect(err).NotTo(BeNil())
+		g.Expect(err).To(HaveOccurred())
 		g.Expect(err.Error()).To(ContainSubstring("failed to get existing resource"))
 	})
 
@@ -400,7 +400,7 @@ func TestCreateOrUpdateResource(t *testing.T) {
 
 		result, err := s.CreateOrUpdateResource(ctx, specMock, "service")
 		g.Expect(result).To(BeNil())
-		g.Expect(err).NotTo(BeNil())
+		g.Expect(err).To(HaveOccurred())
 	})
 
 	t.Run("adopt managed resource in not found state", func(t *testing.T) {
@@ -448,7 +448,7 @@ func TestCreateOrUpdateResource(t *testing.T) {
 
 		result, err := s.CreateOrUpdateResource(ctx, specMock, "service")
 		g.Expect(result).To(BeNil())
-		g.Expect(err).NotTo(BeNil())
+		g.Expect(err).To(HaveOccurred())
 
 		updated := &asoresourcesv1.ResourceGroup{}
 		g.Expect(c.Get(ctx, types.NamespacedName{Name: "name", Namespace: "namespace"}, updated)).To(Succeed())
@@ -503,7 +503,7 @@ func TestCreateOrUpdateResource(t *testing.T) {
 
 		result, err := s.CreateOrUpdateResource(ctx, specMock, "service")
 		g.Expect(result).To(BeNil())
-		g.Expect(err).NotTo(BeNil())
+		g.Expect(err).To(HaveOccurred())
 
 		updated := &asoresourcesv1.ResourceGroup{}
 		g.Expect(c.Get(ctx, types.NamespacedName{Name: "name", Namespace: "namespace"}, updated)).To(Succeed())
@@ -561,7 +561,7 @@ func TestCreateOrUpdateResource(t *testing.T) {
 
 		result, err := s.CreateOrUpdateResource(ctx, specMock, "service")
 		g.Expect(result).To(BeNil())
-		g.Expect(err).NotTo(BeNil())
+		g.Expect(err).To(HaveOccurred())
 
 		updated := &asoresourcesv1.ResourceGroup{}
 		g.Expect(c.Get(ctx, types.NamespacedName{Name: "name", Namespace: "namespace"}, updated)).To(Succeed())
@@ -610,7 +610,7 @@ func TestCreateOrUpdateResource(t *testing.T) {
 
 		result, err := s.CreateOrUpdateResource(ctx, specMock, "service")
 		g.Expect(result).To(BeNil())
-		g.Expect(err).NotTo(BeNil())
+		g.Expect(err).To(HaveOccurred())
 		g.Expect(err.Error()).To(ContainSubstring("parameters error"))
 	})
 
@@ -650,7 +650,7 @@ func TestCreateOrUpdateResource(t *testing.T) {
 
 		result, err := s.CreateOrUpdateResource(ctx, specMock, "service")
 		g.Expect(result).NotTo(BeNil())
-		g.Expect(err).To(BeNil())
+		g.Expect(err).NotTo(HaveOccurred())
 	})
 
 	t.Run("resource up to date", func(t *testing.T) {
@@ -701,7 +701,7 @@ func TestCreateOrUpdateResource(t *testing.T) {
 
 		result, err := s.CreateOrUpdateResource(ctx, specMock, "service")
 		g.Expect(result).NotTo(BeNil())
-		g.Expect(err).To(BeNil())
+		g.Expect(err).NotTo(HaveOccurred())
 
 		g.Expect(result.GetName()).To(Equal("name"))
 		g.Expect(result.GetNamespace()).To(Equal("namespace"))
@@ -750,7 +750,7 @@ func TestCreateOrUpdateResource(t *testing.T) {
 
 		result, err := s.CreateOrUpdateResource(ctx, specMock, "service")
 		g.Expect(result).To(BeNil())
-		g.Expect(err).NotTo(BeNil())
+		g.Expect(err).To(HaveOccurred())
 		g.Expect(err.Error()).To(ContainSubstring("failed to update resource"))
 	})
 
@@ -944,8 +944,7 @@ func TestDeleteResource(t *testing.T) {
 		}
 
 		ctx := context.Background()
-		err := s.DeleteResource(ctx, resource, "service")
-		g.Expect(err).To(BeNil())
+		g.Expect(s.DeleteResource(ctx, resource, "service")).To(Succeed())
 	})
 
 	t.Run("delete in progress", func(t *testing.T) {
@@ -969,7 +968,7 @@ func TestDeleteResource(t *testing.T) {
 		g.Expect(c.Create(ctx, resource)).To(Succeed())
 
 		err := s.DeleteResource(ctx, resource, "service")
-		g.Expect(err).NotTo(BeNil())
+		g.Expect(err).To(HaveOccurred())
 		g.Expect(azure.IsOperationNotDoneError(err)).To(BeTrue())
 		var recerr azure.ReconcileError
 		g.Expect(errors.As(err, &recerr)).To(BeTrue())
@@ -996,8 +995,7 @@ func TestDeleteResource(t *testing.T) {
 		ctx := context.Background()
 		g.Expect(c.Create(ctx, resource)).To(Succeed())
 
-		err := s.DeleteResource(ctx, resource, "service")
-		g.Expect(err).To(BeNil())
+		g.Expect(s.DeleteResource(ctx, resource, "service")).To(Succeed())
 	})
 
 	t.Run("error checking if resource is managed", func(t *testing.T) {
@@ -1046,7 +1044,7 @@ func TestDeleteResource(t *testing.T) {
 		g.Expect(c.Create(ctx, resource)).To(Succeed())
 
 		err := s.DeleteResource(ctx, resource, "service")
-		g.Expect(err).NotTo(BeNil())
+		g.Expect(err).To(HaveOccurred())
 		g.Expect(err.Error()).To(ContainSubstring("failed to delete resource"))
 	})
 }

--- a/azure/services/groups/groups_test.go
+++ b/azure/services/groups/groups_test.go
@@ -159,7 +159,7 @@ func TestIsManaged(t *testing.T) {
 			scopeMock := mock_groups.NewMockGroupScope(mockCtrl)
 
 			scheme := runtime.NewScheme()
-			g.Expect(asoresourcesv1.AddToScheme(scheme))
+			g.Expect(asoresourcesv1.AddToScheme(scheme)).To(Succeed())
 			ctrlClient := fakeclient.NewClientBuilder().
 				WithScheme(scheme).
 				WithObjects(test.objects...).

--- a/azure/services/inboundnatrules/inboundnatrules_test.go
+++ b/azure/services/inboundnatrules/inboundnatrules_test.go
@@ -111,7 +111,7 @@ func TestReconcileInboundNATRule(t *testing.T) {
 			},
 		},
 		{
-			name:          "NAT rule successfully created with with no existing rules",
+			name:          "NAT rule successfully created with no existing rules",
 			expectedError: "",
 			expect: func(s *mock_inboundnatrules.MockInboundNatScopeMockRecorder,
 				m *mock_inboundnatrules.MockclientMockRecorder,
@@ -129,7 +129,7 @@ func TestReconcileInboundNATRule(t *testing.T) {
 			},
 		},
 		{
-			name:          "NAT rule successfully created with with existing rules",
+			name:          "NAT rule successfully created with existing rules",
 			expectedError: "",
 			expect: func(s *mock_inboundnatrules.MockInboundNatScopeMockRecorder,
 				m *mock_inboundnatrules.MockclientMockRecorder,

--- a/azure/services/managedclusters/spec_test.go
+++ b/azure/services/managedclusters/spec_test.go
@@ -92,7 +92,7 @@ func TestParameters(t *testing.T) {
 			},
 			Identity: &infrav1.Identity{
 				Type:                           infrav1.ManagedControlPlaneIdentityType(asocontainerservicev1.ManagedClusterIdentity_Type_UserAssigned),
-				UserAssignedIdentityResourceID: "user assigned id id",
+				UserAssignedIdentityResourceID: "user assigned id",
 			},
 			KubeletUserAssignedIdentity: "kubelet id",
 			HTTPProxyConfig: &HTTPProxyConfig{
@@ -168,7 +168,7 @@ func TestParameters(t *testing.T) {
 					UserAssignedIdentities: []asocontainerservicev1.UserAssignedIdentityDetails{
 						{
 							Reference: genruntime.ResourceReference{
-								ARMID: "user assigned id id",
+								ARMID: "user assigned id",
 							},
 						},
 					},
@@ -316,7 +316,7 @@ func TestParameters(t *testing.T) {
 		g.Expect(actual.Spec.Tags).To(BeNil())
 		g.Expect(actual.Spec.DnsPrefix).To(Equal(ptr.To("managed by CAPZ")))
 		g.Expect(actual.Spec.EnablePodSecurityPolicy).To(Equal(ptr.To(true)))
-		g.Expect(actual.Spec.KubernetesVersion).ToNot(BeNil())
+		g.Expect(actual.Spec.KubernetesVersion).NotTo(BeNil())
 		g.Expect(*actual.Spec.KubernetesVersion).To(Equal("1.26.6"))
 	})
 	t.Run("updating existing managed cluster to a non nil DNS Service IP", func(t *testing.T) {

--- a/azure/services/virtualmachines/spec_test.go
+++ b/azure/services/virtualmachines/spec_test.go
@@ -361,7 +361,7 @@ func TestParameters(t *testing.T) {
 				g.Expect(result.(armcompute.VirtualMachine).Properties.StorageProfile.OSDisk.OSType).To(Equal(ptr.To(armcompute.OperatingSystemTypesWindows)))
 				g.Expect(*result.(armcompute.VirtualMachine).Properties.OSProfile.AdminPassword).Should(HaveLen(123))
 				g.Expect(*result.(armcompute.VirtualMachine).Properties.OSProfile.AdminUsername).Should(Equal("capi"))
-				g.Expect(*result.(armcompute.VirtualMachine).Properties.OSProfile.WindowsConfiguration.EnableAutomaticUpdates).Should(Equal(false))
+				g.Expect(*result.(armcompute.VirtualMachine).Properties.OSProfile.WindowsConfiguration.EnableAutomaticUpdates).Should(BeFalse())
 			},
 			expectedError: "",
 		},
@@ -408,7 +408,7 @@ func TestParameters(t *testing.T) {
 			existing: nil,
 			expect: func(g *WithT, result interface{}) {
 				g.Expect(result).To(BeAssignableToTypeOf(armcompute.VirtualMachine{}))
-				g.Expect(*result.(armcompute.VirtualMachine).Properties.SecurityProfile.EncryptionAtHost).To(Equal(true))
+				g.Expect(*result.(armcompute.VirtualMachine).Properties.SecurityProfile.EncryptionAtHost).To(BeTrue())
 			},
 			expectedError: "",
 		},

--- a/azure/services/virtualmachines/virtualmachines.go
+++ b/azure/services/virtualmachines/virtualmachines.go
@@ -39,6 +39,7 @@ import (
 )
 
 const serviceName = "virtualmachine"
+const vmMissingUAI = "VM is missing expected user assigned identity with client ID: "
 
 // VMScope defines the scope interface for a virtual machines service.
 type VMScope interface {
@@ -191,7 +192,7 @@ func (s *Service) checkUserAssignedIdentities(ctx context.Context, specIdentitie
 	for expectedKey := range expectedMap {
 		_, exists := actualMap[expectedKey]
 		if !exists {
-			s.Scope.SetConditionFalse(infrav1.VMIdentitiesReadyCondition, infrav1.UserAssignedIdentityMissingReason, clusterv1.ConditionSeverityWarning, "VM is missing expected user assigned identity with client ID: "+expectedKey)
+			s.Scope.SetConditionFalse(infrav1.VMIdentitiesReadyCondition, infrav1.UserAssignedIdentityMissingReason, clusterv1.ConditionSeverityWarning, vmMissingUAI+expectedKey)
 			return nil
 		}
 	}

--- a/azure/services/virtualmachines/virtualmachines_test.go
+++ b/azure/services/virtualmachines/virtualmachines_test.go
@@ -346,7 +346,7 @@ func TestCheckUserAssignedIdentities(t *testing.T) {
 			expect: func(s *mock_virtualmachines.MockVMScopeMockRecorder, i *mock_identities.MockClientMockRecorder) {
 				i.GetClientID(gomockinternal.AContext(), fakeUserAssignedIdentity.ProviderID).AnyTimes().Return(fakeUserAssignedIdentity.ProviderID, nil)
 				i.GetClientID(gomockinternal.AContext(), fakeUserAssignedIdentity2.ProviderID).AnyTimes().Return(fakeUserAssignedIdentity2.ProviderID, nil)
-				s.SetConditionFalse(infrav1.VMIdentitiesReadyCondition, infrav1.UserAssignedIdentityMissingReason, clusterv1.ConditionSeverityWarning, "VM is missing expected user assigned identity with client ID: "+fakeUserAssignedIdentity2.ProviderID).Times(1)
+				s.SetConditionFalse(infrav1.VMIdentitiesReadyCondition, infrav1.UserAssignedIdentityMissingReason, clusterv1.ConditionSeverityWarning, vmMissingUAI+fakeUserAssignedIdentity2.ProviderID).Times(1)
 			},
 			expectedError: "",
 		},
@@ -365,7 +365,7 @@ func TestCheckUserAssignedIdentities(t *testing.T) {
 			actualIdentities: []infrav1.UserAssignedIdentity{fakeUserAssignedIdentity2},
 			expect: func(s *mock_virtualmachines.MockVMScopeMockRecorder, i *mock_identities.MockClientMockRecorder) {
 				i.GetClientID(gomockinternal.AContext(), fakeUserAssignedIdentity.ProviderID).AnyTimes().Return(fakeUserAssignedIdentity.ProviderID, nil)
-				s.SetConditionFalse(infrav1.VMIdentitiesReadyCondition, infrav1.UserAssignedIdentityMissingReason, clusterv1.ConditionSeverityWarning, "VM is missing expected user assigned identity with client ID: "+fakeUserAssignedIdentity.ProviderID).Times(1)
+				s.SetConditionFalse(infrav1.VMIdentitiesReadyCondition, infrav1.UserAssignedIdentityMissingReason, clusterv1.ConditionSeverityWarning, vmMissingUAI+fakeUserAssignedIdentity.ProviderID).Times(1)
 			},
 			expectedError: "",
 		},

--- a/controllers/azurecluster_controller.go
+++ b/controllers/azurecluster_controller.go
@@ -263,6 +263,7 @@ func (acr *AzureClusterReconciler) reconcileNormal(ctx context.Context, clusterS
 	return reconcile.Result{}, nil
 }
 
+//nolint:unparam // Always returns an empty struct for reconcile.Result
 func (acr *AzureClusterReconciler) reconcilePause(ctx context.Context, clusterScope *scope.ClusterScope) (reconcile.Result, error) {
 	ctx, log, done := tele.StartSpanWithLogger(ctx, "controllers.AzureClusterReconciler.reconcilePause")
 	defer done()

--- a/controllers/azurecluster_controller_test.go
+++ b/controllers/azurecluster_controller_test.go
@@ -79,7 +79,7 @@ var _ = Describe("AzureClusterReconciler", func() {
 				},
 			})
 
-			Expect(err).To(BeNil())
+			Expect(err).NotTo(HaveOccurred())
 			Expect(result.RequeueAfter).To(BeZero())
 		})
 	})
@@ -349,7 +349,7 @@ func TestAzureClusterReconcilePaused(t *testing.T) {
 		},
 	})
 
-	g.Expect(err).To(BeNil())
+	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(result.RequeueAfter).To(BeZero())
 
 	g.Eventually(recorder.Events).Should(Receive(Equal("Normal ClusterPaused AzureCluster or linked Cluster is marked as paused. Won't reconcile normally")))

--- a/controllers/azurejson_machinepool_controller_test.go
+++ b/controllers/azurejson_machinepool_controller_test.go
@@ -250,7 +250,7 @@ func TestAzureJSONPoolReconcilerUserAssignedIdentities(t *testing.T) {
 	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: "fake-machine-pool", Namespace: "fake-ns"}}
 	ctx := context.Background()
 	scheme, err := newScheme()
-	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(err).NotTo(HaveOccurred())
 
 	azureMP := &infrav1exp.AzureMachinePool{
 		ObjectMeta: metav1.ObjectMeta{
@@ -386,5 +386,5 @@ func TestAzureJSONPoolReconcilerUserAssignedIdentities(t *testing.T) {
 	}
 
 	_, err = rec.Reconcile(ctx, req)
-	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(err).NotTo(HaveOccurred())
 }

--- a/controllers/azuremachine_controller.go
+++ b/controllers/azuremachine_controller.go
@@ -343,6 +343,7 @@ func (amr *AzureMachineReconciler) reconcileNormal(ctx context.Context, machineS
 	return reconcile.Result{}, nil
 }
 
+//nolint:unparam // Always returns an empty struct for reconcile.Result
 func (amr *AzureMachineReconciler) reconcilePause(ctx context.Context, machineScope *scope.MachineScope) (reconcile.Result, error) {
 	ctx, log, done := tele.StartSpanWithLogger(ctx, "controllers.AzureMachine.reconcilePause")
 	defer done()

--- a/controllers/azuremachine_controller_test.go
+++ b/controllers/azuremachine_controller_test.go
@@ -116,6 +116,7 @@ func TestAzureMachineReconcile(t *testing.T) {
 				defaultAzureCluster,
 				defaultAzureMachine,
 				defaultMachine,
+				defaultAzureClusterIdentity,
 			},
 			event: "Unable to get cluster from metadata",
 		},
@@ -124,6 +125,7 @@ func TestAzureMachineReconcile(t *testing.T) {
 				defaultCluster,
 				defaultAzureMachine,
 				defaultMachine,
+				defaultAzureClusterIdentity,
 			},
 			event: "AzureCluster unavailable",
 		},
@@ -141,7 +143,7 @@ func TestAzureMachineReconcile(t *testing.T) {
 
 			resultIdentity := &infrav1.AzureClusterIdentity{}
 			key := client.ObjectKey{Name: defaultAzureClusterIdentity.Name, Namespace: defaultAzureClusterIdentity.Namespace}
-			g.Expect(fakeClient.Get(context.TODO(), key, resultIdentity))
+			g.Expect(fakeClient.Get(context.TODO(), key, resultIdentity)).To(Succeed())
 
 			reconciler := &AzureMachineReconciler{
 				Client:   fakeClient,
@@ -251,7 +253,7 @@ func TestAzureMachineReconcileNormal(t *testing.T) {
 				g.Expect(machineScope.AzureMachine.Status.Ready).To(BeTrue())
 			}
 			if tc.machineScopeFailureReason != "" {
-				g.Expect(machineScope.AzureMachine.Status.FailureReason).ToNot(BeNil())
+				g.Expect(machineScope.AzureMachine.Status.FailureReason).NotTo(BeNil())
 				g.Expect(*machineScope.AzureMachine.Status.FailureReason).To(Equal(tc.machineScopeFailureReason))
 			}
 			if tc.expectedErr != "" {
@@ -779,7 +781,7 @@ func TestConditions(t *testing.T) {
 			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(initObjects...).Build()
 			resultIdentity := &infrav1.AzureClusterIdentity{}
 			key := client.ObjectKey{Name: azureClusterIdentity.Name, Namespace: azureClusterIdentity.Namespace}
-			g.Expect(fakeClient.Get(context.TODO(), key, resultIdentity))
+			g.Expect(fakeClient.Get(context.TODO(), key, resultIdentity)).To(Succeed())
 			recorder := record.NewFakeRecorder(10)
 
 			reconciler := NewAzureMachineReconciler(fakeClient, recorder, reconciler.Timeouts{}, "")
@@ -803,7 +805,7 @@ func TestConditions(t *testing.T) {
 			_, err = reconciler.reconcileNormal(context.TODO(), machineScope, clusterScope)
 			g.Expect(err).NotTo(HaveOccurred())
 
-			g.Expect(len(machineScope.AzureMachine.GetConditions())).To(Equal(len(tc.expectedConditions)))
+			g.Expect(machineScope.AzureMachine.GetConditions()).To(HaveLen(len(tc.expectedConditions)))
 			for i, c := range machineScope.AzureMachine.GetConditions() {
 				g.Expect(conditionsMatch(c, tc.expectedConditions[i])).To(BeTrue())
 			}

--- a/controllers/azuremanagedcontrolplane_controller.go
+++ b/controllers/azuremanagedcontrolplane_controller.go
@@ -283,6 +283,7 @@ func (amcpr *AzureManagedControlPlaneReconciler) reconcileNormal(ctx context.Con
 	return reconcile.Result{}, nil
 }
 
+//nolint:unparam // Always returns an empty struct for reconcile.Result
 func (amcpr *AzureManagedControlPlaneReconciler) reconcilePause(ctx context.Context, scope *scope.ManagedControlPlaneScope) (reconcile.Result, error) {
 	ctx, log, done := tele.StartSpanWithLogger(ctx, "controllers.AzureManagedControlPlane.reconcilePause")
 	defer done()

--- a/controllers/azuremanagedcontrolplane_controller_test.go
+++ b/controllers/azuremanagedcontrolplane_controller_test.go
@@ -252,7 +252,7 @@ func TestAzureManagedControlPlaneReconcilePaused(t *testing.T) {
 		},
 	})
 
-	g.Expect(err).To(BeNil())
+	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(result.RequeueAfter).To(BeZero())
 }
 
@@ -275,7 +275,7 @@ func TestAzureManagedControlPlaneReconcileNormal(t *testing.T) {
 		},
 	}
 	scheme, err := newScheme()
-	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(err).NotTo(HaveOccurred())
 
 	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cp).WithStatusSubresource(cp).Build()
 	amcpr := &AzureManagedControlPlaneReconciler{
@@ -283,7 +283,7 @@ func TestAzureManagedControlPlaneReconcileNormal(t *testing.T) {
 	}
 
 	helper, err := patch.NewHelper(cp, client)
-	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(err).NotTo(HaveOccurred())
 
 	scopes := &scope.ManagedControlPlaneScope{
 		Cluster: &clusterv1.Cluster{

--- a/controllers/azuremanagedmachinepool_controller.go
+++ b/controllers/azuremanagedmachinepool_controller.go
@@ -300,6 +300,7 @@ func (ammpr *AzureManagedMachinePoolReconciler) reconcileNormal(ctx context.Cont
 	return reconcile.Result{}, nil
 }
 
+//nolint:unparam // Always returns an empty struct for reconcile.Result
 func (ammpr *AzureManagedMachinePoolReconciler) reconcilePause(ctx context.Context, scope *scope.ManagedMachinePoolScope) (reconcile.Result, error) {
 	ctx, log, done := tele.StartSpanWithLogger(ctx, "controllers.AzureManagedMachinePool.reconcilePause")
 	defer done()

--- a/exp/api/v1beta1/azuremachinepool_default_test.go
+++ b/exp/api/v1beta1/azuremachinepool_default_test.go
@@ -44,11 +44,11 @@ func TestAzureMachinePool_SetDefaultSSHPublicKey(t *testing.T) {
 	publicKeyNotExistTest := test{amp: createMachinePoolWithSSHPublicKey("")}
 
 	err := publicKeyExistTest.amp.SetDefaultSSHPublicKey()
-	g.Expect(err).To(BeNil())
+	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(publicKeyExistTest.amp.Spec.Template.SSHPublicKey).To(Equal(existingPublicKey))
 
 	err = publicKeyNotExistTest.amp.SetDefaultSSHPublicKey()
-	g.Expect(err).To(BeNil())
+	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(publicKeyNotExistTest.amp.Spec.Template.SSHPublicKey).NotTo(BeEmpty())
 }
 
@@ -280,7 +280,7 @@ func TestAzureMachinePool_SetSpotEvictionPolicyDefaults(t *testing.T) {
 		machinePool *AzureMachinePool
 	}
 
-	// test to Ensure the the default policy is set to Deallocate if EvictionPolicy is nil
+	// test to Ensure the default policy is set to Deallocate if EvictionPolicy is nil
 	defaultEvictionPolicy := infrav1.SpotEvictionPolicyDeallocate
 	nilDiffDiskSettingsPolicy := test{machinePool: &AzureMachinePool{
 		Spec: AzureMachinePoolSpec{
@@ -294,7 +294,7 @@ func TestAzureMachinePool_SetSpotEvictionPolicyDefaults(t *testing.T) {
 	nilDiffDiskSettingsPolicy.machinePool.SetSpotEvictionPolicyDefaults()
 	g.Expect(nilDiffDiskSettingsPolicy.machinePool.Spec.Template.SpotVMOptions.EvictionPolicy).To(Equal(&defaultEvictionPolicy))
 
-	// test to Ensure the the default policy is set to Delete if diffDiskSettings option is set to "Local"
+	// test to Ensure the default policy is set to Delete if diffDiskSettings option is set to "Local"
 	expectedEvictionPolicy := infrav1.SpotEvictionPolicyDelete
 	diffDiskSettingsPolicy := test{machinePool: &AzureMachinePool{
 		Spec: AzureMachinePoolSpec{

--- a/exp/api/v1beta1/azuremachinepool_test.go
+++ b/exp/api/v1beta1/azuremachinepool_test.go
@@ -160,7 +160,7 @@ func TestAzureMachinePool_Validate(t *testing.T) {
 				}
 			},
 			Expect: func(g *gomega.GomegaWithT, actual error) {
-				g.Expect(actual).ToNot(gomega.HaveOccurred())
+				g.Expect(actual).NotTo(gomega.HaveOccurred())
 			},
 		},
 		{

--- a/exp/controllers/azuremachinepool_controller.go
+++ b/exp/controllers/azuremachinepool_controller.go
@@ -354,6 +354,7 @@ func (ampr *AzureMachinePoolReconciler) reconcileNormal(ctx context.Context, mac
 	return reconcile.Result{}, nil
 }
 
+//nolint:unparam // Always returns an empty struct for reconcile.Result
 func (ampr *AzureMachinePoolReconciler) reconcilePause(ctx context.Context, machinePoolScope *scope.MachinePoolScope) (reconcile.Result, error) {
 	ctx, log, done := tele.StartSpanWithLogger(ctx, "controllers.AzureMachinePoolReconciler.reconcilePause")
 	defer done()
@@ -373,6 +374,7 @@ func (ampr *AzureMachinePoolReconciler) reconcilePause(ctx context.Context, mach
 	return reconcile.Result{}, nil
 }
 
+//nolint:unparam // Always returns an empty struct for reconcile.Result
 func (ampr *AzureMachinePoolReconciler) reconcileDelete(ctx context.Context, machinePoolScope *scope.MachinePoolScope, clusterScope infracontroller.ClusterScoper) (reconcile.Result, error) {
 	ctx, log, done := tele.StartSpanWithLogger(ctx, "controllers.AzureMachinePoolReconciler.reconcileDelete")
 	defer done()

--- a/exp/controllers/azuremachinepool_controller_test.go
+++ b/exp/controllers/azuremachinepool_controller_test.go
@@ -53,7 +53,7 @@ var _ = Describe("AzureMachinePoolReconciler", func() {
 					Name:      instance.Name,
 				},
 			})
-			Expect(err).To(BeNil())
+			Expect(err).NotTo(HaveOccurred())
 			Expect(result.RequeueAfter).To(BeZero())
 		})
 	})
@@ -184,6 +184,6 @@ func TestAzureMachinePoolReconcilePaused(t *testing.T) {
 		},
 	})
 
-	g.Expect(err).To(BeNil())
+	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(result.RequeueAfter).To(BeZero())
 }

--- a/pkg/coalescing/reconciler.go
+++ b/pkg/coalescing/reconciler.go
@@ -77,7 +77,7 @@ func (cache *ReconcileCache) Reconciled(key string) {
 
 // NewReconciler returns a reconcile wrapper that will delay new reconcile.Requests
 // after the cache expiry of the request string key.
-// A successful reconciliation is defined as as one where no error is returned.
+// A successful reconciliation is defined as one where no error is returned.
 func NewReconciler(upstream reconcile.Reconciler, cache ReconcileCacher, log logr.Logger) reconcile.Reconciler {
 	return &reconciler{
 		upstream: upstream,

--- a/test/e2e/aks.go
+++ b/test/e2e/aks.go
@@ -215,5 +215,5 @@ func WaitForAKSSystemNodePoolMachinesToExist(ctx context.Context, input WaitForC
 		}
 
 		return false
-	}, intervals...).Should(Equal(true), "System machine pools not detected")
+	}, intervals...).Should(BeTrue(), "System machine pools not detected")
 }

--- a/test/e2e/aks_azure_cluster_autoscaler.go
+++ b/test/e2e/aks_azure_cluster_autoscaler.go
@@ -108,7 +108,7 @@ func AKSAzureClusterAutoscalerSettingsSpec(ctx context.Context, inputGetter func
 		aks, err := containerserviceClient.Get(ctx, amcp.Spec.ResourceGroupName, amcp.Name, nil)
 		g.Expect(err).NotTo(HaveOccurred())
 		g.Expect(aks.Properties.ProvisioningState).To(Equal(ptr.To("Succeeded")))
-		g.Expect(aks.Properties.AutoScalerProfile).ToNot(BeNil())
+		g.Expect(aks.Properties.AutoScalerProfile).NotTo(BeNil())
 		g.Expect(aks.Properties.AutoScalerProfile.Expander).To(Equal(&expectedAksExpander))
 	}, input.WaitIntervals...).Should(Succeed())
 

--- a/test/e2e/azure_csidriver.go
+++ b/test/e2e/azure_csidriver.go
@@ -68,13 +68,13 @@ func AzureDiskCSISpec(ctx context.Context, inputGetter func() AzureDiskCSISpecIn
 		By("Deploying persistent volume claim")
 		pvcName = "dd-managed-hdd-5g" + util.RandomString(6)
 		pvcBuilder, err := e2e_pvc.Create(pvcName, "5Gi")
-		Expect(err).To(BeNil())
+		Expect(err).NotTo(HaveOccurred())
 		annotations := map[string]string{
 			"volume.beta.kubernetes.io/storage-class": scName,
 		}
 		pvcBuilder.WithAnnotations(annotations)
 		err = pvcBuilder.DeployPVC(clientset)
-		Expect(err).To(BeNil())
+		Expect(err).NotTo(HaveOccurred())
 	} else {
 		By("[External]Deploying storage class and pvc")
 		By("Deploying managed disk storage class")
@@ -86,10 +86,10 @@ func AzureDiskCSISpec(ctx context.Context, inputGetter func() AzureDiskCSISpecIn
 		By("Deploying persistent volume claim")
 		pvcName = "oot-dd-managed-hdd-5g" + util.RandomString(6)
 		pvcBuilder, err := e2e_pvc.Create(pvcName, "5Gi")
-		Expect(err).To(BeNil())
+		Expect(err).NotTo(HaveOccurred())
 		pvcBuilder.WithStorageClass(scName)
 		err = pvcBuilder.DeployPVC(clientset)
-		Expect(err).To(BeNil())
+		Expect(err).NotTo(HaveOccurred())
 	}
 
 	By("creating a deployment that uses pvc")

--- a/test/e2e/azure_failuredomains.go
+++ b/test/e2e/azure_failuredomains.go
@@ -72,7 +72,7 @@ func AzureFailureDomainsSpec(ctx context.Context, inputGetter func() AzureFailur
 				LogWarning(err.Error())
 			}
 			g.Expect(err).NotTo(HaveOccurred())
-			g.Expect(len(input.Cluster.Status.FailureDomains)).To(Equal(len(zones)))
+			g.Expect(input.Cluster.Status.FailureDomains).To(HaveLen(len(zones)))
 			for _, z := range zones {
 				g.Expect(input.Cluster.Status.FailureDomains[z]).NotTo(BeNil())
 			}

--- a/test/e2e/azure_machinepools.go
+++ b/test/e2e/azure_machinepools.go
@@ -143,7 +143,7 @@ func AzureMachinePoolsSpec(ctx context.Context, inputGetter func() AzureMachineP
 	selector := labels.NewSelector().Add(*workloadNodeRequirement)
 	nodeList, err := clientset.CoreV1().Nodes().List(ctx, metav1.ListOptions{LabelSelector: selector.String()})
 	Expect(err).NotTo(HaveOccurred())
-	Expect(len(nodeList.Items)).NotTo(BeZero())
+	Expect(nodeList.Items).NotTo(BeEmpty())
 	for _, node := range nodeList.Items {
 		for _, taint := range node.Spec.Taints {
 			Expect(taint.Effect).NotTo(BeElementOf(

--- a/test/e2e/azure_privatecluster.go
+++ b/test/e2e/azure_privatecluster.go
@@ -170,7 +170,7 @@ func AzurePrivateClusterSpec(ctx context.Context, inputGetter func() AzurePrivat
 		Expect(err).NotTo(HaveOccurred())
 
 		azureBastionClient, err := armnetwork.NewBastionHostsClient(getSubscriptionID(Default), cred, nil)
-		Expect(err).To(BeNil())
+		Expect(err).NotTo(HaveOccurred())
 
 		groupName := os.Getenv(AzureResourceGroup)
 		azureBastionName := fmt.Sprintf("%s-azure-bastion", clusterName)
@@ -200,7 +200,7 @@ func AzurePrivateClusterSpec(ctx context.Context, inputGetter func() AzurePrivat
 		}
 		err = wait.ExponentialBackoff(backoff, retryFn)
 
-		Expect(err).To(BeNil())
+		Expect(err).NotTo(HaveOccurred())
 	}
 }
 
@@ -229,7 +229,7 @@ func SetupExistingVNet(ctx context.Context, vnetCidr string, cpSubnetCidrs, node
 			"creationTimestamp": ptr.To(os.Getenv(Timestamp)),
 		},
 	}, nil)
-	Expect(err).To(BeNil())
+	Expect(err).NotTo(HaveOccurred())
 
 	By("creating a network security group")
 	nsgName := "control-plane-nsg"
@@ -269,9 +269,9 @@ func SetupExistingVNet(ctx context.Context, vnetCidr string, cpSubnetCidrs, node
 			SecurityRules: securityRules,
 		},
 	}, nil)
-	Expect(err).To(BeNil())
+	Expect(err).NotTo(HaveOccurred())
 	_, err = nsgPoller.PollUntilDone(ctx, nil)
-	Expect(err).To(BeNil())
+	Expect(err).NotTo(HaveOccurred())
 
 	By("creating a node security group")
 	nsgNodeName := "node-nsg"
@@ -282,9 +282,9 @@ func SetupExistingVNet(ctx context.Context, vnetCidr string, cpSubnetCidrs, node
 			SecurityRules: securityRulesNode,
 		},
 	}, nil)
-	Expect(err).To(BeNil())
+	Expect(err).NotTo(HaveOccurred())
 	_, err = nsgNodePoller.PollUntilDone(ctx, nil)
-	Expect(err).To(BeNil())
+	Expect(err).NotTo(HaveOccurred())
 
 	By("creating a node routetable")
 	routeTableName := "node-routetable"
@@ -293,9 +293,9 @@ func SetupExistingVNet(ctx context.Context, vnetCidr string, cpSubnetCidrs, node
 		Properties: &armnetwork.RouteTablePropertiesFormat{},
 	}
 	routetablePoller, err := routetableClient.BeginCreateOrUpdate(ctx, groupName, routeTableName, routeTable, nil)
-	Expect(err).To(BeNil())
+	Expect(err).NotTo(HaveOccurred())
 	_, err = routetablePoller.PollUntilDone(ctx, nil)
-	Expect(err).To(BeNil())
+	Expect(err).NotTo(HaveOccurred())
 
 	By("creating a virtual network")
 	var subnets []*armnetwork.Subnet
@@ -345,9 +345,9 @@ func SetupExistingVNet(ctx context.Context, vnetCidr string, cpSubnetCidrs, node
 	if err != nil {
 		fmt.Print(err.Error())
 	}
-	Expect(err).To(BeNil())
+	Expect(err).NotTo(HaveOccurred())
 	_, err = vnetPoller.PollUntilDone(ctx, nil)
-	Expect(err).To(BeNil())
+	Expect(err).NotTo(HaveOccurred())
 
 	return func() {
 		Logf("deleting an existing virtual network %q", os.Getenv(AzureCustomVNetName))

--- a/test/e2e/azure_securitygroups.go
+++ b/test/e2e/azure_securitygroups.go
@@ -76,9 +76,9 @@ func AzureSecurityGroupsSpec(ctx context.Context, inputGetter func() AzureSecuri
 	Expect(ctx).NotTo(BeNil(), "ctx is required for %s spec", specName)
 
 	input = inputGetter()
-	Expect(input.BootstrapClusterProxy).ToNot(BeNil(), "Invalid argument. input.BootstrapClusterProxy can't be nil when calling %s spec", specName)
-	Expect(input.Namespace).ToNot(BeNil(), "Invalid argument. input.Namespace can't be nil when calling %s spec", specName)
-	Expect(input.ClusterName).ToNot(BeEmpty(), "Invalid argument. input.ClusterName can't be empty when calling %s spec", specName)
+	Expect(input.BootstrapClusterProxy).NotTo(BeNil(), "Invalid argument. input.BootstrapClusterProxy can't be nil when calling %s spec", specName)
+	Expect(input.Namespace).NotTo(BeNil(), "Invalid argument. input.Namespace can't be nil when calling %s spec", specName)
+	Expect(input.ClusterName).NotTo(BeEmpty(), "Invalid argument. input.ClusterName can't be empty when calling %s spec", specName)
 
 	By("creating a Kubernetes client to the workload cluster")
 	workloadClusterProxy := input.BootstrapClusterProxy.GetWorkloadCluster(ctx, input.Namespace.Name, input.ClusterName)
@@ -154,7 +154,7 @@ func AzureSecurityGroupsSpec(ctx context.Context, inputGetter func() AzureSecuri
 	Eventually(checkSubnets, input.WaitForUpdate...).Should(Succeed())
 
 	By("Creating new security rule for the subnet")
-	Expect(len(expectedSubnets)).To(Not(Equal(0)))
+	Expect(expectedSubnets).NotTo(BeEmpty())
 	testSubnet.SecurityGroup.SecurityRules = infrav1.SecurityRules{testSecurityRule, testSecurityRule2}
 	expectedSubnets = originalSubnets
 	expectedSubnets = append(expectedSubnets, testSubnet)
@@ -166,7 +166,7 @@ func AzureSecurityGroupsSpec(ctx context.Context, inputGetter func() AzureSecuri
 	Eventually(checkSubnets, input.WaitForUpdate...).Should(Succeed())
 
 	By("Deleting security rule from the subnet")
-	Expect(len(expectedSubnets)).To(Not(Equal(0)))
+	Expect(expectedSubnets).NotTo(BeEmpty())
 	testSubnet.SecurityGroup.SecurityRules = infrav1.SecurityRules{testSecurityRule2}
 	expectedSubnets = originalSubnets
 	expectedSubnets = append(expectedSubnets, testSubnet)

--- a/test/e2e/azure_test.go
+++ b/test/e2e/azure_test.go
@@ -92,7 +92,7 @@ var _ = Describe("Workload cluster creation", func() {
 		}
 		_, err = bootstrapClusterProxy.GetClientSet().CoreV1().Secrets(defaultNamespace).Get(ctx, secret.Name, metav1.GetOptions{})
 		if err != nil && !apierrors.IsNotFound(err) {
-			Expect(err).ShouldNot(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 		}
 		if err != nil {
 			Logf("Creating cluster identity secret \"%s\"", secret.Name)
@@ -694,10 +694,10 @@ var _ = Describe("Workload cluster creation", func() {
 			clusterName = getClusterName(clusterNamePrefix, aksClusterNameSuffix)
 			kubernetesVersionUpgradeFrom, err := GetAKSKubernetesVersion(ctx, e2eConfig, AKSKubernetesVersionUpgradeFrom)
 			Byf("Upgrading from k8s version %s", kubernetesVersionUpgradeFrom)
-			Expect(err).To(BeNil())
+			Expect(err).NotTo(HaveOccurred())
 			kubernetesVersion, err := GetAKSKubernetesVersion(ctx, e2eConfig, AKSKubernetesVersion)
 			Byf("Upgrading to k8s version %s", kubernetesVersion)
-			Expect(err).To(BeNil())
+			Expect(err).NotTo(HaveOccurred())
 
 			clusterctl.ApplyClusterTemplateAndWait(ctx, createApplyClusterTemplateInput(
 				specName,
@@ -761,7 +761,7 @@ var _ = Describe("Workload cluster creation", func() {
 		It("with a single control plane node and 1 node", func() {
 			clusterName = getClusterName(clusterNamePrefix, "pool")
 			kubernetesVersion, err := GetAKSKubernetesVersion(ctx, e2eConfig, AKSKubernetesVersion)
-			Expect(err).To(BeNil())
+			Expect(err).NotTo(HaveOccurred())
 
 			clusterctl.ApplyClusterTemplateAndWait(ctx, createApplyClusterTemplateInput(
 				specName,
@@ -875,10 +875,10 @@ var _ = Describe("Workload cluster creation", func() {
 			clusterName = getClusterName(clusterNamePrefix, "cc")
 			kubernetesVersionUpgradeFrom, err := GetAKSKubernetesVersion(ctx, e2eConfig, AKSKubernetesVersionUpgradeFrom)
 			Byf("Upgrading from k8s version %s", kubernetesVersionUpgradeFrom)
-			Expect(err).To(BeNil())
+			Expect(err).NotTo(HaveOccurred())
 			kubernetesVersion, err := GetAKSKubernetesVersion(ctx, e2eConfig, AKSKubernetesVersion)
 			Byf("Upgrading to k8s version %s", kubernetesVersion)
-			Expect(err).To(BeNil())
+			Expect(err).NotTo(HaveOccurred())
 
 			// Create a cluster using the cluster class created above
 			clusterctl.ApplyClusterTemplateAndWait(ctx, createApplyClusterTemplateInput(

--- a/test/e2e/azure_vmextensions.go
+++ b/test/e2e/azure_vmextensions.go
@@ -52,9 +52,9 @@ func AzureVMExtensionsSpec(ctx context.Context, inputGetter func() AzureVMExtens
 	Expect(ctx).NotTo(BeNil(), "ctx is required for %s spec", specName)
 
 	input = inputGetter()
-	Expect(input.BootstrapClusterProxy).ToNot(BeNil(), "Invalid argument. input.BootstrapClusterProxy can't be nil when calling %s spec", specName)
-	Expect(input.Namespace).ToNot(BeNil(), "Invalid argument. input.Namespace can't be nil when calling %s spec", specName)
-	Expect(input.ClusterName).ToNot(BeEmpty(), "Invalid argument. input.ClusterName can't be empty when calling %s spec", specName)
+	Expect(input.BootstrapClusterProxy).NotTo(BeNil(), "Invalid argument. input.BootstrapClusterProxy can't be nil when calling %s spec", specName)
+	Expect(input.Namespace).NotTo(BeNil(), "Invalid argument. input.Namespace can't be nil when calling %s spec", specName)
+	Expect(input.ClusterName).NotTo(BeEmpty(), "Invalid argument. input.ClusterName can't be empty when calling %s spec", specName)
 
 	By("creating a Kubernetes client to the workload cluster")
 	workloadClusterProxy := input.BootstrapClusterProxy.GetWorkloadCluster(ctx, input.Namespace.Name, input.ClusterName)

--- a/test/e2e/cni.go
+++ b/test/e2e/cni.go
@@ -57,7 +57,7 @@ func InstallCNIManifest(ctx context.Context, input clusterctl.ApplyCustomCluster
 	workloadCluster := input.ClusterProxy.GetWorkloadCluster(ctx, input.Namespace, input.ClusterName)
 
 	cniYaml, err := os.ReadFile(input.CNIManifestPath)
-	Expect(err).ShouldNot(HaveOccurred())
+	Expect(err).NotTo(HaveOccurred())
 
 	Expect(workloadCluster.Apply(ctx, cniYaml)).To(Succeed())
 }

--- a/test/e2e/conformance_test.go
+++ b/test/e2e/conformance_test.go
@@ -173,7 +173,7 @@ var _ = Describe("Conformance Tests", func() {
 		workloadProxy := bootstrapClusterProxy.GetWorkloadCluster(ctx, namespace.Name, clusterName)
 
 		if isWindows(kubetestConfigFilePath) {
-			// Windows requires a taint on control nodes nodes since not all conformance tests have ability to run
+			// Windows requires a taint on control nodes since not all conformance tests have ability to run
 			options := metav1.ListOptions{
 				LabelSelector: "kubernetes.io/os=linux",
 			}

--- a/test/e2e/daemonsets.go
+++ b/test/e2e/daemonsets.go
@@ -47,9 +47,9 @@ func EnsureDaemonsets(ctx context.Context, inputGetter func() DaemonsetsSpecInpu
 	Expect(ctx).NotTo(BeNil(), "ctx is required for %s spec", specName)
 
 	input = inputGetter()
-	Expect(input.BootstrapClusterProxy).ToNot(BeNil(), "Invalid argument. input.BootstrapClusterProxy can't be nil when calling %s spec", specName)
-	Expect(input.Namespace).ToNot(BeNil(), "Invalid argument. input.Namespace can't be nil when calling %s spec", specName)
-	Expect(input.ClusterName).ToNot(BeEmpty(), "Invalid argument. input.ClusterName can't be empty when calling %s spec", specName)
+	Expect(input.BootstrapClusterProxy).NotTo(BeNil(), "Invalid argument. input.BootstrapClusterProxy can't be nil when calling %s spec", specName)
+	Expect(input.Namespace).NotTo(BeNil(), "Invalid argument. input.Namespace can't be nil when calling %s spec", specName)
+	Expect(input.ClusterName).NotTo(BeEmpty(), "Invalid argument. input.ClusterName can't be empty when calling %s spec", specName)
 
 	mgmtClient := bootstrapClusterProxy.GetClient()
 	Expect(mgmtClient).NotTo(BeNil())

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -178,7 +178,7 @@ func setupBootstrapCluster(config *clusterctl.E2EConfig, useExistingCluster bool
 			Images: config.Images,
 		}
 		err := bootstrap.LoadImagesToKindCluster(context.TODO(), imagesInput)
-		Expect(err).To(BeNil(), "Failed to load images to the bootstrap cluster: %s", err)
+		Expect(err).NotTo(HaveOccurred(), "Failed to load images to the bootstrap cluster: %s", err)
 	}
 	clusterProxy := NewAzureClusterProxy("bootstrap", kubeconfigPath)
 	Expect(clusterProxy).NotTo(BeNil(), "Failed to get a bootstrap cluster proxy")

--- a/test/e2e/e2e_suite_vars.go
+++ b/test/e2e/e2e_suite_vars.go
@@ -58,7 +58,7 @@ var (
 	// with the providers specified in the configPath.
 	clusterctlConfigPath string
 
-	// bootstrapClusterProvider manages provisioning of the the bootstrap cluster to be used for the e2e tests.
+	// bootstrapClusterProvider manages provisioning of the bootstrap cluster to be used for the e2e tests.
 	// Please note that provisioning will be skipped if e2e.use-existing-cluster is provided.
 	bootstrapClusterProvider bootstrap.ClusterProvider
 

--- a/test/e2e/gpu_operator.go
+++ b/test/e2e/gpu_operator.go
@@ -52,9 +52,9 @@ func InstallGPUOperator(ctx context.Context, inputGetter func() GPUOperatorSpecI
 	Expect(ctx).NotTo(BeNil(), "ctx is required for %s spec", specName)
 
 	input = inputGetter()
-	Expect(input.BootstrapClusterProxy).ToNot(BeNil(), "Invalid argument. input.BootstrapClusterProxy can't be nil when calling %s spec", specName)
-	Expect(input.Namespace).ToNot(BeNil(), "Invalid argument. input.Namespace can't be nil when calling %s spec", specName)
-	Expect(input.ClusterName).ToNot(BeEmpty(), "Invalid argument. input.ClusterName can't be empty when calling %s spec", specName)
+	Expect(input.BootstrapClusterProxy).NotTo(BeNil(), "Invalid argument. input.BootstrapClusterProxy can't be nil when calling %s spec", specName)
+	Expect(input.Namespace).NotTo(BeNil(), "Invalid argument. input.Namespace can't be nil when calling %s spec", specName)
+	Expect(input.ClusterName).NotTo(BeEmpty(), "Invalid argument. input.ClusterName can't be empty when calling %s spec", specName)
 	clusterProxy := input.BootstrapClusterProxy.GetWorkloadCluster(ctx, input.Namespace.Name, input.ClusterName)
 	InstallNvidiaGPUOperatorChart(ctx, clusterProxy)
 }

--- a/util/cache/ttllru/ttllru_test.go
+++ b/util/cache/ttllru/ttllru_test.go
@@ -34,7 +34,7 @@ const (
 func TestNew(t *testing.T) {
 	g := NewWithT(t)
 	subject, err := New(128, defaultCacheDuration)
-	g.Expect(err).Should(BeNil())
+	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(subject).ShouldNot(BeNil())
 }
 
@@ -44,7 +44,7 @@ func TestCache_Add(t *testing.T) {
 	mockCache := mockttllru.NewMockCacher(mockCtrl)
 	defer mockCtrl.Finish()
 	subject, err := newCache(defaultCacheDuration, mockCache)
-	g.Expect(err).Should(BeNil())
+	g.Expect(err).NotTo(HaveOccurred())
 
 	key, value := "foo", "bar"
 	mockCache.EXPECT().Add(gomock.Eq(key), gomockinternal.CustomMatcher(
@@ -155,7 +155,7 @@ func TestCache_Get(t *testing.T) {
 			mockCache := mockttllru.NewMockCacher(mockCtrl)
 			defer mockCtrl.Finish()
 			subject, err := newCache(defaultCacheDuration, mockCache)
-			g.Expect(err).Should(BeNil())
+			g.Expect(err).NotTo(HaveOccurred())
 			c.TestCase(g, subject, mockCache)
 		})
 	}


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Updates the golangci-lint tool to v1.55.2, adds linters that have been added by CAPI, and fixes its new complaints.

This syncs up CAPZ with CAPI in this respect. See also #4585.

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

- [x] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests

**Release note**:

```release-note
NONE
```
