### PR TITLE
Allow setting ResourceGroupName in AzureManagedControlPlaneTemplate

### DIFF
--- a/api/v1beta1/azuremanagedcontrolplane_types.go
+++ b/api/v1beta1/azuremanagedcontrolplane_types.go
@@ -139,10 +139,6 @@ const (
 type AzureManagedControlPlaneSpec struct {
 	AzureManagedControlPlaneClassSpec `json:",inline"`
 
-	// ResourceGroupName is the name of the Azure resource group for this AKS Cluster.
-	// Immutable.
-	ResourceGroupName string `json:"resourceGroupName"`
-
 	// NodeResourceGroupName is the name of the resource group
 	// containing cluster IaaS resources. Will be populated to default
 	// in webhook.

--- a/api/v1beta1/azuremanagedcontrolplane_webhook_test.go
+++ b/api/v1beta1/azuremanagedcontrolplane_webhook_test.go
@@ -55,18 +55,18 @@ func TestDefaultingWebhook(t *testing.T) {
 					},
 				},
 			},
-			ResourceGroupName: "fooRg",
-			SSHPublicKey:      ptr.To(""),
+			SSHPublicKey: ptr.To(""),
 		},
 	}
 	mcpw := &azureManagedControlPlaneWebhook{}
 	err := mcpw.Default(context.Background(), amcp)
 	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(amcp.Spec.ResourceGroupName).To(Equal("fooCluster"))
 	g.Expect(amcp.Spec.NetworkPlugin).To(Equal(ptr.To(AzureNetworkPluginName)))
 	g.Expect(amcp.Spec.LoadBalancerSKU).To(Equal(ptr.To("Standard")))
 	g.Expect(amcp.Spec.Version).To(Equal("v1.17.5"))
 	g.Expect(*amcp.Spec.SSHPublicKey).NotTo(BeEmpty())
-	g.Expect(amcp.Spec.NodeResourceGroupName).To(Equal("MC_fooRg_fooName_fooLocation"))
+	g.Expect(amcp.Spec.NodeResourceGroupName).To(Equal("MC_fooCluster_fooName_fooLocation"))
 	g.Expect(amcp.Spec.VirtualNetwork.Name).To(Equal("fooName"))
 	g.Expect(amcp.Spec.VirtualNetwork.CIDRBlock).To(Equal(defaultAKSVnetCIDR))
 	g.Expect(amcp.Spec.VirtualNetwork.Subnet.Name).To(Equal("fooName"))
@@ -87,6 +87,7 @@ func TestDefaultingWebhook(t *testing.T) {
 	amcp.Spec.NetworkPolicy = &netPol
 	amcp.Spec.Version = "9.99.99"
 	amcp.Spec.SSHPublicKey = nil
+	amcp.Spec.ResourceGroupName = "fooRg"
 	amcp.Spec.NodeResourceGroupName = "fooNodeRg"
 	amcp.Spec.VirtualNetwork.Name = "fooVnetName"
 	amcp.Spec.VirtualNetwork.Subnet.Name = "fooSubnetName"
@@ -116,6 +117,7 @@ func TestDefaultingWebhook(t *testing.T) {
 	g.Expect(*amcp.Spec.NetworkPolicy).To(Equal(netPol))
 	g.Expect(amcp.Spec.Version).To(Equal("v9.99.99"))
 	g.Expect(amcp.Spec.SSHPublicKey).To(BeNil())
+	g.Expect(amcp.Spec.ResourceGroupName).To(Equal("fooRg"))
 	g.Expect(amcp.Spec.NodeResourceGroupName).To(Equal("fooNodeRg"))
 	g.Expect(amcp.Spec.VirtualNetwork.Name).To(Equal("fooVnetName"))
 	g.Expect(amcp.Spec.VirtualNetwork.Subnet.Name).To(Equal("fooSubnetName"))
@@ -142,6 +144,7 @@ func TestDefaultingWebhook(t *testing.T) {
 		},
 		Spec: AzureManagedControlPlaneSpec{
 			AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+				ResourceGroupName: "fooRg",
 				Location:          "fooLocation",
 				Version:           "1.17.5",
 				NetworkPluginMode: ptr.To(NetworkPluginModeOverlay),
@@ -160,8 +163,7 @@ func TestDefaultingWebhook(t *testing.T) {
 					},
 				},
 			},
-			ResourceGroupName: "fooRg",
-			SSHPublicKey:      ptr.To(""),
+			SSHPublicKey: ptr.To(""),
 		},
 	}
 	err = mcpw.Default(context.Background(), amcp)
@@ -1991,19 +1993,19 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 			oldAMCP: &AzureManagedControlPlane{
 				Spec: AzureManagedControlPlaneSpec{
 					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
-						DNSServiceIP: ptr.To("192.168.0.10"),
-						Version:      "v1.18.0",
+						DNSServiceIP:      ptr.To("192.168.0.10"),
+						Version:           "v1.18.0",
+						ResourceGroupName: "hello-1",
 					},
-					ResourceGroupName: "hello-1",
 				},
 			},
 			amcp: &AzureManagedControlPlane{
 				Spec: AzureManagedControlPlaneSpec{
 					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
-						DNSServiceIP: ptr.To("192.168.0.10"),
-						Version:      "v1.18.0",
+						DNSServiceIP:      ptr.To("192.168.0.10"),
+						Version:           "v1.18.0",
+						ResourceGroupName: "hello-2",
 					},
-					ResourceGroupName: "hello-2",
 				},
 			},
 			wantErr: true,
@@ -4054,8 +4056,8 @@ func TestValidateAMCPVirtualNetwork(t *testing.T) {
 					},
 				},
 				Spec: AzureManagedControlPlaneSpec{
-					ResourceGroupName: "rg1",
 					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+						ResourceGroupName: "rg1",
 						VirtualNetwork: ManagedControlPlaneVirtualNetwork{
 							ResourceGroup: "rg1",
 							Name:          "vnet1",
@@ -4082,8 +4084,8 @@ func TestValidateAMCPVirtualNetwork(t *testing.T) {
 					},
 				},
 				Spec: AzureManagedControlPlaneSpec{
-					ResourceGroupName: "rg1",
 					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+						ResourceGroupName: "rg1",
 						VirtualNetwork: ManagedControlPlaneVirtualNetwork{
 							ResourceGroup: "rg2",
 							Name:          "vnet1",
@@ -4110,8 +4112,8 @@ func TestValidateAMCPVirtualNetwork(t *testing.T) {
 					},
 				},
 				Spec: AzureManagedControlPlaneSpec{
-					ResourceGroupName: "rg1",
 					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+						ResourceGroupName: "rg1",
 						VirtualNetwork: ManagedControlPlaneVirtualNetwork{
 							ResourceGroup: "rg2",
 							Name:          "vnet1",
@@ -4138,8 +4140,8 @@ func TestValidateAMCPVirtualNetwork(t *testing.T) {
 					},
 				},
 				Spec: AzureManagedControlPlaneSpec{
-					ResourceGroupName: "rg1",
 					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+						ResourceGroupName: "rg1",
 						VirtualNetwork: ManagedControlPlaneVirtualNetwork{
 							ResourceGroup: "rg2",
 							Name:          "vnet1",
@@ -4165,8 +4167,8 @@ func TestValidateAMCPVirtualNetwork(t *testing.T) {
 					},
 				},
 				Spec: AzureManagedControlPlaneSpec{
-					ResourceGroupName: "rg1",
 					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+						ResourceGroupName: "rg1",
 						VirtualNetwork: ManagedControlPlaneVirtualNetwork{
 							ResourceGroup: "rg2",
 							Name:          "vnet1",
@@ -4192,8 +4194,8 @@ func TestValidateAMCPVirtualNetwork(t *testing.T) {
 					},
 				},
 				Spec: AzureManagedControlPlaneSpec{
-					ResourceGroupName: "rg1",
 					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+						ResourceGroupName: "rg1",
 						VirtualNetwork: ManagedControlPlaneVirtualNetwork{
 							ResourceGroup: "rg2",
 							Name:          "vnet1",
@@ -4220,8 +4222,8 @@ func TestValidateAMCPVirtualNetwork(t *testing.T) {
 					},
 				},
 				Spec: AzureManagedControlPlaneSpec{
-					ResourceGroupName: "rg1",
 					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+						ResourceGroupName: "rg1",
 						VirtualNetwork: ManagedControlPlaneVirtualNetwork{
 							ResourceGroup: "rg2",
 							Name:          "vnet1",

--- a/api/v1beta1/types_class.go
+++ b/api/v1beta1/types_class.go
@@ -88,6 +88,10 @@ type AzureManagedControlPlaneClassSpec struct {
 	// +optional
 	MachineTemplate *AzureManagedControlPlaneTemplateMachineTemplate `json:"machineTemplate,omitempty"`
 
+	// ResourceGroupName is the name of the Azure resource group for this AKS Cluster.
+	// Immutable.
+	ResourceGroupName string `json:"resourceGroupName"`
+
 	// Version defines the desired Kubernetes version.
 	// +kubebuilder:validation:MinLength:=2
 	Version string `json:"version"`

--- a/azure/scope/managedcontrolplane_test.go
+++ b/azure/scope/managedcontrolplane_test.go
@@ -1638,8 +1638,8 @@ func TestManagedControlPlaneScope_GroupSpecs(t *testing.T) {
 				},
 				ControlPlane: &infrav1.AzureManagedControlPlane{
 					Spec: infrav1.AzureManagedControlPlaneSpec{
-						ResourceGroupName: "dummy-rg",
 						AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
+							ResourceGroupName: "dummy-rg",
 							VirtualNetwork: infrav1.ManagedControlPlaneVirtualNetwork{
 								ResourceGroup: "different-rg",
 							},
@@ -1674,8 +1674,8 @@ func TestManagedControlPlaneScope_GroupSpecs(t *testing.T) {
 				},
 				ControlPlane: &infrav1.AzureManagedControlPlane{
 					Spec: infrav1.AzureManagedControlPlaneSpec{
-						ResourceGroupName: "dummy-rg",
 						AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
+							ResourceGroupName: "dummy-rg",
 							VirtualNetwork: infrav1.ManagedControlPlaneVirtualNetwork{
 								ResourceGroup: "dummy-rg",
 							},
@@ -1704,8 +1704,8 @@ func TestManagedControlPlaneScope_GroupSpecs(t *testing.T) {
 				},
 				ControlPlane: &infrav1.AzureManagedControlPlane{
 					Spec: infrav1.AzureManagedControlPlaneSpec{
-						ResourceGroupName: "dummy-rg",
 						AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
+							ResourceGroupName: "dummy-rg",
 							VirtualNetwork: infrav1.ManagedControlPlaneVirtualNetwork{
 								Name: "vnet1",
 							},
@@ -1734,8 +1734,8 @@ func TestManagedControlPlaneScope_GroupSpecs(t *testing.T) {
 				},
 				ControlPlane: &infrav1.AzureManagedControlPlane{
 					Spec: infrav1.AzureManagedControlPlaneSpec{
-						ResourceGroupName: "dummy-rg",
 						AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
+							ResourceGroupName: "dummy-rg",
 							VirtualNetwork: infrav1.ManagedControlPlaneVirtualNetwork{
 								ResourceGroup: "my_custom_rg",
 								Name:          "vnet1",

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremanagedcontrolplanetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremanagedcontrolplanetemplates.yaml
@@ -615,6 +615,11 @@ spec:
                         - userAssignedNATGateway
                         - userDefinedRouting
                         type: string
+                      resourceGroupName:
+                        description: |-
+                          ResourceGroupName is the name of the Azure resource group for this AKS Cluster.
+                          Immutable.
+                        type: string
                       securityProfile:
                         description: SecurityProfile defines the security profile
                           for cluster.
@@ -860,6 +865,7 @@ spec:
                     required:
                     - identityRef
                     - location
+                    - resourceGroupName
                     - version
                     type: object
                 required:

--- a/controllers/azuremanagedcontrolplane_controller_test.go
+++ b/controllers/azuremanagedcontrolplane_controller_test.go
@@ -199,8 +199,8 @@ func TestAzureManagedControlPlaneReconcilePaused(t *testing.T) {
 					Namespace: "default",
 					Kind:      "AzureClusterIdentity",
 				},
+				ResourceGroupName: name,
 			},
-			ResourceGroupName: name,
 		},
 	}
 	g.Expect(c.Create(ctx, instance)).To(Succeed())


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind feature

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
This PR allows setting ResourceGroupName in AzureManagedControlPlaneTemplate type instead of just in the non-template type.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4721

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Allow setting ResourceGroupName in AzureManagedControlPlaneTemplate
```
