### PR TITLE
Remove projected service account volume for workload identity

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -29,10 +29,6 @@ spec:
           image: controller:latest
           imagePullPolicy: Always
           name: manager
-          volumeMounts:
-            - mountPath: /var/run/secrets/azure/tokens
-              name: azure-identity-token
-              readOnly: true
           ports:
             - containerPort: 9440
               name: healthz
@@ -83,12 +79,3 @@ spec:
           key: node-role.kubernetes.io/master
         - effect: NoSchedule
           key: node-role.kubernetes.io/control-plane
-      volumes:
-      - name: azure-identity-token
-        projected:
-          defaultMode: 420
-          sources:
-          - serviceAccountToken:
-              audience: api://AzureADTokenExchange
-              expirationSeconds: 3600
-              path: azure-identity-token


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/kind cleanup

**What this PR does / why we need it**:
See https://github.com/kubernetes-sigs/cluster-api-provider-azure/issues/4681.

Currently, in the manager spec, the projected volume for the service account token is manually specified.

The Workload Identity webhook takes care of this (and more) as seen [here](https://github.com/Azure/azure-workload-identity/blob/main/pkg/webhook/webhook.go#L401).

It is better to rely on the webhook because it is more future proof and removes YAML lines. Not only this, but as explained in https://github.com/kubernetes-sigs/cluster-api-provider-azure/issues/4681, not relying on the webhook makes it impossible to use `cluster-api-provider-azure` inside a vCluster on AKS with Workload Identity.

With this change, the *resulting* Pod spec in a vanilla case (i.e. not inside vCluster) is completely identical (webhook sets the volume), and it also works in vCluster because the Workload Identity webhook (on the host cluster) will do what is needed.

**Which issue(s) this PR fixes**:
Fixes #4681

**TODOs**:

- [X] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
```release-note
NONE
```
