### PR TITLE
Add principal type to role assignment create parameters

### DIFF
--- a/azure/scope/machine.go
+++ b/azure/scope/machine.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"strings"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v2"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
@@ -352,6 +353,7 @@ func (m *MachineScope) RoleAssignmentSpecs(principalID *string) []azure.Resource
 			Scope:            m.SystemAssignedIdentityScope(),
 			RoleDefinitionID: m.SystemAssignedIdentityDefinitionID(),
 			PrincipalID:      principalID,
+			PrincipalType:    armauthorization.PrincipalTypeServicePrincipal,
 		}
 		return roles
 	}

--- a/azure/scope/machine_test.go
+++ b/azure/scope/machine_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v2"
 	azureautorest "github.com/Azure/go-autorest/autorest/azure"
 	"github.com/Azure/go-autorest/autorest/azure/auth"
 	"github.com/google/go-cmp/cmp"
@@ -478,6 +479,7 @@ func TestMachineScope_RoleAssignmentSpecs(t *testing.T) {
 					Name:          "azure-role-assignment-name",
 					ResourceGroup: "my-rg",
 					PrincipalID:   ptr.To("fakePrincipalID"),
+					PrincipalType: armauthorization.PrincipalTypeServicePrincipal,
 				},
 			},
 		},
@@ -525,6 +527,7 @@ func TestMachineScope_RoleAssignmentSpecs(t *testing.T) {
 					Scope:            "/subscriptions/123/resourceGroups/my-rg",
 					RoleDefinitionID: "/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Authorization/roleAssignments/123",
 					PrincipalID:      ptr.To("fakePrincipalID"),
+					PrincipalType:    armauthorization.PrincipalTypeServicePrincipal,
 				},
 			},
 		},

--- a/azure/scope/machinepool.go
+++ b/azure/scope/machinepool.go
@@ -24,6 +24,7 @@ import (
 	"io"
 	"strings"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v2"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -798,6 +799,7 @@ func (m *MachinePoolScope) RoleAssignmentSpecs(principalID *string) []azure.Reso
 			Scope:            m.SystemAssignedIdentityScope(),
 			RoleDefinitionID: m.SystemAssignedIdentityDefinitionID(),
 			PrincipalID:      principalID,
+			PrincipalType:    armauthorization.PrincipalTypeServicePrincipal,
 		}
 		return roles
 	}

--- a/azure/scope/machinepool_test.go
+++ b/azure/scope/machinepool_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v2"
 	azureautorest "github.com/Azure/go-autorest/autorest/azure"
 	"github.com/Azure/go-autorest/autorest/azure/auth"
 	. "github.com/onsi/gomega"
@@ -800,6 +801,7 @@ func TestMachinePoolScope_RoleAssignmentSpecs(t *testing.T) {
 					Name:          "role-assignment-name",
 					ResourceGroup: "my-rg",
 					PrincipalID:   ptr.To("fakePrincipalID"),
+					PrincipalType: armauthorization.PrincipalTypeServicePrincipal,
 				},
 			},
 		},
@@ -847,6 +849,7 @@ func TestMachinePoolScope_RoleAssignmentSpecs(t *testing.T) {
 					Scope:            "scope",
 					RoleDefinitionID: "role-definition-id",
 					PrincipalID:      ptr.To("fakePrincipalID"),
+					PrincipalType:    armauthorization.PrincipalTypeServicePrincipal,
 				},
 			},
 		},

--- a/azure/services/roleassignments/spec.go
+++ b/azure/services/roleassignments/spec.go
@@ -31,6 +31,7 @@ type RoleAssignmentSpec struct {
 	ResourceGroup    string
 	ResourceType     string
 	PrincipalID      *string
+	PrincipalType    armauthorization.PrincipalType
 	RoleDefinitionID string
 	Scope            string
 }
@@ -64,6 +65,7 @@ func (s *RoleAssignmentSpec) Parameters(ctx context.Context, existing interface{
 		Properties: &armauthorization.RoleAssignmentProperties{
 			PrincipalID:      s.PrincipalID,
 			RoleDefinitionID: ptr.To(s.RoleDefinitionID),
+			PrincipalType:    ptr.To(s.PrincipalType),
 		},
 	}, nil
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Context: when using `identity: SystemAssigned` in an AzureMachineTemplate with role definition ID `myrole`.

Accordingly to the CAPZ documentation: https://capz.sigs.k8s.io/topics/vm-identity#system-assigned-managed-identity the service principal used to run CAPZ controller manager requires `User Access Administrator` on the Subscription of Workload cluster.

Based on customer feedback, we agree that this is a very wide permissions set assigned to the service principal at hand. The only restriction that can be achieved right now is to limit this access to Role Based Access Control Administrator  with a condition on a role to be assigned, for example:

```
(
 (
  !(ActionMatches{'Microsoft.Authorization/roleAssignments/write'})
 )
 OR 
 (
  @Request[Microsoft.Authorization/roleAssignments:RoleDefinitionId] ForAnyOfAnyValues:GuidEquals <myrole guid>
 )
)
AND
(
 (
  !(ActionMatches{'Microsoft.Authorization/roleAssignments/delete'})
 )
 OR 
 (
  @Resource[Microsoft.Authorization/roleAssignments:RoleDefinitionId] ForAnyOfAnyValues:GuidEquals <myrole guid>
 )
)
```

This however creates a security flaw, where, if the CAPZ service principal is leaked, the `myrole` role can be assigned to any resource type, including users.

Desired behaviour: I would like to restrict the role assignment using a constraint like this one:

```
(
 (
  !(ActionMatches{'Microsoft.Authorization/roleAssignments/write'})
 )
 OR 
 (
  @Request[Microsoft.Authorization/roleAssignments:RoleDefinitionId] ForAnyOfAnyValues:GuidEquals <myrole guid>  AND
  @Request[Microsoft.Authorization/roleAssignments:PrincipalType] ForAnyOfAnyValues:StringEqualsIgnoreCase {'ServicePrincipal'}
 )
)
AND
(
 (
  !(ActionMatches{'Microsoft.Authorization/roleAssignments/delete'})
 )
 OR 
 (
  @Resource[Microsoft.Authorization/roleAssignments:RoleDefinitionId] ForAnyOfAnyValues:GuidEquals <myrole guid>
  AND
  @Resource[Microsoft.Authorization/roleAssignments:PrincipalType] ForAnyOfAnyValues:StringEqualsIgnoreCase {'ServicePrincipal'}
 )
)
```

This would prevent assigning the `myrole` role to a User or Group while still allowing assignment to Service Principals.

Problem: doing so without the changes introduced in this PR leads to a permission error:

```
E0305 14:05:39.993346      14 controller.go:329] "Reconciler error" err=<
	failed to reconcile AzureMachine: failed to reconcile AzureMachine service roleassignments: cannot assign role to VirtualMachine system assigned identity: failed to create or update resource systemassignedidentity-4639/244a1de6-b46f-4fe4-b9cf-58f9b57643fe (service: roleassignments): PUT https://management.azure.com/subscriptions/6b1f6e4a-6d0e-4aa4-9a5a-fbaca65a23b3/resourceGroups/systemassignedidentity-4639/providers/Microsoft.Authorization/roleAssignments/244a1de6-b46f-4fe4-b9cf-58f9b57643fe
	--------------------------------------------------------------------------------
	RESPONSE 403: 403 Forbidden
	ERROR CODE: AuthorizationFailed
	--------------------------------------------------------------------------------
	{
	  "error": {
	    "code": "AuthorizationFailed",
	    "message": "The client 'cab64998-4bbb-447d-a0f5-0f6590b46db7' with object id 'cab64998-4bbb-447d-a0f5-0f6590b46db7' does not have authorization to perform action 'Microsoft.Authorization/roleAssignments/write' over scope '/subscriptions/6b1f6e4a-6d0e-4aa4-9a5a-fbaca65a23b3/resourceGroups/systemassignedidentity-4639/providers/Microsoft.Authorization/roleAssignments/244a1de6-b46f-4fe4-b9cf-58f9b57643fe' or the scope is invalid. If access was recently granted, please refresh your credentials."
	  }
	}
	--------------------------------------------------------------------------------
```

This is because in the RoleAssignmentCreate API call, the principalType field is not assigned.

This PR addresses that problem by setting the PrincipalType to `ServicePrincipal` in the role assignment creation API call.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

None that I'm aware of.

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [x] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:

```release-note
Set `PrincipalType` in RoleAssignment creation API call when using `SystemAssigned` identity.
```
