### PR TITLE
add AZURE_USER_AGENT_SUFFIX to aso-controller-settings

### DIFF
--- a/config/aso/settings.yaml
+++ b/config/aso/settings.yaml
@@ -8,6 +8,7 @@ stringData:
   AZURE_RESOURCE_MANAGER_ENDPOINT: ${AZURE_RESOURCE_MANAGER_ENDPOINT:=""}
   AZURE_RESOURCE_MANAGER_AUDIENCE: ${AZURE_RESOURCE_MANAGER_AUDIENCE:=""}
   AZURE_SYNC_PERIOD: ${AZURE_SYNC_PERIOD:="1h"}
+  AZURE_USER_AGENT_SUFFIX: cluster-api-provider-azure/main
   # Per-resource Secrets will be created based on a Cluster's AzureClusterIdentity.
   AZURE_SUBSCRIPTION_ID: ""
   AZURE_TENANT_ID: ""

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -3,3 +3,21 @@ resources:
 
 components:
   - ../aso
+
+replacements:
+  - source:
+      kind: Deployment
+      name: capz-controller-manager
+      fieldPath: spec.template.spec.containers.[name=manager].image
+      options:
+        delimiter: ':'
+        index: 1
+    targets:
+      - select:
+          kind: Secret
+          name: aso-controller-settings
+        fieldPaths:
+          - stringData.AZURE_USER_AGENT_SUFFIX
+        options:
+          delimiter: '/'
+          index: 1


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind cleanup

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

This PR adds default configuration to customize the HTTP user agent used by CAPZ's installation of ASO to match the user agent used within CAPZ for its HTTP calls.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
