### PR TITLE
Don't include vnet name in template type

### DIFF
--- a/api/v1beta1/azuremanagedcontrolplane_types.go
+++ b/api/v1beta1/azuremanagedcontrolplane_types.go
@@ -379,6 +379,9 @@ type ManagedControlPlaneVirtualNetwork struct {
 	// +optional
 	ResourceGroup string `json:"resourceGroup,omitempty"`
 
+	// Name is the name of the virtual network.
+	Name string `json:"name"`
+
 	ManagedControlPlaneVirtualNetworkClassSpec `json:",inline"`
 }
 

--- a/api/v1beta1/azuremanagedcontrolplane_webhook_test.go
+++ b/api/v1beta1/azuremanagedcontrolplane_webhook_test.go
@@ -2445,8 +2445,8 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 						DNSServiceIP: ptr.To("192.168.0.10"),
 						Version:      "v1.18.0",
 						VirtualNetwork: ManagedControlPlaneVirtualNetwork{
+							Name: "test-network",
 							ManagedControlPlaneVirtualNetworkClassSpec: ManagedControlPlaneVirtualNetworkClassSpec{
-								Name:      "test-network",
 								CIDRBlock: "10.0.0.0/8",
 								Subnet: ManagedControlPlaneSubnet{
 									Name:      "test-subnet",
@@ -2493,8 +2493,8 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 						DNSServiceIP: ptr.To("192.168.0.10"),
 						Version:      "v1.18.0",
 						VirtualNetwork: ManagedControlPlaneVirtualNetwork{
+							Name: "test-network",
 							ManagedControlPlaneVirtualNetworkClassSpec: ManagedControlPlaneVirtualNetworkClassSpec{
-								Name:      "test-network",
 								CIDRBlock: "10.0.0.0/8",
 								Subnet: ManagedControlPlaneSubnet{
 									Name:      "test-subnet",
@@ -2519,8 +2519,8 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 						DNSServiceIP: ptr.To("192.168.0.10"),
 						Version:      "v1.18.0",
 						VirtualNetwork: ManagedControlPlaneVirtualNetwork{
+							Name: "test-network",
 							ManagedControlPlaneVirtualNetworkClassSpec: ManagedControlPlaneVirtualNetworkClassSpec{
-								Name:      "test-network",
 								CIDRBlock: "10.0.0.0/8",
 								Subnet: ManagedControlPlaneSubnet{
 									Name:      "test-subnet",
@@ -2541,8 +2541,8 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 						DNSServiceIP: ptr.To("192.168.0.10"),
 						Version:      "v1.18.0",
 						VirtualNetwork: ManagedControlPlaneVirtualNetwork{
+							Name: "test-network",
 							ManagedControlPlaneVirtualNetworkClassSpec: ManagedControlPlaneVirtualNetworkClassSpec{
-								Name:      "test-network",
 								CIDRBlock: "10.0.0.0/8",
 								Subnet: ManagedControlPlaneSubnet{
 									Name:      "test-subnet",
@@ -4029,8 +4029,8 @@ func TestValidateAMCPVirtualNetwork(t *testing.T) {
 					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
 						VirtualNetwork: ManagedControlPlaneVirtualNetwork{
 							ResourceGroup: "rg1",
+							Name:          "vnet1",
 							ManagedControlPlaneVirtualNetworkClassSpec: ManagedControlPlaneVirtualNetworkClassSpec{
-								Name:      "vnet1",
 								CIDRBlock: defaultAKSVnetCIDR,
 								Subnet: ManagedControlPlaneSubnet{
 									Name:      "subnet1",
@@ -4057,8 +4057,8 @@ func TestValidateAMCPVirtualNetwork(t *testing.T) {
 					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
 						VirtualNetwork: ManagedControlPlaneVirtualNetwork{
 							ResourceGroup: "rg2",
+							Name:          "vnet1",
 							ManagedControlPlaneVirtualNetworkClassSpec: ManagedControlPlaneVirtualNetworkClassSpec{
-								Name:      "vnet1",
 								CIDRBlock: defaultAKSVnetCIDR,
 								Subnet: ManagedControlPlaneSubnet{
 									Name:      "subnet1",
@@ -4085,8 +4085,8 @@ func TestValidateAMCPVirtualNetwork(t *testing.T) {
 					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
 						VirtualNetwork: ManagedControlPlaneVirtualNetwork{
 							ResourceGroup: "rg2",
+							Name:          "vnet1",
 							ManagedControlPlaneVirtualNetworkClassSpec: ManagedControlPlaneVirtualNetworkClassSpec{
-								Name:      "vnet1",
 								CIDRBlock: "10.1.0.0/16",
 								Subnet: ManagedControlPlaneSubnet{
 									Name:      "subnet1",
@@ -4113,8 +4113,8 @@ func TestValidateAMCPVirtualNetwork(t *testing.T) {
 					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
 						VirtualNetwork: ManagedControlPlaneVirtualNetwork{
 							ResourceGroup: "rg2",
+							Name:          "vnet1",
 							ManagedControlPlaneVirtualNetworkClassSpec: ManagedControlPlaneVirtualNetworkClassSpec{
-								Name:      "vnet1",
 								CIDRBlock: "10.1.0.0/16",
 								Subnet: ManagedControlPlaneSubnet{
 									Name: "subnet1",
@@ -4140,8 +4140,8 @@ func TestValidateAMCPVirtualNetwork(t *testing.T) {
 					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
 						VirtualNetwork: ManagedControlPlaneVirtualNetwork{
 							ResourceGroup: "rg2",
+							Name:          "vnet1",
 							ManagedControlPlaneVirtualNetworkClassSpec: ManagedControlPlaneVirtualNetworkClassSpec{
-								Name: "vnet1",
 								Subnet: ManagedControlPlaneSubnet{
 									Name:      "subnet1",
 									CIDRBlock: "11.0.0.0/24",
@@ -4167,8 +4167,8 @@ func TestValidateAMCPVirtualNetwork(t *testing.T) {
 					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
 						VirtualNetwork: ManagedControlPlaneVirtualNetwork{
 							ResourceGroup: "rg2",
+							Name:          "vnet1",
 							ManagedControlPlaneVirtualNetworkClassSpec: ManagedControlPlaneVirtualNetworkClassSpec{
-								Name:      "vnet1",
 								CIDRBlock: "invalid_vnet_CIDR",
 								Subnet: ManagedControlPlaneSubnet{
 									Name:      "subnet1",
@@ -4195,8 +4195,8 @@ func TestValidateAMCPVirtualNetwork(t *testing.T) {
 					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
 						VirtualNetwork: ManagedControlPlaneVirtualNetwork{
 							ResourceGroup: "rg2",
+							Name:          "vnet1",
 							ManagedControlPlaneVirtualNetworkClassSpec: ManagedControlPlaneVirtualNetworkClassSpec{
-								Name: "vnet1",
 								Subnet: ManagedControlPlaneSubnet{
 									Name:      "subnet1",
 									CIDRBlock: "invalid_subnet_CIDR",

--- a/api/v1beta1/azuremanagedcontrolplanetemplate_default.go
+++ b/api/v1beta1/azuremanagedcontrolplanetemplate_default.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
 )
 
 func (mcp *AzureManagedControlPlaneTemplate) setDefaults() {
@@ -39,8 +40,10 @@ func (mcp *AzureManagedControlPlaneTemplate) setDefaults() {
 
 // setDefaultVirtualNetwork sets the default VirtualNetwork for an AzureManagedControlPlaneTemplate.
 func (mcp *AzureManagedControlPlaneTemplate) setDefaultVirtualNetwork() {
-	if mcp.Spec.Template.Spec.VirtualNetwork.Name == "" {
-		mcp.Spec.Template.Spec.VirtualNetwork.Name = mcp.Name
+	if mcp.Spec.Template.Spec.VirtualNetwork.Name != "" {
+		// Being able to set the vnet name in the template type is a bug, as vnet names cannot be reused across clusters.
+		// To avoid a breaking API change, a warning is logged.
+		ctrl.Log.WithName("AzureManagedControlPlaneTemplateWebHookLogger").Info("WARNING: VirtualNetwork.Name should not be set in the template. Virtual Network names cannot be shared across clusters.")
 	}
 	if mcp.Spec.Template.Spec.VirtualNetwork.CIDRBlock == "" {
 		mcp.Spec.Template.Spec.VirtualNetwork.CIDRBlock = defaultAKSVnetCIDR

--- a/api/v1beta1/azuremanagedcontrolplanetemplate_default_test.go
+++ b/api/v1beta1/azuremanagedcontrolplanetemplate_default_test.go
@@ -51,47 +51,6 @@ func TestDefaultVirtualNetworkTemplate(t *testing.T) {
 							AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
 								VirtualNetwork: ManagedControlPlaneVirtualNetwork{
 									ManagedControlPlaneVirtualNetworkClassSpec: ManagedControlPlaneVirtualNetworkClassSpec{
-										Name:      "test-cluster-template",
-										CIDRBlock: defaultAKSVnetCIDR,
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "custom name",
-			controlPlaneTemplate: &AzureManagedControlPlaneTemplate{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "test-cluster-template",
-				},
-				Spec: AzureManagedControlPlaneTemplateSpec{
-					Template: AzureManagedControlPlaneTemplateResource{
-						Spec: AzureManagedControlPlaneTemplateResourceSpec{
-							AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
-								VirtualNetwork: ManagedControlPlaneVirtualNetwork{
-									ManagedControlPlaneVirtualNetworkClassSpec: ManagedControlPlaneVirtualNetworkClassSpec{
-										Name: "custom-vnet-name",
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-			outputTemplate: &AzureManagedControlPlaneTemplate{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "test-cluster-template",
-				},
-				Spec: AzureManagedControlPlaneTemplateSpec{
-					Template: AzureManagedControlPlaneTemplateResource{
-						Spec: AzureManagedControlPlaneTemplateResourceSpec{
-							AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
-								VirtualNetwork: ManagedControlPlaneVirtualNetwork{
-									ManagedControlPlaneVirtualNetworkClassSpec: ManagedControlPlaneVirtualNetworkClassSpec{
-										Name:      "custom-vnet-name",
 										CIDRBlock: defaultAKSVnetCIDR,
 									},
 								},
@@ -131,7 +90,6 @@ func TestDefaultVirtualNetworkTemplate(t *testing.T) {
 							AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
 								VirtualNetwork: ManagedControlPlaneVirtualNetwork{
 									ManagedControlPlaneVirtualNetworkClassSpec: ManagedControlPlaneVirtualNetworkClassSpec{
-										Name:      "test-cluster-template",
 										CIDRBlock: "10.0.0.16/24",
 									},
 								},

--- a/api/v1beta1/azuremanagedcontrolplanetemplate_webhook.go
+++ b/api/v1beta1/azuremanagedcontrolplanetemplate_webhook.go
@@ -252,13 +252,6 @@ func (mcp *AzureManagedControlPlaneTemplate) validateK8sVersionUpdate(old *Azure
 // validateVirtualNetworkTemplateUpdate validates update to VirtualNetworkTemplate.
 func (mcp *AzureManagedControlPlaneTemplate) validateVirtualNetworkTemplateUpdate(old *AzureManagedControlPlaneTemplate) field.ErrorList {
 	var allErrs field.ErrorList
-	if old.Spec.Template.Spec.VirtualNetwork.Name != mcp.Spec.Template.Spec.VirtualNetwork.Name {
-		allErrs = append(allErrs,
-			field.Invalid(
-				field.NewPath("Spec", "Template", "Spec", "VirtualNetwork.Name"),
-				mcp.Spec.Template.Spec.VirtualNetwork.Name,
-				"Virtual Network Name is immutable"))
-	}
 
 	if old.Spec.Template.Spec.VirtualNetwork.CIDRBlock != mcp.Spec.Template.Spec.VirtualNetwork.CIDRBlock {
 		allErrs = append(allErrs,

--- a/api/v1beta1/azuremanagedcontrolplanetemplate_webhook_test.go
+++ b/api/v1beta1/azuremanagedcontrolplanetemplate_webhook_test.go
@@ -36,7 +36,6 @@ func TestControlPlaneTemplateDefaultingWebhook(t *testing.T) {
 	g.Expect(*amcpt.Spec.Template.Spec.NetworkPlugin).To(Equal("azure"))
 	g.Expect(*amcpt.Spec.Template.Spec.LoadBalancerSKU).To(Equal("Standard"))
 	g.Expect(amcpt.Spec.Template.Spec.Version).To(Equal("v1.17.5"))
-	g.Expect(amcpt.Spec.Template.Spec.VirtualNetwork.Name).To(Equal("fooName"))
 	g.Expect(amcpt.Spec.Template.Spec.VirtualNetwork.CIDRBlock).To(Equal(defaultAKSVnetCIDR))
 	g.Expect(amcpt.Spec.Template.Spec.VirtualNetwork.Subnet.Name).To(Equal("fooName"))
 	g.Expect(amcpt.Spec.Template.Spec.VirtualNetwork.Subnet.CIDRBlock).To(Equal(defaultAKSNodeSubnetCIDR))
@@ -300,18 +299,18 @@ func TestValidateVirtualNetworkTemplateUpdate(t *testing.T) {
 			wantErr:                 false,
 		},
 		{
-			name: "azuremanagedcontrolplanetemplate name is immutable",
+			name: "azuremanagedcontrolplanetemplate vnet is immutable",
 			oldControlPlaneTemplate: getAzureManagedControlPlaneTemplate(func(cpt *AzureManagedControlPlaneTemplate) {
 				cpt.Spec.Template.Spec.VirtualNetwork = ManagedControlPlaneVirtualNetwork{
 					ManagedControlPlaneVirtualNetworkClassSpec: ManagedControlPlaneVirtualNetworkClassSpec{
-						Name: "fooName",
+						CIDRBlock: "fooCIDRBlock",
 					},
 				}
 			}),
 			controlPlaneTemplate: getAzureManagedControlPlaneTemplate(func(cpt *AzureManagedControlPlaneTemplate) {
 				cpt.Spec.Template.Spec.VirtualNetwork = ManagedControlPlaneVirtualNetwork{
 					ManagedControlPlaneVirtualNetworkClassSpec: ManagedControlPlaneVirtualNetworkClassSpec{
-						Name: "barName",
+						CIDRBlock: "barCIDRBlock",
 					},
 				}
 			}),

--- a/api/v1beta1/types_class.go
+++ b/api/v1beta1/types_class.go
@@ -415,7 +415,6 @@ type AzureManagedMachinePoolClassSpec struct {
 
 // ManagedControlPlaneVirtualNetworkClassSpec defines the ManagedControlPlaneVirtualNetwork properties that may be shared across several managed control plane vnets.
 type ManagedControlPlaneVirtualNetworkClassSpec struct {
-	Name      string `json:"name"`
 	CIDRBlock string `json:"cidrBlock"`
 	// +optional
 	Subnet ManagedControlPlaneSubnet `json:"subnet,omitempty"`

--- a/azure/scope/managedcontrolplane_test.go
+++ b/azure/scope/managedcontrolplane_test.go
@@ -1349,8 +1349,8 @@ func TestManagedControlPlaneScope_PrivateEndpointSpecs(t *testing.T) {
 							SubscriptionID: "00000000-0000-0000-0000-000000000001",
 							VirtualNetwork: infrav1.ManagedControlPlaneVirtualNetwork{
 								ResourceGroup: "dummy-rg",
+								Name:          "vnet1",
 								ManagedControlPlaneVirtualNetworkClassSpec: infrav1.ManagedControlPlaneVirtualNetworkClassSpec{
-									Name: "vnet1",
 									Subnet: infrav1.ManagedControlPlaneSubnet{
 										Name: "subnet1",
 										PrivateEndpoints: infrav1.PrivateEndpoints{
@@ -1707,9 +1707,7 @@ func TestManagedControlPlaneScope_GroupSpecs(t *testing.T) {
 						ResourceGroupName: "dummy-rg",
 						AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 							VirtualNetwork: infrav1.ManagedControlPlaneVirtualNetwork{
-								ManagedControlPlaneVirtualNetworkClassSpec: infrav1.ManagedControlPlaneVirtualNetworkClassSpec{
-									Name: "vnet1",
-								},
+								Name: "vnet1",
 							},
 						},
 					},
@@ -1740,9 +1738,7 @@ func TestManagedControlPlaneScope_GroupSpecs(t *testing.T) {
 						AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 							VirtualNetwork: infrav1.ManagedControlPlaneVirtualNetwork{
 								ResourceGroup: "my_custom_rg",
-								ManagedControlPlaneVirtualNetworkClassSpec: infrav1.ManagedControlPlaneVirtualNetworkClassSpec{
-									Name: "vnet1",
-								},
+								Name:          "vnet1",
 							},
 						},
 					},

--- a/azure/scope/managedmachinepool_test.go
+++ b/azure/scope/managedmachinepool_test.go
@@ -711,8 +711,8 @@ func TestManagedMachinePoolScope_SubnetName(t *testing.T) {
 						AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 							SubscriptionID: "00000000-0000-0000-0000-000000000000",
 							VirtualNetwork: infrav1.ManagedControlPlaneVirtualNetwork{
+								Name: "my-vnet",
 								ManagedControlPlaneVirtualNetworkClassSpec: infrav1.ManagedControlPlaneVirtualNetworkClassSpec{
-									Name: "my-vnet",
 									Subnet: infrav1.ManagedControlPlaneSubnet{
 										Name: "my-vnet-subnet",
 									},
@@ -755,8 +755,8 @@ func TestManagedMachinePoolScope_SubnetName(t *testing.T) {
 						AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 							SubscriptionID: "00000000-0000-0000-0000-000000000000",
 							VirtualNetwork: infrav1.ManagedControlPlaneVirtualNetwork{
+								Name: "my-vnet",
 								ManagedControlPlaneVirtualNetworkClassSpec: infrav1.ManagedControlPlaneVirtualNetworkClassSpec{
-									Name: "my-vnet",
 									Subnet: infrav1.ManagedControlPlaneSubnet{
 										Name: "my-vnet-subnet",
 									},

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremanagedcontrolplanes.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremanagedcontrolplanes.yaml
@@ -763,6 +763,7 @@ spec:
                   cidrBlock:
                     type: string
                   name:
+                    description: Name is the name of the virtual network.
                     type: string
                   resourceGroup:
                     description: ResourceGroup is the name of the Azure resource group

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremanagedcontrolplanetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremanagedcontrolplanetemplates.yaml
@@ -731,6 +731,7 @@ spec:
                           cidrBlock:
                             type: string
                           name:
+                            description: Name is the name of the virtual network.
                             type: string
                           resourceGroup:
                             description: ResourceGroup is the name of the Azure resource

--- a/controllers/azuremanagedcontrolplane_controller_test.go
+++ b/controllers/azuremanagedcontrolplane_controller_test.go
@@ -182,8 +182,8 @@ func TestAzureManagedControlPlaneReconcilePaused(t *testing.T) {
 			AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 				SubscriptionID: "something",
 				VirtualNetwork: infrav1.ManagedControlPlaneVirtualNetwork{
+					Name: name,
 					ManagedControlPlaneVirtualNetworkClassSpec: infrav1.ManagedControlPlaneVirtualNetworkClassSpec{
-						Name: name,
 						Subnet: infrav1.ManagedControlPlaneSubnet{
 							Name: "subnet",
 						},

--- a/docs/book/src/topics/clusterclass.md
+++ b/docs/book/src/topics/clusterclass.md
@@ -48,6 +48,14 @@ spec:
 
 Deploying an AKS cluster with ClusterClass is similar to deploying a self-managed cluster. However, both an AzureManagedClusterTemplate and AzureManagedControlPlaneTemplate must be used instead of the AzureClusterTemplate. Due to the nature of managed Kubernetes and the control plane implementation, the infrastructure provider (and therefore the AzureManagedClusterTemplate) for AKS cluster is basically a no-op. The AzureManagedControlPlaneTemplate is used to define the AKS cluster configuration, such as the Kubernetes version and the number of nodes. Finally, the AzureManagedMachinePoolTemplate defines the worker nodes (agentpools) for the AKS cluster.
 
+<aside class="note warning">
+
+<h1> Warning </h1>
+
+The field `virtualNetwork.Name` should not be set in the AzureManagedControlPlaneTemplate. Setting this field will result in an error with conflicting vnet names when creating multiple clusters with one template. To prevent a breaking API change, this field is not removed from the API, but it should not be used.
+
+</aside>
+
 The following example shows a basic AzureManagedClusterTemplate, AzureManagedControlPlaneTemplate, and AzureManagedMachinePoolTemplate resource:
 
 ```yaml


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->
/kind bug

**What this PR does / why we need it**:
This PR fixes a bug where the `name` field for the virtual network is erroneously being defaulted to a name that is shared across clusters. The vnet name should not be shared across clusters and this will cause issues with any cluster that is created via a ClusterClass template after the first one.

To avoid breaking API changes, this PR does the following:
- Print out a webhook warning if the vnet name is specified in the AzureManagedControlPlaneTemplate
- Update docs and comments to reflect this change

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4556

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [x] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix ClusterClass MP: Don't include vnet name in template type. BREAKING Go API but not real-world usage
```
