### PR TITLE
[WIP] Support existing IP as node outbound IPs

### DIFF
--- a/api/v1beta1/azurecluster_default.go
+++ b/api/v1beta1/azurecluster_default.go
@@ -284,6 +284,8 @@ func (c *AzureCluster) SetNodeOutboundLBDefaults() {
 
 	c.setOutboundLBFrontendIPs(lb, generateNodeOutboundIPName)
 	c.SetNodeOutboundLBBackendPoolNameDefault()
+
+	// TODO: should there be a default for the outboundIPs? Most likely no.
 }
 
 // SetControlPlaneOutboundLBDefaults sets the default values for the control plane's outbound LB.

--- a/api/v1beta1/azurecluster_validation.go
+++ b/api/v1beta1/azurecluster_validation.go
@@ -430,6 +430,8 @@ func validateAPIServerLB(lb LoadBalancerSpec, old LoadBalancerSpec, cidrs []stri
 		}
 	}
 
+	// TODO: should OutboundIPs be mutable?
+
 	return allErrs
 }
 

--- a/api/v1beta1/types.go
+++ b/api/v1beta1/types.go
@@ -342,6 +342,7 @@ type LoadBalancerSpec struct {
 	BackendPool BackendPool `json:"backendPool,omitempty"`
 	// OutboundIPs describes the outbound IP configuration for the load balancer.
 	// +optional
+	// TODO: should OutboundIPs moved to LoadBalancerClassSpec for AzureClusterTemplate?
 	OutboundIPs []PublicIPSpec `json:"outboundIPs,omitempty"`
 
 	LoadBalancerClassSpec `json:",inline"`

--- a/api/v1beta1/types.go
+++ b/api/v1beta1/types.go
@@ -340,6 +340,9 @@ type LoadBalancerSpec struct {
 	// BackendPool describes the backend pool of the load balancer.
 	// +optional
 	BackendPool BackendPool `json:"backendPool,omitempty"`
+	// OutboundIPs describes the outbound IP configuration for the load balancer.
+	// +optional
+	OutboundIPs []PublicIPSpec `json:"outboundIPs,omitempty"`
 
 	LoadBalancerClassSpec `json:",inline"`
 }

--- a/azure/scope/cluster.go
+++ b/azure/scope/cluster.go
@@ -274,6 +274,7 @@ func (s *ClusterScope) LBSpecs() []azure.ResourceSpecGetter {
 			BackendPoolName:      s.APIServerLB().BackendPool.Name,
 			IdleTimeoutInMinutes: s.APIServerLB().IdleTimeoutInMinutes,
 			AdditionalTags:       s.AdditionalTags(),
+			OutboundIPs:          s.APIServerLB().OutboundIPs,
 		},
 	}
 
@@ -295,6 +296,7 @@ func (s *ClusterScope) LBSpecs() []azure.ResourceSpecGetter {
 			IdleTimeoutInMinutes: s.NodeOutboundLB().IdleTimeoutInMinutes,
 			Role:                 infrav1.NodeOutboundRole,
 			AdditionalTags:       s.AdditionalTags(),
+			OutboundIPs:          s.APIServerLB().OutboundIPs,
 		})
 	}
 
@@ -316,6 +318,7 @@ func (s *ClusterScope) LBSpecs() []azure.ResourceSpecGetter {
 			IdleTimeoutInMinutes: s.ControlPlaneOutboundLB().IdleTimeoutInMinutes,
 			Role:                 infrav1.ControlPlaneOutboundRole,
 			AdditionalTags:       s.AdditionalTags(),
+			OutboundIPs:          s.APIServerLB().OutboundIPs,
 		})
 	}
 

--- a/azure/scope/cluster.go
+++ b/azure/scope/cluster.go
@@ -165,6 +165,19 @@ func (s *ClusterScope) PublicIPSpecs() []azure.ResourceSpecGetter {
 					AdditionalTags:   s.AdditionalTags(),
 				})
 			}
+			for _, ip := range s.ControlPlaneOutboundLB().OutboundIPs {
+				controlPlaneOutboundIPSpecs = append(controlPlaneOutboundIPSpecs, &publicips.PublicIPSpec{
+					Name:             ip.Name,
+					ResourceGroup:    s.ResourceGroup(),
+					ClusterName:      s.ClusterName(),
+					DNSName:          "",    // Set to default value
+					IsIPv6:           false, // Set to default value
+					Location:         s.Location(),
+					ExtendedLocation: s.ExtendedLocation(),
+					FailureDomains:   s.FailureDomains(),
+					AdditionalTags:   s.AdditionalTags(),
+				})
+			}
 		}
 	} else {
 		controlPlaneOutboundIPSpecs = []azure.ResourceSpecGetter{
@@ -249,6 +262,7 @@ func (s *ClusterScope) PublicIPSpecs() []azure.ResourceSpecGetter {
 		publicIPSpecs = append(publicIPSpecs, azureBastionPublicIP)
 	}
 
+	// TODO: why are API Server LB outbound IPs not included here?
 	return publicIPSpecs
 }
 

--- a/azure/scope/cluster.go
+++ b/azure/scope/cluster.go
@@ -199,6 +199,19 @@ func (s *ClusterScope) PublicIPSpecs() []azure.ResourceSpecGetter {
 				AdditionalTags:   s.AdditionalTags(),
 			})
 		}
+		for _, ip := range s.NodeOutboundLB().OutboundIPs {
+			publicIPSpecs = append(publicIPSpecs, &publicips.PublicIPSpec{
+				Name:             ip.Name,
+				ResourceGroup:    s.ResourceGroup(),
+				ClusterName:      s.ClusterName(),
+				DNSName:          "",    // Set to default value
+				IsIPv6:           false, // Set to default value
+				Location:         s.Location(),
+				ExtendedLocation: s.ExtendedLocation(),
+				FailureDomains:   s.FailureDomains(),
+				AdditionalTags:   s.AdditionalTags(),
+			})
+		}
 	}
 
 	// Public IP specs for node NAT gateways


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind feature

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
- Should add support existing IP as node outbound IPs.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1394 

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
support existing IP as node outbound IPs
```
