### PR TITLE
Minor update to v1.14.0 CHANGELOG

### DIFF
--- a/CHANGELOG/v1.14.0.md
+++ b/CHANGELOG/v1.14.0.md
@@ -3,7 +3,7 @@
 ### Feature
 
 - Add additional Printer Columns like "Ready", "Severity", "Reason" and "Message" to CAPZ resources ([#4442](https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/4442), [@prashantrewar](https://github.com/prashantrewar))
-- Add support for AKS Extensions & Marketplace Offers ([#4360](https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/4360), [@willie-yao](https://github.com/willie-yao))
+- Add support for AKS Extensions and Marketplace Offers ([#4360](https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/4360), [@willie-yao](https://github.com/willie-yao))
 - Add support for Azure CNI Powered by Cilium ([#4522](https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/4522), [@willie-yao](https://github.com/willie-yao))
 - Allow ASO to install other CRDs ([#4547](https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/4547), [@nawazkh](https://github.com/nawazkh))
 - Allow adding pre-existing privateDNSZone to AKS clusters ([#4572](https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/4572), [@nawazkh](https://github.com/nawazkh))


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

This is a trivial change to the v1.14.0 CHANGELOG, in order to trigger the release action that wasn't triggered by #4627.

The current logic only fires if there is literally one CHANGELOG/<name>.md file in the commit. We're exploring how to make that more flexible in #4631.

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
