### PR TITLE
implement top-level Reconcile methods for AzureASO... resources

### DIFF
--- a/exp/controllers/azureasomanagedcluster_controller.go
+++ b/exp/controllers/azureasomanagedcluster_controller.go
@@ -18,12 +18,20 @@ package controllers
 
 import (
 	"context"
+	"fmt"
 
+	infracontroller "sigs.k8s.io/cluster-api-provider-azure/controllers"
 	infrav1exp "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1alpha1"
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/util"
+	"sigs.k8s.io/cluster-api/util/annotations"
+	"sigs.k8s.io/cluster-api/util/patch"
 	"sigs.k8s.io/cluster-api/util/predicates"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 )
 
 // AzureASOManagedClusterReconciler reconciles a AzureASOManagedCluster object.
@@ -34,7 +42,7 @@ type AzureASOManagedClusterReconciler struct {
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *AzureASOManagedClusterReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {
-	_, log, done := tele.StartSpanWithLogger(ctx,
+	ctx, log, done := tele.StartSpanWithLogger(ctx,
 		"controllers.AzureASOManagedClusterReconciler.SetupWithManager",
 		tele.KVP("controller", infrav1exp.AzureASOManagedClusterKind),
 	)
@@ -43,6 +51,18 @@ func (r *AzureASOManagedClusterReconciler) SetupWithManager(ctx context.Context,
 	_, err := ctrl.NewControllerManagedBy(mgr).
 		For(&infrav1exp.AzureASOManagedCluster{}).
 		WithEventFilter(predicates.ResourceHasFilterLabel(log, r.WatchFilterValue)).
+		WithEventFilter(predicates.ResourceIsNotExternallyManaged(log)).
+		// Watch clusters for pause/unpause notifications
+		Watches(
+			&clusterv1.Cluster{},
+			handler.EnqueueRequestsFromMapFunc(
+				util.ClusterToInfrastructureMapFunc(ctx, infrav1exp.GroupVersion.WithKind(infrav1exp.AzureASOManagedClusterKind), mgr.GetClient(), &infrav1exp.AzureASOManagedCluster{}),
+			),
+			builder.WithPredicates(
+				predicates.ResourceHasFilterLabel(log, r.WatchFilterValue),
+				infracontroller.ClusterUpdatePauseChange(log),
+			),
+		).
 		Build(r)
 	if err != nil {
 		return err
@@ -57,5 +77,81 @@ func (r *AzureASOManagedClusterReconciler) SetupWithManager(ctx context.Context,
 
 // Reconcile reconciles an AzureASOManagedCluster.
 func (r *AzureASOManagedClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, resultErr error) {
+	ctx, _, done := tele.StartSpanWithLogger(ctx,
+		"controllers.AzureASOManagedClusterReconciler.Reconcile",
+		tele.KVP("namespace", req.Namespace),
+		tele.KVP("name", req.Name),
+		tele.KVP("kind", infrav1exp.AzureASOManagedClusterKind),
+	)
+	defer done()
+
+	asoManagedCluster := &infrav1exp.AzureASOManagedCluster{}
+	err := r.Get(ctx, req.NamespacedName, asoManagedCluster)
+	if err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	patchHelper, err := patch.NewHelper(asoManagedCluster, r.Client)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to create patch helper: %w", err)
+	}
+	defer func() {
+		err := patchHelper.Patch(ctx, asoManagedCluster)
+		if err != nil && resultErr == nil {
+			resultErr = err
+			result = ctrl.Result{}
+		}
+	}()
+
+	cluster, err := util.GetOwnerCluster(ctx, r.Client, asoManagedCluster.ObjectMeta)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	if cluster != nil && cluster.Spec.Paused ||
+		annotations.HasPaused(asoManagedCluster) {
+		return r.reconcilePaused(ctx, asoManagedCluster, cluster)
+	}
+
+	if !asoManagedCluster.GetDeletionTimestamp().IsZero() {
+		return r.reconcileDelete(ctx, asoManagedCluster)
+	}
+
+	return r.reconcileNormal(ctx, asoManagedCluster, cluster)
+}
+
+//nolint:unparam // these parameters will be used soon enough
+func (r *AzureASOManagedClusterReconciler) reconcileNormal(ctx context.Context, asoManagedCluster *infrav1exp.AzureASOManagedCluster, cluster *clusterv1.Cluster) (ctrl.Result, error) {
+	//nolint:all // ctx will be used soon
+	ctx, log, done := tele.StartSpanWithLogger(ctx,
+		"controllers.AzureASOManagedClusterReconciler.reconcileNormal",
+	)
+	defer done()
+	log.V(4).Info("reconciling normally")
+
+	return ctrl.Result{}, nil
+}
+
+//nolint:unparam // these parameters will be used soon enough
+func (r *AzureASOManagedClusterReconciler) reconcilePaused(ctx context.Context, asoManagedCluster *infrav1exp.AzureASOManagedCluster, cluster *clusterv1.Cluster) (ctrl.Result, error) {
+	//nolint:all // ctx will be used soon
+	ctx, log, done := tele.StartSpanWithLogger(ctx,
+		"controllers.AzureASOManagedClusterReconciler.reconcilePaused",
+	)
+	defer done()
+	log.V(4).Info("reconciling pause")
+
+	return ctrl.Result{}, nil
+}
+
+//nolint:unparam // these parameters will be used soon enough
+func (r *AzureASOManagedClusterReconciler) reconcileDelete(ctx context.Context, asoManagedCluster *infrav1exp.AzureASOManagedCluster) (ctrl.Result, error) {
+	//nolint:all // ctx will be used soon
+	ctx, log, done := tele.StartSpanWithLogger(ctx,
+		"controllers.AzureASOManagedClusterReconciler.reconcileDelete",
+	)
+	defer done()
+	log.V(4).Info("reconciling delete")
+
 	return ctrl.Result{}, nil
 }

--- a/exp/controllers/azureasomanagedcluster_controller_test.go
+++ b/exp/controllers/azureasomanagedcluster_controller_test.go
@@ -19,12 +19,16 @@ package controllers
 import (
 	"context"
 	"testing"
+	"time"
 
 	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	infrav1exp "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1alpha1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
@@ -34,6 +38,7 @@ func TestAzureASOManagedClusterReconcile(t *testing.T) {
 	s := runtime.NewScheme()
 	sb := runtime.NewSchemeBuilder(
 		infrav1exp.AddToScheme,
+		clusterv1.AddToScheme,
 	)
 	NewGomegaWithT(t).Expect(sb.AddToScheme(s)).To(Succeed())
 
@@ -52,6 +57,112 @@ func TestAzureASOManagedClusterReconcile(t *testing.T) {
 			Client: c,
 		}
 		result, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Namespace: "doesn't", Name: "exist"}})
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(result).To(Equal(ctrl.Result{}))
+	})
+
+	t.Run("Cluster does not exist", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+
+		asoManagedCluster := &infrav1exp.AzureASOManagedCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "amc",
+				Namespace: "ns",
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion: clusterv1.GroupVersion.Identifier(),
+						Kind:       "Cluster",
+						Name:       "cluster",
+					},
+				},
+			},
+		}
+		c := fakeClientBuilder().
+			WithObjects(asoManagedCluster).
+			Build()
+		r := &AzureASOManagedClusterReconciler{
+			Client: c,
+		}
+		_, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(asoManagedCluster)})
+		g.Expect(err).To(HaveOccurred())
+	})
+
+	t.Run("successfully reconciles normally", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+
+		asoManagedCluster := &infrav1exp.AzureASOManagedCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "amc",
+				Namespace: "ns",
+			},
+		}
+		c := fakeClientBuilder().
+			WithObjects(asoManagedCluster).
+			Build()
+		r := &AzureASOManagedClusterReconciler{
+			Client: c,
+		}
+		result, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(asoManagedCluster)})
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(result).To(Equal(ctrl.Result{}))
+	})
+
+	t.Run("successfully reconciles pause", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+
+		cluster := &clusterv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "cluster",
+				Namespace: "ns",
+			},
+			Spec: clusterv1.ClusterSpec{
+				Paused: true,
+			},
+		}
+		asoManagedCluster := &infrav1exp.AzureASOManagedCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "amc",
+				Namespace: cluster.Namespace,
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion: clusterv1.GroupVersion.Identifier(),
+						Kind:       "Cluster",
+						Name:       cluster.Name,
+					},
+				},
+			},
+		}
+		c := fakeClientBuilder().
+			WithObjects(cluster, asoManagedCluster).
+			Build()
+		r := &AzureASOManagedClusterReconciler{
+			Client: c,
+		}
+		result, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(asoManagedCluster)})
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(result).To(Equal(ctrl.Result{}))
+	})
+
+	t.Run("successfully reconciles delete", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+
+		asoManagedCluster := &infrav1exp.AzureASOManagedCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "amc",
+				Namespace: "ns",
+				Finalizers: []string{
+					clusterv1.ClusterFinalizer,
+				},
+				DeletionTimestamp: &metav1.Time{Time: time.Date(1, 0, 0, 0, 0, 0, 0, time.UTC)},
+			},
+		}
+		c := fakeClientBuilder().
+			WithObjects(asoManagedCluster).
+			Build()
+		r := &AzureASOManagedClusterReconciler{
+			Client: c,
+		}
+		result, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(asoManagedCluster)})
 		g.Expect(err).NotTo(HaveOccurred())
 		g.Expect(result).To(Equal(ctrl.Result{}))
 	})

--- a/exp/controllers/azureasomanagedcontrolplane_controller.go
+++ b/exp/controllers/azureasomanagedcontrolplane_controller.go
@@ -18,12 +18,20 @@ package controllers
 
 import (
 	"context"
+	"fmt"
 
+	infracontroller "sigs.k8s.io/cluster-api-provider-azure/controllers"
 	infrav1exp "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1alpha1"
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/util"
+	"sigs.k8s.io/cluster-api/util/annotations"
+	"sigs.k8s.io/cluster-api/util/patch"
 	"sigs.k8s.io/cluster-api/util/predicates"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 )
 
 // AzureASOManagedControlPlaneReconciler reconciles a AzureASOManagedControlPlane object.
@@ -43,11 +51,28 @@ func (r *AzureASOManagedControlPlaneReconciler) SetupWithManager(ctx context.Con
 	_, err := ctrl.NewControllerManagedBy(mgr).
 		For(&infrav1exp.AzureASOManagedControlPlane{}).
 		WithEventFilter(predicates.ResourceHasFilterLabel(log, r.WatchFilterValue)).
+		Watches(&clusterv1.Cluster{},
+			handler.EnqueueRequestsFromMapFunc(clusterToAzureASOManagedControlPlane),
+			builder.WithPredicates(
+				predicates.ResourceHasFilterLabel(log, r.WatchFilterValue),
+				infracontroller.ClusterPauseChangeAndInfrastructureReady(log),
+			),
+		).
 		Build(r)
 	if err != nil {
 		return err
 	}
 
+	return nil
+}
+
+func clusterToAzureASOManagedControlPlane(_ context.Context, o client.Object) []ctrl.Request {
+	controlPlaneRef := o.(*clusterv1.Cluster).Spec.ControlPlaneRef
+	if controlPlaneRef != nil &&
+		controlPlaneRef.APIVersion == infrav1exp.GroupVersion.Identifier() &&
+		controlPlaneRef.Kind == infrav1exp.AzureASOManagedControlPlaneKind {
+		return []ctrl.Request{{NamespacedName: client.ObjectKey{Namespace: controlPlaneRef.Namespace, Name: controlPlaneRef.Name}}}
+	}
 	return nil
 }
 
@@ -57,5 +82,81 @@ func (r *AzureASOManagedControlPlaneReconciler) SetupWithManager(ctx context.Con
 
 // Reconcile reconciles an AzureASOManagedControlPlane.
 func (r *AzureASOManagedControlPlaneReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, resultErr error) {
+	ctx, _, done := tele.StartSpanWithLogger(ctx,
+		"controllers.AzureASOManagedControlPlaneReconciler.Reconcile",
+		tele.KVP("namespace", req.Namespace),
+		tele.KVP("name", req.Name),
+		tele.KVP("kind", infrav1exp.AzureASOManagedControlPlaneKind),
+	)
+	defer done()
+
+	asoManagedControlPlane := &infrav1exp.AzureASOManagedControlPlane{}
+	err := r.Get(ctx, req.NamespacedName, asoManagedControlPlane)
+	if err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	patchHelper, err := patch.NewHelper(asoManagedControlPlane, r.Client)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to create patch helper: %w", err)
+	}
+	defer func() {
+		err := patchHelper.Patch(ctx, asoManagedControlPlane)
+		if err != nil && resultErr == nil {
+			resultErr = err
+			result = ctrl.Result{}
+		}
+	}()
+
+	cluster, err := util.GetOwnerCluster(ctx, r.Client, asoManagedControlPlane.ObjectMeta)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	if cluster != nil && cluster.Spec.Paused ||
+		annotations.HasPaused(asoManagedControlPlane) {
+		return r.reconcilePaused(ctx, asoManagedControlPlane, cluster)
+	}
+
+	if !asoManagedControlPlane.GetDeletionTimestamp().IsZero() {
+		return r.reconcileDelete(ctx, asoManagedControlPlane)
+	}
+
+	return r.reconcileNormal(ctx, asoManagedControlPlane, cluster)
+}
+
+//nolint:unparam // these parameters will be used soon enough
+func (r *AzureASOManagedControlPlaneReconciler) reconcileNormal(ctx context.Context, asoManagedControlPlane *infrav1exp.AzureASOManagedControlPlane, cluster *clusterv1.Cluster) (ctrl.Result, error) {
+	//nolint:all // ctx will be used soon
+	ctx, log, done := tele.StartSpanWithLogger(ctx,
+		"controllers.AzureASOManagedControlPlaneReconciler.reconcileNormal",
+	)
+	defer done()
+	log.V(4).Info("reconciling normally")
+
+	return ctrl.Result{}, nil
+}
+
+//nolint:unparam // these parameters will be used soon enough
+func (r *AzureASOManagedControlPlaneReconciler) reconcilePaused(ctx context.Context, asoManagedControlPlane *infrav1exp.AzureASOManagedControlPlane, cluster *clusterv1.Cluster) (ctrl.Result, error) {
+	//nolint:all // ctx will be used soon
+	ctx, log, done := tele.StartSpanWithLogger(ctx,
+		"controllers.AzureASOManagedControlPlaneReconciler.reconcilePaused",
+	)
+	defer done()
+	log.V(4).Info("reconciling pause")
+
+	return ctrl.Result{}, nil
+}
+
+//nolint:unparam // these parameters will be used soon enough
+func (r *AzureASOManagedControlPlaneReconciler) reconcileDelete(ctx context.Context, asoManagedControlPlane *infrav1exp.AzureASOManagedControlPlane) (ctrl.Result, error) {
+	//nolint:all // ctx will be used soon
+	ctx, log, done := tele.StartSpanWithLogger(ctx,
+		"controllers.AzureASOManagedControlPlaneReconciler.reconcileDelete",
+	)
+	defer done()
+	log.V(4).Info("reconciling delete")
+
 	return ctrl.Result{}, nil
 }

--- a/exp/controllers/azureasomanagedcontrolplane_controller_test.go
+++ b/exp/controllers/azureasomanagedcontrolplane_controller_test.go
@@ -19,12 +19,16 @@ package controllers
 import (
 	"context"
 	"testing"
+	"time"
 
 	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	infrav1exp "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1alpha1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
@@ -34,6 +38,7 @@ func TestAzureASOManagedControlPlaneReconcile(t *testing.T) {
 	s := runtime.NewScheme()
 	sb := runtime.NewSchemeBuilder(
 		infrav1exp.AddToScheme,
+		clusterv1.AddToScheme,
 	)
 	NewGomegaWithT(t).Expect(sb.AddToScheme(s)).To(Succeed())
 	fakeClientBuilder := func() *fakeclient.ClientBuilder {
@@ -51,6 +56,112 @@ func TestAzureASOManagedControlPlaneReconcile(t *testing.T) {
 			Client: c,
 		}
 		result, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Namespace: "doesn't", Name: "exist"}})
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(result).To(Equal(ctrl.Result{}))
+	})
+
+	t.Run("Cluster does not exist", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+
+		asoManagedControlPlane := &infrav1exp.AzureASOManagedControlPlane{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "amcp",
+				Namespace: "ns",
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion: clusterv1.GroupVersion.Identifier(),
+						Kind:       "Cluster",
+						Name:       "cluster",
+					},
+				},
+			},
+		}
+		c := fakeClientBuilder().
+			WithObjects(asoManagedControlPlane).
+			Build()
+		r := &AzureASOManagedControlPlaneReconciler{
+			Client: c,
+		}
+		_, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(asoManagedControlPlane)})
+		g.Expect(err).To(HaveOccurred())
+	})
+
+	t.Run("successfully reconciles normally", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+
+		asoManagedControlPlane := &infrav1exp.AzureASOManagedControlPlane{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "amc",
+				Namespace: "ns",
+			},
+		}
+		c := fakeClientBuilder().
+			WithObjects(asoManagedControlPlane).
+			Build()
+		r := &AzureASOManagedControlPlaneReconciler{
+			Client: c,
+		}
+		result, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(asoManagedControlPlane)})
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(result).To(Equal(ctrl.Result{}))
+	})
+
+	t.Run("successfully reconciles pause", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+
+		cluster := &clusterv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "cluster",
+				Namespace: "ns",
+			},
+			Spec: clusterv1.ClusterSpec{
+				Paused: true,
+			},
+		}
+		asoManagedControlPlane := &infrav1exp.AzureASOManagedControlPlane{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "amc",
+				Namespace: cluster.Namespace,
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion: clusterv1.GroupVersion.Identifier(),
+						Kind:       "Cluster",
+						Name:       cluster.Name,
+					},
+				},
+			},
+		}
+		c := fakeClientBuilder().
+			WithObjects(cluster, asoManagedControlPlane).
+			Build()
+		r := &AzureASOManagedControlPlaneReconciler{
+			Client: c,
+		}
+		result, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(asoManagedControlPlane)})
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(result).To(Equal(ctrl.Result{}))
+	})
+
+	t.Run("successfully reconciles delete", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+
+		asoManagedControlPlane := &infrav1exp.AzureASOManagedControlPlane{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "amc",
+				Namespace: "ns",
+				Finalizers: []string{
+					clusterv1.ClusterFinalizer,
+				},
+				DeletionTimestamp: &metav1.Time{Time: time.Date(1, 0, 0, 0, 0, 0, 0, time.UTC)},
+			},
+		}
+		c := fakeClientBuilder().
+			WithObjects(asoManagedControlPlane).
+			Build()
+		r := &AzureASOManagedControlPlaneReconciler{
+			Client: c,
+		}
+		result, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(asoManagedControlPlane)})
 		g.Expect(err).NotTo(HaveOccurred())
 		g.Expect(result).To(Equal(ctrl.Result{}))
 	})

--- a/exp/controllers/azureasomanagedmachinepool_controller.go
+++ b/exp/controllers/azureasomanagedmachinepool_controller.go
@@ -18,12 +18,23 @@ package controllers
 
 import (
 	"context"
+	"fmt"
 
+	infracontroller "sigs.k8s.io/cluster-api-provider-azure/controllers"
 	infrav1exp "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1alpha1"
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	expv1 "sigs.k8s.io/cluster-api/exp/api/v1beta1"
+	utilexp "sigs.k8s.io/cluster-api/exp/util"
+	"sigs.k8s.io/cluster-api/util"
+	"sigs.k8s.io/cluster-api/util/annotations"
+	"sigs.k8s.io/cluster-api/util/patch"
 	"sigs.k8s.io/cluster-api/util/predicates"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 // AzureASOManagedMachinePoolReconciler reconciles a AzureASOManagedMachinePool object.
@@ -40,9 +51,34 @@ func (r *AzureASOManagedMachinePoolReconciler) SetupWithManager(ctx context.Cont
 	)
 	defer done()
 
-	_, err := ctrl.NewControllerManagedBy(mgr).
+	clusterToAzureASOManagedMachinePools, err := util.ClusterToTypedObjectsMapper(mgr.GetClient(), &infrav1exp.AzureASOManagedMachinePoolList{}, mgr.GetScheme())
+	if err != nil {
+		return fmt.Errorf("failed to get Cluster to AzureASOManagedMachinePool mapper: %w", err)
+	}
+
+	_, err = ctrl.NewControllerManagedBy(mgr).
 		For(&infrav1exp.AzureASOManagedMachinePool{}).
 		WithEventFilter(predicates.ResourceHasFilterLabel(log, r.WatchFilterValue)).
+		Watches(
+			&clusterv1.Cluster{},
+			handler.EnqueueRequestsFromMapFunc(clusterToAzureASOManagedMachinePools),
+			builder.WithPredicates(
+				predicates.ResourceHasFilterLabel(log, r.WatchFilterValue),
+				predicates.Any(log,
+					predicates.ClusterControlPlaneInitialized(log),
+					infracontroller.ClusterUpdatePauseChange(log),
+				),
+			),
+		).
+		Watches(
+			&expv1.MachinePool{},
+			handler.EnqueueRequestsFromMapFunc(utilexp.MachinePoolToInfrastructureMapFunc(
+				infrav1exp.GroupVersion.WithKind(infrav1exp.AzureASOManagedMachinePoolKind), log),
+			),
+			builder.WithPredicates(
+				predicates.ResourceHasFilterLabel(log, r.WatchFilterValue),
+			),
+		).
 		Build(r)
 	if err != nil {
 		return err
@@ -57,5 +93,108 @@ func (r *AzureASOManagedMachinePoolReconciler) SetupWithManager(ctx context.Cont
 
 // Reconcile reconciles an AzureASOManagedMachinePool.
 func (r *AzureASOManagedMachinePoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, resultErr error) {
+	ctx, log, done := tele.StartSpanWithLogger(ctx,
+		"controllers.AzureASOManagedMachinePoolReconciler.Reconcile",
+		tele.KVP("namespace", req.Namespace),
+		tele.KVP("name", req.Name),
+		tele.KVP("kind", infrav1exp.AzureASOManagedMachinePoolKind),
+	)
+	defer done()
+
+	asoManagedMachinePool := &infrav1exp.AzureASOManagedMachinePool{}
+	err := r.Get(ctx, req.NamespacedName, asoManagedMachinePool)
+	if err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	patchHelper, err := patch.NewHelper(asoManagedMachinePool, r.Client)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to create patch helper: %w", err)
+	}
+	defer func() {
+		err := patchHelper.Patch(ctx, asoManagedMachinePool)
+		if err != nil && resultErr == nil {
+			resultErr = err
+			result = ctrl.Result{}
+		}
+	}()
+
+	machinePool, err := utilexp.GetOwnerMachinePool(ctx, r.Client, asoManagedMachinePool.ObjectMeta)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	if machinePool == nil {
+		log.V(4).Info("Waiting for MachinePool Controller to set OwnerRef on AzureASOManagedMachinePool")
+		return ctrl.Result{}, nil
+	}
+
+	machinePoolBefore := machinePool.DeepCopy()
+	defer func() {
+		// Skip using a patch helper here because we will never modify the MachinePool status.
+		err := r.Patch(ctx, machinePool, client.MergeFrom(machinePoolBefore))
+		if err != nil && resultErr == nil {
+			resultErr = err
+			result = ctrl.Result{}
+		}
+	}()
+
+	cluster, err := util.GetClusterFromMetadata(ctx, r.Client, machinePool.ObjectMeta)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("AzureASOManagedMachinePool owner MachinePool is missing cluster label or cluster does not exist: %w", err)
+	}
+	if cluster == nil {
+		log.Info(fmt.Sprintf("Waiting for MachinePool controller to set %s label on MachinePool", clusterv1.ClusterNameLabel))
+		return ctrl.Result{}, nil
+	}
+	if cluster.Spec.ControlPlaneRef == nil ||
+		cluster.Spec.ControlPlaneRef.APIVersion != infrav1exp.GroupVersion.Identifier() ||
+		cluster.Spec.ControlPlaneRef.Kind != infrav1exp.AzureASOManagedControlPlaneKind {
+		return ctrl.Result{}, reconcile.TerminalError(fmt.Errorf("AzureASOManagedMachinePool cannot be used without AzureASOManagedControlPlane"))
+	}
+
+	if annotations.IsPaused(cluster, asoManagedMachinePool) {
+		return r.reconcilePause(ctx, asoManagedMachinePool, cluster)
+	}
+
+	if !asoManagedMachinePool.DeletionTimestamp.IsZero() {
+		return r.reconcileDelete(ctx, asoManagedMachinePool, cluster)
+	}
+
+	return r.reconcileNormal(ctx, asoManagedMachinePool, machinePool, cluster)
+}
+
+//nolint:unparam // these parameters will be used soon enough
+func (r *AzureASOManagedMachinePoolReconciler) reconcileNormal(ctx context.Context, asoManagedMachinePool *infrav1exp.AzureASOManagedMachinePool, machinePool *expv1.MachinePool, cluster *clusterv1.Cluster) (ctrl.Result, error) {
+	//nolint:all // ctx will be used soon
+	ctx, log, done := tele.StartSpanWithLogger(ctx,
+		"controllers.AzureASOManagedMachinePoolReconciler.reconcileNormal",
+	)
+	defer done()
+	log.V(4).Info("reconciling normally")
+
+	return ctrl.Result{}, nil
+}
+
+//nolint:unparam // these parameters will be used soon enough
+func (r *AzureASOManagedMachinePoolReconciler) reconcilePause(ctx context.Context, asoManagedMachinePool *infrav1exp.AzureASOManagedMachinePool, cluster *clusterv1.Cluster) (ctrl.Result, error) {
+	//nolint:all // ctx will be used soon
+	ctx, log, done := tele.StartSpanWithLogger(ctx,
+		"controllers.AzureASOManagedMachinePoolReconciler.reconcilePaused",
+	)
+	defer done()
+	log.V(4).Info("reconciling pause")
+
+	return ctrl.Result{}, nil
+}
+
+//nolint:unparam // these parameters will be used soon enough
+func (r *AzureASOManagedMachinePoolReconciler) reconcileDelete(ctx context.Context, asoManagedMachinePool *infrav1exp.AzureASOManagedMachinePool, cluster *clusterv1.Cluster) (ctrl.Result, error) {
+	//nolint:all // ctx will be used soon
+	ctx, log, done := tele.StartSpanWithLogger(ctx,
+		"controllers.AzureASOManagedMachinePoolReconciler.reconcileDelete",
+	)
+	defer done()
+	log.V(4).Info("reconciling delete")
+
 	return ctrl.Result{}, nil
 }

--- a/exp/controllers/azureasomanagedmachinepool_controller_test.go
+++ b/exp/controllers/azureasomanagedmachinepool_controller_test.go
@@ -19,12 +19,18 @@ package controllers
 import (
 	"context"
 	"testing"
+	"time"
 
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	infrav1exp "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1alpha1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	expv1 "sigs.k8s.io/cluster-api/exp/api/v1beta1"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
@@ -34,6 +40,8 @@ func TestAzureASOManagedMachinePoolReconcile(t *testing.T) {
 	s := runtime.NewScheme()
 	sb := runtime.NewSchemeBuilder(
 		infrav1exp.AddToScheme,
+		clusterv1.AddToScheme,
+		expv1.AddToScheme,
 	)
 	NewGomegaWithT(t).Expect(sb.AddToScheme(s)).To(Succeed())
 	fakeClientBuilder := func() *fakeclient.ClientBuilder {
@@ -51,6 +59,220 @@ func TestAzureASOManagedMachinePoolReconcile(t *testing.T) {
 			Client: c,
 		}
 		result, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Namespace: "doesn't", Name: "exist"}})
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(result).To(Equal(ctrl.Result{}))
+	})
+
+	t.Run("MachinePool does not exist", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+
+		asoManagedMachinePool := &infrav1exp.AzureASOManagedMachinePool{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "ammp",
+				Namespace: "ns",
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion: expv1.GroupVersion.Identifier(),
+						Kind:       "MachinePool",
+						Name:       "mp",
+					},
+				},
+			},
+		}
+		c := fakeClientBuilder().
+			WithObjects(asoManagedMachinePool).
+			Build()
+		r := &AzureASOManagedMachinePoolReconciler{
+			Client: c,
+		}
+		result, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(asoManagedMachinePool)})
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("machinepools.cluster.x-k8s.io \"mp\" not found"))
+		g.Expect(result).To(Equal(ctrl.Result{}))
+	})
+
+	t.Run("Cluster does not exist", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+
+		asoManagedMachinePool := &infrav1exp.AzureASOManagedMachinePool{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "ammp",
+				Namespace: "ns",
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion: expv1.GroupVersion.Identifier(),
+						Kind:       "MachinePool",
+						Name:       "mp",
+					},
+				},
+			},
+		}
+		machinePool := &expv1.MachinePool{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "mp",
+				Namespace: asoManagedMachinePool.Namespace,
+				Labels: map[string]string{
+					clusterv1.ClusterNameLabel: "cluster",
+				},
+			},
+		}
+		c := fakeClientBuilder().
+			WithObjects(asoManagedMachinePool, machinePool).
+			Build()
+		r := &AzureASOManagedMachinePoolReconciler{
+			Client: c,
+		}
+		result, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(asoManagedMachinePool)})
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("clusters.cluster.x-k8s.io \"cluster\" not found"))
+		g.Expect(result).To(Equal(ctrl.Result{}))
+	})
+
+	t.Run("successfully reconciles normally", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+
+		cluster := &clusterv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "cluster",
+				Namespace: "ns",
+			},
+			Spec: clusterv1.ClusterSpec{
+				ControlPlaneRef: &corev1.ObjectReference{
+					APIVersion: infrav1exp.GroupVersion.Identifier(),
+					Kind:       infrav1exp.AzureASOManagedControlPlaneKind,
+				},
+			},
+		}
+		asoManagedMachinePool := &infrav1exp.AzureASOManagedMachinePool{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "ammp",
+				Namespace: cluster.Namespace,
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion: expv1.GroupVersion.Identifier(),
+						Kind:       "MachinePool",
+						Name:       "mp",
+					},
+				},
+			},
+		}
+		machinePool := &expv1.MachinePool{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "mp",
+				Namespace: cluster.Namespace,
+				Labels: map[string]string{
+					clusterv1.ClusterNameLabel: "cluster",
+				},
+			},
+		}
+		c := fakeClientBuilder().
+			WithObjects(asoManagedMachinePool, machinePool, cluster).
+			Build()
+		r := &AzureASOManagedMachinePoolReconciler{
+			Client: c,
+		}
+		result, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(asoManagedMachinePool)})
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(result).To(Equal(ctrl.Result{}))
+	})
+
+	t.Run("successfully reconciles pause", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+
+		cluster := &clusterv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "cluster",
+				Namespace: "ns",
+			},
+			Spec: clusterv1.ClusterSpec{
+				Paused: true,
+				ControlPlaneRef: &corev1.ObjectReference{
+					APIVersion: infrav1exp.GroupVersion.Identifier(),
+					Kind:       infrav1exp.AzureASOManagedControlPlaneKind,
+				},
+			},
+		}
+		asoManagedMachinePool := &infrav1exp.AzureASOManagedMachinePool{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "ammp",
+				Namespace: cluster.Namespace,
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion: expv1.GroupVersion.Identifier(),
+						Kind:       "MachinePool",
+						Name:       "mp",
+					},
+				},
+			},
+		}
+		machinePool := &expv1.MachinePool{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "mp",
+				Namespace: cluster.Namespace,
+				Labels: map[string]string{
+					clusterv1.ClusterNameLabel: "cluster",
+				},
+			},
+		}
+		c := fakeClientBuilder().
+			WithObjects(asoManagedMachinePool, machinePool, cluster).
+			Build()
+		r := &AzureASOManagedMachinePoolReconciler{
+			Client: c,
+		}
+		result, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(asoManagedMachinePool)})
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(result).To(Equal(ctrl.Result{}))
+	})
+
+	t.Run("successfully reconciles delete", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+
+		cluster := &clusterv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "cluster",
+				Namespace: "ns",
+			},
+			Spec: clusterv1.ClusterSpec{
+				ControlPlaneRef: &corev1.ObjectReference{
+					APIVersion: infrav1exp.GroupVersion.Identifier(),
+					Kind:       infrav1exp.AzureASOManagedControlPlaneKind,
+				},
+			},
+		}
+		asoManagedMachinePool := &infrav1exp.AzureASOManagedMachinePool{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "ammp",
+				Namespace: cluster.Namespace,
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion: expv1.GroupVersion.Identifier(),
+						Kind:       "MachinePool",
+						Name:       "mp",
+					},
+				},
+				DeletionTimestamp: &metav1.Time{Time: time.Date(1, 0, 0, 0, 0, 0, 0, time.UTC)},
+				Finalizers: []string{
+					"// TODO",
+				},
+			},
+		}
+		machinePool := &expv1.MachinePool{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "mp",
+				Namespace: cluster.Namespace,
+				Labels: map[string]string{
+					clusterv1.ClusterNameLabel: "cluster",
+				},
+			},
+		}
+		c := fakeClientBuilder().
+			WithObjects(asoManagedMachinePool, machinePool, cluster).
+			Build()
+		r := &AzureASOManagedMachinePoolReconciler{
+			Client: c,
+		}
+		result, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(asoManagedMachinePool)})
 		g.Expect(err).NotTo(HaveOccurred())
 		g.Expect(result).To(Equal(ctrl.Result{}))
 	})


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind feature

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

This PR implements the top-level `Reconcile` methods for the ASOAPI controllers, enough to distinguish between reconciling normally, pause, and delete.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #4713

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [ ] includes documentation
- [X] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
