### PR TITLE
add AKS adoption e2e test and docs

### DIFF
--- a/test/e2e/aks_adopt.go
+++ b/test/e2e/aks_adopt.go
@@ -1,0 +1,149 @@
+//go:build e2e
+// +build e2e
+
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+
+	. "github.com/onsi/gomega"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	clusterctlv1 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
+	expv1 "sigs.k8s.io/cluster-api/exp/api/v1beta1"
+	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type AKSAdoptSpecInput struct {
+	ApplyInput   clusterctl.ApplyClusterTemplateAndWaitInput
+	ApplyResult  *clusterctl.ApplyClusterTemplateAndWaitResult
+	Cluster      *clusterv1.Cluster
+	MachinePools []*expv1.MachinePool
+}
+
+// AKSAdoptSpec tests adopting an existing AKS cluster into management by CAPZ. It first relies on a CAPZ AKS
+// cluster having already been created. Then, it will orphan that cluster such that the CAPI and CAPZ
+// resources are deleted but the Azure resources remain. Finally, it applies the cluster template again and
+// waits for the cluster to become ready.
+func AKSAdoptSpec(ctx context.Context, inputGetter func() AKSAdoptSpecInput) {
+	input := inputGetter()
+
+	mgmtClient := bootstrapClusterProxy.GetClient()
+	Expect(mgmtClient).NotTo(BeNil())
+
+	updateResource := []any{"30s", "5s"}
+
+	waitForNoBlockMove := func(obj client.Object) {
+		waitForBlockMoveGone := []any{"30s", "5s"}
+		Eventually(func(g Gomega) {
+			g.Expect(mgmtClient.Get(ctx, client.ObjectKeyFromObject(obj), obj)).To(Succeed())
+			g.Expect(obj.GetAnnotations()).NotTo(HaveKey(clusterctlv1.BlockMoveAnnotation))
+		}, waitForBlockMoveGone...).Should(Succeed())
+	}
+
+	removeFinalizers := func(obj client.Object) {
+		Eventually(func(g Gomega) {
+			g.Expect(mgmtClient.Get(ctx, client.ObjectKeyFromObject(obj), obj)).To(Succeed())
+			obj.SetFinalizers([]string{})
+			g.Expect(mgmtClient.Update(ctx, obj)).To(Succeed())
+		}, updateResource...).Should(Succeed())
+	}
+
+	waitForImmediateDelete := []any{"30s", "5s"}
+	beginDelete := func(obj client.Object) {
+		Eventually(func(g Gomega) {
+			err := mgmtClient.Delete(ctx, obj)
+			g.Expect(err).NotTo(HaveOccurred())
+		}, updateResource...).Should(Succeed())
+	}
+	shouldNotExist := func(obj client.Object) {
+		waitForGone := []any{"30s", "5s"}
+		Eventually(func(g Gomega) {
+			err := mgmtClient.Get(ctx, client.ObjectKeyFromObject(obj), obj)
+			g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
+		}, waitForGone...).Should(Succeed())
+	}
+	deleteAndWait := func(obj client.Object) {
+		Eventually(func(g Gomega) {
+			err := mgmtClient.Delete(ctx, obj)
+			g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
+		}, waitForImmediateDelete...).Should(Succeed())
+	}
+
+	cluster := input.Cluster
+	Eventually(func(g Gomega) {
+		g.Expect(mgmtClient.Get(ctx, client.ObjectKeyFromObject(cluster), cluster)).To(Succeed())
+		cluster.Spec.Paused = true
+		g.Expect(mgmtClient.Update(ctx, cluster)).To(Succeed())
+	}, updateResource...).Should(Succeed())
+
+	// wait for the pause to take effect before deleting anything
+	amcp := &infrav1.AzureManagedControlPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: cluster.Spec.ControlPlaneRef.Namespace,
+			Name:      cluster.Spec.ControlPlaneRef.Name,
+		},
+	}
+	waitForNoBlockMove(amcp)
+	for _, mp := range input.MachinePools {
+		ammp := &infrav1.AzureManagedMachinePool{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: mp.Spec.Template.Spec.InfrastructureRef.Namespace,
+				Name:      mp.Spec.Template.Spec.InfrastructureRef.Name,
+			},
+		}
+		waitForNoBlockMove(ammp)
+	}
+
+	beginDelete(cluster)
+
+	for _, mp := range input.MachinePools {
+		beginDelete(mp)
+
+		ammp := &infrav1.AzureManagedMachinePool{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: mp.Spec.Template.Spec.InfrastructureRef.Namespace,
+				Name:      mp.Spec.Template.Spec.InfrastructureRef.Name,
+			},
+		}
+		removeFinalizers(ammp)
+		deleteAndWait(ammp)
+
+		removeFinalizers(mp)
+		shouldNotExist(mp)
+	}
+
+	removeFinalizers(amcp)
+	deleteAndWait(amcp)
+	// AzureManagedCluster never gets a finalizer
+	deleteAndWait(&infrav1.AzureManagedCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: cluster.Spec.InfrastructureRef.Namespace,
+			Name:      cluster.Spec.InfrastructureRef.Name,
+		},
+	})
+
+	removeFinalizers(cluster)
+	shouldNotExist(cluster)
+
+	clusterctl.ApplyClusterTemplateAndWait(ctx, input.ApplyInput, input.ApplyResult)
+}


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind feature

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

This PR tests and documents adopting an existing AKS cluster under management by CAPZ using features that already exist in CAPZ.

Thank you to @mtougeron for blazing this trail!

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1173

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [X] includes documentation
- [X] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Added documentation describing how to adopt an existing AKS cluster.
```
