### PR TITLE
Allow upper-case resource names

### DIFF
--- a/azure/services/agentpools/spec.go
+++ b/azure/services/agentpools/spec.go
@@ -166,13 +166,13 @@ func (s *AgentPoolSpec) ResourceRef() genruntime.MetaObject {
 	if s.Preview {
 		return &asocontainerservicev1preview.ManagedClustersAgentPool{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: s.Name,
+				Name: azure.GetNormalizedKubernetesName(s.Name),
 			},
 		}
 	}
 	return &asocontainerservicev1.ManagedClustersAgentPool{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: s.Name,
+			Name: azure.GetNormalizedKubernetesName(s.Name),
 		},
 	}
 }

--- a/azure/services/aksextensions/spec.go
+++ b/azure/services/aksextensions/spec.go
@@ -24,6 +24,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
+	"sigs.k8s.io/cluster-api-provider-azure/azure"
 )
 
 // AKSExtensionSpec defines the specification for an AKS Extension.
@@ -47,7 +48,7 @@ type AKSExtensionSpec struct {
 func (s *AKSExtensionSpec) ResourceRef() *asokubernetesconfigurationv1.Extension {
 	return &asokubernetesconfigurationv1.Extension{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      s.Name,
+			Name:      azure.GetNormalizedKubernetesName(s.Name),
 			Namespace: s.Namespace,
 		},
 	}

--- a/azure/services/bastionhosts/spec.go
+++ b/azure/services/bastionhosts/spec.go
@@ -26,6 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
+	"sigs.k8s.io/cluster-api-provider-azure/azure"
 )
 
 // AzureBastionSpec defines the specification for azure bastion feature.
@@ -44,7 +45,7 @@ type AzureBastionSpec struct {
 func (s *AzureBastionSpec) ResourceRef() *asonetworkv1.BastionHost {
 	return &asonetworkv1.BastionHost{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: s.Name,
+			Name: azure.GetNormalizedKubernetesName(s.Name),
 		},
 	}
 }
@@ -60,7 +61,7 @@ func (s *AzureBastionSpec) Parameters(ctx context.Context, existingBastionHost *
 	bastionHost.Spec.AzureName = s.Name
 	bastionHost.Spec.Location = ptr.To(s.Location)
 	bastionHost.Spec.Owner = &genruntime.KnownResourceReference{
-		Name: s.ResourceGroup,
+		Name: azure.GetNormalizedKubernetesName(s.ResourceGroup),
 	}
 	bastionHost.Spec.Tags = infrav1.Build(infrav1.BuildParams{
 		ClusterName: s.ClusterName,

--- a/azure/services/groups/groups.go
+++ b/azure/services/groups/groups.go
@@ -70,7 +70,7 @@ func (s *Service) IsManaged(ctx context.Context) (bool, error) {
 		// resource. We also need to check that deleting the ASO resource will really
 		// delete the underlying resource group by checking the ASO reconcile-policy.
 		group := spec.ResourceRef()
-		groupName := group.Name
+		groupName := azure.GetNormalizedKubernetesName(group.Name)
 		groupNamespace := s.Scope.ASOOwner().GetNamespace()
 		err = s.Scope.GetClient().Get(ctx, client.ObjectKey{Namespace: groupNamespace, Name: groupName}, group)
 		if err != nil || group.GetAnnotations()[asoannotations.ReconcilePolicy] != string(asoannotations.ReconcilePolicyManage) {

--- a/azure/services/groups/spec.go
+++ b/azure/services/groups/spec.go
@@ -23,6 +23,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
+	"sigs.k8s.io/cluster-api-provider-azure/azure"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/services/aso"
 )
 
@@ -39,7 +40,7 @@ type GroupSpec struct {
 func (s *GroupSpec) ResourceRef() *asoresourcesv1.ResourceGroup {
 	return &asoresourcesv1.ResourceGroup{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: s.Name,
+			Name: azure.GetNormalizedKubernetesName(s.Name),
 		},
 	}
 }

--- a/azure/services/managedclusters/spec.go
+++ b/azure/services/managedclusters/spec.go
@@ -385,13 +385,13 @@ func (s *ManagedClusterSpec) ResourceRef() genruntime.MetaObject {
 	if s.Preview {
 		return &asocontainerservicev1preview.ManagedCluster{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: s.Name,
+				Name: azure.GetNormalizedKubernetesName(s.Name),
 			},
 		}
 	}
 	return &asocontainerservicev1.ManagedCluster{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: s.Name,
+			Name: azure.GetNormalizedKubernetesName(s.Name),
 		},
 	}
 }
@@ -441,7 +441,7 @@ func (s *ManagedClusterSpec) Parameters(ctx context.Context, existingObj genrunt
 
 	managedCluster.Spec.AzureName = s.Name
 	managedCluster.Spec.Owner = &genruntime.KnownResourceReference{
-		Name: s.ResourceGroup,
+		Name: azure.GetNormalizedKubernetesName(s.ResourceGroup),
 	}
 	managedCluster.Spec.Identity = &asocontainerservicev1.ManagedClusterIdentity{
 		Type: ptr.To(asocontainerservicev1.ManagedClusterIdentity_Type_SystemAssigned),

--- a/azure/services/natgateways/spec.go
+++ b/azure/services/natgateways/spec.go
@@ -43,7 +43,7 @@ type NatGatewaySpec struct {
 func (s *NatGatewaySpec) ResourceRef() *asonetworkv1.NatGateway {
 	return &asonetworkv1.NatGateway{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: s.Name,
+			Name: azure.GetNormalizedKubernetesName(s.Name),
 		},
 	}
 }
@@ -59,7 +59,7 @@ func (s *NatGatewaySpec) Parameters(ctx context.Context, existingNatGateway *aso
 
 	natGateway.Spec.AzureName = s.Name
 	natGateway.Spec.Owner = &genruntime.KnownResourceReference{
-		Name: s.ResourceGroup,
+		Name: azure.GetNormalizedKubernetesName(s.ResourceGroup),
 	}
 	natGateway.Spec.Location = ptr.To(s.Location)
 	natGateway.Spec.Sku = &asonetworkv1.NatGatewaySku{

--- a/azure/services/privateendpoints/spec.go
+++ b/azure/services/privateendpoints/spec.go
@@ -25,6 +25,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
+	"sigs.k8s.io/cluster-api-provider-azure/azure"
 )
 
 // PrivateLinkServiceConnection defines the specification for a private link service connection associated with a private endpoint.
@@ -54,7 +55,7 @@ type PrivateEndpointSpec struct {
 func (s *PrivateEndpointSpec) ResourceRef() *asonetworkv1.PrivateEndpoint {
 	return &asonetworkv1.PrivateEndpoint{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: s.Name,
+			Name: azure.GetNormalizedKubernetesName(s.Name),
 		},
 	}
 }
@@ -129,7 +130,7 @@ func (s *PrivateEndpointSpec) Parameters(ctx context.Context, existingPrivateEnd
 	}
 
 	privateEndpoint.Spec.Owner = &genruntime.KnownResourceReference{
-		Name: s.ResourceGroup,
+		Name: azure.GetNormalizedKubernetesName(s.ResourceGroup),
 	}
 
 	privateEndpoint.Spec.Subnet = &asonetworkv1.Subnet_PrivateEndpoint_SubResourceEmbedded{

--- a/azure/services/privateendpoints/spec_test.go
+++ b/azure/services/privateendpoints/spec_test.go
@@ -31,7 +31,7 @@ import (
 var (
 	fakePrivateEndpoint = PrivateEndpointSpec{
 		Name:                       "test_private_endpoint_1",
-		ResourceGroup:              "test_rg",
+		ResourceGroup:              "test-rg",
 		Location:                   "test_location",
 		CustomNetworkInterfaceName: "test_if_name",
 		PrivateIPAddresses:         []string{"1.2.3.4", "5.6.7.8"},

--- a/azure/services/subnets/spec.go
+++ b/azure/services/subnets/spec.go
@@ -49,7 +49,7 @@ func (s *SubnetSpec) ResourceRef() *asonetworkv1.VirtualNetworksSubnet {
 		ObjectMeta: metav1.ObjectMeta{
 			// s.Name isn't unique per-cluster, so combine with vnet name to avoid collisions.
 			// ToLower makes the name compatible with standard Kubernetes name requirements.
-			Name: s.VNetName + "-" + strings.ToLower(s.Name),
+			Name: azure.GetNormalizedKubernetesName(s.VNetName + "-" + strings.ToLower(s.Name)),
 		},
 	}
 }
@@ -64,7 +64,7 @@ func (s *SubnetSpec) Parameters(ctx context.Context, existing *asonetworkv1.Virt
 	subnet.Spec = asonetworkv1.VirtualNetworks_Subnet_Spec{
 		AzureName: s.Name,
 		Owner: &genruntime.KnownResourceReference{
-			Name: s.VNetName,
+			Name: azure.GetNormalizedKubernetesName(s.VNetName),
 		},
 		AddressPrefixes: s.CIDRs,
 	}

--- a/azure/services/virtualnetworks/spec.go
+++ b/azure/services/virtualnetworks/spec.go
@@ -24,6 +24,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
+	"sigs.k8s.io/cluster-api-provider-azure/azure"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/converters"
 )
 
@@ -42,7 +43,7 @@ type VNetSpec struct {
 func (s *VNetSpec) ResourceRef() *asonetworkv1.VirtualNetwork {
 	return &asonetworkv1.VirtualNetwork{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: s.Name,
+			Name: azure.GetNormalizedKubernetesName(s.Name),
 		},
 	}
 }
@@ -66,7 +67,7 @@ func (s *VNetSpec) Parameters(ctx context.Context, existing *asonetworkv1.Virtua
 
 	vnet.Spec.AzureName = s.Name
 	vnet.Spec.Owner = &genruntime.KnownResourceReference{
-		Name: s.ResourceGroup,
+		Name: azure.GetNormalizedKubernetesName(s.ResourceGroup),
 	}
 	vnet.Spec.Location = ptr.To(s.Location)
 	vnet.Spec.ExtendedLocation = converters.ExtendedLocationToNetworkASO(s.ExtendedLocation)

--- a/docs/book/src/topics/managedcluster.md
+++ b/docs/book/src/topics/managedcluster.md
@@ -35,6 +35,8 @@ export AZURE_LOCATION="southcentralus"
 export AZURE_RESOURCE_GROUP="${CLUSTER_NAME}"
 ```
 
+***NOTE***: `${CLUSTER_NAME}` should adhere to the RFC 1123 standard. This means that it must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character.
+
 Create a new service principal and save to a local file:
 
 ```bash

--- a/test/e2e/aks_marketplace.go
+++ b/test/e2e/aks_marketplace.go
@@ -43,7 +43,7 @@ type AKSMarketplaceExtensionSpecInput struct {
 }
 
 const (
-	extensionName         = "aks-marketplace-extension"
+	extensionName         = "AKS-marketplace-extension" // Test that upper case name is allowed
 	officialExtensionName = "official-aks-extension"
 )
 


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->
/kind bug

**What this PR does / why we need it**:
This PR allows Azure resources (resource groups, vnet, extensions, etc..) to be created with upper case characters in its name. It also adds a note to the managedcluster docs stating that `${CLUSTER_NAME}` should adhere to the RFC 1123 standard

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4699

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [x] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Allow upper-case Azure resource names
```
