### PR TITLE
ignore k8s v1.29 in AKS e2e test

### DIFF
--- a/test/e2e/aks_versions.go
+++ b/test/e2e/aks_versions.go
@@ -22,6 +22,7 @@ package e2e
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v4"
@@ -168,6 +169,10 @@ func getLatestStableAKSKubernetesVersionOffset(ctx context.Context, subscription
 			// semver comparisons require a "v" prefix
 			if patch[:1] != "v" && !ptr.Deref(minor.IsPreview, false) {
 				version = "v" + patch
+			}
+			// v1.29 is broken for our pool1 configuration.
+			if strings.HasPrefix(version, "v1.29.") {
+				continue
 			}
 			orchestratorversions = append(orchestratorversions, version)
 		}


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind failing-test

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

Recently, our e2e tests started building AKS clusters with Kubernetes v1.29 and the pool1 config we define in our test templates has failed to produce Nodes and causing e2e tests to fail. This PR is a hack to ignore v1.29 in our e2e tests to unblock merging PRs.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [X] cherry-pick candidate <-- tests are also blocking merging to release branches

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
