### PR TITLE
enable the use of an external control plane

### DIFF
--- a/api/v1beta1/azurecluster_default_test.go
+++ b/api/v1beta1/azurecluster_default_test.go
@@ -95,6 +95,7 @@ func TestVnetDefaults(t *testing.T) {
 					Name: "test-cluster",
 				},
 				Spec: AzureClusterSpec{
+					ControlPlaneEnabled: true,
 					NetworkSpec: NetworkSpec{
 						Vnet: VnetSpec{
 							ResourceGroup: "custom-vnet",
@@ -122,7 +123,7 @@ func TestVnetDefaults(t *testing.T) {
 								RouteTable:    RouteTable{},
 							},
 						},
-						APIServerLB: LoadBalancerSpec{
+						APIServerLB: &LoadBalancerSpec{
 							Name: "my-lb",
 							FrontendIPs: []FrontendIP{
 								{
@@ -158,7 +159,8 @@ func TestVnetDefaults(t *testing.T) {
 					Name: "cluster-test",
 				},
 				Spec: AzureClusterSpec{
-					ResourceGroup: "cluster-test",
+					ControlPlaneEnabled: true,
+					ResourceGroup:       "cluster-test",
 					AzureClusterClassSpec: AzureClusterClassSpec{
 						IdentityRef: &corev1.ObjectReference{
 							Kind: AzureClusterIdentityKind,
@@ -171,7 +173,8 @@ func TestVnetDefaults(t *testing.T) {
 					Name: "cluster-test",
 				},
 				Spec: AzureClusterSpec{
-					ResourceGroup: "cluster-test",
+					ControlPlaneEnabled: true,
+					ResourceGroup:       "cluster-test",
 					NetworkSpec: NetworkSpec{
 						Vnet: VnetSpec{
 							ResourceGroup: "cluster-test",
@@ -196,7 +199,8 @@ func TestVnetDefaults(t *testing.T) {
 					Name: "cluster-test",
 				},
 				Spec: AzureClusterSpec{
-					ResourceGroup: "cluster-test",
+					ControlPlaneEnabled: true,
+					ResourceGroup:       "cluster-test",
 					NetworkSpec: NetworkSpec{
 						Vnet: VnetSpec{
 							VnetClassSpec: VnetClassSpec{
@@ -216,7 +220,8 @@ func TestVnetDefaults(t *testing.T) {
 					Name: "cluster-test",
 				},
 				Spec: AzureClusterSpec{
-					ResourceGroup: "cluster-test",
+					ControlPlaneEnabled: true,
+					ResourceGroup:       "cluster-test",
 					NetworkSpec: NetworkSpec{
 						Vnet: VnetSpec{
 							ResourceGroup: "cluster-test",
@@ -241,7 +246,8 @@ func TestVnetDefaults(t *testing.T) {
 					Name: "cluster-test",
 				},
 				Spec: AzureClusterSpec{
-					ResourceGroup: "cluster-test",
+					ControlPlaneEnabled: true,
+					ResourceGroup:       "cluster-test",
 					NetworkSpec: NetworkSpec{
 						Vnet: VnetSpec{
 							VnetClassSpec: VnetClassSpec{
@@ -261,7 +267,8 @@ func TestVnetDefaults(t *testing.T) {
 					Name: "cluster-test",
 				},
 				Spec: AzureClusterSpec{
-					ResourceGroup: "cluster-test",
+					ControlPlaneEnabled: true,
+					ResourceGroup:       "cluster-test",
 					NetworkSpec: NetworkSpec{
 						Vnet: VnetSpec{
 							ResourceGroup: "cluster-test",
@@ -308,7 +315,8 @@ func TestSubnetDefaults(t *testing.T) {
 					Name: "cluster-test",
 				},
 				Spec: AzureClusterSpec{
-					NetworkSpec: NetworkSpec{},
+					ControlPlaneEnabled: true,
+					NetworkSpec:         NetworkSpec{},
 				},
 			},
 			output: &AzureCluster{
@@ -316,6 +324,7 @@ func TestSubnetDefaults(t *testing.T) {
 					Name: "cluster-test",
 				},
 				Spec: AzureClusterSpec{
+					ControlPlaneEnabled: true,
 					NetworkSpec: NetworkSpec{
 						Subnets: Subnets{
 							{
@@ -352,6 +361,7 @@ func TestSubnetDefaults(t *testing.T) {
 					Name: "cluster-test",
 				},
 				Spec: AzureClusterSpec{
+					ControlPlaneEnabled: true,
 					NetworkSpec: NetworkSpec{
 						Subnets: Subnets{
 							{
@@ -382,6 +392,7 @@ func TestSubnetDefaults(t *testing.T) {
 					Name: "cluster-test",
 				},
 				Spec: AzureClusterSpec{
+					ControlPlaneEnabled: true,
 					NetworkSpec: NetworkSpec{
 						Subnets: Subnets{
 							{
@@ -422,6 +433,7 @@ func TestSubnetDefaults(t *testing.T) {
 					Name: "cluster-test",
 				},
 				Spec: AzureClusterSpec{
+					ControlPlaneEnabled: true,
 					NetworkSpec: NetworkSpec{
 						Subnets: Subnets{
 							{
@@ -445,6 +457,7 @@ func TestSubnetDefaults(t *testing.T) {
 					Name: "cluster-test",
 				},
 				Spec: AzureClusterSpec{
+					ControlPlaneEnabled: true,
 					NetworkSpec: NetworkSpec{
 						Subnets: Subnets{
 							{
@@ -486,6 +499,7 @@ func TestSubnetDefaults(t *testing.T) {
 					Name: "cluster-test",
 				},
 				Spec: AzureClusterSpec{
+					ControlPlaneEnabled: true,
 					NetworkSpec: NetworkSpec{
 						Subnets: Subnets{
 							{
@@ -509,6 +523,7 @@ func TestSubnetDefaults(t *testing.T) {
 					Name: "cluster-test",
 				},
 				Spec: AzureClusterSpec{
+					ControlPlaneEnabled: true,
 					NetworkSpec: NetworkSpec{
 						Subnets: Subnets{
 							{
@@ -540,6 +555,7 @@ func TestSubnetDefaults(t *testing.T) {
 					Name: "cluster-test",
 				},
 				Spec: AzureClusterSpec{
+					ControlPlaneEnabled: true,
 					NetworkSpec: NetworkSpec{
 						Subnets: Subnets{
 							{
@@ -557,6 +573,7 @@ func TestSubnetDefaults(t *testing.T) {
 					Name: "cluster-test",
 				},
 				Spec: AzureClusterSpec{
+					ControlPlaneEnabled: true,
 					NetworkSpec: NetworkSpec{
 						Subnets: Subnets{
 							{
@@ -588,6 +605,7 @@ func TestSubnetDefaults(t *testing.T) {
 					Name: "cluster-test",
 				},
 				Spec: AzureClusterSpec{
+					ControlPlaneEnabled: true,
 					NetworkSpec: NetworkSpec{
 						Subnets: Subnets{
 							{
@@ -614,6 +632,7 @@ func TestSubnetDefaults(t *testing.T) {
 					Name: "cluster-test",
 				},
 				Spec: AzureClusterSpec{
+					ControlPlaneEnabled: true,
 					NetworkSpec: NetworkSpec{
 						Subnets: Subnets{
 							{
@@ -654,6 +673,7 @@ func TestSubnetDefaults(t *testing.T) {
 					Name: "cluster-test",
 				},
 				Spec: AzureClusterSpec{
+					ControlPlaneEnabled: true,
 					NetworkSpec: NetworkSpec{
 						Subnets: Subnets{
 							{
@@ -671,6 +691,7 @@ func TestSubnetDefaults(t *testing.T) {
 					Name: "cluster-test",
 				},
 				Spec: AzureClusterSpec{
+					ControlPlaneEnabled: true,
 					NetworkSpec: NetworkSpec{
 						Subnets: Subnets{
 							{
@@ -712,6 +733,7 @@ func TestSubnetDefaults(t *testing.T) {
 					Name: "cluster-test",
 				},
 				Spec: AzureClusterSpec{
+					ControlPlaneEnabled: true,
 					NetworkSpec: NetworkSpec{
 						Vnet: VnetSpec{
 							VnetClassSpec: VnetClassSpec{
@@ -742,6 +764,7 @@ func TestSubnetDefaults(t *testing.T) {
 					Name: "cluster-test",
 				},
 				Spec: AzureClusterSpec{
+					ControlPlaneEnabled: true,
 					NetworkSpec: NetworkSpec{
 						Vnet: VnetSpec{
 							VnetClassSpec: VnetClassSpec{
@@ -779,6 +802,7 @@ func TestSubnetDefaults(t *testing.T) {
 					Name: "cluster-test",
 				},
 				Spec: AzureClusterSpec{
+					ControlPlaneEnabled: true,
 					NetworkSpec: NetworkSpec{
 						Subnets: Subnets{
 							{
@@ -838,6 +862,7 @@ func TestSubnetDefaults(t *testing.T) {
 					Name: "cluster-test",
 				},
 				Spec: AzureClusterSpec{
+					ControlPlaneEnabled: true,
 					NetworkSpec: NetworkSpec{
 						Subnets: Subnets{
 							{
@@ -913,6 +938,7 @@ func TestSubnetDefaults(t *testing.T) {
 					Name: "cluster-test",
 				},
 				Spec: AzureClusterSpec{
+					ControlPlaneEnabled: true,
 					NetworkSpec: NetworkSpec{
 						Subnets: Subnets{
 							{
@@ -948,6 +974,7 @@ func TestSubnetDefaults(t *testing.T) {
 					Name: "cluster-test",
 				},
 				Spec: AzureClusterSpec{
+					ControlPlaneEnabled: true,
 					NetworkSpec: NetworkSpec{
 						Subnets: Subnets{
 							{
@@ -1005,6 +1032,7 @@ func TestSubnetDefaults(t *testing.T) {
 					Name: "cluster-test",
 				},
 				Spec: AzureClusterSpec{
+					ControlPlaneEnabled: true,
 					NetworkSpec: NetworkSpec{
 						Subnets: Subnets{
 							{
@@ -1030,6 +1058,7 @@ func TestSubnetDefaults(t *testing.T) {
 					Name: "cluster-test",
 				},
 				Spec: AzureClusterSpec{
+					ControlPlaneEnabled: true,
 					NetworkSpec: NetworkSpec{
 						Subnets: Subnets{
 							{
@@ -1218,7 +1247,8 @@ func TestAPIServerLBDefaults(t *testing.T) {
 					Name: "cluster-test",
 				},
 				Spec: AzureClusterSpec{
-					NetworkSpec: NetworkSpec{},
+					ControlPlaneEnabled: true,
+					NetworkSpec:         NetworkSpec{},
 				},
 			},
 			output: &AzureCluster{
@@ -1226,8 +1256,9 @@ func TestAPIServerLBDefaults(t *testing.T) {
 					Name: "cluster-test",
 				},
 				Spec: AzureClusterSpec{
+					ControlPlaneEnabled: true,
 					NetworkSpec: NetworkSpec{
-						APIServerLB: LoadBalancerSpec{
+						APIServerLB: &LoadBalancerSpec{
 							Name: "cluster-test-public-lb",
 							FrontendIPs: []FrontendIP{
 								{
@@ -1259,7 +1290,7 @@ func TestAPIServerLBDefaults(t *testing.T) {
 				},
 				Spec: AzureClusterSpec{
 					NetworkSpec: NetworkSpec{
-						APIServerLB: LoadBalancerSpec{
+						APIServerLB: &LoadBalancerSpec{
 							LoadBalancerClassSpec: LoadBalancerClassSpec{
 								Type: Internal,
 							},
@@ -1273,7 +1304,7 @@ func TestAPIServerLBDefaults(t *testing.T) {
 				},
 				Spec: AzureClusterSpec{
 					NetworkSpec: NetworkSpec{
-						APIServerLB: LoadBalancerSpec{
+						APIServerLB: &LoadBalancerSpec{
 							FrontendIPs: []FrontendIP{
 								{
 									Name: "cluster-test-internal-lb-frontEnd",
@@ -1304,7 +1335,7 @@ func TestAPIServerLBDefaults(t *testing.T) {
 				},
 				Spec: AzureClusterSpec{
 					NetworkSpec: NetworkSpec{
-						APIServerLB: LoadBalancerSpec{
+						APIServerLB: &LoadBalancerSpec{
 							LoadBalancerClassSpec: LoadBalancerClassSpec{
 								Type: Internal,
 							},
@@ -1321,7 +1352,7 @@ func TestAPIServerLBDefaults(t *testing.T) {
 				},
 				Spec: AzureClusterSpec{
 					NetworkSpec: NetworkSpec{
-						APIServerLB: LoadBalancerSpec{
+						APIServerLB: &LoadBalancerSpec{
 							FrontendIPs: []FrontendIP{
 								{
 									Name: "cluster-test-internal-lb-frontEnd",
@@ -1456,8 +1487,9 @@ func TestNodeOutboundLBDefaults(t *testing.T) {
 					Name: "cluster-test",
 				},
 				Spec: AzureClusterSpec{
+					ControlPlaneEnabled: true,
 					NetworkSpec: NetworkSpec{
-						APIServerLB: LoadBalancerSpec{LoadBalancerClassSpec: LoadBalancerClassSpec{Type: Public}},
+						APIServerLB: &LoadBalancerSpec{LoadBalancerClassSpec: LoadBalancerClassSpec{Type: Public}},
 						Subnets: Subnets{
 							{
 								SubnetClassSpec: SubnetClassSpec{
@@ -1484,6 +1516,7 @@ func TestNodeOutboundLBDefaults(t *testing.T) {
 					Name: "cluster-test",
 				},
 				Spec: AzureClusterSpec{
+					ControlPlaneEnabled: true,
 					NetworkSpec: NetworkSpec{
 						Subnets: Subnets{
 							{
@@ -1503,7 +1536,7 @@ func TestNodeOutboundLBDefaults(t *testing.T) {
 								RouteTable:    RouteTable{},
 							},
 						},
-						APIServerLB: LoadBalancerSpec{
+						APIServerLB: &LoadBalancerSpec{
 							LoadBalancerClassSpec: LoadBalancerClassSpec{
 								Type: Public,
 							},
@@ -1519,8 +1552,9 @@ func TestNodeOutboundLBDefaults(t *testing.T) {
 					Name: "cluster-test",
 				},
 				Spec: AzureClusterSpec{
+					ControlPlaneEnabled: true,
 					NetworkSpec: NetworkSpec{
-						APIServerLB: LoadBalancerSpec{LoadBalancerClassSpec: LoadBalancerClassSpec{Type: Public}},
+						APIServerLB: &LoadBalancerSpec{LoadBalancerClassSpec: LoadBalancerClassSpec{Type: Public}},
 						Subnets: Subnets{
 							{
 								SubnetClassSpec: SubnetClassSpec{
@@ -1548,6 +1582,7 @@ func TestNodeOutboundLBDefaults(t *testing.T) {
 					Name: "cluster-test",
 				},
 				Spec: AzureClusterSpec{
+					ControlPlaneEnabled: true,
 					NetworkSpec: NetworkSpec{
 						Subnets: Subnets{
 							{
@@ -1568,7 +1603,7 @@ func TestNodeOutboundLBDefaults(t *testing.T) {
 								RouteTable:    RouteTable{},
 							},
 						},
-						APIServerLB: LoadBalancerSpec{
+						APIServerLB: &LoadBalancerSpec{
 							LoadBalancerClassSpec: LoadBalancerClassSpec{
 								Type: Public,
 							},
@@ -1602,8 +1637,9 @@ func TestNodeOutboundLBDefaults(t *testing.T) {
 					Name: "cluster-test",
 				},
 				Spec: AzureClusterSpec{
+					ControlPlaneEnabled: true,
 					NetworkSpec: NetworkSpec{
-						APIServerLB: LoadBalancerSpec{LoadBalancerClassSpec: LoadBalancerClassSpec{Type: Public}},
+						APIServerLB: &LoadBalancerSpec{LoadBalancerClassSpec: LoadBalancerClassSpec{Type: Public}},
 						Subnets: Subnets{
 							{
 								SubnetClassSpec: SubnetClassSpec{
@@ -1639,6 +1675,7 @@ func TestNodeOutboundLBDefaults(t *testing.T) {
 					Name: "cluster-test",
 				},
 				Spec: AzureClusterSpec{
+					ControlPlaneEnabled: true,
 					NetworkSpec: NetworkSpec{
 						Subnets: Subnets{
 							{
@@ -1667,7 +1704,7 @@ func TestNodeOutboundLBDefaults(t *testing.T) {
 								RouteTable:    RouteTable{},
 							},
 						},
-						APIServerLB: LoadBalancerSpec{
+						APIServerLB: &LoadBalancerSpec{
 							LoadBalancerClassSpec: LoadBalancerClassSpec{
 								Type: Public,
 							},
@@ -1702,7 +1739,7 @@ func TestNodeOutboundLBDefaults(t *testing.T) {
 				},
 				Spec: AzureClusterSpec{
 					NetworkSpec: NetworkSpec{
-						APIServerLB: LoadBalancerSpec{LoadBalancerClassSpec: LoadBalancerClassSpec{Type: Public}},
+						APIServerLB: &LoadBalancerSpec{LoadBalancerClassSpec: LoadBalancerClassSpec{Type: Public}},
 						Subnets: Subnets{
 							{
 								SubnetClassSpec: SubnetClassSpec{
@@ -1780,7 +1817,7 @@ func TestNodeOutboundLBDefaults(t *testing.T) {
 								RouteTable:    RouteTable{},
 							},
 						},
-						APIServerLB: LoadBalancerSpec{
+						APIServerLB: &LoadBalancerSpec{
 							LoadBalancerClassSpec: LoadBalancerClassSpec{
 								Type: Public,
 							},
@@ -1796,8 +1833,9 @@ func TestNodeOutboundLBDefaults(t *testing.T) {
 					Name: "cluster-test",
 				},
 				Spec: AzureClusterSpec{
+					ControlPlaneEnabled: true,
 					NetworkSpec: NetworkSpec{
-						APIServerLB: LoadBalancerSpec{LoadBalancerClassSpec: LoadBalancerClassSpec{Type: Public}},
+						APIServerLB: &LoadBalancerSpec{LoadBalancerClassSpec: LoadBalancerClassSpec{Type: Public}},
 						Subnets: Subnets{
 							{
 								SubnetClassSpec: SubnetClassSpec{
@@ -1843,6 +1881,7 @@ func TestNodeOutboundLBDefaults(t *testing.T) {
 					Name: "cluster-test",
 				},
 				Spec: AzureClusterSpec{
+					ControlPlaneEnabled: true,
 					NetworkSpec: NetworkSpec{
 						Subnets: Subnets{
 							{
@@ -1881,7 +1920,7 @@ func TestNodeOutboundLBDefaults(t *testing.T) {
 								RouteTable:    RouteTable{},
 							},
 						},
-						APIServerLB: LoadBalancerSpec{
+						APIServerLB: &LoadBalancerSpec{
 							LoadBalancerClassSpec: LoadBalancerClassSpec{
 								Type: Public,
 							},
@@ -1916,7 +1955,7 @@ func TestNodeOutboundLBDefaults(t *testing.T) {
 				},
 				Spec: AzureClusterSpec{
 					NetworkSpec: NetworkSpec{
-						APIServerLB: LoadBalancerSpec{LoadBalancerClassSpec: LoadBalancerClassSpec{Type: Internal}},
+						APIServerLB: &LoadBalancerSpec{LoadBalancerClassSpec: LoadBalancerClassSpec{Type: Internal}},
 					},
 				},
 			},
@@ -1926,7 +1965,7 @@ func TestNodeOutboundLBDefaults(t *testing.T) {
 				},
 				Spec: AzureClusterSpec{
 					NetworkSpec: NetworkSpec{
-						APIServerLB: LoadBalancerSpec{
+						APIServerLB: &LoadBalancerSpec{
 							LoadBalancerClassSpec: LoadBalancerClassSpec{
 								Type: Internal,
 							},
@@ -1943,7 +1982,7 @@ func TestNodeOutboundLBDefaults(t *testing.T) {
 				},
 				Spec: AzureClusterSpec{
 					NetworkSpec: NetworkSpec{
-						APIServerLB: LoadBalancerSpec{LoadBalancerClassSpec: LoadBalancerClassSpec{Type: Public}},
+						APIServerLB: &LoadBalancerSpec{LoadBalancerClassSpec: LoadBalancerClassSpec{Type: Public}},
 						NodeOutboundLB: &LoadBalancerSpec{
 							FrontendIPsCount: ptr.To[int32](2),
 							BackendPool: BackendPool{
@@ -1962,7 +2001,7 @@ func TestNodeOutboundLBDefaults(t *testing.T) {
 				},
 				Spec: AzureClusterSpec{
 					NetworkSpec: NetworkSpec{
-						APIServerLB: LoadBalancerSpec{
+						APIServerLB: &LoadBalancerSpec{
 							LoadBalancerClassSpec: LoadBalancerClassSpec{
 								Type: Public,
 							},
@@ -2005,7 +2044,7 @@ func TestNodeOutboundLBDefaults(t *testing.T) {
 				},
 				Spec: AzureClusterSpec{
 					NetworkSpec: NetworkSpec{
-						APIServerLB: LoadBalancerSpec{
+						APIServerLB: &LoadBalancerSpec{
 							Name: "user-defined-name",
 							LoadBalancerClassSpec: LoadBalancerClassSpec{
 								Type: Public,
@@ -2062,7 +2101,7 @@ func TestNodeOutboundLBDefaults(t *testing.T) {
 								RouteTable:    RouteTable{},
 							},
 						},
-						APIServerLB: LoadBalancerSpec{
+						APIServerLB: &LoadBalancerSpec{
 							Name: "user-defined-name",
 							LoadBalancerClassSpec: LoadBalancerClassSpec{
 								Type: Public,
@@ -2123,7 +2162,7 @@ func TestControlPlaneOutboundLBDefaults(t *testing.T) {
 				},
 				Spec: AzureClusterSpec{
 					NetworkSpec: NetworkSpec{
-						APIServerLB: LoadBalancerSpec{LoadBalancerClassSpec: LoadBalancerClassSpec{Type: Public}},
+						APIServerLB: &LoadBalancerSpec{LoadBalancerClassSpec: LoadBalancerClassSpec{Type: Public}},
 					},
 				},
 			},
@@ -2133,7 +2172,7 @@ func TestControlPlaneOutboundLBDefaults(t *testing.T) {
 				},
 				Spec: AzureClusterSpec{
 					NetworkSpec: NetworkSpec{
-						APIServerLB: LoadBalancerSpec{
+						APIServerLB: &LoadBalancerSpec{
 							LoadBalancerClassSpec: LoadBalancerClassSpec{
 								Type: Public,
 							},
@@ -2150,7 +2189,7 @@ func TestControlPlaneOutboundLBDefaults(t *testing.T) {
 				},
 				Spec: AzureClusterSpec{
 					NetworkSpec: NetworkSpec{
-						APIServerLB: LoadBalancerSpec{LoadBalancerClassSpec: LoadBalancerClassSpec{Type: Internal}},
+						APIServerLB: &LoadBalancerSpec{LoadBalancerClassSpec: LoadBalancerClassSpec{Type: Internal}},
 					},
 				},
 			},
@@ -2160,7 +2199,7 @@ func TestControlPlaneOutboundLBDefaults(t *testing.T) {
 				},
 				Spec: AzureClusterSpec{
 					NetworkSpec: NetworkSpec{
-						APIServerLB: LoadBalancerSpec{
+						APIServerLB: &LoadBalancerSpec{
 							LoadBalancerClassSpec: LoadBalancerClassSpec{
 								Type: Internal,
 							},
@@ -2177,7 +2216,7 @@ func TestControlPlaneOutboundLBDefaults(t *testing.T) {
 				},
 				Spec: AzureClusterSpec{
 					NetworkSpec: NetworkSpec{
-						APIServerLB: LoadBalancerSpec{LoadBalancerClassSpec: LoadBalancerClassSpec{Type: Internal}},
+						APIServerLB: &LoadBalancerSpec{LoadBalancerClassSpec: LoadBalancerClassSpec{Type: Internal}},
 						ControlPlaneOutboundLB: &LoadBalancerSpec{
 							FrontendIPsCount: ptr.To[int32](2),
 							LoadBalancerClassSpec: LoadBalancerClassSpec{
@@ -2193,7 +2232,7 @@ func TestControlPlaneOutboundLBDefaults(t *testing.T) {
 				},
 				Spec: AzureClusterSpec{
 					NetworkSpec: NetworkSpec{
-						APIServerLB: LoadBalancerSpec{
+						APIServerLB: &LoadBalancerSpec{
 							LoadBalancerClassSpec: LoadBalancerClassSpec{
 								Type: Internal,
 							},
@@ -2236,7 +2275,7 @@ func TestControlPlaneOutboundLBDefaults(t *testing.T) {
 				},
 				Spec: AzureClusterSpec{
 					NetworkSpec: NetworkSpec{
-						APIServerLB: LoadBalancerSpec{LoadBalancerClassSpec: LoadBalancerClassSpec{Type: Internal}},
+						APIServerLB: &LoadBalancerSpec{LoadBalancerClassSpec: LoadBalancerClassSpec{Type: Internal}},
 						ControlPlaneOutboundLB: &LoadBalancerSpec{
 							BackendPool: BackendPool{
 								Name: "custom-outbound-lb",
@@ -2254,7 +2293,7 @@ func TestControlPlaneOutboundLBDefaults(t *testing.T) {
 				},
 				Spec: AzureClusterSpec{
 					NetworkSpec: NetworkSpec{
-						APIServerLB: LoadBalancerSpec{
+						APIServerLB: &LoadBalancerSpec{
 							LoadBalancerClassSpec: LoadBalancerClassSpec{
 								Type: Internal,
 							},

--- a/api/v1beta1/azurecluster_types.go
+++ b/api/v1beta1/azurecluster_types.go
@@ -45,6 +45,11 @@ type AzureClusterSpec struct {
 	// +optional
 	BastionSpec BastionSpec `json:"bastionSpec,omitempty"`
 
+	// ControlPlaneEnabled enables control plane components in the cluster.
+	// +kubebuilder:default=true
+	// +optional
+	ControlPlaneEnabled bool `json:"controlPlaneEnabled,omitempty"`
+
 	// ControlPlaneEndpoint represents the endpoint used to communicate with the control plane. It is not recommended to set
 	// this when creating an AzureCluster as CAPZ will set this for you. However, if it is set, CAPZ will not change it.
 	// +optional

--- a/api/v1beta1/azurecluster_validation_test.go
+++ b/api/v1beta1/azurecluster_validation_test.go
@@ -316,7 +316,21 @@ func TestNetworkSpecWithPreexistingVnetValid(t *testing.T) {
 	for _, test := range testCase {
 		t.Run(test.name, func(t *testing.T) {
 			g := NewWithT(t)
-			errs := validateNetworkSpec(test.networkSpec, NetworkSpec{}, field.NewPath("spec").Child("networkSpec"))
+			errs := validateNetworkSpec(true, test.networkSpec, NetworkSpec{
+				Vnet:    VnetSpec{},
+				Subnets: nil,
+				APIServerLB: &LoadBalancerSpec{
+					ID:                    "",
+					Name:                  "",
+					FrontendIPs:           nil,
+					FrontendIPsCount:      nil,
+					BackendPool:           BackendPool{},
+					LoadBalancerClassSpec: LoadBalancerClassSpec{},
+				},
+				NodeOutboundLB:         nil,
+				ControlPlaneOutboundLB: nil,
+				NetworkClassSpec:       NetworkClassSpec{},
+			}, field.NewPath("spec").Child("networkSpec"))
 			g.Expect(errs).To(BeNil())
 		})
 	}
@@ -338,7 +352,21 @@ func TestNetworkSpecWithPreexistingVnetLackRequiredSubnets(t *testing.T) {
 
 	t.Run(testCase.name, func(t *testing.T) {
 		g := NewWithT(t)
-		errs := validateNetworkSpec(testCase.networkSpec, NetworkSpec{}, field.NewPath("spec").Child("networkSpec"))
+		errs := validateNetworkSpec(true, testCase.networkSpec, NetworkSpec{
+			Vnet:    VnetSpec{},
+			Subnets: nil,
+			APIServerLB: &LoadBalancerSpec{
+				ID:                    "",
+				Name:                  "",
+				FrontendIPs:           nil,
+				FrontendIPsCount:      nil,
+				BackendPool:           BackendPool{},
+				LoadBalancerClassSpec: LoadBalancerClassSpec{},
+			},
+			NodeOutboundLB:         nil,
+			ControlPlaneOutboundLB: nil,
+			NetworkClassSpec:       NetworkClassSpec{},
+		}, field.NewPath("spec").Child("networkSpec"))
 		g.Expect(errs).To(HaveLen(1))
 		g.Expect(errs[0].Type).To(Equal(field.ErrorTypeRequired))
 		g.Expect(errs[0].Field).To(Equal("spec.networkSpec.subnets"))
@@ -361,7 +389,21 @@ func TestNetworkSpecWithPreexistingVnetInvalidResourceGroup(t *testing.T) {
 
 	t.Run(testCase.name, func(t *testing.T) {
 		g := NewWithT(t)
-		errs := validateNetworkSpec(testCase.networkSpec, NetworkSpec{}, field.NewPath("spec").Child("networkSpec"))
+		errs := validateNetworkSpec(true, testCase.networkSpec, NetworkSpec{
+			Vnet:    VnetSpec{},
+			Subnets: nil,
+			APIServerLB: &LoadBalancerSpec{
+				ID:                    "",
+				Name:                  "",
+				FrontendIPs:           nil,
+				FrontendIPsCount:      nil,
+				BackendPool:           BackendPool{},
+				LoadBalancerClassSpec: LoadBalancerClassSpec{},
+			},
+			NodeOutboundLB:         nil,
+			ControlPlaneOutboundLB: nil,
+			NetworkClassSpec:       NetworkClassSpec{},
+		}, field.NewPath("spec").Child("networkSpec"))
 		g.Expect(errs).To(HaveLen(1))
 		g.Expect(errs[0].Type).To(Equal(field.ErrorTypeInvalid))
 		g.Expect(errs[0].Field).To(Equal("spec.networkSpec.vnet.resourceGroup"))
@@ -384,7 +426,21 @@ func TestNetworkSpecWithoutPreexistingVnetValid(t *testing.T) {
 
 	t.Run(testCase.name, func(t *testing.T) {
 		g := NewWithT(t)
-		errs := validateNetworkSpec(testCase.networkSpec, NetworkSpec{}, field.NewPath("spec").Child("networkSpec"))
+		errs := validateNetworkSpec(true, testCase.networkSpec, NetworkSpec{
+			Vnet:    VnetSpec{},
+			Subnets: nil,
+			APIServerLB: &LoadBalancerSpec{
+				ID:                    "",
+				Name:                  "",
+				FrontendIPs:           nil,
+				FrontendIPsCount:      nil,
+				BackendPool:           BackendPool{},
+				LoadBalancerClassSpec: LoadBalancerClassSpec{},
+			},
+			NodeOutboundLB:         nil,
+			ControlPlaneOutboundLB: nil,
+			NetworkClassSpec:       NetworkClassSpec{},
+		}, field.NewPath("spec").Child("networkSpec"))
 		g.Expect(errs).To(BeNil())
 	})
 }
@@ -551,7 +607,7 @@ func TestClusterSubnetsValid(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			g := NewWithT(t)
-			errs := validateSubnets(tc.subnets, createValidVnet(),
+			errs := validateSubnets(true, tc.subnets, createValidVnet(),
 				field.NewPath("spec").Child("networkSpec").Child("subnets"))
 			g.Expect(errs).To(ConsistOf(tc.err))
 		})
@@ -571,7 +627,7 @@ func TestSubnetsValid(t *testing.T) {
 
 	t.Run(testCase.name, func(t *testing.T) {
 		g := NewWithT(t)
-		errs := validateSubnets(testCase.subnets, createValidVnet(),
+		errs := validateSubnets(true, testCase.subnets, createValidVnet(),
 			field.NewPath("spec").Child("networkSpec").Child("subnets"))
 		g.Expect(errs).To(BeNil())
 	})
@@ -592,7 +648,7 @@ func TestSubnetsInvalidSubnetName(t *testing.T) {
 
 	t.Run(testCase.name, func(t *testing.T) {
 		g := NewWithT(t)
-		errs := validateSubnets(testCase.subnets, createValidVnet(),
+		errs := validateSubnets(true, testCase.subnets, createValidVnet(),
 			field.NewPath("spec").Child("networkSpec").Child("subnets"))
 		g.Expect(errs).To(HaveLen(1))
 		g.Expect(errs[0].Type).To(Equal(field.ErrorTypeInvalid))
@@ -616,7 +672,7 @@ func TestSubnetsInvalidLackRequiredSubnet(t *testing.T) {
 
 	t.Run(testCase.name, func(t *testing.T) {
 		g := NewWithT(t)
-		errs := validateSubnets(testCase.subnets, createValidVnet(),
+		errs := validateSubnets(true, testCase.subnets, createValidVnet(),
 			field.NewPath("spec").Child("networkSpec").Child("subnets"))
 		g.Expect(errs).To(HaveLen(1))
 		g.Expect(errs[0].Type).To(Equal(field.ErrorTypeRequired))
@@ -641,7 +697,7 @@ func TestSubnetNamesNotUnique(t *testing.T) {
 
 	t.Run(testCase.name, func(t *testing.T) {
 		g := NewWithT(t)
-		errs := validateSubnets(testCase.subnets, createValidVnet(),
+		errs := validateSubnets(true, testCase.subnets, createValidVnet(),
 			field.NewPath("spec").Child("networkSpec").Child("subnets"))
 		g.Expect(errs).To(HaveLen(1))
 		g.Expect(errs[0].Type).To(Equal(field.ErrorTypeDuplicate))
@@ -1032,7 +1088,7 @@ func TestValidateAPIServerLB(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			g := NewWithT(t)
-			err := validateAPIServerLB(test.lb, test.old, test.cpCIDRS, field.NewPath("apiServerLB"))
+			err := validateAPIServerLB(&test.lb, &test.old, test.cpCIDRS, field.NewPath("apiServerLB"))
 			if test.wantErr {
 				g.Expect(err).To(ContainElement(MatchError(test.expectedErr.Error())))
 			} else {
@@ -1090,7 +1146,7 @@ func TestPrivateDNSZoneName(t *testing.T) {
 				NetworkClassSpec: NetworkClassSpec{
 					PrivateDNSZoneName: "good.dns.io",
 				},
-				APIServerLB: LoadBalancerSpec{
+				APIServerLB: &LoadBalancerSpec{
 					Name: "my-lb",
 					LoadBalancerClassSpec: LoadBalancerClassSpec{
 						Type: Public,
@@ -1111,7 +1167,7 @@ func TestPrivateDNSZoneName(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			g := NewWithT(t)
-			err := validatePrivateDNSZoneName(test.network.PrivateDNSZoneName, test.network.APIServerLB.Type, field.NewPath("spec", "networkSpec", "privateDNSZoneName"))
+			err := validatePrivateDNSZoneName(test.network.PrivateDNSZoneName, true, test.network.APIServerLB.Type, field.NewPath("spec", "networkSpec", "privateDNSZoneName"))
 			if test.wantErr {
 				g.Expect(err).To(ContainElement(MatchError(test.expectedErr.Error())))
 			} else {
@@ -1267,7 +1323,7 @@ func TestValidateNodeOutboundLB(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			g := NewWithT(t)
-			err := validateNodeOutboundLB(test.lb, test.old, test.apiServerLB, field.NewPath("nodeOutboundLB"))
+			err := validateNodeOutboundLB(test.lb, test.old, &test.apiServerLB, field.NewPath("nodeOutboundLB"))
 			if test.wantErr {
 				g.Expect(err).To(ContainElement(MatchError(test.expectedErr.Error())))
 			} else {
@@ -1346,7 +1402,7 @@ func TestValidateControlPlaneNodeOutboundLB(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			g := NewWithT(t)
-			err := validateControlPlaneOutboundLB(test.lb, test.apiServerLB, field.NewPath("controlPlaneOutboundLB"))
+			err := validateControlPlaneOutboundLB(test.lb, &test.apiServerLB, field.NewPath("controlPlaneOutboundLB"))
 			if test.wantErr {
 				g.Expect(err).To(ContainElement(MatchError(test.expectedErr.Error())))
 			} else {
@@ -1452,7 +1508,8 @@ func createValidClusterWithClusterSubnet() *AzureCluster {
 			Name: "test-cluster",
 		},
 		Spec: AzureClusterSpec{
-			NetworkSpec: createValidNetworkSpecWithClusterSubnet(),
+			ControlPlaneEnabled: true,
+			NetworkSpec:         createValidNetworkSpecWithClusterSubnet(),
 			AzureClusterClassSpec: AzureClusterClassSpec{
 				IdentityRef: &corev1.ObjectReference{
 					Kind: "AzureClusterIdentity",
@@ -1468,7 +1525,8 @@ func createValidCluster() *AzureCluster {
 			Name: "test-cluster",
 		},
 		Spec: AzureClusterSpec{
-			NetworkSpec: createValidNetworkSpec(),
+			ControlPlaneEnabled: true,
+			NetworkSpec:         createValidNetworkSpec(),
 			AzureClusterClassSpec: AzureClusterClassSpec{
 				IdentityRef: &corev1.ObjectReference{
 					Kind: AzureClusterIdentityKind,
@@ -1555,8 +1613,8 @@ func createValidVnet() VnetSpec {
 	}
 }
 
-func createValidAPIServerLB() LoadBalancerSpec {
-	return LoadBalancerSpec{
+func createValidAPIServerLB() *LoadBalancerSpec {
+	return &LoadBalancerSpec{
 		Name: "my-lb",
 		FrontendIPs: []FrontendIP{
 			{
@@ -1580,8 +1638,8 @@ func createValidNodeOutboundLB() *LoadBalancerSpec {
 	}
 }
 
-func createValidAPIServerInternalLB() LoadBalancerSpec {
-	return LoadBalancerSpec{
+func createValidAPIServerInternalLB() *LoadBalancerSpec {
+	return &LoadBalancerSpec{
 		Name: "my-lb",
 		FrontendIPs: []FrontendIP{
 			{

--- a/api/v1beta1/azureclustertemplate_validation.go
+++ b/api/v1beta1/azureclustertemplate_validation.go
@@ -162,6 +162,7 @@ func (c *AzureClusterTemplate) validatePrivateDNSZoneName() field.ErrorList {
 
 	allErrs = append(allErrs, validatePrivateDNSZoneName(
 		networkSpec.PrivateDNSZoneName,
+		true,
 		networkSpec.APIServerLB.Type,
 		fldPath,
 	)...)

--- a/api/v1beta1/types.go
+++ b/api/v1beta1/types.go
@@ -100,7 +100,7 @@ type NetworkSpec struct {
 
 	// APIServerLB is the configuration for the control-plane load balancer.
 	// +optional
-	APIServerLB LoadBalancerSpec `json:"apiServerLB,omitempty"`
+	APIServerLB *LoadBalancerSpec `json:"apiServerLB,omitempty"`
 
 	// NodeOutboundLB is the configuration for the node outbound load balancer.
 	// +optional

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -3102,7 +3102,11 @@ func (in *NetworkSpec) DeepCopyInto(out *NetworkSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
-	in.APIServerLB.DeepCopyInto(&out.APIServerLB)
+	if in.APIServerLB != nil {
+		in, out := &in.APIServerLB, &out.APIServerLB
+		*out = new(LoadBalancerSpec)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.NodeOutboundLB != nil {
 		in, out := &in.NodeOutboundLB, &out.NodeOutboundLB
 		*out = new(LoadBalancerSpec)

--- a/azure/scope/cluster_test.go
+++ b/azure/scope/cluster_test.go
@@ -52,6 +52,7 @@ import (
 
 const fakeClientID = "fake-client-id"
 const fakeTenantID = "fake-tenant-id"
+const fakeSubscriptionID = "123"
 
 func specToString(spec any) string {
 	var sb strings.Builder
@@ -79,8 +80,6 @@ func TestNewClusterScope(t *testing.T) {
 	_ = clusterv1.AddToScheme(scheme)
 	_ = infrav1.AddToScheme(scheme)
 	_ = corev1.AddToScheme(scheme)
-
-	fakeSubscriptionID := "123"
 
 	cluster := &clusterv1.Cluster{
 		ObjectMeta: metav1.ObjectMeta{
@@ -134,8 +133,15 @@ func TestAPIServerHost(t *testing.T) {
 			name: "public apiserver lb (user-defined dns)",
 			azureCluster: infrav1.AzureCluster{
 				Spec: infrav1.AzureClusterSpec{
+					AzureClusterClassSpec: infrav1.AzureClusterClassSpec{
+						SubscriptionID: fakeSubscriptionID,
+						IdentityRef: &corev1.ObjectReference{
+							Kind: infrav1.AzureClusterIdentityKind,
+						},
+					},
+					ControlPlaneEnabled: true,
 					NetworkSpec: infrav1.NetworkSpec{
-						APIServerLB: infrav1.LoadBalancerSpec{
+						APIServerLB: &infrav1.LoadBalancerSpec{
 							FrontendIPs: []infrav1.FrontendIP{
 								{
 									PublicIP: &infrav1.PublicIPSpec{
@@ -156,8 +162,15 @@ func TestAPIServerHost(t *testing.T) {
 			name: "private apiserver lb (default private dns zone)",
 			azureCluster: infrav1.AzureCluster{
 				Spec: infrav1.AzureClusterSpec{
+					AzureClusterClassSpec: infrav1.AzureClusterClassSpec{
+						SubscriptionID: fakeSubscriptionID,
+						IdentityRef: &corev1.ObjectReference{
+							Kind: infrav1.AzureClusterIdentityKind,
+						},
+					},
+					ControlPlaneEnabled: true,
 					NetworkSpec: infrav1.NetworkSpec{
-						APIServerLB: infrav1.LoadBalancerSpec{
+						APIServerLB: &infrav1.LoadBalancerSpec{
 							FrontendIPs: []infrav1.FrontendIP{
 								{
 									PublicIP: &infrav1.PublicIPSpec{
@@ -178,11 +191,18 @@ func TestAPIServerHost(t *testing.T) {
 			name: "private apiserver (user-defined private dns zone)",
 			azureCluster: infrav1.AzureCluster{
 				Spec: infrav1.AzureClusterSpec{
+					AzureClusterClassSpec: infrav1.AzureClusterClassSpec{
+						SubscriptionID: fakeSubscriptionID,
+						IdentityRef: &corev1.ObjectReference{
+							Kind: infrav1.AzureClusterIdentityKind,
+						},
+					},
+					ControlPlaneEnabled: true,
 					NetworkSpec: infrav1.NetworkSpec{
 						NetworkClassSpec: infrav1.NetworkClassSpec{
 							PrivateDNSZoneName: "example.private",
 						},
-						APIServerLB: infrav1.LoadBalancerSpec{
+						APIServerLB: &infrav1.LoadBalancerSpec{
 							LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{
 								Type: infrav1.Internal,
 							},
@@ -233,6 +253,13 @@ func TestGettingSecurityRules(t *testing.T) {
 			Name: "my-azure-cluster",
 		},
 		Spec: infrav1.AzureClusterSpec{
+			AzureClusterClassSpec: infrav1.AzureClusterClassSpec{
+				SubscriptionID: "123",
+				IdentityRef: &corev1.ObjectReference{
+					Kind: infrav1.AzureClusterIdentityKind,
+				},
+			},
+			ControlPlaneEnabled: true,
 			NetworkSpec: infrav1.NetworkSpec{
 				Subnets: infrav1.Subnets{
 					{
@@ -287,7 +314,7 @@ func TestPublicIPSpecs(t *testing.T) {
 						},
 					},
 					NetworkSpec: infrav1.NetworkSpec{
-						APIServerLB: infrav1.LoadBalancerSpec{
+						APIServerLB: &infrav1.LoadBalancerSpec{
 							LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{
 								Type: infrav1.Internal,
 							},
@@ -311,7 +338,8 @@ func TestPublicIPSpecs(t *testing.T) {
 					},
 				},
 				Spec: infrav1.AzureClusterSpec{
-					ResourceGroup: "my-rg",
+					ResourceGroup:       "my-rg",
+					ControlPlaneEnabled: true,
 					AzureClusterClassSpec: infrav1.AzureClusterClassSpec{
 						Location: "centralIndia",
 						AdditionalTags: infrav1.Tags{
@@ -323,7 +351,7 @@ func TestPublicIPSpecs(t *testing.T) {
 						ControlPlaneOutboundLB: &infrav1.LoadBalancerSpec{
 							FrontendIPsCount: ptr.To[int32](0),
 						},
-						APIServerLB: infrav1.LoadBalancerSpec{
+						APIServerLB: &infrav1.LoadBalancerSpec{
 							LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{
 								Type: infrav1.Internal,
 							},
@@ -347,7 +375,8 @@ func TestPublicIPSpecs(t *testing.T) {
 					},
 				},
 				Spec: infrav1.AzureClusterSpec{
-					ResourceGroup: "my-rg",
+					ResourceGroup:       "my-rg",
+					ControlPlaneEnabled: true,
 					AzureClusterClassSpec: infrav1.AzureClusterClassSpec{
 						Location: "centralIndia",
 						AdditionalTags: infrav1.Tags{
@@ -368,7 +397,7 @@ func TestPublicIPSpecs(t *testing.T) {
 							},
 							LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{},
 						},
-						APIServerLB: infrav1.LoadBalancerSpec{
+						APIServerLB: &infrav1.LoadBalancerSpec{
 							LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{
 								Type: infrav1.Internal,
 							},
@@ -406,7 +435,8 @@ func TestPublicIPSpecs(t *testing.T) {
 					},
 				},
 				Spec: infrav1.AzureClusterSpec{
-					ResourceGroup: "my-rg",
+					ResourceGroup:       "my-rg",
+					ControlPlaneEnabled: true,
 					AzureClusterClassSpec: infrav1.AzureClusterClassSpec{
 						Location: "centralIndia",
 						AdditionalTags: infrav1.Tags{
@@ -439,7 +469,7 @@ func TestPublicIPSpecs(t *testing.T) {
 							},
 							LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{},
 						},
-						APIServerLB: infrav1.LoadBalancerSpec{
+						APIServerLB: &infrav1.LoadBalancerSpec{
 							LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{
 								Type: infrav1.Internal,
 							},
@@ -503,7 +533,8 @@ func TestPublicIPSpecs(t *testing.T) {
 					},
 				},
 				Spec: infrav1.AzureClusterSpec{
-					ResourceGroup: "my-rg",
+					ResourceGroup:       "my-rg",
+					ControlPlaneEnabled: true,
 					AzureClusterClassSpec: infrav1.AzureClusterClassSpec{
 						Location: "centralIndia",
 						AdditionalTags: infrav1.Tags{
@@ -515,7 +546,7 @@ func TestPublicIPSpecs(t *testing.T) {
 						ControlPlaneOutboundLB: &infrav1.LoadBalancerSpec{
 							LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{},
 						},
-						APIServerLB: infrav1.LoadBalancerSpec{
+						APIServerLB: &infrav1.LoadBalancerSpec{
 							LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{},
 							FrontendIPs: []infrav1.FrontendIP{
 								{
@@ -559,7 +590,8 @@ func TestPublicIPSpecs(t *testing.T) {
 					},
 				},
 				Spec: infrav1.AzureClusterSpec{
-					ResourceGroup: "my-rg",
+					ResourceGroup:       "my-rg",
+					ControlPlaneEnabled: true,
 					AzureClusterClassSpec: infrav1.AzureClusterClassSpec{
 						Location: "centralIndia",
 						AdditionalTags: infrav1.Tags{
@@ -574,7 +606,7 @@ func TestPublicIPSpecs(t *testing.T) {
 						NodeOutboundLB: &infrav1.LoadBalancerSpec{
 							LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{},
 						},
-						APIServerLB: infrav1.LoadBalancerSpec{
+						APIServerLB: &infrav1.LoadBalancerSpec{
 							FrontendIPs: []infrav1.FrontendIP{
 								{
 									PublicIP: &infrav1.PublicIPSpec{
@@ -618,7 +650,8 @@ func TestPublicIPSpecs(t *testing.T) {
 					},
 				},
 				Spec: infrav1.AzureClusterSpec{
-					ResourceGroup: "my-rg",
+					ResourceGroup:       "my-rg",
+					ControlPlaneEnabled: true,
 					BastionSpec: infrav1.BastionSpec{
 						AzureBastion: &infrav1.AzureBastion{
 							PublicIP: infrav1.PublicIPSpec{
@@ -654,7 +687,7 @@ func TestPublicIPSpecs(t *testing.T) {
 						NodeOutboundLB: &infrav1.LoadBalancerSpec{
 							LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{},
 						},
-						APIServerLB: infrav1.LoadBalancerSpec{
+						APIServerLB: &infrav1.LoadBalancerSpec{
 							FrontendIPs: []infrav1.FrontendIP{
 								{
 									PublicIP: &infrav1.PublicIPSpec{
@@ -2001,7 +2034,7 @@ func TestAPIServerLBPoolName(t *testing.T) {
 				},
 				Spec: infrav1.AzureClusterSpec{
 					NetworkSpec: infrav1.NetworkSpec{
-						APIServerLB: infrav1.LoadBalancerSpec{
+						APIServerLB: &infrav1.LoadBalancerSpec{
 							Name: tc.lbName,
 						},
 					},
@@ -2093,6 +2126,13 @@ func TestOutboundLBName(t *testing.T) {
 					Name: tc.clusterName,
 				},
 				Spec: infrav1.AzureClusterSpec{
+					ControlPlaneEnabled: true,
+					AzureClusterClassSpec: infrav1.AzureClusterClassSpec{
+						SubscriptionID: "123",
+						IdentityRef: &corev1.ObjectReference{
+							Kind: infrav1.AzureClusterIdentityKind,
+						},
+					},
 					NetworkSpec: infrav1.NetworkSpec{
 						Subnets: infrav1.Subnets{
 							{
@@ -2107,7 +2147,7 @@ func TestOutboundLBName(t *testing.T) {
 			}
 
 			if tc.apiServerLB != nil {
-				azureCluster.Spec.NetworkSpec.APIServerLB = *tc.apiServerLB
+				azureCluster.Spec.NetworkSpec.APIServerLB = tc.apiServerLB
 			}
 
 			if tc.controlPlaneOutboundLB != nil {
@@ -2191,6 +2231,13 @@ func TestBackendPoolName(t *testing.T) {
 					Name: tc.clusterName,
 				},
 				Spec: infrav1.AzureClusterSpec{
+					AzureClusterClassSpec: infrav1.AzureClusterClassSpec{
+						SubscriptionID: "123",
+						IdentityRef: &corev1.ObjectReference{
+							Kind: infrav1.AzureClusterIdentityKind,
+						},
+					},
+					ControlPlaneEnabled: true,
 					NetworkSpec: infrav1.NetworkSpec{
 						Subnets: infrav1.Subnets{
 							{
@@ -2200,7 +2247,7 @@ func TestBackendPoolName(t *testing.T) {
 								},
 							},
 						},
-						APIServerLB: infrav1.LoadBalancerSpec{
+						APIServerLB: &infrav1.LoadBalancerSpec{
 							Name: "APIServerLBName",
 						},
 						ControlPlaneOutboundLB: &infrav1.LoadBalancerSpec{
@@ -2285,6 +2332,22 @@ func TestOutboundPoolName(t *testing.T) {
 			azureCluster := &infrav1.AzureCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: tc.clusterName,
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion: "cluster.x-k8s.io/v1beta1",
+							Kind:       "Cluster",
+							Name:       "my-cluster",
+						},
+					},
+				},
+				Spec: infrav1.AzureClusterSpec{
+					ControlPlaneEnabled: true,
+					AzureClusterClassSpec: infrav1.AzureClusterClassSpec{
+						SubscriptionID: "123",
+						IdentityRef: &corev1.ObjectReference{
+							Kind: infrav1.AzureClusterIdentityKind,
+						},
+					},
 				},
 			}
 
@@ -2565,7 +2628,8 @@ func TestClusterScope_LBSpecs(t *testing.T) {
 						SubscriptionID: "123",
 						Location:       "westus2",
 					},
-					ResourceGroup: "my-rg",
+					ControlPlaneEnabled: true,
+					ResourceGroup:       "my-rg",
 					NetworkSpec: infrav1.NetworkSpec{
 						Vnet: infrav1.VnetSpec{
 							Name:          "my-vnet",
@@ -2585,7 +2649,7 @@ func TestClusterScope_LBSpecs(t *testing.T) {
 								},
 							},
 						},
-						APIServerLB: infrav1.LoadBalancerSpec{
+						APIServerLB: &infrav1.LoadBalancerSpec{
 							Name: "api-server-lb",
 							BackendPool: infrav1.BackendPool{
 								Name: "api-server-lb-backend-pool",
@@ -2763,7 +2827,8 @@ func TestClusterScope_LBSpecs(t *testing.T) {
 						SubscriptionID: "123",
 						Location:       "westus2",
 					},
-					ResourceGroup: "my-rg",
+					ControlPlaneEnabled: true,
+					ResourceGroup:       "my-rg",
 					NetworkSpec: infrav1.NetworkSpec{
 						Vnet: infrav1.VnetSpec{
 							Name:          "my-vnet",
@@ -2783,7 +2848,7 @@ func TestClusterScope_LBSpecs(t *testing.T) {
 								},
 							},
 						},
-						APIServerLB: infrav1.LoadBalancerSpec{
+						APIServerLB: &infrav1.LoadBalancerSpec{
 							Name: "api-server-lb",
 							BackendPool: infrav1.BackendPool{
 								Name: "api-server-lb-backend-pool",

--- a/azure/scope/machine_test.go
+++ b/azure/scope/machine_test.go
@@ -303,7 +303,7 @@ func TestMachineScope_PublicIPSpecs(t *testing.T) {
 								},
 							},
 							NetworkSpec: infrav1.NetworkSpec{
-								APIServerLB: infrav1.LoadBalancerSpec{
+								APIServerLB: &infrav1.LoadBalancerSpec{
 									LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{
 										Type: infrav1.Internal,
 									},
@@ -387,7 +387,7 @@ func TestMachineScope_InboundNatSpecs(t *testing.T) {
 								SubscriptionID: "123",
 							},
 							NetworkSpec: infrav1.NetworkSpec{
-								APIServerLB: infrav1.LoadBalancerSpec{
+								APIServerLB: &infrav1.LoadBalancerSpec{
 									Name: "foo-loadbalancer",
 									FrontendIPs: []infrav1.FrontendIP{
 										{
@@ -2215,7 +2215,7 @@ func TestMachineScope_NICSpecs(t *testing.T) {
 										},
 									},
 								},
-								APIServerLB: infrav1.LoadBalancerSpec{
+								APIServerLB: &infrav1.LoadBalancerSpec{
 									Name: "api-lb",
 									LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{
 										Type: infrav1.Internal,
@@ -2328,7 +2328,7 @@ func TestMachineScope_NICSpecs(t *testing.T) {
 										},
 									},
 								},
-								APIServerLB: infrav1.LoadBalancerSpec{
+								APIServerLB: &infrav1.LoadBalancerSpec{
 									Name: "api-lb",
 									BackendPool: infrav1.BackendPool{
 										Name: "api-lb-backendPool",
@@ -2438,7 +2438,7 @@ func TestMachineScope_NICSpecs(t *testing.T) {
 										},
 									},
 								},
-								APIServerLB: infrav1.LoadBalancerSpec{
+								APIServerLB: &infrav1.LoadBalancerSpec{
 									Name: "api-lb",
 									BackendPool: infrav1.BackendPool{
 										Name: "api-lb-backendPool",
@@ -2549,7 +2549,7 @@ func TestMachineScope_NICSpecs(t *testing.T) {
 										},
 									},
 								},
-								APIServerLB: infrav1.LoadBalancerSpec{
+								APIServerLB: &infrav1.LoadBalancerSpec{
 									Name: "api-lb",
 								},
 								NodeOutboundLB: &infrav1.LoadBalancerSpec{
@@ -2689,7 +2689,7 @@ func TestMachineScope_NICSpecs(t *testing.T) {
 										},
 									},
 								},
-								APIServerLB: infrav1.LoadBalancerSpec{
+								APIServerLB: &infrav1.LoadBalancerSpec{
 									Name: "api-lb",
 								},
 								NodeOutboundLB: &infrav1.LoadBalancerSpec{
@@ -2827,7 +2827,7 @@ func TestMachineScope_NICSpecs(t *testing.T) {
 										},
 									},
 								},
-								APIServerLB: infrav1.LoadBalancerSpec{
+								APIServerLB: &infrav1.LoadBalancerSpec{
 									Name: "api-lb",
 								},
 								NodeOutboundLB: &infrav1.LoadBalancerSpec{

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azureclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azureclusters.yaml
@@ -551,6 +551,11 @@ spec:
                       type: object
                     type: array
                 type: object
+              controlPlaneEnabled:
+                default: true
+                description: ControlPlaneEnabled enables control plane components
+                  in the cluster.
+                type: boolean
               controlPlaneEndpoint:
                 description: |-
                   ControlPlaneEndpoint represents the endpoint used to communicate with the control plane. It is not recommended to set

--- a/controllers/azurecluster_reconciler.go
+++ b/controllers/azurecluster_reconciler.go
@@ -115,10 +115,11 @@ func (s *azureClusterService) reconcile(ctx context.Context) error {
 	if err := s.setFailureDomainsForLocation(ctx); err != nil {
 		return errors.Wrap(err, "failed to get availability zones")
 	}
-
-	s.scope.AzureCluster.SetBackendPoolNameDefault()
-	s.scope.SetDNSName()
-	s.scope.SetControlPlaneSecurityRules()
+	if s.scope.ControlPlaneEnabled() {
+		s.scope.AzureCluster.SetBackendPoolNameDefault()
+		s.scope.SetDNSName()
+		s.scope.SetControlPlaneSecurityRules()
+	}
 
 	for _, service := range s.services {
 		if err := service.Reconcile(ctx); err != nil {

--- a/controllers/azuremachine_controller_test.go
+++ b/controllers/azuremachine_controller_test.go
@@ -565,6 +565,7 @@ func getFakeAzureCluster(changes ...func(*infrav1.AzureCluster)) *infrav1.AzureC
 					Kind:      "AzureClusterIdentity",
 				},
 			},
+			ControlPlaneEnabled: true,
 			NetworkSpec: infrav1.NetworkSpec{
 				Subnets: infrav1.Subnets{
 					{
@@ -574,7 +575,7 @@ func getFakeAzureCluster(changes ...func(*infrav1.AzureCluster)) *infrav1.AzureC
 						},
 					},
 				},
-				APIServerLB: infrav1.LoadBalancerSpec{
+				APIServerLB: &infrav1.LoadBalancerSpec{
 					Name: "my-cluster-public-lb",
 					FrontendIPs: []infrav1.FrontendIP{
 						{


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

/kind feature

This PR enables the use off an external control plane (e.g. https://github.com/clastix/cluster-api-control-plane-provider-kamaji)

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Enable the use of an external control plane
```
