### PR TITLE
add watch filter value to AzureASO... controllers

### DIFF
--- a/exp/controllers/azureasomanagedcluster_controller.go
+++ b/exp/controllers/azureasomanagedcluster_controller.go
@@ -20,6 +20,8 @@ import (
 	"context"
 
 	infrav1exp "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1alpha1"
+	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
+	"sigs.k8s.io/cluster-api/util/predicates"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -27,12 +29,20 @@ import (
 // AzureASOManagedClusterReconciler reconciles a AzureASOManagedCluster object.
 type AzureASOManagedClusterReconciler struct {
 	client.Client
+	WatchFilterValue string
 }
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *AzureASOManagedClusterReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {
+	_, log, done := tele.StartSpanWithLogger(ctx,
+		"controllers.AzureASOManagedClusterReconciler.SetupWithManager",
+		tele.KVP("controller", infrav1exp.AzureASOManagedClusterKind),
+	)
+	defer done()
+
 	_, err := ctrl.NewControllerManagedBy(mgr).
 		For(&infrav1exp.AzureASOManagedCluster{}).
+		WithEventFilter(predicates.ResourceHasFilterLabel(log, r.WatchFilterValue)).
 		Build(r)
 	if err != nil {
 		return err

--- a/exp/controllers/azureasomanagedmachinepool_controller.go
+++ b/exp/controllers/azureasomanagedmachinepool_controller.go
@@ -20,6 +20,8 @@ import (
 	"context"
 
 	infrav1exp "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1alpha1"
+	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
+	"sigs.k8s.io/cluster-api/util/predicates"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -27,12 +29,20 @@ import (
 // AzureASOManagedMachinePoolReconciler reconciles a AzureASOManagedMachinePool object.
 type AzureASOManagedMachinePoolReconciler struct {
 	client.Client
+	WatchFilterValue string
 }
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *AzureASOManagedMachinePoolReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {
+	_, log, done := tele.StartSpanWithLogger(ctx,
+		"controllers.AzureASOManagedMachinePoolReconciler.SetupWithManager",
+		tele.KVP("controller", infrav1exp.AzureASOManagedMachinePoolKind),
+	)
+	defer done()
+
 	_, err := ctrl.NewControllerManagedBy(mgr).
 		For(&infrav1exp.AzureASOManagedMachinePool{}).
+		WithEventFilter(predicates.ResourceHasFilterLabel(log, r.WatchFilterValue)).
 		Build(r)
 	if err != nil {
 		return err

--- a/main.go
+++ b/main.go
@@ -502,21 +502,24 @@ func registerControllers(ctx context.Context, mgr manager.Manager) {
 
 	if feature.Gates.Enabled(feature.ASOAPI) {
 		if err := (&infrav1controllersexp.AzureASOManagedClusterReconciler{
-			Client: mgr.GetClient(),
+			Client:           mgr.GetClient(),
+			WatchFilterValue: watchFilterValue,
 		}).SetupWithManager(ctx, mgr); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "AzureASOManagedCluster")
 			os.Exit(1)
 		}
 
 		if err := (&infrav1controllersexp.AzureASOManagedControlPlaneReconciler{
-			Client: mgr.GetClient(),
+			Client:           mgr.GetClient(),
+			WatchFilterValue: watchFilterValue,
 		}).SetupWithManager(ctx, mgr); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "AzureASOManagedControlPlane")
 			os.Exit(1)
 		}
 
 		if err := (&infrav1controllersexp.AzureASOManagedMachinePoolReconciler{
-			Client: mgr.GetClient(),
+			Client:           mgr.GetClient(),
+			WatchFilterValue: watchFilterValue,
 		}).SetupWithManager(ctx, mgr); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "AzureASOManagedMachinePool")
 			os.Exit(1)


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind feature

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

This PR adds some follow-up boilerplate to propagate the `--watch-filter` flag on the controller manager binary to the new ASOAPI controllers.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #4713

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
