### PR TITLE
skip prealloc linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -42,7 +42,6 @@ linters:
     - noctx
     - nolintlint
     - nosprintfhostport
-    - prealloc
     - predeclared
     - reassign
     - revive

--- a/azure/services/subnets/spec.go
+++ b/azure/services/subnets/spec.go
@@ -97,8 +97,6 @@ func (s *SubnetSpec) Parameters(ctx context.Context, existing *asonetworkv1.Virt
 		}
 	}
 
-	//nolint:prealloc // pre-allocating this slice isn't going to make any meaningful performance difference
-	// and makes it harder to keep this value nil when s.ServiceEndpoints is empty as is necessary.
 	var serviceEndpoints []asonetworkv1.ServiceEndpointPropertiesFormat
 	for _, se := range s.ServiceEndpoints {
 		serviceEndpoints = append(serviceEndpoints, asonetworkv1.ServiceEndpointPropertiesFormat{Service: ptr.To(se.Service), Locations: se.Locations})


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind cleanup

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

I've been finding the `prealloc` linter supremely annoying lately when I want to do something like this:
```go
var a []any
```
where it instead wants you to do
```go
a := make([]any, 0, someKnownLength)
```

I think the syntax it wants is verbose and error-prone (I know at least I and @willie-yao have gotten mixed up with this before), and almost certainly doesn't make any meaningful performance difference since we don't ever create slices with more than a handful of elements that I can think of. This PR is my vote not to enforce this everywhere unless we find some case where reducing potential allocations this way actually solves a problem.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
