### PR TITLE
use existing virtualNetwork from a different rg

### DIFF
--- a/api/v1beta1/azuremanagedcontrolplane_webhook.go
+++ b/api/v1beta1/azuremanagedcontrolplane_webhook.go
@@ -288,6 +288,9 @@ func (m *AzureManagedControlPlane) Validate(cli client.Client) error {
 	allErrs = append(allErrs, validateNetworkDataplane(m.Spec.NetworkDataplane, m.Spec.NetworkPolicy, m.Spec.NetworkPluginMode, field.NewPath("spec").Child("NetworkDataplane"))...)
 
 	allErrs = append(allErrs, validateAPIServerAccessProfile(m.Spec.APIServerAccessProfile, field.NewPath("spec").Child("APIServerAccessProfile"))...)
+
+	allErrs = append(allErrs, validateAMCPVirtualNetwork(m.Spec.VirtualNetwork, field.NewPath("spec").Child("VirtualNetwork"))...)
+
 	return allErrs.ToAggregate()
 }
 
@@ -436,6 +439,26 @@ func validateLoadBalancerProfile(loadBalancerProfile *LoadBalancerProfile, fldPa
 		}
 	}
 
+	return allErrs
+}
+
+func validateAMCPVirtualNetwork(virtualNetwork ManagedControlPlaneVirtualNetwork, fldPath *field.Path) field.ErrorList {
+	var allErrs field.ErrorList
+
+	// VirtualNetwork and the CIDR blocks get defaulted in the defaulting webhook, so we can assume they are always set.
+	if !reflect.DeepEqual(virtualNetwork, ManagedControlPlaneVirtualNetwork{}) {
+		_, parentNet, vnetErr := net.ParseCIDR(virtualNetwork.CIDRBlock)
+		if vnetErr != nil {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("CIDRBlock"), virtualNetwork.CIDRBlock, "pre-existing virtual networks CIDR block is invalid"))
+		}
+		subnetIP, _, subnetErr := net.ParseCIDR(virtualNetwork.Subnet.CIDRBlock)
+		if subnetErr != nil {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("Subnet", "CIDRBlock"), virtualNetwork.CIDRBlock, "pre-existing subnets CIDR block is invalid"))
+		}
+		if vnetErr == nil && subnetErr == nil && !parentNet.Contains(subnetIP) {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("CIDRBlock"), virtualNetwork.CIDRBlock, "pre-existing virtual networks CIDR block should contain the subnet CIDR block"))
+		}
+	}
 	return allErrs
 }
 

--- a/api/v1beta1/azuremanagedcontrolplane_webhook_test.go
+++ b/api/v1beta1/azuremanagedcontrolplane_webhook_test.go
@@ -4003,3 +4003,222 @@ func TestValidateAPIServerAccessProfile(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateAMCPVirtualNetwork(t *testing.T) {
+	tests := []struct {
+		name    string
+		amcp    *AzureManagedControlPlane
+		wantErr string
+	}{
+		{
+			name: "Testing valid VirtualNetwork in same resource group",
+			amcp: &AzureManagedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "fooName",
+					Labels: map[string]string{
+						clusterv1.ClusterNameLabel: "fooCluster",
+					},
+				},
+				Spec: AzureManagedControlPlaneSpec{
+					ResourceGroupName: "rg1",
+					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+						VirtualNetwork: ManagedControlPlaneVirtualNetwork{
+							ResourceGroup: "rg1",
+							ManagedControlPlaneVirtualNetworkClassSpec: ManagedControlPlaneVirtualNetworkClassSpec{
+								Name:      "vnet1",
+								CIDRBlock: defaultAKSVnetCIDR,
+								Subnet: ManagedControlPlaneSubnet{
+									Name:      "subnet1",
+									CIDRBlock: defaultAKSNodeSubnetCIDR,
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: "",
+		},
+		{
+			name: "Testing valid VirtualNetwork in different resource group",
+			amcp: &AzureManagedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "fooName",
+					Labels: map[string]string{
+						clusterv1.ClusterNameLabel: "fooCluster",
+					},
+				},
+				Spec: AzureManagedControlPlaneSpec{
+					ResourceGroupName: "rg1",
+					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+						VirtualNetwork: ManagedControlPlaneVirtualNetwork{
+							ResourceGroup: "rg2",
+							ManagedControlPlaneVirtualNetworkClassSpec: ManagedControlPlaneVirtualNetworkClassSpec{
+								Name:      "vnet1",
+								CIDRBlock: defaultAKSVnetCIDR,
+								Subnet: ManagedControlPlaneSubnet{
+									Name:      "subnet1",
+									CIDRBlock: defaultAKSNodeSubnetCIDR,
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: "",
+		},
+		{
+			name: "Testing invalid VirtualNetwork in different resource group: invalid subnet CIDR",
+			amcp: &AzureManagedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "fooName",
+					Labels: map[string]string{
+						clusterv1.ClusterNameLabel: "fooCluster",
+					},
+				},
+				Spec: AzureManagedControlPlaneSpec{
+					ResourceGroupName: "rg1",
+					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+						VirtualNetwork: ManagedControlPlaneVirtualNetwork{
+							ResourceGroup: "rg2",
+							ManagedControlPlaneVirtualNetworkClassSpec: ManagedControlPlaneVirtualNetworkClassSpec{
+								Name:      "vnet1",
+								CIDRBlock: "10.1.0.0/16",
+								Subnet: ManagedControlPlaneSubnet{
+									Name:      "subnet1",
+									CIDRBlock: "10.0.0.0/24",
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: "pre-existing virtual networks CIDR block should contain the subnet CIDR block",
+		},
+		{
+			name: "Testing invalid VirtualNetwork in different resource group: no subnet CIDR",
+			amcp: &AzureManagedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "fooName",
+					Labels: map[string]string{
+						clusterv1.ClusterNameLabel: "fooCluster",
+					},
+				},
+				Spec: AzureManagedControlPlaneSpec{
+					ResourceGroupName: "rg1",
+					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+						VirtualNetwork: ManagedControlPlaneVirtualNetwork{
+							ResourceGroup: "rg2",
+							ManagedControlPlaneVirtualNetworkClassSpec: ManagedControlPlaneVirtualNetworkClassSpec{
+								Name:      "vnet1",
+								CIDRBlock: "10.1.0.0/16",
+								Subnet: ManagedControlPlaneSubnet{
+									Name: "subnet1",
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: "pre-existing virtual networks CIDR block should contain the subnet CIDR block",
+		},
+		{
+			name: "Testing invalid VirtualNetwork in different resource group: no VNet CIDR",
+			amcp: &AzureManagedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "fooName",
+					Labels: map[string]string{
+						clusterv1.ClusterNameLabel: "fooCluster",
+					},
+				},
+				Spec: AzureManagedControlPlaneSpec{
+					ResourceGroupName: "rg1",
+					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+						VirtualNetwork: ManagedControlPlaneVirtualNetwork{
+							ResourceGroup: "rg2",
+							ManagedControlPlaneVirtualNetworkClassSpec: ManagedControlPlaneVirtualNetworkClassSpec{
+								Name: "vnet1",
+								Subnet: ManagedControlPlaneSubnet{
+									Name:      "subnet1",
+									CIDRBlock: "11.0.0.0/24",
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: "pre-existing virtual networks CIDR block should contain the subnet CIDR block",
+		},
+		{
+			name: "Testing invalid VirtualNetwork in different resource group: invalid VNet CIDR",
+			amcp: &AzureManagedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "fooName",
+					Labels: map[string]string{
+						clusterv1.ClusterNameLabel: "fooCluster",
+					},
+				},
+				Spec: AzureManagedControlPlaneSpec{
+					ResourceGroupName: "rg1",
+					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+						VirtualNetwork: ManagedControlPlaneVirtualNetwork{
+							ResourceGroup: "rg2",
+							ManagedControlPlaneVirtualNetworkClassSpec: ManagedControlPlaneVirtualNetworkClassSpec{
+								Name:      "vnet1",
+								CIDRBlock: "invalid_vnet_CIDR",
+								Subnet: ManagedControlPlaneSubnet{
+									Name:      "subnet1",
+									CIDRBlock: "11.0.0.0/24",
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: "pre-existing virtual networks CIDR block is invalid",
+		},
+		{
+			name: "Testing invalid VirtualNetwork in different resource group: invalid Subnet CIDR",
+			amcp: &AzureManagedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "fooName",
+					Labels: map[string]string{
+						clusterv1.ClusterNameLabel: "fooCluster",
+					},
+				},
+				Spec: AzureManagedControlPlaneSpec{
+					ResourceGroupName: "rg1",
+					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+						VirtualNetwork: ManagedControlPlaneVirtualNetwork{
+							ResourceGroup: "rg2",
+							ManagedControlPlaneVirtualNetworkClassSpec: ManagedControlPlaneVirtualNetworkClassSpec{
+								Name: "vnet1",
+								Subnet: ManagedControlPlaneSubnet{
+									Name:      "subnet1",
+									CIDRBlock: "invalid_subnet_CIDR",
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: "pre-existing subnets CIDR block is invalid",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			mcpw := &azureManagedControlPlaneWebhook{}
+			err := mcpw.Default(context.Background(), tc.amcp)
+			g.Expect(err).NotTo(HaveOccurred())
+
+			errs := validateAMCPVirtualNetwork(tc.amcp.Spec.VirtualNetwork, field.NewPath("spec", "VirtualNetwork"))
+			if tc.wantErr != "" {
+				g.Expect(errs).ToNot(BeEmpty())
+				g.Expect(errs[0].Detail).To(Equal(tc.wantErr))
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
+			}
+		})
+	}
+}

--- a/api/v1beta1/azuremanagedcontrolplanetemplate_webhook.go
+++ b/api/v1beta1/azuremanagedcontrolplanetemplate_webhook.go
@@ -228,6 +228,8 @@ func (mcp *AzureManagedControlPlaneTemplate) validateManagedControlPlaneTemplate
 
 	allErrs = append(allErrs, validateAPIServerAccessProfile(mcp.Spec.Template.Spec.APIServerAccessProfile, field.NewPath("spec").Child("template").Child("spec").Child("APIServerAccessProfile"))...)
 
+	allErrs = append(allErrs, validateAMCPVirtualNetwork(mcp.Spec.Template.Spec.VirtualNetwork, field.NewPath("spec").Child("template").Child("spec").Child("VirtualNetwork"))...)
+
 	return allErrs.ToAggregate()
 }
 

--- a/azure/defaults.go
+++ b/azure/defaults.go
@@ -19,6 +19,8 @@ package azure
 import (
 	"fmt"
 	"net/http"
+	"regexp"
+	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
@@ -411,4 +413,16 @@ func (p CustomPutPatchHeaderPolicy) Do(req *policy.Request) (*http.Response, err
 	}
 
 	return req.Next()
+}
+
+// GetNormalizedKubernetesName returns a normalized name for a Kubernetes resource.
+func GetNormalizedKubernetesName(name string) string {
+	// Remove non-alphanumeric characters, convert to lowercase, and replace underscores with hyphens
+	name = strings.ToLower(name)
+	re := regexp.MustCompile(`[^a-z0-9\-]+`)
+	name = re.ReplaceAllString(name, "-")
+
+	// Remove leading and trailing hyphens
+	name = strings.Trim(name, "-")
+	return name
 }

--- a/azure/defaults_test.go
+++ b/azure/defaults_test.go
@@ -277,3 +277,79 @@ func TestGetBootstrappingVMExtension(t *testing.T) {
 		})
 	}
 }
+
+func TestNormalizeAzureName(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "should return lower case",
+			input:    "Test",
+			expected: "test",
+		},
+		{
+			name:     "should return lower case with spaces replaced by hyphens",
+			input:    "Test Name",
+			expected: "test-name",
+		},
+		{
+			name:     "should return lower case with spaces replaced by hyphens and non-alphanumeric characters removed",
+			input:    "Test Name 1",
+			expected: "test-name-1",
+		},
+		{
+			name:     "should return lower case with spaces replaced by hyphens and non-alphanumeric characters removed",
+			input:    "Test-Name-1-",
+			expected: "test-name-1",
+		},
+		{
+			name:     "should return lower case with spaces replaced by hyphens and non-alphanumeric characters removed",
+			input:    "Test-Name-1-@",
+			expected: "test-name-1",
+		},
+		{
+			name:     "should return lower case with spaces replaced by hyphens and non-alphanumeric characters removed",
+			input:    "Test-Name-1-@-",
+			expected: "test-name-1",
+		},
+		{
+			name:     "should return lower case with spaces replaced by hyphens and non-alphanumeric characters removed",
+			input:    "Test-Name-1-@-@",
+			expected: "test-name-1",
+		},
+		{
+			name:     "should return lower case with underscores replaced by hyphens and non-alphanumeric characters removed",
+			input:    "Test_Name_1-@-@",
+			expected: "test-name-1",
+		},
+		{
+			name:     "should return lower case with underscores replaced by hyphens and non-alphanumeric characters removed",
+			input:    "0_Test_Name_1-@-@",
+			expected: "0-test-name-1",
+		},
+		{
+			name:     "should return lower case with underscores replaced by hyphens and non-alphanumeric characters removed",
+			input:    "_Test_Name_1-@-@",
+			expected: "test-name-1",
+		},
+		{
+			name:     "should return lower case with name without hyphens",
+			input:    "_Test_Name_1---",
+			expected: "test-name-1",
+		},
+		{
+			name:     "should not change the input since input is valid k8s name",
+			input:    "test-name-1",
+			expected: "test-name-1",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			normalizedNamed := GetNormalizedKubernetesName(tc.input)
+			g.Expect(normalizedNamed).To(Equal(tc.expected))
+		})
+	}
+}

--- a/azure/scope/cluster.go
+++ b/azure/scope/cluster.go
@@ -425,14 +425,16 @@ func (s *ClusterScope) GroupSpecs() []azure.ASOResourceSpecGetter[*asoresourcesv
 	specs := []azure.ASOResourceSpecGetter[*asoresourcesv1.ResourceGroup]{
 		&groups.GroupSpec{
 			Name:           s.ResourceGroup(),
+			AzureName:      s.ResourceGroup(),
 			Location:       s.Location(),
 			ClusterName:    s.ClusterName(),
 			AdditionalTags: s.AdditionalTags(),
 		},
 	}
-	if s.Vnet().ResourceGroup != s.ResourceGroup() {
+	if s.Vnet().ResourceGroup != "" && s.Vnet().ResourceGroup != s.ResourceGroup() {
 		specs = append(specs, &groups.GroupSpec{
-			Name:           s.Vnet().ResourceGroup,
+			Name:           azure.GetNormalizedKubernetesName(s.Vnet().ResourceGroup),
+			AzureName:      s.Vnet().ResourceGroup,
 			Location:       s.Location(),
 			ClusterName:    s.ClusterName(),
 			AdditionalTags: s.AdditionalTags(),

--- a/azure/scope/managedcontrolplane.go
+++ b/azure/scope/managedcontrolplane.go
@@ -270,14 +270,25 @@ func (s *ManagedControlPlaneScope) Vnet() *infrav1.VnetSpec {
 
 // GroupSpecs returns the resource group spec.
 func (s *ManagedControlPlaneScope) GroupSpecs() []azure.ASOResourceSpecGetter[*asoresourcesv1.ResourceGroup] {
-	return []azure.ASOResourceSpecGetter[*asoresourcesv1.ResourceGroup]{
+	specs := []azure.ASOResourceSpecGetter[*asoresourcesv1.ResourceGroup]{
 		&groups.GroupSpec{
 			Name:           s.ResourceGroup(),
+			AzureName:      s.ResourceGroup(),
 			Location:       s.Location(),
 			ClusterName:    s.ClusterName(),
 			AdditionalTags: s.AdditionalTags(),
 		},
 	}
+	if s.Vnet().ResourceGroup != "" && s.Vnet().ResourceGroup != s.ResourceGroup() {
+		specs = append(specs, &groups.GroupSpec{
+			Name:           azure.GetNormalizedKubernetesName(s.Vnet().ResourceGroup),
+			AzureName:      s.Vnet().ResourceGroup,
+			Location:       s.Location(),
+			ClusterName:    s.ClusterName(),
+			AdditionalTags: s.AdditionalTags(),
+		})
+	}
+	return specs
 }
 
 // VNetSpec returns the virtual network spec.

--- a/azure/services/groups/spec.go
+++ b/azure/services/groups/spec.go
@@ -29,6 +29,7 @@ import (
 // GroupSpec defines the specification for a Resource Group.
 type GroupSpec struct {
 	Name           string
+	AzureName      string
 	Location       string
 	ClusterName    string
 	AdditionalTags infrav1.Tags
@@ -49,7 +50,7 @@ func (s *GroupSpec) Parameters(ctx context.Context, existing *asoresourcesv1.Res
 		return existing, nil
 	}
 
-	return &asoresourcesv1.ResourceGroup{
+	resourceGroup := &asoresourcesv1.ResourceGroup{
 		Spec: asoresourcesv1.ResourceGroup_Spec{
 			Location: ptr.To(s.Location),
 			Tags: infrav1.Build(infrav1.BuildParams{
@@ -60,7 +61,11 @@ func (s *GroupSpec) Parameters(ctx context.Context, existing *asoresourcesv1.Res
 				Additional:  s.AdditionalTags,
 			}),
 		},
-	}, nil
+	}
+	if s.AzureName != "" {
+		resourceGroup.Spec.AzureName = s.AzureName
+	}
+	return resourceGroup, nil
 }
 
 // WasManaged implements azure.ASOResourceSpecGetter.

--- a/azure/services/groups/spec_test.go
+++ b/azure/services/groups/spec_test.go
@@ -38,6 +38,7 @@ func TestParameters(t *testing.T) {
 			name: "no existing group",
 			spec: &GroupSpec{
 				Name:           "name",
+				AzureName:      "azure-name",
 				Location:       "location",
 				ClusterName:    "cluster",
 				AdditionalTags: infrav1.Tags{"some": "tags"},
@@ -45,7 +46,8 @@ func TestParameters(t *testing.T) {
 			existing: nil,
 			expected: &asoresourcesv1.ResourceGroup{
 				Spec: asoresourcesv1.ResourceGroup_Spec{
-					Location: ptr.To("location"),
+					AzureName: "azure-name",
+					Location:  ptr.To("location"),
 					Tags: map[string]string{
 						"some": "tags",
 						"sigs.k8s.io_cluster-api-provider-azure_cluster_cluster": "owned",


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind feature

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
This PR will enable using existing virtualNetwork from a different rg.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4595 

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
use existing virtualNetwork from a different rg 
```
