### PR TITLE
Follow-up tasks for enabling AKS preview features

### DIFF
--- a/azure/converters/managedagentpool.go
+++ b/azure/converters/managedagentpool.go
@@ -17,56 +17,14 @@ limitations under the License.
 package converters
 
 import (
-	asocontainerservicev1preview "github.com/Azure/azure-service-operator/v2/api/containerservice/v1api20230202preview"
-	asocontainerservicev1 "github.com/Azure/azure-service-operator/v2/api/containerservice/v1api20231001"
+	asocontainerservicev1hub "github.com/Azure/azure-service-operator/v2/api/containerservice/v1api20231001/storage"
 	"k8s.io/utils/ptr"
 )
 
 // AgentPoolToManagedClusterAgentPoolProfile converts a AgentPoolSpec to an Azure SDK ManagedClusterAgentPoolProfile used in managedcluster reconcile.
-func AgentPoolToManagedClusterAgentPoolProfile(pool *asocontainerservicev1.ManagedClustersAgentPool) asocontainerservicev1.ManagedClusterAgentPoolProfile {
+func AgentPoolToManagedClusterAgentPoolProfile(pool *asocontainerservicev1hub.ManagedClustersAgentPool) asocontainerservicev1hub.ManagedClusterAgentPoolProfile {
 	properties := pool.Spec
-	agentPool := asocontainerservicev1.ManagedClusterAgentPoolProfile{
-		Name:                        ptr.To(pool.AzureName()),
-		VmSize:                      properties.VmSize,
-		OsType:                      properties.OsType,
-		OsDiskSizeGB:                properties.OsDiskSizeGB,
-		Count:                       properties.Count,
-		Type:                        properties.Type,
-		OrchestratorVersion:         properties.OrchestratorVersion,
-		VnetSubnetReference:         properties.VnetSubnetReference,
-		Mode:                        properties.Mode,
-		EnableAutoScaling:           properties.EnableAutoScaling,
-		MaxCount:                    properties.MaxCount,
-		MinCount:                    properties.MinCount,
-		NodeTaints:                  properties.NodeTaints,
-		AvailabilityZones:           properties.AvailabilityZones,
-		MaxPods:                     properties.MaxPods,
-		OsDiskType:                  properties.OsDiskType,
-		NodeLabels:                  properties.NodeLabels,
-		EnableUltraSSD:              properties.EnableUltraSSD,
-		EnableNodePublicIP:          properties.EnableNodePublicIP,
-		NodePublicIPPrefixReference: properties.NodePublicIPPrefixReference,
-		ScaleSetPriority:            properties.ScaleSetPriority,
-		ScaleDownMode:               properties.ScaleDownMode,
-		SpotMaxPrice:                properties.SpotMaxPrice,
-		Tags:                        properties.Tags,
-		KubeletDiskType:             properties.KubeletDiskType,
-		LinuxOSConfig:               properties.LinuxOSConfig,
-		EnableFIPS:                  properties.EnableFIPS,
-		EnableEncryptionAtHost:      properties.EnableEncryptionAtHost,
-	}
-	if properties.KubeletConfig != nil {
-		agentPool.KubeletConfig = properties.KubeletConfig
-	}
-	return agentPool
-}
-
-// AgentPoolToManagedClusterAgentPoolPreviewProfile converts an AgentPoolSpec to an Azure SDK ManagedClusterAgentPoolPreviewProfile used in managedcluster reconcile.
-func AgentPoolToManagedClusterAgentPoolPreviewProfile(pool *asocontainerservicev1preview.ManagedClustersAgentPool) asocontainerservicev1preview.ManagedClusterAgentPoolProfile {
-	properties := pool.Spec
-
-	// Populate the same properties as the stable version since the patcher will handle the preview-only fields.
-	agentPool := asocontainerservicev1preview.ManagedClusterAgentPoolProfile{
+	agentPool := asocontainerservicev1hub.ManagedClusterAgentPoolProfile{
 		Name:                        ptr.To(pool.AzureName()),
 		VmSize:                      properties.VmSize,
 		OsType:                      properties.OsType,

--- a/azure/converters/managedagentpool_test.go
+++ b/azure/converters/managedagentpool_test.go
@@ -19,8 +19,8 @@ package converters
 import (
 	"testing"
 
-	asocontainerservicev1preview "github.com/Azure/azure-service-operator/v2/api/containerservice/v1api20230202preview"
 	asocontainerservicev1 "github.com/Azure/azure-service-operator/v2/api/containerservice/v1api20231001"
+	asocontainerservicev1hub "github.com/Azure/azure-service-operator/v2/api/containerservice/v1api20231001/storage"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	. "github.com/onsi/gomega"
 	"k8s.io/utils/ptr"
@@ -29,31 +29,31 @@ import (
 func Test_AgentPoolToManagedClusterAgentPoolProfile(t *testing.T) {
 	cases := []struct {
 		name   string
-		pool   *asocontainerservicev1.ManagedClustersAgentPool
-		expect func(*GomegaWithT, asocontainerservicev1.ManagedClusterAgentPoolProfile)
+		pool   *asocontainerservicev1hub.ManagedClustersAgentPool
+		expect func(*GomegaWithT, asocontainerservicev1hub.ManagedClusterAgentPoolProfile)
 	}{
 		{
 			name: "Should set all values correctly",
-			pool: &asocontainerservicev1.ManagedClustersAgentPool{
-				Spec: asocontainerservicev1.ManagedClusters_AgentPool_Spec{
+			pool: &asocontainerservicev1hub.ManagedClustersAgentPool{
+				Spec: asocontainerservicev1hub.ManagedClusters_AgentPool_Spec{
 					AzureName:           "agentpool1",
 					VmSize:              ptr.To("Standard_D2s_v3"),
-					OsType:              ptr.To(asocontainerservicev1.OSType_Linux),
-					OsDiskSizeGB:        ptr.To[asocontainerservicev1.ContainerServiceOSDisk](100),
+					OsType:              ptr.To(string(asocontainerservicev1.OSType_Linux)),
+					OsDiskSizeGB:        ptr.To(100),
 					Count:               ptr.To(2),
-					Type:                ptr.To(asocontainerservicev1.AgentPoolType_VirtualMachineScaleSets),
+					Type:                ptr.To(string(asocontainerservicev1.AgentPoolType_VirtualMachineScaleSets)),
 					OrchestratorVersion: ptr.To("1.22.6"),
 					VnetSubnetReference: &genruntime.ResourceReference{
 						ARMID: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-123/providers/Microsoft.Network/virtualNetworks/vnet-123/subnets/subnet-123",
 					},
-					Mode:              ptr.To(asocontainerservicev1.AgentPoolMode_User),
+					Mode:              ptr.To(string(asocontainerservicev1.AgentPoolMode_User)),
 					EnableAutoScaling: ptr.To(true),
 					MaxCount:          ptr.To(5),
 					MinCount:          ptr.To(2),
 					NodeTaints:        []string{"key1=value1:NoSchedule"},
 					AvailabilityZones: []string{"zone1"},
 					MaxPods:           ptr.To(60),
-					OsDiskType:        ptr.To(asocontainerservicev1.OSDiskType_Managed),
+					OsDiskType:        ptr.To(string(asocontainerservicev1.OSDiskType_Managed)),
 					NodeLabels: map[string]string{
 						"custom": "default",
 					},
@@ -65,26 +65,26 @@ func Test_AgentPoolToManagedClusterAgentPoolProfile(t *testing.T) {
 				},
 			},
 
-			expect: func(g *GomegaWithT, result asocontainerservicev1.ManagedClusterAgentPoolProfile) {
-				g.Expect(result).To(Equal(asocontainerservicev1.ManagedClusterAgentPoolProfile{
+			expect: func(g *GomegaWithT, result asocontainerservicev1hub.ManagedClusterAgentPoolProfile) {
+				g.Expect(result).To(Equal(asocontainerservicev1hub.ManagedClusterAgentPoolProfile{
 					Name:                ptr.To("agentpool1"),
 					VmSize:              ptr.To("Standard_D2s_v3"),
-					OsType:              ptr.To(asocontainerservicev1.OSType_Linux),
-					OsDiskSizeGB:        ptr.To[asocontainerservicev1.ContainerServiceOSDisk](100),
+					OsType:              ptr.To(string(asocontainerservicev1.OSType_Linux)),
+					OsDiskSizeGB:        ptr.To(100),
 					Count:               ptr.To(2),
-					Type:                ptr.To(asocontainerservicev1.AgentPoolType_VirtualMachineScaleSets),
+					Type:                ptr.To(string(asocontainerservicev1.AgentPoolType_VirtualMachineScaleSets)),
 					OrchestratorVersion: ptr.To("1.22.6"),
 					VnetSubnetReference: &genruntime.ResourceReference{
 						ARMID: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-123/providers/Microsoft.Network/virtualNetworks/vnet-123/subnets/subnet-123",
 					},
-					Mode:              ptr.To(asocontainerservicev1.AgentPoolMode_User),
+					Mode:              ptr.To(string(asocontainerservicev1.AgentPoolMode_User)),
 					EnableAutoScaling: ptr.To(true),
 					MaxCount:          ptr.To(5),
 					MinCount:          ptr.To(2),
 					NodeTaints:        []string{"key1=value1:NoSchedule"},
 					AvailabilityZones: []string{"zone1"},
 					MaxPods:           ptr.To(60),
-					OsDiskType:        ptr.To(asocontainerservicev1.OSDiskType_Managed),
+					OsDiskType:        ptr.To(string(asocontainerservicev1.OSDiskType_Managed)),
 					NodeLabels: map[string]string{
 						"custom": "default",
 					},
@@ -104,89 +104,6 @@ func Test_AgentPoolToManagedClusterAgentPoolProfile(t *testing.T) {
 			t.Parallel()
 			g := NewGomegaWithT(t)
 			result := AgentPoolToManagedClusterAgentPoolProfile(c.pool)
-			c.expect(g, result)
-		})
-	}
-}
-
-func Test_AgentPoolToManagedClusterAgentPoolPreviewProfile(t *testing.T) {
-	cases := []struct {
-		name   string
-		pool   *asocontainerservicev1preview.ManagedClustersAgentPool
-		expect func(*GomegaWithT, asocontainerservicev1preview.ManagedClusterAgentPoolProfile)
-	}{
-		{
-			name: "Should set all values correctly",
-			pool: &asocontainerservicev1preview.ManagedClustersAgentPool{
-				Spec: asocontainerservicev1preview.ManagedClusters_AgentPool_Spec{
-					AzureName:           "agentpool1",
-					VmSize:              ptr.To("Standard_D2s_v3"),
-					OsType:              ptr.To(asocontainerservicev1preview.OSType_Linux),
-					OsDiskSizeGB:        ptr.To[asocontainerservicev1preview.ContainerServiceOSDisk](100),
-					Count:               ptr.To(2),
-					Type:                ptr.To(asocontainerservicev1preview.AgentPoolType_VirtualMachineScaleSets),
-					OrchestratorVersion: ptr.To("1.22.6"),
-					VnetSubnetReference: &genruntime.ResourceReference{
-						ARMID: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-123/providers/Microsoft.Network/virtualNetworks/vnet-123/subnets/subnet-123",
-					},
-					Mode:              ptr.To(asocontainerservicev1preview.AgentPoolMode_User),
-					EnableAutoScaling: ptr.To(true),
-					MaxCount:          ptr.To(5),
-					MinCount:          ptr.To(2),
-					NodeTaints:        []string{"key1=value1:NoSchedule"},
-					AvailabilityZones: []string{"zone1"},
-					MaxPods:           ptr.To(60),
-					OsDiskType:        ptr.To(asocontainerservicev1preview.OSDiskType_Managed),
-					NodeLabels: map[string]string{
-						"custom": "default",
-					},
-					Tags: map[string]string{
-						"custom": "default",
-					},
-					EnableFIPS:             ptr.To(true),
-					EnableEncryptionAtHost: ptr.To(true),
-				},
-			},
-
-			expect: func(g *GomegaWithT, result asocontainerservicev1preview.ManagedClusterAgentPoolProfile) {
-				g.Expect(result).To(Equal(asocontainerservicev1preview.ManagedClusterAgentPoolProfile{
-					Name:                ptr.To("agentpool1"),
-					VmSize:              ptr.To("Standard_D2s_v3"),
-					OsType:              ptr.To(asocontainerservicev1preview.OSType_Linux),
-					OsDiskSizeGB:        ptr.To[asocontainerservicev1preview.ContainerServiceOSDisk](100),
-					Count:               ptr.To(2),
-					Type:                ptr.To(asocontainerservicev1preview.AgentPoolType_VirtualMachineScaleSets),
-					OrchestratorVersion: ptr.To("1.22.6"),
-					VnetSubnetReference: &genruntime.ResourceReference{
-						ARMID: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-123/providers/Microsoft.Network/virtualNetworks/vnet-123/subnets/subnet-123",
-					},
-					Mode:              ptr.To(asocontainerservicev1preview.AgentPoolMode_User),
-					EnableAutoScaling: ptr.To(true),
-					MaxCount:          ptr.To(5),
-					MinCount:          ptr.To(2),
-					NodeTaints:        []string{"key1=value1:NoSchedule"},
-					AvailabilityZones: []string{"zone1"},
-					MaxPods:           ptr.To(60),
-					OsDiskType:        ptr.To(asocontainerservicev1preview.OSDiskType_Managed),
-					NodeLabels: map[string]string{
-						"custom": "default",
-					},
-					Tags: map[string]string{
-						"custom": "default",
-					},
-					EnableFIPS:             ptr.To(true),
-					EnableEncryptionAtHost: ptr.To(true),
-				}))
-			},
-		},
-	}
-
-	for _, c := range cases {
-		c := c
-		t.Run(c.name, func(t *testing.T) {
-			t.Parallel()
-			g := NewGomegaWithT(t)
-			result := AgentPoolToManagedClusterAgentPoolPreviewProfile(c.pool)
 			c.expect(g, result)
 		})
 	}

--- a/azure/scope/managedcontrolplane.go
+++ b/azure/scope/managedcontrolplane.go
@@ -528,11 +528,6 @@ func (s *ManagedControlPlaneScope) IsManagedVersionUpgrade() bool {
 	return isManagedVersionUpgrade(s.ControlPlane)
 }
 
-// IsPreviewEnabled checks if the preview feature is enabled.
-func (s *ManagedControlPlaneScope) IsPreviewEnabled() bool {
-	return ptr.Deref(s.ControlPlane.Spec.EnablePreviewFeatures, false)
-}
-
 func isManagedVersionUpgrade(managedControlPlane *infrav1.AzureManagedControlPlane) bool {
 	return managedControlPlane.Spec.AutoUpgradeProfile != nil &&
 		managedControlPlane.Spec.AutoUpgradeProfile.UpgradeChannel != nil &&

--- a/azure/services/agentpools/agentpools_test.go
+++ b/azure/services/agentpools/agentpools_test.go
@@ -46,7 +46,6 @@ func TestPostCreateOrUpdateResourceHook(t *testing.T) {
 		scope := mock_agentpools.NewMockAgentPoolScope(mockCtrl)
 
 		scope.EXPECT().RemoveCAPIMachinePoolAnnotation(clusterv1.ReplicasManagedByAnnotation)
-		scope.EXPECT().IsPreviewEnabled().Return(false)
 
 		managedCluster := &asocontainerservicev1.ManagedClustersAgentPool{
 			Status: asocontainerservicev1.ManagedClusters_AgentPool_STATUS{
@@ -65,7 +64,6 @@ func TestPostCreateOrUpdateResourceHook(t *testing.T) {
 
 		scope.EXPECT().SetCAPIMachinePoolAnnotation(clusterv1.ReplicasManagedByAnnotation, "true")
 		scope.EXPECT().SetCAPIMachinePoolReplicas(ptr.To(1234))
-		scope.EXPECT().IsPreviewEnabled().Return(false)
 
 		managedCluster := &asocontainerservicev1.ManagedClustersAgentPool{
 			Status: asocontainerservicev1.ManagedClusters_AgentPool_STATUS{
@@ -85,7 +83,6 @@ func TestPostCreateOrUpdateResourceHook(t *testing.T) {
 
 		scope.EXPECT().SetCAPIMachinePoolAnnotation(clusterv1.ReplicasManagedByAnnotation, "true")
 		scope.EXPECT().SetCAPIMachinePoolReplicas(ptr.To(1234))
-		scope.EXPECT().IsPreviewEnabled().Return(true)
 
 		agentPool := &asocontainerservicev1preview.ManagedClustersAgentPool{
 			Status: asocontainerservicev1preview.ManagedClusters_AgentPool_STATUS{

--- a/azure/services/agentpools/spec.go
+++ b/azure/services/agentpools/spec.go
@@ -31,6 +31,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-azure/azure/services/aso"
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
 	"sigs.k8s.io/cluster-api-provider-azure/util/versions"
+	"sigs.k8s.io/controller-runtime/pkg/conversion"
 )
 
 // KubeletConfig defines the set of kubelet configurations for nodes in pools.
@@ -181,7 +182,7 @@ func (s *AgentPoolSpec) ResourceRef() genruntime.MetaObject {
 // If the auto upgrade channel is set to patch, stable or rapid, clusters can be upgraded to a higher version by AKS.
 // If auto upgrade is triggered, the existing Kubernetes version will be higher than the user's desired Kubernetes version.
 // CAPZ should honour the upgrade and it should not downgrade to the lower desired version.
-func (s *AgentPoolSpec) getManagedMachinePoolVersion(existing *asocontainerservicev1.ManagedClustersAgentPool) *string {
+func (s *AgentPoolSpec) getManagedMachinePoolVersion(existing *asocontainerservicev1hub.ManagedClustersAgentPool) *string {
 	if existing == nil || existing.Spec.OrchestratorVersion == nil {
 		return s.Version
 	}
@@ -198,29 +199,18 @@ func (s *AgentPoolSpec) Parameters(ctx context.Context, existingObj genruntime.M
 	defer done()
 
 	// If existing is preview, convert to stable then back to preview at the end of the function.
-	var existing *asocontainerservicev1.ManagedClustersAgentPool
-	var existingStatus asocontainerservicev1preview.ManagedClusters_AgentPool_STATUS
+	var existing *asocontainerservicev1hub.ManagedClustersAgentPool
 	if existingObj != nil {
-		if s.Preview {
-			existingPreview := existingObj.(*asocontainerservicev1preview.ManagedClustersAgentPool)
-			existingStatus = existingPreview.Status
-			hub := &asocontainerservicev1hub.ManagedClustersAgentPool{}
-			if err := existingPreview.ConvertTo(hub); err != nil {
-				return nil, err
-			}
-			stable := &asocontainerservicev1.ManagedClustersAgentPool{}
-			if err := stable.ConvertFrom(hub); err != nil {
-				return nil, err
-			}
-			existing = stable
-		} else {
-			existing = existingObj.(*asocontainerservicev1.ManagedClustersAgentPool)
+		hub := &asocontainerservicev1hub.ManagedClustersAgentPool{}
+		if err := existingObj.(conversion.Convertible).ConvertTo(hub); err != nil {
+			return nil, err
 		}
+		existing = hub
 	}
 
 	agentPool := existing
 	if agentPool == nil {
-		agentPool = &asocontainerservicev1.ManagedClustersAgentPool{}
+		agentPool = &asocontainerservicev1hub.ManagedClustersAgentPool{}
 	}
 
 	agentPool.Spec.AzureName = s.AzureName
@@ -231,19 +221,19 @@ func (s *AgentPoolSpec) Parameters(ctx context.Context, existingObj genruntime.M
 	agentPool.Spec.Count = &s.Replicas
 	agentPool.Spec.EnableAutoScaling = ptr.To(s.EnableAutoScaling)
 	agentPool.Spec.EnableUltraSSD = s.EnableUltraSSD
-	agentPool.Spec.KubeletDiskType = azure.AliasOrNil[asocontainerservicev1.KubeletDiskType]((*string)(s.KubeletDiskType))
+	agentPool.Spec.KubeletDiskType = azure.AliasOrNil[string]((*string)(s.KubeletDiskType))
 	agentPool.Spec.MaxCount = s.MaxCount
 	agentPool.Spec.MaxPods = s.MaxPods
 	agentPool.Spec.MinCount = s.MinCount
-	agentPool.Spec.Mode = ptr.To(asocontainerservicev1.AgentPoolMode(s.Mode))
+	agentPool.Spec.Mode = ptr.To(string(asocontainerservicev1.AgentPoolMode(s.Mode)))
 	agentPool.Spec.NodeLabels = s.NodeLabels
 	agentPool.Spec.NodeTaints = s.NodeTaints
-	agentPool.Spec.OsDiskSizeGB = ptr.To(asocontainerservicev1.ContainerServiceOSDisk(s.OSDiskSizeGB))
-	agentPool.Spec.OsDiskType = azure.AliasOrNil[asocontainerservicev1.OSDiskType](s.OsDiskType)
-	agentPool.Spec.OsType = azure.AliasOrNil[asocontainerservicev1.OSType](s.OSType)
-	agentPool.Spec.ScaleSetPriority = azure.AliasOrNil[asocontainerservicev1.ScaleSetPriority](s.ScaleSetPriority)
-	agentPool.Spec.ScaleDownMode = azure.AliasOrNil[asocontainerservicev1.ScaleDownMode](s.ScaleDownMode)
-	agentPool.Spec.Type = ptr.To(asocontainerservicev1.AgentPoolType_VirtualMachineScaleSets)
+	agentPool.Spec.OsDiskSizeGB = ptr.To(int(asocontainerservicev1.ContainerServiceOSDisk(s.OSDiskSizeGB)))
+	agentPool.Spec.OsDiskType = azure.AliasOrNil[string](s.OsDiskType)
+	agentPool.Spec.OsType = azure.AliasOrNil[string](s.OSType)
+	agentPool.Spec.ScaleSetPriority = azure.AliasOrNil[string](s.ScaleSetPriority)
+	agentPool.Spec.ScaleDownMode = azure.AliasOrNil[string](s.ScaleDownMode)
+	agentPool.Spec.Type = ptr.To(string(asocontainerservicev1.AgentPoolType_VirtualMachineScaleSets))
 	agentPool.Spec.EnableNodePublicIP = s.EnableNodePublicIP
 	agentPool.Spec.Tags = s.AdditionalTags
 	agentPool.Spec.EnableFIPS = s.EnableFIPS
@@ -253,7 +243,7 @@ func (s *AgentPoolSpec) Parameters(ctx context.Context, existingObj genruntime.M
 	}
 
 	if s.KubeletConfig != nil {
-		agentPool.Spec.KubeletConfig = &asocontainerservicev1.KubeletConfig{
+		agentPool.Spec.KubeletConfig = &asocontainerservicev1hub.KubeletConfig{
 			CpuManagerPolicy:      s.KubeletConfig.CPUManagerPolicy,
 			CpuCfsQuota:           s.KubeletConfig.CPUCfsQuota,
 			CpuCfsQuotaPeriod:     s.KubeletConfig.CPUCfsQuotaPeriod,
@@ -289,13 +279,13 @@ func (s *AgentPoolSpec) Parameters(ctx context.Context, existingObj genruntime.M
 	}
 
 	if s.LinuxOSConfig != nil {
-		agentPool.Spec.LinuxOSConfig = &asocontainerservicev1.LinuxOSConfig{
+		agentPool.Spec.LinuxOSConfig = &asocontainerservicev1hub.LinuxOSConfig{
 			SwapFileSizeMB:             s.LinuxOSConfig.SwapFileSizeMB,
 			TransparentHugePageEnabled: (*string)(s.LinuxOSConfig.TransparentHugePageEnabled),
 			TransparentHugePageDefrag:  (*string)(s.LinuxOSConfig.TransparentHugePageDefrag),
 		}
 		if s.LinuxOSConfig.Sysctls != nil {
-			agentPool.Spec.LinuxOSConfig.Sysctls = &asocontainerservicev1.SysctlConfig{
+			agentPool.Spec.LinuxOSConfig.Sysctls = &asocontainerservicev1hub.SysctlConfig{
 				FsAioMaxNr:                     s.LinuxOSConfig.Sysctls.FsAioMaxNr,
 				FsFileMax:                      s.LinuxOSConfig.Sysctls.FsFileMax,
 				FsInotifyMaxUserWatches:        s.LinuxOSConfig.Sysctls.FsInotifyMaxUserWatches,
@@ -336,21 +326,19 @@ func (s *AgentPoolSpec) Parameters(ctx context.Context, existingObj genruntime.M
 	}
 
 	if s.Preview {
-		hub := &asocontainerservicev1hub.ManagedClustersAgentPool{}
-		if err := agentPool.ConvertTo(hub); err != nil {
-			return nil, err
-		}
 		prev := &asocontainerservicev1preview.ManagedClustersAgentPool{}
-		if err := prev.ConvertFrom(hub); err != nil {
+		if err := prev.ConvertFrom(agentPool); err != nil {
 			return nil, err
-		}
-		if existing != nil {
-			prev.Status = existingStatus
 		}
 		return prev, nil
 	}
 
-	return agentPool, nil
+	stable := &asocontainerservicev1.ManagedClustersAgentPool{}
+	if err := stable.ConvertFrom(agentPool); err != nil {
+		return nil, err
+	}
+
+	return stable, nil
 }
 
 // WasManaged implements azure.ASOResourceSpecGetter.

--- a/azure/services/aso/aso.go
+++ b/azure/services/aso/aso.go
@@ -31,7 +31,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/util/yaml"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
@@ -250,7 +249,7 @@ func applyPatches[T genruntime.MetaObject](scheme *runtime.Scheme, spec azure.AS
 		return zero, errors.Wrap(err, "failed to get GroupVersionKind for object")
 	}
 
-	(genruntime.MetaObject)(parameters).(interface{ SetGroupVersionKind(schema.GroupVersionKind) }).SetGroupVersionKind(gvk)
+	parameters.GetObjectKind().SetGroupVersionKind(gvk)
 	paramData, err := json.Marshal(parameters)
 	if err != nil {
 		return zero, errors.Wrap(err, "failed to marshal JSON for patch")

--- a/azure/services/managedclusters/managedclusters_test.go
+++ b/azure/services/managedclusters/managedclusters_test.go
@@ -49,7 +49,6 @@ func TestPostCreateOrUpdateResourceHook(t *testing.T) {
 		g := NewGomegaWithT(t)
 		namespace := "default"
 		scope := setupMockScope(t)
-		scope.EXPECT().IsPreviewEnabled().Return(false)
 
 		managedCluster := &asocontainerservicev1.ManagedCluster{
 			ObjectMeta: metav1.ObjectMeta{
@@ -79,8 +78,6 @@ func TestPostCreateOrUpdateResourceHook(t *testing.T) {
 		g := NewGomegaWithT(t)
 		namespace := "default"
 		scope := setupMockScope(t)
-
-		scope.EXPECT().IsPreviewEnabled().Return(true)
 
 		managedCluster := &asocontainerservicev1preview.ManagedCluster{
 			ObjectMeta: metav1.ObjectMeta{
@@ -123,7 +120,6 @@ func TestPostCreateOrUpdateResourceHook(t *testing.T) {
 		})
 		scope.EXPECT().ClusterName().Return(clusterName).AnyTimes()
 		scope.EXPECT().IsAADEnabled().Return(true)
-		scope.EXPECT().IsPreviewEnabled().Return(false)
 
 		managedCluster := &asocontainerservicev1.ManagedCluster{
 			ObjectMeta: metav1.ObjectMeta{

--- a/azure/services/managedclusters/mock_managedclusters/managedclusters_mock.go
+++ b/azure/services/managedclusters/mock_managedclusters/managedclusters_mock.go
@@ -313,20 +313,6 @@ func (mr *MockManagedClusterScopeMockRecorder) IsManagedVersionUpgrade() *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsManagedVersionUpgrade", reflect.TypeOf((*MockManagedClusterScope)(nil).IsManagedVersionUpgrade))
 }
 
-// IsPreviewEnabled mocks base method.
-func (m *MockManagedClusterScope) IsPreviewEnabled() bool {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsPreviewEnabled")
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-// IsPreviewEnabled indicates an expected call of IsPreviewEnabled.
-func (mr *MockManagedClusterScopeMockRecorder) IsPreviewEnabled() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsPreviewEnabled", reflect.TypeOf((*MockManagedClusterScope)(nil).IsPreviewEnabled))
-}
-
 // MakeClusterCA mocks base method.
 func (m *MockManagedClusterScope) MakeClusterCA() *v1.Secret {
 	m.ctrl.T.Helper()

--- a/azure/services/managedclusters/spec.go
+++ b/azure/services/managedclusters/spec.go
@@ -38,6 +38,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
 	"sigs.k8s.io/cluster-api-provider-azure/util/versions"
 	"sigs.k8s.io/cluster-api/util/secret"
+	"sigs.k8s.io/controller-runtime/pkg/conversion"
 )
 
 // ManagedClusterSpec contains properties to create a managed cluster.
@@ -339,12 +340,12 @@ type AzureKeyVaultKms struct {
 }
 
 // buildAutoScalerProfile builds the AutoScalerProfile for the ManagedClusterProperties.
-func buildAutoScalerProfile(autoScalerProfile *AutoScalerProfile) *asocontainerservicev1.ManagedClusterProperties_AutoScalerProfile {
+func buildAutoScalerProfile(autoScalerProfile *AutoScalerProfile) *asocontainerservicev1hub.ManagedClusterProperties_AutoScalerProfile {
 	if autoScalerProfile == nil {
 		return nil
 	}
 
-	mcAutoScalerProfile := &asocontainerservicev1.ManagedClusterProperties_AutoScalerProfile{
+	mcAutoScalerProfile := &asocontainerservicev1hub.ManagedClusterProperties_AutoScalerProfile{
 		BalanceSimilarNodeGroups:      autoScalerProfile.BalanceSimilarNodeGroups,
 		MaxEmptyBulkDelete:            autoScalerProfile.MaxEmptyBulkDelete,
 		MaxGracefulTerminationSec:     autoScalerProfile.MaxGracefulTerminationSec,
@@ -363,7 +364,7 @@ func buildAutoScalerProfile(autoScalerProfile *AutoScalerProfile) *asocontainers
 		SkipNodesWithSystemPods:       autoScalerProfile.SkipNodesWithSystemPods,
 	}
 	if autoScalerProfile.Expander != nil {
-		mcAutoScalerProfile.Expander = ptr.To(asocontainerservicev1.ManagedClusterProperties_AutoScalerProfile_Expander(*autoScalerProfile.Expander))
+		mcAutoScalerProfile.Expander = ptr.To(string(asocontainerservicev1.ManagedClusterProperties_AutoScalerProfile_Expander(*autoScalerProfile.Expander)))
 	}
 
 	return mcAutoScalerProfile
@@ -373,7 +374,7 @@ func buildAutoScalerProfile(autoScalerProfile *AutoScalerProfile) *asocontainers
 // If autoupgrade channels is set to patch, stable or rapid, clusters can be upgraded to higher version by AKS.
 // If autoupgrade is triggered, existing kubernetes version will be higher than the user desired kubernetes version.
 // CAPZ should honour the upgrade and it should not downgrade to the lower desired version.
-func (s *ManagedClusterSpec) getManagedClusterVersion(existing *asocontainerservicev1.ManagedCluster) string {
+func (s *ManagedClusterSpec) getManagedClusterVersion(existing *asocontainerservicev1hub.ManagedCluster) string {
 	if existing == nil || existing.Status.CurrentKubernetesVersion == nil {
 		return s.Version
 	}
@@ -404,30 +405,20 @@ func (s *ManagedClusterSpec) Parameters(ctx context.Context, existingObj genrunt
 	defer done()
 
 	// If existing is preview, convert to stable then back to preview at the end of the function.
-	var existing *asocontainerservicev1.ManagedCluster
+	var existing *asocontainerservicev1hub.ManagedCluster
 	var existingStatus asocontainerservicev1preview.ManagedCluster_STATUS
 	if existingObj != nil {
-		if s.Preview {
-			existingPreview := existingObj.(*asocontainerservicev1preview.ManagedCluster)
-			existingStatus = existingPreview.Status
-			hub := &asocontainerservicev1hub.ManagedCluster{}
-			if err := existingPreview.ConvertTo(hub); err != nil {
-				return nil, err
-			}
-			stable := &asocontainerservicev1.ManagedCluster{}
-			if err := stable.ConvertFrom(hub); err != nil {
-				return nil, err
-			}
-			existing = stable.DeepCopy()
-		} else {
-			existing = existingObj.(*asocontainerservicev1.ManagedCluster)
+		hub := &asocontainerservicev1hub.ManagedCluster{}
+		if err := existingObj.(conversion.Convertible).ConvertTo(hub); err != nil {
+			return nil, err
 		}
+		existing = hub
 	}
 
 	managedCluster := existing
 	if managedCluster == nil {
-		managedCluster = &asocontainerservicev1.ManagedCluster{
-			Spec: asocontainerservicev1.ManagedCluster_Spec{
+		managedCluster = &asocontainerservicev1hub.ManagedCluster{
+			Spec: asocontainerservicev1hub.ManagedCluster_Spec{
 				Tags: infrav1.Build(infrav1.BuildParams{
 					Lifecycle:   infrav1.ResourceLifecycleOwned,
 					ClusterName: s.ClusterName,
@@ -443,8 +434,8 @@ func (s *ManagedClusterSpec) Parameters(ctx context.Context, existingObj genrunt
 	managedCluster.Spec.Owner = &genruntime.KnownResourceReference{
 		Name: s.ResourceGroup,
 	}
-	managedCluster.Spec.Identity = &asocontainerservicev1.ManagedClusterIdentity{
-		Type: ptr.To(asocontainerservicev1.ManagedClusterIdentity_Type_SystemAssigned),
+	managedCluster.Spec.Identity = &asocontainerservicev1hub.ManagedClusterIdentity{
+		Type: ptr.To(string(asocontainerservicev1.ManagedClusterIdentity_Type_SystemAssigned)),
 	}
 	managedCluster.Spec.Location = &s.Location
 	managedCluster.Spec.NodeResourceGroup = &s.NodeResourceGroup
@@ -455,16 +446,16 @@ func (s *ManagedClusterSpec) Parameters(ctx context.Context, existingObj genrunt
 		managedCluster.Spec.KubernetesVersion = &kubernetesVersion
 	}
 
-	managedCluster.Spec.ServicePrincipalProfile = &asocontainerservicev1.ManagedClusterServicePrincipalProfile{
+	managedCluster.Spec.ServicePrincipalProfile = &asocontainerservicev1hub.ManagedClusterServicePrincipalProfile{
 		ClientId: ptr.To("msi"),
 	}
-	managedCluster.Spec.NetworkProfile = &asocontainerservicev1.ContainerServiceNetworkProfile{
-		NetworkPlugin:   azure.AliasOrNil[asocontainerservicev1.NetworkPlugin](&s.NetworkPlugin),
-		LoadBalancerSku: azure.AliasOrNil[asocontainerservicev1.ContainerServiceNetworkProfile_LoadBalancerSku](&s.LoadBalancerSKU),
-		NetworkPolicy:   azure.AliasOrNil[asocontainerservicev1.ContainerServiceNetworkProfile_NetworkPolicy](&s.NetworkPolicy),
+	managedCluster.Spec.NetworkProfile = &asocontainerservicev1hub.ContainerServiceNetworkProfile{
+		NetworkPlugin:   azure.AliasOrNil[string](ptr.To(s.NetworkPlugin)),
+		LoadBalancerSku: azure.AliasOrNil[string](ptr.To(s.LoadBalancerSKU)),
+		NetworkPolicy:   azure.AliasOrNil[string](ptr.To(s.NetworkPolicy)),
 	}
 	if s.NetworkDataplane != nil {
-		managedCluster.Spec.NetworkProfile.NetworkDataplane = ptr.To(asocontainerservicev1.ContainerServiceNetworkProfile_NetworkDataplane(*s.NetworkDataplane))
+		managedCluster.Spec.NetworkProfile.NetworkDataplane = ptr.To(string(asocontainerservicev1.ContainerServiceNetworkProfile_NetworkDataplane(*s.NetworkDataplane)))
 	}
 	managedCluster.Spec.AutoScalerProfile = buildAutoScalerProfile(s.AutoScalerProfile)
 
@@ -477,10 +468,10 @@ func (s *ManagedClusterSpec) Parameters(ctx context.Context, existingObj genrunt
 	}
 
 	if decodedSSHPublicKey != nil {
-		managedCluster.Spec.LinuxProfile = &asocontainerservicev1.ContainerServiceLinuxProfile{
+		managedCluster.Spec.LinuxProfile = &asocontainerservicev1hub.ContainerServiceLinuxProfile{
 			AdminUsername: ptr.To(azure.DefaultAKSUserName),
-			Ssh: &asocontainerservicev1.ContainerServiceSshConfiguration{
-				PublicKeys: []asocontainerservicev1.ContainerServiceSshPublicKey{
+			Ssh: &asocontainerservicev1hub.ContainerServiceSshConfiguration{
+				PublicKeys: []asocontainerservicev1hub.ContainerServiceSshPublicKey{
 					{
 						KeyData: ptr.To(string(decodedSSHPublicKey)),
 					},
@@ -490,7 +481,7 @@ func (s *ManagedClusterSpec) Parameters(ctx context.Context, existingObj genrunt
 	}
 
 	if s.NetworkPluginMode != nil {
-		managedCluster.Spec.NetworkProfile.NetworkPluginMode = ptr.To(asocontainerservicev1.ContainerServiceNetworkProfile_NetworkPluginMode(*s.NetworkPluginMode))
+		managedCluster.Spec.NetworkProfile.NetworkPluginMode = ptr.To(string(asocontainerservicev1.ContainerServiceNetworkProfile_NetworkPluginMode(*s.NetworkPluginMode)))
 	}
 
 	if s.PodCIDR != "" {
@@ -517,8 +508,8 @@ func (s *ManagedClusterSpec) Parameters(ctx context.Context, existingObj genrunt
 
 	// OperatorSpec defines how the Secrets generated by ASO should look for the AKS cluster kubeconfigs.
 	// There is no prescribed naming convention that must be followed.
-	managedCluster.Spec.OperatorSpec = &asocontainerservicev1.ManagedClusterOperatorSpec{
-		Secrets: &asocontainerservicev1.ManagedClusterOperatorSecrets{
+	managedCluster.Spec.OperatorSpec = &asocontainerservicev1hub.ManagedClusterOperatorSpec{
+		Secrets: &asocontainerservicev1hub.ManagedClusterOperatorSecrets{
 			AdminCredentials: &genruntime.SecretDestination{
 				Name: adminKubeconfigSecretName(s.ClusterName),
 				Key:  secret.KubeconfigDataName,
@@ -527,7 +518,7 @@ func (s *ManagedClusterSpec) Parameters(ctx context.Context, existingObj genrunt
 	}
 
 	if s.AADProfile != nil {
-		managedCluster.Spec.AadProfile = &asocontainerservicev1.ManagedClusterAADProfile{
+		managedCluster.Spec.AadProfile = &asocontainerservicev1hub.ManagedClusterAADProfile{
 			Managed:             &s.AADProfile.Managed,
 			EnableAzureRBAC:     &s.AADProfile.EnableAzureRBAC,
 			AdminGroupObjectIDs: s.AADProfile.AdminGroupObjectIDs,
@@ -550,10 +541,10 @@ func (s *ManagedClusterSpec) Parameters(ctx context.Context, existingObj genrunt
 
 	for i := range s.AddonProfiles {
 		if managedCluster.Spec.AddonProfiles == nil {
-			managedCluster.Spec.AddonProfiles = map[string]asocontainerservicev1.ManagedClusterAddonProfile{}
+			managedCluster.Spec.AddonProfiles = map[string]asocontainerservicev1hub.ManagedClusterAddonProfile{}
 		}
 		item := s.AddonProfiles[i]
-		addonProfile := asocontainerservicev1.ManagedClusterAddonProfile{
+		addonProfile := asocontainerservicev1hub.ManagedClusterAddonProfile{
 			Enabled: &item.Enabled,
 		}
 		if item.Config != nil {
@@ -564,9 +555,9 @@ func (s *ManagedClusterSpec) Parameters(ctx context.Context, existingObj genrunt
 
 	if s.SKU != nil {
 		tierName := asocontainerservicev1.ManagedClusterSKU_Tier(s.SKU.Tier)
-		managedCluster.Spec.Sku = &asocontainerservicev1.ManagedClusterSKU{
-			Name: ptr.To(asocontainerservicev1.ManagedClusterSKU_Name("Base")),
-			Tier: ptr.To(tierName),
+		managedCluster.Spec.Sku = &asocontainerservicev1hub.ManagedClusterSKU{
+			Name: ptr.To(string(asocontainerservicev1.ManagedClusterSKU_Name("Base"))),
+			Tier: ptr.To(string(tierName)),
 		}
 	}
 
@@ -575,7 +566,7 @@ func (s *ManagedClusterSpec) Parameters(ctx context.Context, existingObj genrunt
 	}
 
 	if s.APIServerAccessProfile != nil {
-		managedCluster.Spec.ApiServerAccessProfile = &asocontainerservicev1.ManagedClusterAPIServerAccessProfile{
+		managedCluster.Spec.ApiServerAccessProfile = &asocontainerservicev1hub.ManagedClusterAPIServerAccessProfile{
 			EnablePrivateCluster:           s.APIServerAccessProfile.EnablePrivateCluster,
 			PrivateDNSZone:                 s.APIServerAccessProfile.PrivateDNSZone,
 			EnablePrivateClusterPublicFQDN: s.APIServerAccessProfile.EnablePrivateClusterPublicFQDN,
@@ -587,7 +578,7 @@ func (s *ManagedClusterSpec) Parameters(ctx context.Context, existingObj genrunt
 	}
 
 	if s.OutboundType != nil {
-		managedCluster.Spec.NetworkProfile.OutboundType = ptr.To(asocontainerservicev1.ContainerServiceNetworkProfile_OutboundType(*s.OutboundType))
+		managedCluster.Spec.NetworkProfile.OutboundType = ptr.To(string(asocontainerservicev1.ContainerServiceNetworkProfile_OutboundType(*s.OutboundType)))
 	}
 
 	if s.Identity != nil {
@@ -598,7 +589,7 @@ func (s *ManagedClusterSpec) Parameters(ctx context.Context, existingObj genrunt
 	}
 
 	if s.KubeletUserAssignedIdentity != "" {
-		managedCluster.Spec.IdentityProfile = map[string]asocontainerservicev1.UserAssignedIdentity{
+		managedCluster.Spec.IdentityProfile = map[string]asocontainerservicev1hub.UserAssignedIdentity{
 			kubeletIdentityKey: {
 				ResourceReference: &genruntime.ResourceReference{
 					ARMID: s.KubeletUserAssignedIdentity,
@@ -608,7 +599,7 @@ func (s *ManagedClusterSpec) Parameters(ctx context.Context, existingObj genrunt
 	}
 
 	if s.HTTPProxyConfig != nil {
-		managedCluster.Spec.HttpProxyConfig = &asocontainerservicev1.ManagedClusterHTTPProxyConfig{
+		managedCluster.Spec.HttpProxyConfig = &asocontainerservicev1hub.ManagedClusterHTTPProxyConfig{
 			HttpProxy:  s.HTTPProxyConfig.HTTPProxy,
 			HttpsProxy: s.HTTPProxyConfig.HTTPSProxy,
 			TrustedCa:  s.HTTPProxyConfig.TrustedCA,
@@ -620,11 +611,11 @@ func (s *ManagedClusterSpec) Parameters(ctx context.Context, existingObj genrunt
 	}
 
 	if s.OIDCIssuerProfile != nil {
-		managedCluster.Spec.OidcIssuerProfile = &asocontainerservicev1.ManagedClusterOIDCIssuerProfile{
+		managedCluster.Spec.OidcIssuerProfile = &asocontainerservicev1hub.ManagedClusterOIDCIssuerProfile{
 			Enabled: s.OIDCIssuerProfile.Enabled,
 		}
 		if ptr.Deref(s.OIDCIssuerProfile.Enabled, false) {
-			managedCluster.Spec.OperatorSpec.ConfigMaps = &asocontainerservicev1.ManagedClusterOperatorConfigMaps{
+			managedCluster.Spec.OperatorSpec.ConfigMaps = &asocontainerservicev1hub.ManagedClusterOperatorConfigMaps{
 				OIDCIssuerProfile: &genruntime.ConfigMapDestination{
 					Name: oidcIssuerURLConfigMapName(s.ClusterName),
 					Key:  oidcIssuerProfileURL,
@@ -634,21 +625,21 @@ func (s *ManagedClusterSpec) Parameters(ctx context.Context, existingObj genrunt
 	}
 
 	if s.AutoUpgradeProfile != nil {
-		managedCluster.Spec.AutoUpgradeProfile = &asocontainerservicev1.ManagedClusterAutoUpgradeProfile{
-			UpgradeChannel: (*asocontainerservicev1.ManagedClusterAutoUpgradeProfile_UpgradeChannel)(s.AutoUpgradeProfile.UpgradeChannel),
+		managedCluster.Spec.AutoUpgradeProfile = &asocontainerservicev1hub.ManagedClusterAutoUpgradeProfile{
+			UpgradeChannel: (*string)(s.AutoUpgradeProfile.UpgradeChannel),
 		}
 	}
 
 	if s.SecurityProfile != nil {
-		securityProfile := &asocontainerservicev1.ManagedClusterSecurityProfile{}
+		securityProfile := &asocontainerservicev1hub.ManagedClusterSecurityProfile{}
 		if s.SecurityProfile.AzureKeyVaultKms != nil {
-			securityProfile.AzureKeyVaultKms = &asocontainerservicev1.AzureKeyVaultKms{
+			securityProfile.AzureKeyVaultKms = &asocontainerservicev1hub.AzureKeyVaultKms{
 				Enabled: s.SecurityProfile.AzureKeyVaultKms.Enabled,
 				KeyId:   s.SecurityProfile.AzureKeyVaultKms.KeyID,
 			}
 			if s.SecurityProfile.AzureKeyVaultKms.KeyVaultNetworkAccess != nil {
 				keyVaultNetworkAccess := string(*s.SecurityProfile.AzureKeyVaultKms.KeyVaultNetworkAccess)
-				securityProfile.AzureKeyVaultKms.KeyVaultNetworkAccess = ptr.To(asocontainerservicev1.AzureKeyVaultKms_KeyVaultNetworkAccess(keyVaultNetworkAccess))
+				securityProfile.AzureKeyVaultKms.KeyVaultNetworkAccess = ptr.To(string(asocontainerservicev1.AzureKeyVaultKms_KeyVaultNetworkAccess(keyVaultNetworkAccess)))
 			}
 			if s.SecurityProfile.AzureKeyVaultKms.KeyVaultResourceID != nil {
 				securityProfile.AzureKeyVaultKms.KeyVaultResourceReference = &genruntime.ResourceReference{
@@ -657,25 +648,25 @@ func (s *ManagedClusterSpec) Parameters(ctx context.Context, existingObj genrunt
 			}
 		}
 		if s.SecurityProfile.Defender != nil {
-			securityProfile.Defender = &asocontainerservicev1.ManagedClusterSecurityProfileDefender{
+			securityProfile.Defender = &asocontainerservicev1hub.ManagedClusterSecurityProfileDefender{
 				LogAnalyticsWorkspaceResourceReference: &genruntime.ResourceReference{
 					ARMID: *s.SecurityProfile.Defender.LogAnalyticsWorkspaceResourceID,
 				},
 			}
 			if s.SecurityProfile.Defender.SecurityMonitoring != nil {
-				securityProfile.Defender.SecurityMonitoring = &asocontainerservicev1.ManagedClusterSecurityProfileDefenderSecurityMonitoring{
+				securityProfile.Defender.SecurityMonitoring = &asocontainerservicev1hub.ManagedClusterSecurityProfileDefenderSecurityMonitoring{
 					Enabled: s.SecurityProfile.Defender.SecurityMonitoring.Enabled,
 				}
 			}
 		}
 		if s.SecurityProfile.ImageCleaner != nil {
-			securityProfile.ImageCleaner = &asocontainerservicev1.ManagedClusterSecurityProfileImageCleaner{
+			securityProfile.ImageCleaner = &asocontainerservicev1hub.ManagedClusterSecurityProfileImageCleaner{
 				Enabled:       s.SecurityProfile.ImageCleaner.Enabled,
 				IntervalHours: s.SecurityProfile.ImageCleaner.IntervalHours,
 			}
 		}
 		if s.SecurityProfile.WorkloadIdentity != nil {
-			securityProfile.WorkloadIdentity = &asocontainerservicev1.ManagedClusterSecurityProfileWorkloadIdentity{
+			securityProfile.WorkloadIdentity = &asocontainerservicev1hub.ManagedClusterSecurityProfileWorkloadIdentity{
 				Enabled: s.SecurityProfile.WorkloadIdentity.Enabled,
 			}
 		}
@@ -684,7 +675,7 @@ func (s *ManagedClusterSpec) Parameters(ctx context.Context, existingObj genrunt
 
 	// Only include AgentPoolProfiles during initial cluster creation. Agent pools are managed solely by the
 	// AzureManagedMachinePool controller thereafter.
-	var prevAgentPoolProfiles []asocontainerservicev1preview.ManagedClusterAgentPoolProfile
+	var prevAgentPoolProfiles []asocontainerservicev1hub.ManagedClusterAgentPoolProfile
 	managedCluster.Spec.AgentPoolProfiles = nil
 	if managedCluster.Status.AgentPoolProfiles == nil {
 		// Add all agent pools to cluster spec that will be submitted to the API
@@ -706,68 +697,72 @@ func (s *ManagedClusterSpec) Parameters(ctx context.Context, existingObj genrunt
 				return nil, errors.Wrapf(err, "failed to get agent pool parameters for managed cluster %s", s.Name)
 			}
 			agentPoolSpecTyped := agentPoolSpec.(*agentpools.AgentPoolSpec)
+			hubAgentPool := &asocontainerservicev1hub.ManagedClustersAgentPool{}
 			if s.Preview {
 				agentPoolTyped := agentPool.(*asocontainerservicev1preview.ManagedClustersAgentPool)
-				agentPoolTyped.Spec.AzureName = agentPoolSpecTyped.AzureName
-				profile := converters.AgentPoolToManagedClusterAgentPoolPreviewProfile(agentPoolTyped)
-				prevAgentPoolProfiles = append(prevAgentPoolProfiles, profile)
+				if err := agentPoolTyped.ConvertTo(hubAgentPool); err != nil {
+					return nil, err
+				}
 			} else {
 				agentPoolTyped := agentPool.(*asocontainerservicev1.ManagedClustersAgentPool)
-				agentPoolTyped.Spec.AzureName = agentPoolSpecTyped.AzureName
-				profile := converters.AgentPoolToManagedClusterAgentPoolProfile(agentPoolTyped)
-				managedCluster.Spec.AgentPoolProfiles = append(managedCluster.Spec.AgentPoolProfiles, profile)
+				if err := agentPoolTyped.ConvertTo(hubAgentPool); err != nil {
+					return nil, err
+				}
 			}
+			hubAgentPool.Spec.AzureName = agentPoolSpecTyped.AzureName
+			profile := converters.AgentPoolToManagedClusterAgentPoolProfile(hubAgentPool)
+			prevAgentPoolProfiles = append(prevAgentPoolProfiles, profile)
 		}
 	}
 
+	managedCluster.Spec.AgentPoolProfiles = prevAgentPoolProfiles
+
 	if s.Preview {
-		hub := &asocontainerservicev1hub.ManagedCluster{}
-		if err := managedCluster.ConvertTo(hub); err != nil {
-			return nil, err
-		}
 		prev := &asocontainerservicev1preview.ManagedCluster{}
-		if err := prev.ConvertFrom(hub); err != nil {
+		if err := prev.ConvertFrom(managedCluster); err != nil {
 			return nil, err
 		}
 		if existing != nil {
 			prev.Status = existingStatus
 		}
-		if prevAgentPoolProfiles != nil {
-			prev.Spec.AgentPoolProfiles = prevAgentPoolProfiles
-		}
 		return prev, nil
 	}
 
-	return managedCluster, nil
+	stable := &asocontainerservicev1.ManagedCluster{}
+	if err := stable.ConvertFrom(managedCluster); err != nil {
+		return nil, err
+	}
+
+	return stable, nil
 }
 
 // GetLoadBalancerProfile returns an asocontainerservicev1.ManagedClusterLoadBalancerProfile from the
 // information present in ManagedClusterSpec.LoadBalancerProfile.
-func (s *ManagedClusterSpec) GetLoadBalancerProfile() (loadBalancerProfile *asocontainerservicev1.ManagedClusterLoadBalancerProfile) {
-	loadBalancerProfile = &asocontainerservicev1.ManagedClusterLoadBalancerProfile{
+func (s *ManagedClusterSpec) GetLoadBalancerProfile() (loadBalancerProfile *asocontainerservicev1hub.ManagedClusterLoadBalancerProfile) {
+	loadBalancerProfile = &asocontainerservicev1hub.ManagedClusterLoadBalancerProfile{
 		AllocatedOutboundPorts: s.LoadBalancerProfile.AllocatedOutboundPorts,
 		IdleTimeoutInMinutes:   s.LoadBalancerProfile.IdleTimeoutInMinutes,
 	}
 	if s.LoadBalancerProfile.ManagedOutboundIPs != nil {
-		loadBalancerProfile.ManagedOutboundIPs = &asocontainerservicev1.ManagedClusterLoadBalancerProfile_ManagedOutboundIPs{Count: s.LoadBalancerProfile.ManagedOutboundIPs}
+		loadBalancerProfile.ManagedOutboundIPs = &asocontainerservicev1hub.ManagedClusterLoadBalancerProfile_ManagedOutboundIPs{Count: s.LoadBalancerProfile.ManagedOutboundIPs}
 	}
 	if len(s.LoadBalancerProfile.OutboundIPPrefixes) > 0 {
-		loadBalancerProfile.OutboundIPPrefixes = &asocontainerservicev1.ManagedClusterLoadBalancerProfile_OutboundIPPrefixes{
+		loadBalancerProfile.OutboundIPPrefixes = &asocontainerservicev1hub.ManagedClusterLoadBalancerProfile_OutboundIPPrefixes{
 			PublicIPPrefixes: convertToResourceReferences(s.LoadBalancerProfile.OutboundIPPrefixes),
 		}
 	}
 	if len(s.LoadBalancerProfile.OutboundIPs) > 0 {
-		loadBalancerProfile.OutboundIPs = &asocontainerservicev1.ManagedClusterLoadBalancerProfile_OutboundIPs{
+		loadBalancerProfile.OutboundIPs = &asocontainerservicev1hub.ManagedClusterLoadBalancerProfile_OutboundIPs{
 			PublicIPs: convertToResourceReferences(s.LoadBalancerProfile.OutboundIPs),
 		}
 	}
 	return
 }
 
-func convertToResourceReferences(resources []string) []asocontainerservicev1.ResourceReference {
-	resourceReferences := make([]asocontainerservicev1.ResourceReference, len(resources))
+func convertToResourceReferences(resources []string) []asocontainerservicev1hub.ResourceReference {
+	resourceReferences := make([]asocontainerservicev1hub.ResourceReference, len(resources))
 	for i := range resources {
-		resourceReferences[i] = asocontainerservicev1.ResourceReference{
+		resourceReferences[i] = asocontainerservicev1hub.ResourceReference{
 			Reference: &genruntime.ResourceReference{
 				ARMID: resources[i],
 			},
@@ -776,20 +771,20 @@ func convertToResourceReferences(resources []string) []asocontainerservicev1.Res
 	return resourceReferences
 }
 
-func getIdentity(identity *infrav1.Identity) (managedClusterIdentity *asocontainerservicev1.ManagedClusterIdentity, err error) {
+func getIdentity(identity *infrav1.Identity) (managedClusterIdentity *asocontainerservicev1hub.ManagedClusterIdentity, err error) {
 	if identity.Type == "" {
 		return
 	}
 
-	managedClusterIdentity = &asocontainerservicev1.ManagedClusterIdentity{
-		Type: ptr.To(asocontainerservicev1.ManagedClusterIdentity_Type(identity.Type)),
+	managedClusterIdentity = &asocontainerservicev1hub.ManagedClusterIdentity{
+		Type: ptr.To(string(asocontainerservicev1.ManagedClusterIdentity_Type(identity.Type))),
 	}
-	if ptr.Deref(managedClusterIdentity.Type, "") == asocontainerservicev1.ManagedClusterIdentity_Type_UserAssigned {
+	if ptr.Deref(managedClusterIdentity.Type, "") == string(asocontainerservicev1.ManagedClusterIdentity_Type_UserAssigned) {
 		if identity.UserAssignedIdentityResourceID == "" {
 			err = errors.Errorf("Identity is set to \"UserAssigned\" but no UserAssignedIdentityResourceID is present")
 			return
 		}
-		managedClusterIdentity.UserAssignedIdentities = []asocontainerservicev1.UserAssignedIdentityDetails{
+		managedClusterIdentity.UserAssignedIdentities = []asocontainerservicev1hub.UserAssignedIdentityDetails{
 			{
 				Reference: genruntime.ResourceReference{
 					ARMID: identity.UserAssignedIdentityResourceID,

--- a/controllers/azuremanagedmachinepool_reconciler.go
+++ b/controllers/azuremanagedmachinepool_reconciler.go
@@ -116,11 +116,9 @@ func (s *azureManagedMachinePoolService) Reconcile(ctx context.Context) error {
 	}
 	var agentPoolName string
 	if s.scope.IsPreviewEnabled() {
-		agentPoolTyped := agentPool.(*asocontainerservicev1preview.ManagedClustersAgentPool)
-		agentPoolName = agentPoolTyped.AzureName()
+		agentPoolName = agentPool.(*asocontainerservicev1preview.ManagedClustersAgentPool).AzureName()
 	} else {
-		agentPoolTyped := agentPool.(*asocontainerservicev1.ManagedClustersAgentPool)
-		agentPoolName = agentPoolTyped.AzureName()
+		agentPoolName = agentPool.(*asocontainerservicev1.ManagedClustersAgentPool).AzureName()
 	}
 
 	if err := s.agentPoolsSvc.Reconcile(ctx); err != nil {

--- a/test/e2e/azure_clusterproxy.go
+++ b/test/e2e/azure_clusterproxy.go
@@ -34,6 +34,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/monitor/armmonitor"
+	asocontainerservicev1preview "github.com/Azure/azure-service-operator/v2/api/containerservice/v1api20230202preview"
 	asocontainerservicev1 "github.com/Azure/azure-service-operator/v2/api/containerservice/v1api20231001"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -72,6 +73,7 @@ func initScheme() *runtime.Scheme {
 	Expect(infrav1exp.AddToScheme(scheme)).To(Succeed())
 	Expect(expv1.AddToScheme(scheme)).To(Succeed())
 	Expect(asocontainerservicev1.AddToScheme(scheme)).To(Succeed())
+	Expect(asocontainerservicev1preview.AddToScheme(scheme)).To(Succeed())
 	return scheme
 }
 


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind cleanup

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
This PR includes follow-up tasks for enabling AKS preview features #4617, including:

1. Operating on the hub API version instead of stable
2. Adding E2E tests

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
3. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
