### PR TITLE
remove redundant steps in docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,22 +25,8 @@ WORKDIR /workspace
 ARG goproxy=https://proxy.golang.org
 ENV GOPROXY=$goproxy
 
-# Copy the Go Modules manifests
-COPY go.mod go.mod
-COPY go.sum go.sum
-
-# Cache deps before building and copying source so that we don't need to re-download as much
-# and so that source changes don't invalidate our downloaded layer
-RUN --mount=type=cache,target=/go/pkg/mod \
-    go mod download
-
 # Copy the sources
 COPY ./ ./
-
-# Cache the go build into the the Go’s compiler cache folder so we take benefits of compiler caching across docker build calls
-RUN --mount=type=cache,target=/root/.cache/go-build \
-    --mount=type=cache,target=/go/pkg/mod \
-    go build .
 
 # Build
 ARG package=.


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind cleanup

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**: This PR removes some redundant steps from the Dockerfile which should speed up builds by almost 2x on fresh builds (which includes every CI run) without any tangible side effects in the resulting image.

The main change is to remove the preliminary `go build` step which seems to have been to prime the build cache, but it doesn't look like that wasn't saving much time on the "real" `go build`, likely because the compiler finds a need to recompile based on the different flags being passed to each command. The "real" build step is already configured to use the cache, so the first `go build` step seems to have been mostly overhead.

The mod-related steps are also redundant because `go build` handles downloading dependencies as needed already and the existing build step is already configured to cache them, so there shouldn't be any meaningful difference in build times when dependencies are added/updated.

This is a before/after of a fresh build on my machine:

```
[+] Building 282.5s (18/18) FINISHED                                                                                                                                        docker:default
 => [internal] load build definition from Dockerfile                                                                                                                                  
 ...
 => [builder 5/8] RUN --mount=type=cache,target=/go/pkg/mod     go mod download                                                                                                      17.3s
 => [builder 6/8] COPY ./ ./                                                                                                                                                          0.2s
 => [builder 7/8] RUN --mount=type=cache,target=/root/.cache/go-build     --mount=type=cache,target=/go/pkg/mod     go build .                                                      140.9s
 => [builder 8/8] RUN --mount=type=cache,target=/root/.cache/go-build     --mount=type=cache,target=/go/pkg/mod     CGO_ENABLED=0 GOOS=linux GOARCH=amd64     go build -ldflags "-  120.5
```

```
[+] Building 158.5s (14/14) FINISHED                                                                                                                                        docker:default
 => [internal] load build definition from Dockerfile                                                                                                                                  0.0s
 ...
 => [builder 3/4] COPY ./ ./                                                                                                                                                          0.2s
 => [builder 4/4] RUN --mount=type=cache,target=/root/.cache/go-build     --mount=type=cache,target=/go/pkg/mod     CGO_ENABLED=0 GOOS=linux GOARCH=amd64     go build -ldflags "-  154.6s
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
