### PR TITLE
enable configuring WorkloadIdentity for AzureClusterIdentity in flavor templates

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -34,7 +34,7 @@ settings = {
 }
 
 # Auth keys that need to be loaded from the environment
-keys = ["AZURE_SUBSCRIPTION_ID", "AZURE_TENANT_ID", "AZURE_CLIENT_SECRET", "AZURE_CLIENT_ID"]
+keys = ["AZURE_SUBSCRIPTION_ID", "AZURE_TENANT_ID", "AZURE_CLIENT_ID"]
 
 # Get global settings from tilt-settings.yaml or tilt-settings.json
 tilt_file = "./tilt-settings.yaml" if os.path.exists("./tilt-settings.yaml") else "./tilt-settings.json"
@@ -249,6 +249,9 @@ def capz():
     k8s_yaml(blob(yaml))
 
 def create_identity_secret():
+    if not os.getenv("AZURE_CLIENT_SECRET"):
+        return
+
     #create secret for identity password
     local(kubectl_cmd + " delete secret cluster-identity-secret --ignore-not-found=true")
 

--- a/docs/book/src/topics/workload-identity.md
+++ b/docs/book/src/topics/workload-identity.md
@@ -111,32 +111,13 @@ export AZURE_LOCATION="eastus"
 # need to set them for the sake of generating the workload cluster YAML configuration
 export AZURE_CLUSTER_IDENTITY_SECRET_NAME="cluster-identity-secret"
 export CLUSTER_IDENTITY_NAME="cluster-identity"
+export CLUSTER_IDENTITY_TYPE="WorkloadIdentity"
 export AZURE_CLUSTER_IDENTITY_SECRET_NAMESPACE="default"
 ```
 - Generate a workload cluster template using the following command.
 
 ```bash
 clusterctl generate cluster azwi-quickstart --kubernetes-version v1.27.3  --worker-machine-count=3 > azwi-quickstart.yaml
-```
-
-- Edit the generated `azwi-quickstart.yaml` to make the following changes for
-  workload identity to the `AzureClusterIdentity` object.
-  - Change the type to `WorkloadIdentity`.
-  - Remove the `clientSecret` spec.
-
-The AzureClusterIdentity specification should look like the following.
-```yaml
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-kind: AzureClusterIdentity
-metadata:
-  name: cluster-identity
-spec:
-  type: WorkloadIdentity
-  allowedNamespaces:
-    list:
-    - <cluster-namespace>
-  tenantID: <your-tenant-id>
-  clientID: <your-client-id>
 ```
 
 - Change the `AzureMachineTemplate` for both control plane and worker to include user-assigned-identity by

--- a/templates/azure-cluster-identity/azure-cluster-identity.yaml
+++ b/templates/azure-cluster-identity/azure-cluster-identity.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     clusterctl.cluster.x-k8s.io/move-hierarchy: "true"
 spec:
-  type: ServicePrincipal
+  type: "${CLUSTER_IDENTITY_TYPE:=ServicePrincipal}"
   allowedNamespaces: {}
   tenantID: "${AZURE_TENANT_ID}"
   clientID: "${AZURE_CLIENT_ID}"

--- a/templates/cluster-template-aad.yaml
+++ b/templates/cluster-template-aad.yaml
@@ -208,4 +208,4 @@ spec:
     name: ${AZURE_CLUSTER_IDENTITY_SECRET_NAME}
     namespace: ${AZURE_CLUSTER_IDENTITY_SECRET_NAMESPACE}
   tenantID: ${AZURE_TENANT_ID}
-  type: ServicePrincipal
+  type: ${CLUSTER_IDENTITY_TYPE:=ServicePrincipal}

--- a/templates/cluster-template-aks-clusterclass.yaml
+++ b/templates/cluster-template-aks-clusterclass.yaml
@@ -104,7 +104,7 @@ spec:
     name: ${AZURE_CLUSTER_IDENTITY_SECRET_NAME}
     namespace: ${AZURE_CLUSTER_IDENTITY_SECRET_NAMESPACE}
   tenantID: ${AZURE_TENANT_ID}
-  type: ServicePrincipal
+  type: ${CLUSTER_IDENTITY_TYPE:=ServicePrincipal}
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate

--- a/templates/cluster-template-aks.yaml
+++ b/templates/cluster-template-aks.yaml
@@ -115,4 +115,4 @@ spec:
     name: ${AZURE_CLUSTER_IDENTITY_SECRET_NAME}
     namespace: ${AZURE_CLUSTER_IDENTITY_SECRET_NAMESPACE}
   tenantID: ${AZURE_TENANT_ID}
-  type: ServicePrincipal
+  type: ${CLUSTER_IDENTITY_TYPE:=ServicePrincipal}

--- a/templates/cluster-template-azure-bastion.yaml
+++ b/templates/cluster-template-azure-bastion.yaml
@@ -204,4 +204,4 @@ spec:
     name: ${AZURE_CLUSTER_IDENTITY_SECRET_NAME}
     namespace: ${AZURE_CLUSTER_IDENTITY_SECRET_NAMESPACE}
   tenantID: ${AZURE_TENANT_ID}
-  type: ServicePrincipal
+  type: ${CLUSTER_IDENTITY_TYPE:=ServicePrincipal}

--- a/templates/cluster-template-azure-cni-v1.yaml
+++ b/templates/cluster-template-azure-cni-v1.yaml
@@ -211,4 +211,4 @@ spec:
     name: ${AZURE_CLUSTER_IDENTITY_SECRET_NAME}
     namespace: ${AZURE_CLUSTER_IDENTITY_SECRET_NAMESPACE}
   tenantID: ${AZURE_TENANT_ID}
-  type: ServicePrincipal
+  type: ${CLUSTER_IDENTITY_TYPE:=ServicePrincipal}

--- a/templates/cluster-template-clusterclass.yaml
+++ b/templates/cluster-template-clusterclass.yaml
@@ -236,4 +236,4 @@ spec:
     name: ${AZURE_CLUSTER_IDENTITY_SECRET_NAME}
     namespace: ${AZURE_CLUSTER_IDENTITY_SECRET_NAMESPACE}
   tenantID: ${AZURE_TENANT_ID}
-  type: ServicePrincipal
+  type: ${CLUSTER_IDENTITY_TYPE:=ServicePrincipal}

--- a/templates/cluster-template-dual-stack.yaml
+++ b/templates/cluster-template-dual-stack.yaml
@@ -165,7 +165,7 @@ spec:
     name: ${AZURE_CLUSTER_IDENTITY_SECRET_NAME}
     namespace: ${AZURE_CLUSTER_IDENTITY_SECRET_NAMESPACE}
   tenantID: ${AZURE_TENANT_ID}
-  type: ServicePrincipal
+  type: ${CLUSTER_IDENTITY_TYPE:=ServicePrincipal}
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment

--- a/templates/cluster-template-edgezone.yaml
+++ b/templates/cluster-template-edgezone.yaml
@@ -205,4 +205,4 @@ spec:
     name: ${AZURE_CLUSTER_IDENTITY_SECRET_NAME}
     namespace: ${AZURE_CLUSTER_IDENTITY_SECRET_NAMESPACE}
   tenantID: ${AZURE_TENANT_ID}
-  type: ServicePrincipal
+  type: ${CLUSTER_IDENTITY_TYPE:=ServicePrincipal}

--- a/templates/cluster-template-ephemeral.yaml
+++ b/templates/cluster-template-ephemeral.yaml
@@ -208,4 +208,4 @@ spec:
     name: ${AZURE_CLUSTER_IDENTITY_SECRET_NAME}
     namespace: ${AZURE_CLUSTER_IDENTITY_SECRET_NAMESPACE}
   tenantID: ${AZURE_TENANT_ID}
-  type: ServicePrincipal
+  type: ${CLUSTER_IDENTITY_TYPE:=ServicePrincipal}

--- a/templates/cluster-template-flatcar.yaml
+++ b/templates/cluster-template-flatcar.yaml
@@ -244,4 +244,4 @@ spec:
     name: ${AZURE_CLUSTER_IDENTITY_SECRET_NAME}
     namespace: ${AZURE_CLUSTER_IDENTITY_SECRET_NAMESPACE}
   tenantID: ${AZURE_TENANT_ID}
-  type: ServicePrincipal
+  type: ${CLUSTER_IDENTITY_TYPE:=ServicePrincipal}

--- a/templates/cluster-template-ipv6.yaml
+++ b/templates/cluster-template-ipv6.yaml
@@ -170,7 +170,7 @@ spec:
     name: ${AZURE_CLUSTER_IDENTITY_SECRET_NAME}
     namespace: ${AZURE_CLUSTER_IDENTITY_SECRET_NAMESPACE}
   tenantID: ${AZURE_TENANT_ID}
-  type: ServicePrincipal
+  type: ${CLUSTER_IDENTITY_TYPE:=ServicePrincipal}
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment

--- a/templates/cluster-template-machinepool-windows.yaml
+++ b/templates/cluster-template-machinepool-windows.yaml
@@ -209,7 +209,7 @@ spec:
     name: ${AZURE_CLUSTER_IDENTITY_SECRET_NAME}
     namespace: ${AZURE_CLUSTER_IDENTITY_SECRET_NAMESPACE}
   tenantID: ${AZURE_TENANT_ID}
-  type: ServicePrincipal
+  type: ${CLUSTER_IDENTITY_TYPE:=ServicePrincipal}
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachinePool

--- a/templates/cluster-template-machinepool.yaml
+++ b/templates/cluster-template-machinepool.yaml
@@ -205,4 +205,4 @@ spec:
     name: ${AZURE_CLUSTER_IDENTITY_SECRET_NAME}
     namespace: ${AZURE_CLUSTER_IDENTITY_SECRET_NAMESPACE}
   tenantID: ${AZURE_TENANT_ID}
-  type: ServicePrincipal
+  type: ${CLUSTER_IDENTITY_TYPE:=ServicePrincipal}

--- a/templates/cluster-template-nvidia-gpu.yaml
+++ b/templates/cluster-template-nvidia-gpu.yaml
@@ -141,7 +141,7 @@ spec:
     name: ${AZURE_CLUSTER_IDENTITY_SECRET_NAME}
     namespace: ${AZURE_CLUSTER_IDENTITY_SECRET_NAMESPACE}
   tenantID: ${AZURE_TENANT_ID}
-  type: ServicePrincipal
+  type: ${CLUSTER_IDENTITY_TYPE:=ServicePrincipal}
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment

--- a/templates/cluster-template-private.yaml
+++ b/templates/cluster-template-private.yaml
@@ -216,4 +216,4 @@ spec:
     name: ${AZURE_CLUSTER_IDENTITY_SECRET_NAME}
     namespace: ${AZURE_CLUSTER_IDENTITY_SECRET_NAMESPACE}
   tenantID: ${AZURE_TENANT_ID}
-  type: ServicePrincipal
+  type: ${CLUSTER_IDENTITY_TYPE:=ServicePrincipal}

--- a/templates/cluster-template-windows.yaml
+++ b/templates/cluster-template-windows.yaml
@@ -206,7 +206,7 @@ spec:
     name: ${AZURE_CLUSTER_IDENTITY_SECRET_NAME}
     namespace: ${AZURE_CLUSTER_IDENTITY_SECRET_NAMESPACE}
   tenantID: ${AZURE_TENANT_ID}
-  type: ServicePrincipal
+  type: ${CLUSTER_IDENTITY_TYPE:=ServicePrincipal}
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -202,4 +202,4 @@ spec:
     name: ${AZURE_CLUSTER_IDENTITY_SECRET_NAME}
     namespace: ${AZURE_CLUSTER_IDENTITY_SECRET_NAMESPACE}
   tenantID: ${AZURE_TENANT_ID}
-  type: ServicePrincipal
+  type: ${CLUSTER_IDENTITY_TYPE:=ServicePrincipal}

--- a/templates/test/ci/cluster-template-prow-aks-clusterclass.yaml
+++ b/templates/test/ci/cluster-template-prow-aks-clusterclass.yaml
@@ -200,7 +200,7 @@ spec:
     name: ${AZURE_CLUSTER_IDENTITY_SECRET_NAME}
     namespace: ${AZURE_CLUSTER_IDENTITY_SECRET_NAMESPACE}
   tenantID: ${AZURE_TENANT_ID}
-  type: ServicePrincipal
+  type: ${CLUSTER_IDENTITY_TYPE:=ServicePrincipal}
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate

--- a/templates/test/ci/cluster-template-prow-aks.yaml
+++ b/templates/test/ci/cluster-template-prow-aks.yaml
@@ -188,7 +188,7 @@ spec:
     name: ${AZURE_CLUSTER_IDENTITY_SECRET_NAME}
     namespace: ${AZURE_CLUSTER_IDENTITY_SECRET_NAMESPACE}
   tenantID: ${AZURE_TENANT_ID}
-  type: ServicePrincipal
+  type: ${CLUSTER_IDENTITY_TYPE:=ServicePrincipal}
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachinePool

--- a/templates/test/ci/cluster-template-prow-azure-cni-v1.yaml
+++ b/templates/test/ci/cluster-template-prow-azure-cni-v1.yaml
@@ -218,7 +218,7 @@ spec:
     name: ${AZURE_CLUSTER_IDENTITY_SECRET_NAME}
     namespace: ${AZURE_CLUSTER_IDENTITY_SECRET_NAMESPACE}
   tenantID: ${AZURE_TENANT_ID}
-  type: ServicePrincipal
+  type: ${CLUSTER_IDENTITY_TYPE:=ServicePrincipal}
 ---
 apiVersion: addons.cluster.x-k8s.io/v1alpha1
 kind: HelmChartProxy

--- a/templates/test/ci/cluster-template-prow-ci-version-dual-stack.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version-dual-stack.yaml
@@ -453,7 +453,7 @@ spec:
     name: ${AZURE_CLUSTER_IDENTITY_SECRET_NAME}
     namespace: ${AZURE_CLUSTER_IDENTITY_SECRET_NAMESPACE}
   tenantID: ${AZURE_TENANT_ID}
-  type: ServicePrincipal
+  type: ${CLUSTER_IDENTITY_TYPE:=ServicePrincipal}
 ---
 apiVersion: addons.cluster.x-k8s.io/v1beta1
 kind: ClusterResourceSet

--- a/templates/test/ci/cluster-template-prow-ci-version-ipv6.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version-ipv6.yaml
@@ -471,7 +471,7 @@ spec:
     name: ${AZURE_CLUSTER_IDENTITY_SECRET_NAME}
     namespace: ${AZURE_CLUSTER_IDENTITY_SECRET_NAMESPACE}
   tenantID: ${AZURE_TENANT_ID}
-  type: ServicePrincipal
+  type: ${CLUSTER_IDENTITY_TYPE:=ServicePrincipal}
 ---
 apiVersion: addons.cluster.x-k8s.io/v1beta1
 kind: ClusterResourceSet

--- a/templates/test/ci/cluster-template-prow-ci-version.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version.yaml
@@ -617,7 +617,7 @@ spec:
     name: ${AZURE_CLUSTER_IDENTITY_SECRET_NAME}
     namespace: ${AZURE_CLUSTER_IDENTITY_SECRET_NAMESPACE}
   tenantID: ${AZURE_TENANT_ID}
-  type: ServicePrincipal
+  type: ${CLUSTER_IDENTITY_TYPE:=ServicePrincipal}
 ---
 apiVersion: addons.cluster.x-k8s.io/v1beta1
 kind: ClusterResourceSet

--- a/templates/test/ci/cluster-template-prow-clusterclass-ci-default.yaml
+++ b/templates/test/ci/cluster-template-prow-clusterclass-ci-default.yaml
@@ -579,4 +579,4 @@ spec:
     name: ${AZURE_CLUSTER_IDENTITY_SECRET_NAME}
     namespace: ${AZURE_CLUSTER_IDENTITY_SECRET_NAMESPACE}
   tenantID: ${AZURE_TENANT_ID}
-  type: ServicePrincipal
+  type: ${CLUSTER_IDENTITY_TYPE:=ServicePrincipal}

--- a/templates/test/ci/cluster-template-prow-custom-vnet.yaml
+++ b/templates/test/ci/cluster-template-prow-custom-vnet.yaml
@@ -225,7 +225,7 @@ spec:
     name: ${AZURE_CLUSTER_IDENTITY_SECRET_NAME}
     namespace: ${AZURE_CLUSTER_IDENTITY_SECRET_NAMESPACE}
   tenantID: ${AZURE_TENANT_ID}
-  type: ServicePrincipal
+  type: ${CLUSTER_IDENTITY_TYPE:=ServicePrincipal}
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineHealthCheck

--- a/templates/test/ci/cluster-template-prow-dual-stack.yaml
+++ b/templates/test/ci/cluster-template-prow-dual-stack.yaml
@@ -174,7 +174,7 @@ spec:
     name: ${AZURE_CLUSTER_IDENTITY_SECRET_NAME}
     namespace: ${AZURE_CLUSTER_IDENTITY_SECRET_NAMESPACE}
   tenantID: ${AZURE_TENANT_ID}
-  type: ServicePrincipal
+  type: ${CLUSTER_IDENTITY_TYPE:=ServicePrincipal}
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment

--- a/templates/test/ci/cluster-template-prow-edgezone.yaml
+++ b/templates/test/ci/cluster-template-prow-edgezone.yaml
@@ -225,7 +225,7 @@ spec:
     name: ${AZURE_CLUSTER_IDENTITY_SECRET_NAME}
     namespace: ${AZURE_CLUSTER_IDENTITY_SECRET_NAMESPACE}
   tenantID: ${AZURE_TENANT_ID}
-  type: ServicePrincipal
+  type: ${CLUSTER_IDENTITY_TYPE:=ServicePrincipal}
 ---
 apiVersion: addons.cluster.x-k8s.io/v1alpha1
 kind: HelmChartProxy

--- a/templates/test/ci/cluster-template-prow-flatcar.yaml
+++ b/templates/test/ci/cluster-template-prow-flatcar.yaml
@@ -252,7 +252,7 @@ spec:
     name: ${AZURE_CLUSTER_IDENTITY_SECRET_NAME}
     namespace: ${AZURE_CLUSTER_IDENTITY_SECRET_NAMESPACE}
   tenantID: ${AZURE_TENANT_ID}
-  type: ServicePrincipal
+  type: ${CLUSTER_IDENTITY_TYPE:=ServicePrincipal}
 ---
 apiVersion: addons.cluster.x-k8s.io/v1alpha1
 kind: HelmChartProxy

--- a/templates/test/ci/cluster-template-prow-ipv6.yaml
+++ b/templates/test/ci/cluster-template-prow-ipv6.yaml
@@ -178,7 +178,7 @@ spec:
     name: ${AZURE_CLUSTER_IDENTITY_SECRET_NAME}
     namespace: ${AZURE_CLUSTER_IDENTITY_SECRET_NAMESPACE}
   tenantID: ${AZURE_TENANT_ID}
-  type: ServicePrincipal
+  type: ${CLUSTER_IDENTITY_TYPE:=ServicePrincipal}
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment

--- a/templates/test/ci/cluster-template-prow-machine-pool-ci-version.yaml
+++ b/templates/test/ci/cluster-template-prow-machine-pool-ci-version.yaml
@@ -414,7 +414,7 @@ spec:
     name: ${AZURE_CLUSTER_IDENTITY_SECRET_NAME}
     namespace: ${AZURE_CLUSTER_IDENTITY_SECRET_NAMESPACE}
   tenantID: ${AZURE_TENANT_ID}
-  type: ServicePrincipal
+  type: ${CLUSTER_IDENTITY_TYPE:=ServicePrincipal}
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachinePool

--- a/templates/test/ci/cluster-template-prow-machine-pool-flex.yaml
+++ b/templates/test/ci/cluster-template-prow-machine-pool-flex.yaml
@@ -226,7 +226,7 @@ spec:
     name: ${AZURE_CLUSTER_IDENTITY_SECRET_NAME}
     namespace: ${AZURE_CLUSTER_IDENTITY_SECRET_NAMESPACE}
   tenantID: ${AZURE_TENANT_ID}
-  type: ServicePrincipal
+  type: ${CLUSTER_IDENTITY_TYPE:=ServicePrincipal}
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachinePool

--- a/templates/test/ci/cluster-template-prow-machine-pool.yaml
+++ b/templates/test/ci/cluster-template-prow-machine-pool.yaml
@@ -226,7 +226,7 @@ spec:
     name: ${AZURE_CLUSTER_IDENTITY_SECRET_NAME}
     namespace: ${AZURE_CLUSTER_IDENTITY_SECRET_NAMESPACE}
   tenantID: ${AZURE_TENANT_ID}
-  type: ServicePrincipal
+  type: ${CLUSTER_IDENTITY_TYPE:=ServicePrincipal}
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachinePool

--- a/templates/test/ci/cluster-template-prow-nvidia-gpu.yaml
+++ b/templates/test/ci/cluster-template-prow-nvidia-gpu.yaml
@@ -149,7 +149,7 @@ spec:
     name: ${AZURE_CLUSTER_IDENTITY_SECRET_NAME}
     namespace: ${AZURE_CLUSTER_IDENTITY_SECRET_NAMESPACE}
   tenantID: ${AZURE_TENANT_ID}
-  type: ServicePrincipal
+  type: ${CLUSTER_IDENTITY_TYPE:=ServicePrincipal}
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment

--- a/templates/test/ci/cluster-template-prow-spot.yaml
+++ b/templates/test/ci/cluster-template-prow-spot.yaml
@@ -221,7 +221,7 @@ spec:
     name: ${AZURE_CLUSTER_IDENTITY_SECRET_NAME}
     namespace: ${AZURE_CLUSTER_IDENTITY_SECRET_NAMESPACE}
   tenantID: ${AZURE_TENANT_ID}
-  type: ServicePrincipal
+  type: ${CLUSTER_IDENTITY_TYPE:=ServicePrincipal}
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineHealthCheck

--- a/templates/test/ci/cluster-template-prow.yaml
+++ b/templates/test/ci/cluster-template-prow.yaml
@@ -380,7 +380,7 @@ spec:
     name: ${AZURE_CLUSTER_IDENTITY_SECRET_NAME}
     namespace: ${AZURE_CLUSTER_IDENTITY_SECRET_NAMESPACE}
   tenantID: ${AZURE_TENANT_ID}
-  type: ServicePrincipal
+  type: ${CLUSTER_IDENTITY_TYPE:=ServicePrincipal}
 ---
 apiVersion: addons.cluster.x-k8s.io/v1beta1
 kind: ClusterResourceSet

--- a/templates/test/dev/cluster-template-custom-builds-machine-pool.yaml
+++ b/templates/test/dev/cluster-template-custom-builds-machine-pool.yaml
@@ -361,7 +361,7 @@ spec:
     name: ${AZURE_CLUSTER_IDENTITY_SECRET_NAME}
     namespace: ${AZURE_CLUSTER_IDENTITY_SECRET_NAMESPACE}
   tenantID: ${AZURE_TENANT_ID}
-  type: ServicePrincipal
+  type: ${CLUSTER_IDENTITY_TYPE:=ServicePrincipal}
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachinePool

--- a/templates/test/dev/cluster-template-custom-builds.yaml
+++ b/templates/test/dev/cluster-template-custom-builds.yaml
@@ -592,7 +592,7 @@ spec:
     name: ${AZURE_CLUSTER_IDENTITY_SECRET_NAME}
     namespace: ${AZURE_CLUSTER_IDENTITY_SECRET_NAMESPACE}
   tenantID: ${AZURE_TENANT_ID}
-  type: ServicePrincipal
+  type: ${CLUSTER_IDENTITY_TYPE:=ServicePrincipal}
 ---
 apiVersion: addons.cluster.x-k8s.io/v1beta1
 kind: ClusterResourceSet

--- a/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-kcp-remediation.yaml
+++ b/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-kcp-remediation.yaml
@@ -287,7 +287,7 @@ spec:
     name: ${AZURE_CLUSTER_IDENTITY_SECRET_NAME}
     namespace: ${AZURE_CLUSTER_IDENTITY_SECRET_NAMESPACE}
   tenantID: ${AZURE_TENANT_ID}
-  type: ServicePrincipal
+  type: ${CLUSTER_IDENTITY_TYPE:=ServicePrincipal}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: AzureMachineTemplate

--- a/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-kcp-scale-in.yaml
+++ b/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-kcp-scale-in.yaml
@@ -276,7 +276,7 @@ spec:
     name: ${AZURE_CLUSTER_IDENTITY_SECRET_NAME}
     namespace: ${AZURE_CLUSTER_IDENTITY_SECRET_NAMESPACE}
   tenantID: ${AZURE_TENANT_ID}
-  type: ServicePrincipal
+  type: ${CLUSTER_IDENTITY_TYPE:=ServicePrincipal}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: AzureMachineTemplate

--- a/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-machine-pool.yaml
+++ b/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-machine-pool.yaml
@@ -269,7 +269,7 @@ spec:
     name: ${AZURE_CLUSTER_IDENTITY_SECRET_NAME}
     namespace: ${AZURE_CLUSTER_IDENTITY_SECRET_NAMESPACE}
   tenantID: ${AZURE_TENANT_ID}
-  type: ServicePrincipal
+  type: ${CLUSTER_IDENTITY_TYPE:=ServicePrincipal}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: AzureMachinePool

--- a/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-md-remediation.yaml
+++ b/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-md-remediation.yaml
@@ -290,7 +290,7 @@ spec:
     name: ${AZURE_CLUSTER_IDENTITY_SECRET_NAME}
     namespace: ${AZURE_CLUSTER_IDENTITY_SECRET_NAMESPACE}
   tenantID: ${AZURE_TENANT_ID}
-  type: ServicePrincipal
+  type: ${CLUSTER_IDENTITY_TYPE:=ServicePrincipal}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: AzureMachineTemplate

--- a/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-node-drain.yaml
+++ b/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-node-drain.yaml
@@ -274,7 +274,7 @@ spec:
     name: ${AZURE_CLUSTER_IDENTITY_SECRET_NAME}
     namespace: ${AZURE_CLUSTER_IDENTITY_SECRET_NAMESPACE}
   tenantID: ${AZURE_TENANT_ID}
-  type: ServicePrincipal
+  type: ${CLUSTER_IDENTITY_TYPE:=ServicePrincipal}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: AzureMachineTemplate

--- a/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-upgrades.yaml
+++ b/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-upgrades.yaml
@@ -214,7 +214,7 @@ spec:
     name: ${AZURE_CLUSTER_IDENTITY_SECRET_NAME}
     namespace: ${AZURE_CLUSTER_IDENTITY_SECRET_NAMESPACE}
   tenantID: ${AZURE_TENANT_ID}
-  type: ServicePrincipal
+  type: ${CLUSTER_IDENTITY_TYPE:=ServicePrincipal}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: AzureMachinePool

--- a/test/e2e/data/infrastructure-azure/v1beta1/cluster-template.yaml
+++ b/test/e2e/data/infrastructure-azure/v1beta1/cluster-template.yaml
@@ -273,7 +273,7 @@ spec:
     name: ${AZURE_CLUSTER_IDENTITY_SECRET_NAME}
     namespace: ${AZURE_CLUSTER_IDENTITY_SECRET_NAMESPACE}
   tenantID: ${AZURE_TENANT_ID}
-  type: ServicePrincipal
+  type: ${CLUSTER_IDENTITY_TYPE:=ServicePrincipal}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: AzureMachineTemplate


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind feature

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

This change makes it possible to configure the AzureClusterIdentity that comes with the published flavor templates with a `CLUSTER_IDENTITY_TYPE` environment variable which sets `spec.type`. This allows configuring that field for `clusterctl generate` or our Tilt environment to use Workload Identity or your other preferred auth mechanism. It defaults to "ServicePrincipal" for compatibility. There should be no functional changes here unless you happen to already have that variable set.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Somewhat related to #3590

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
In the published flavor templates, AzureClusterIdentity's `spec.type` can now be set from a `CLUSTER_IDENTITY_TYPE` environment variable.
```
