### PR TITLE
Make AKS extension.Plan optional

### DIFF
--- a/api/v1beta1/azuremanagedcontrolplane_default.go
+++ b/api/v1beta1/azuremanagedcontrolplane_default.go
@@ -210,7 +210,7 @@ func (m *AzureManagedControlPlane) setDefaultDNSPrefix() {
 
 func (m *AzureManagedControlPlane) setDefaultAKSExtensions() {
 	for _, extension := range m.Spec.Extensions {
-		if extension.Plan.Name == "" {
+		if extension.Plan != nil && extension.Plan.Name == "" {
 			extension.Plan.Name = fmt.Sprintf("%s-%s", m.Name, extension.Plan.Product)
 		}
 		if extension.AutoUpgradeMinorVersion == nil {

--- a/api/v1beta1/azuremanagedcontrolplane_types.go
+++ b/api/v1beta1/azuremanagedcontrolplane_types.go
@@ -608,7 +608,8 @@ type AKSExtension struct {
 	ExtensionType *string `json:"extensionType"`
 
 	// Plan is the plan of the extension.
-	Plan *ExtensionPlan `json:"plan"`
+	// +optional
+	Plan *ExtensionPlan `json:"plan,omitempty"`
 
 	// ReleaseTrain is the release train this extension participates in for auto-upgrade (e.g. Stable, Preview, etc.)
 	// This is only used if autoUpgradeMinorVersion is ‘true’.

--- a/api/v1beta1/azuremanagedcontrolplane_webhook.go
+++ b/api/v1beta1/azuremanagedcontrolplane_webhook.go
@@ -1002,12 +1002,6 @@ func validateAKSExtensions(extensions []AKSExtension, fldPath *field.Path) field
 		if extension.Version != nil && (extension.AutoUpgradeMinorVersion == nil || (extension.AutoUpgradeMinorVersion != nil && *extension.AutoUpgradeMinorVersion)) {
 			allErrs = append(allErrs, field.Forbidden(fldPath.Child("Version"), "Version must not be given if AutoUpgradeMinorVersion is true (or not provided, as it is true by default)"))
 		}
-		if extension.Plan.Product == "" {
-			allErrs = append(allErrs, field.Required(fldPath.Child("Plan", "Product"), "Product must be provided"))
-		}
-		if extension.Plan.Publisher == "" {
-			allErrs = append(allErrs, field.Required(fldPath.Child("Plan", "Publisher"), "Publisher must be provided"))
-		}
 		if extension.AutoUpgradeMinorVersion == ptr.To(false) && extension.ReleaseTrain != nil {
 			allErrs = append(allErrs, field.Forbidden(fldPath.Child("ReleaseTrain"), "ReleaseTrain must not be given if AutoUpgradeMinorVersion is false"))
 		}

--- a/api/v1beta1/types.go
+++ b/api/v1beta1/types.go
@@ -1119,14 +1119,16 @@ type ExtensionPlan struct {
 	Name string `json:"name,omitempty"`
 
 	// Product is the name of the 3rd Party artifact that is being procured.
-	Product string `json:"product"`
+	// +optional
+	Product string `json:"product,omitempty"`
 
 	// PromotionCode is a publisher-provided promotion code as provisioned in Data Market for the said product/artifact.
 	// +optional
 	PromotionCode string `json:"promotionCode,omitempty"`
 
 	// Publisher is the name of the publisher of the 3rd Party Artifact that is being bought.
-	Publisher string `json:"publisher"`
+	// +optional
+	Publisher string `json:"publisher,omitempty"`
 
 	// Version is the version of the plan.
 	// +optional

--- a/azure/scope/managedcontrolplane.go
+++ b/azure/scope/managedcontrolplane.go
@@ -1030,7 +1030,7 @@ func (s *ManagedControlPlaneScope) AKSExtensionSpecs() []azure.ASOResourceSpecGe
 			ReleaseTrain:            extension.ReleaseTrain,
 			Version:                 extension.Version,
 			Owner:                   azure.ManagedClusterID(s.SubscriptionID(), s.ResourceGroup(), s.ControlPlane.Name),
-			Plan:                    *extension.Plan,
+			Plan:                    extension.Plan,
 			AKSAssignedIdentityType: extension.AKSAssignedIdentityType,
 			ExtensionIdentity:       extension.Identity,
 		}

--- a/azure/scope/managedcontrolplane_test.go
+++ b/azure/scope/managedcontrolplane_test.go
@@ -1510,7 +1510,7 @@ func TestManagedControlPlaneScope_AKSExtensionSpecs(t *testing.T) {
 					ReleaseTrain:  ptr.To("my-release-train"),
 					Version:       ptr.To("my-version"),
 					Owner:         "/subscriptions//resourceGroups//providers/Microsoft.ContainerService/managedClusters/my-cluster",
-					Plan: infrav1.ExtensionPlan{
+					Plan: &infrav1.ExtensionPlan{
 						Name:      "my-plan-name",
 						Product:   "my-product",
 						Publisher: "my-publisher",

--- a/azure/services/aksextensions/spec.go
+++ b/azure/services/aksextensions/spec.go
@@ -39,7 +39,7 @@ type AKSExtensionSpec struct {
 	Version                 *string
 	Owner                   string
 	OwnerRef                metav1.OwnerReference
-	Plan                    infrav1.ExtensionPlan
+	Plan                    *infrav1.ExtensionPlan
 	Scope                   infrav1.ExtensionScope
 }
 
@@ -70,11 +70,14 @@ func (s *AKSExtensionSpec) Parameters(ctx context.Context, existingAKSExtension 
 	aksExtension.Spec.Owner = &genruntime.ArbitraryOwnerReference{
 		ARMID: s.Owner,
 	}
-	aksExtension.Spec.Plan = &asokubernetesconfigurationv1.Plan{
-		Name:      ptr.To(s.Plan.Name),
-		Product:   ptr.To(s.Plan.Product),
-		Publisher: ptr.To(s.Plan.Publisher),
-		Version:   ptr.To(s.Plan.Version),
+
+	if s.Plan != nil {
+		aksExtension.Spec.Plan = &asokubernetesconfigurationv1.Plan{
+			Name:      ptr.To(s.Plan.Name),
+			Product:   ptr.To(s.Plan.Product),
+			Publisher: ptr.To(s.Plan.Publisher),
+			Version:   ptr.To(s.Plan.Version),
+		}
 	}
 	if s.ExtensionIdentity != "" {
 		aksExtension.Spec.Identity = &asokubernetesconfigurationv1.Identity{

--- a/azure/services/aksextensions/spec_test.go
+++ b/azure/services/aksextensions/spec_test.go
@@ -68,7 +68,7 @@ var (
 		ReleaseTrain:  ptr.To("fake-release-train"),
 		Version:       ptr.To("fake-version"),
 		Owner:         "fake-owner",
-		Plan: infrav1.ExtensionPlan{
+		Plan: &infrav1.ExtensionPlan{
 			Name: "fake-plan-name",
 		},
 		ExtensionIdentity: "SystemAssigned",

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremanagedcontrolplanes.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremanagedcontrolplanes.yaml
@@ -367,9 +367,6 @@ spec:
                         version:
                           description: Version is the version of the plan.
                           type: string
-                      required:
-                      - product
-                      - publisher
                       type: object
                     releaseTrain:
                       description: ReleaseTrain is the release train this extension
@@ -405,7 +402,6 @@ spec:
                   required:
                   - extensionType
                   - name
-                  - plan
                   type: object
                 type: array
               fleetsMember:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremanagedcontrolplanetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremanagedcontrolplanetemplates.yaml
@@ -351,9 +351,6 @@ spec:
                                 version:
                                   description: Version is the version of the plan.
                                   type: string
-                              required:
-                              - product
-                              - publisher
                               type: object
                             releaseTrain:
                               description: ReleaseTrain is the release train this
@@ -392,7 +389,6 @@ spec:
                           required:
                           - extensionType
                           - name
-                          - plan
                           type: object
                         type: array
                       fleetsMember:

--- a/docs/book/src/topics/managedcluster.md
+++ b/docs/book/src/topics/managedcluster.md
@@ -326,7 +326,13 @@ spec:
       publisher: "containous"
 ```
 
-To find the `extensionType` and plan details for your desired extension, refer to the [az k8s-extension cli reference](https://learn.microsoft.com/cli/azure/k8s-extension).
+To list all of the available extensions for your cluster as well as its plan details, use the following az cli command:
+
+```bash
+az k8s-extension extension-types list-by-cluster --resource-group my-resource-group --cluster-name mycluster --cluster-type managedClusters
+```
+
+For more details, please refer to the [az k8s-extension cli reference](https://learn.microsoft.com/cli/azure/k8s-extension).
 
 
 ### Security Profile for AKS clusters.


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
Many AKS extensions, especially official Microsoft ones, do not accept a `Plan`. Currently, the CAPZ API has `extensions.Plan` as a required field. This PR fixes this issue by making it optional.

This PR also adds additional notes on how to use the az cli to find the details of available extensions for any given cluster.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #4678

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [x] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [x] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Make AKS extension.Plan optional
```
