### PR TITLE
[release-1.13] use existing virtualNetwork from a different rg

### DIFF
--- a/api/v1beta1/azuremanagedcontrolplanetemplate_webhook.go
+++ b/api/v1beta1/azuremanagedcontrolplanetemplate_webhook.go
@@ -203,6 +203,8 @@ func (mcp *AzureManagedControlPlaneTemplate) validateManagedControlPlaneTemplate
 
 	allErrs = append(allErrs, validateAutoScalerProfile(mcp.Spec.Template.Spec.AutoScalerProfile, field.NewPath("spec").Child("template").Child("spec").Child("AutoScalerProfile"))...)
 
+	allErrs = append(allErrs, validateAMCPVirtualNetwork(mcp.Spec.Template.Spec.VirtualNetwork, field.NewPath("spec").Child("template").Child("spec").Child("VirtualNetwork"))...)
+
 	return allErrs.ToAggregate()
 }
 

--- a/azure/defaults.go
+++ b/azure/defaults.go
@@ -19,6 +19,8 @@ package azure
 import (
 	"fmt"
 	"net/http"
+	"regexp"
+	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
@@ -411,4 +413,16 @@ func (p CustomPutPatchHeaderPolicy) Do(req *policy.Request) (*http.Response, err
 	}
 
 	return req.Next()
+}
+
+// GetNormalizedKubernetesName returns a normalized name for a Kubernetes resource.
+func GetNormalizedKubernetesName(name string) string {
+	// Remove non-alphanumeric characters, convert to lowercase, and replace underscores with hyphens
+	name = strings.ToLower(name)
+	re := regexp.MustCompile(`[^a-z0-9\-]+`)
+	name = re.ReplaceAllString(name, "-")
+
+	// Remove leading and trailing hyphens
+	name = strings.Trim(name, "-")
+	return name
 }

--- a/azure/defaults_test.go
+++ b/azure/defaults_test.go
@@ -277,3 +277,79 @@ func TestGetBootstrappingVMExtension(t *testing.T) {
 		})
 	}
 }
+
+func TestNormalizeAzureName(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "should return lower case",
+			input:    "Test",
+			expected: "test",
+		},
+		{
+			name:     "should return lower case with spaces replaced by hyphens",
+			input:    "Test Name",
+			expected: "test-name",
+		},
+		{
+			name:     "should return lower case with spaces replaced by hyphens and non-alphanumeric characters removed",
+			input:    "Test Name 1",
+			expected: "test-name-1",
+		},
+		{
+			name:     "should return lower case with spaces replaced by hyphens and non-alphanumeric characters removed",
+			input:    "Test-Name-1-",
+			expected: "test-name-1",
+		},
+		{
+			name:     "should return lower case with spaces replaced by hyphens and non-alphanumeric characters removed",
+			input:    "Test-Name-1-@",
+			expected: "test-name-1",
+		},
+		{
+			name:     "should return lower case with spaces replaced by hyphens and non-alphanumeric characters removed",
+			input:    "Test-Name-1-@-",
+			expected: "test-name-1",
+		},
+		{
+			name:     "should return lower case with spaces replaced by hyphens and non-alphanumeric characters removed",
+			input:    "Test-Name-1-@-@",
+			expected: "test-name-1",
+		},
+		{
+			name:     "should return lower case with underscores replaced by hyphens and non-alphanumeric characters removed",
+			input:    "Test_Name_1-@-@",
+			expected: "test-name-1",
+		},
+		{
+			name:     "should return lower case with underscores replaced by hyphens and non-alphanumeric characters removed",
+			input:    "0_Test_Name_1-@-@",
+			expected: "0-test-name-1",
+		},
+		{
+			name:     "should return lower case with underscores replaced by hyphens and non-alphanumeric characters removed",
+			input:    "_Test_Name_1-@-@",
+			expected: "test-name-1",
+		},
+		{
+			name:     "should return lower case with name without hyphens",
+			input:    "_Test_Name_1---",
+			expected: "test-name-1",
+		},
+		{
+			name:     "should not change the input since input is valid k8s name",
+			input:    "test-name-1",
+			expected: "test-name-1",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			normalizedNamed := GetNormalizedKubernetesName(tc.input)
+			g.Expect(normalizedNamed).To(Equal(tc.expected))
+		})
+	}
+}

--- a/azure/scope/cluster.go
+++ b/azure/scope/cluster.go
@@ -424,6 +424,7 @@ func (s *ClusterScope) GroupSpecs() []azure.ASOResourceSpecGetter[*asoresourcesv
 	specs := []azure.ASOResourceSpecGetter[*asoresourcesv1.ResourceGroup]{
 		&groups.GroupSpec{
 			Name:           s.ResourceGroup(),
+			AzureName:      s.ResourceGroup(),
 			Namespace:      s.Namespace(),
 			Location:       s.Location(),
 			ClusterName:    s.ClusterName(),
@@ -431,9 +432,10 @@ func (s *ClusterScope) GroupSpecs() []azure.ASOResourceSpecGetter[*asoresourcesv
 			Owner:          owner,
 		},
 	}
-	if s.Vnet().ResourceGroup != s.ResourceGroup() {
+	if s.Vnet().ResourceGroup != "" && s.Vnet().ResourceGroup != s.ResourceGroup() {
 		specs = append(specs, &groups.GroupSpec{
-			Name:           s.Vnet().ResourceGroup,
+			Name:           azure.GetNormalizedKubernetesName(s.Vnet().ResourceGroup),
+			AzureName:      s.Vnet().ResourceGroup,
 			Namespace:      s.Namespace(),
 			Location:       s.Location(),
 			ClusterName:    s.ClusterName(),

--- a/azure/services/groups/spec.go
+++ b/azure/services/groups/spec.go
@@ -29,6 +29,7 @@ import (
 // GroupSpec defines the specification for a Resource Group.
 type GroupSpec struct {
 	Name           string
+	AzureName      string
 	Namespace      string
 	Location       string
 	ClusterName    string
@@ -52,7 +53,7 @@ func (s *GroupSpec) Parameters(ctx context.Context, existing *asoresourcesv1.Res
 		return existing, nil
 	}
 
-	return &asoresourcesv1.ResourceGroup{
+	resourceGroup := &asoresourcesv1.ResourceGroup{
 		ObjectMeta: metav1.ObjectMeta{
 			OwnerReferences: []metav1.OwnerReference{s.Owner},
 		},
@@ -66,7 +67,11 @@ func (s *GroupSpec) Parameters(ctx context.Context, existing *asoresourcesv1.Res
 				Additional:  s.AdditionalTags,
 			}),
 		},
-	}, nil
+	}
+	if s.AzureName != "" {
+		resourceGroup.Spec.AzureName = s.AzureName
+	}
+	return resourceGroup, nil
 }
 
 // WasManaged implements azure.ASOResourceSpecGetter.

--- a/azure/services/groups/spec_test.go
+++ b/azure/services/groups/spec_test.go
@@ -38,6 +38,7 @@ func TestParameters(t *testing.T) {
 			name: "no existing group",
 			spec: &GroupSpec{
 				Name:           "name",
+				AzureName:      "azure-name",
 				Location:       "location",
 				ClusterName:    "cluster",
 				AdditionalTags: infrav1.Tags{"some": "tags"},
@@ -56,7 +57,8 @@ func TestParameters(t *testing.T) {
 					},
 				},
 				Spec: asoresourcesv1.ResourceGroup_Spec{
-					Location: ptr.To("location"),
+					AzureName: "azure-name",
+					Location:  ptr.To("location"),
 					Tags: map[string]string{
 						"some": "tags",
 						"sigs.k8s.io_cluster-api-provider-azure_cluster_cluster": "owned",


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind feature

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
This is a manual cherry-pick of #4606

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
use existing virtualNetwork from a different rg 
```
