### PR TITLE
remove kubeletConfig.topologyManagerPolicy from AKS test templates

### DIFF
--- a/templates/test/ci/cluster-template-prow-aks-clusterclass.yaml
+++ b/templates/test/ci/cluster-template-prow-aks-clusterclass.yaml
@@ -138,7 +138,6 @@ spec:
         imageGcHighThreshold: 70
         imageGcLowThreshold: 50
         podMaxPids: 2048
-        topologyManagerPolicy: best-effort
       linuxOSConfig:
         swapFileSizeMB: 1500
         sysctls:

--- a/templates/test/ci/cluster-template-prow-aks.yaml
+++ b/templates/test/ci/cluster-template-prow-aks.yaml
@@ -126,7 +126,6 @@ spec:
     imageGcHighThreshold: 70
     imageGcLowThreshold: 50
     podMaxPids: 2048
-    topologyManagerPolicy: best-effort
   linuxOSConfig:
     swapFileSizeMB: 1500
     sysctls:

--- a/templates/test/ci/prow-aks-clusterclass/patches/aks-clusterclass-pool1.yaml
+++ b/templates/test/ci/prow-aks-clusterclass/patches/aks-clusterclass-pool1.yaml
@@ -24,7 +24,6 @@ spec:
         cpuCfsQuotaPeriod: "110ms"
         imageGcHighThreshold: 70
         imageGcLowThreshold: 50
-        topologyManagerPolicy: "best-effort"
         allowedUnsafeSysctls:
           - "net.*"
           - "kernel.msg*"

--- a/templates/test/ci/prow-aks/patches/aks-pool1.yaml
+++ b/templates/test/ci/prow-aks/patches/aks-pool1.yaml
@@ -22,7 +22,6 @@ spec:
     cpuCfsQuotaPeriod: "110ms"
     imageGcHighThreshold: 70
     imageGcLowThreshold: 50
-    topologyManagerPolicy: "best-effort"
     allowedUnsafeSysctls:
       - "net.*"
       - "kernel.msg*"

--- a/test/e2e/aks_versions.go
+++ b/test/e2e/aks_versions.go
@@ -22,7 +22,6 @@ package e2e
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v4"
@@ -169,10 +168,6 @@ func getLatestStableAKSKubernetesVersionOffset(ctx context.Context, subscription
 			// semver comparisons require a "v" prefix
 			if patch[:1] != "v" && !ptr.Deref(minor.IsPreview, false) {
 				version = "v" + patch
-			}
-			// v1.29 is broken for our pool1 configuration.
-			if strings.HasPrefix(version, "v1.29.") {
-				continue
 			}
 			orchestratorversions = append(orchestratorversions, version)
 		}


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind cleanup

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

This is a follow-up to #4686 with maybe a more sensible fix which tweaks the test templates to remove one particular field that I think is causing issues with Kubernetes 1.29 which is rolling out to the regions where we test. I'm following up separately on the potential bug in AKS.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [X] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
