### PR TITLE
ASOAPI: reconcile status.ready

### DIFF
--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azureasomanagedclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azureasomanagedclusters.yaml
@@ -70,6 +70,11 @@ spec:
             description: AzureASOManagedClusterStatus defines the observed state of
               AzureASOManagedCluster.
             properties:
+              ready:
+                description: |-
+                  Ready represents whether or not the cluster has been provisioned and is ready. It fulfills Cluster
+                  API's cluster infrastructure provider contract.
+                type: boolean
               resources:
                 items:
                   description: ResourceStatus represents the status of a resource.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azureasomanagedcontrolplanes.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azureasomanagedcontrolplanes.yaml
@@ -73,6 +73,16 @@ spec:
                 - host
                 - port
                 type: object
+              initialized:
+                description: |-
+                  Initialized represents whether or not the API server has been provisioned. It fulfills Cluster API's
+                  control plane provider contract. For AKS, this is equivalent to `ready`.
+                type: boolean
+              ready:
+                description: |-
+                  Ready represents whether or not the API server is ready to receive requests. It fulfills Cluster API's
+                  control plane provider contract. For AKS, this is equivalent to `initialized`.
+                type: boolean
               resources:
                 items:
                   description: ResourceStatus represents the status of a resource.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azureasomanagedmachinepools.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azureasomanagedmachinepools.yaml
@@ -60,6 +60,11 @@ spec:
             description: AzureASOManagedMachinePoolStatus defines the observed state
               of AzureASOManagedMachinePool.
             properties:
+              ready:
+                description: |-
+                  Ready represents whether or not the infrastructure is ready to be used. It fulfills Cluster API's
+                  machine pool infrastructure provider contract.
+                type: boolean
               replicas:
                 description: |-
                   Replicas is the current number of provisioned replicas. It fulfills Cluster API's machine pool

--- a/exp/api/v1alpha1/azureasomanagedcluster_types.go
+++ b/exp/api/v1alpha1/azureasomanagedcluster_types.go
@@ -43,6 +43,11 @@ type AzureASOManagedClusterSpec struct {
 
 // AzureASOManagedClusterStatus defines the observed state of AzureASOManagedCluster.
 type AzureASOManagedClusterStatus struct {
+	// Ready represents whether or not the cluster has been provisioned and is ready. It fulfills Cluster
+	// API's cluster infrastructure provider contract.
+	//+optional
+	Ready bool `json:"ready"`
+
 	//+optional
 	Resources []ResourceStatus `json:"resources,omitempty"`
 }

--- a/exp/api/v1alpha1/azureasomanagedcontrolplane_types.go
+++ b/exp/api/v1alpha1/azureasomanagedcontrolplane_types.go
@@ -31,6 +31,16 @@ type AzureASOManagedControlPlaneSpec struct {
 
 // AzureASOManagedControlPlaneStatus defines the observed state of AzureASOManagedControlPlane.
 type AzureASOManagedControlPlaneStatus struct {
+	// Initialized represents whether or not the API server has been provisioned. It fulfills Cluster API's
+	// control plane provider contract. For AKS, this is equivalent to `ready`.
+	//+optional
+	Initialized bool `json:"initialized"`
+
+	// Ready represents whether or not the API server is ready to receive requests. It fulfills Cluster API's
+	// control plane provider contract. For AKS, this is equivalent to `initialized`.
+	//+optional
+	Ready bool `json:"ready"`
+
 	// Version is the observed Kubernetes version of the control plane. It fulfills Cluster API's control
 	// plane provider contract.
 	//+optional

--- a/exp/api/v1alpha1/azureasomanagedmachinepool_types.go
+++ b/exp/api/v1alpha1/azureasomanagedmachinepool_types.go
@@ -35,6 +35,11 @@ type AzureASOManagedMachinePoolStatus struct {
 	//+optional
 	Replicas int32 `json:"replicas"`
 
+	// Ready represents whether or not the infrastructure is ready to be used. It fulfills Cluster API's
+	// machine pool infrastructure provider contract.
+	//+optional
+	Ready bool `json:"ready"`
+
 	//+optional
 	Resources []ResourceStatus `json:"resources,omitempty"`
 }

--- a/exp/controllers/azureasomanagedcluster_controller.go
+++ b/exp/controllers/azureasomanagedcluster_controller.go
@@ -186,6 +186,8 @@ func (r *AzureASOManagedClusterReconciler) Reconcile(ctx context.Context, req ct
 		}
 	}()
 
+	asoManagedCluster.Status.Ready = false
+
 	cluster, err := util.GetOwnerCluster(ctx, r.Client, asoManagedCluster.ObjectMeta)
 	if err != nil {
 		return ctrl.Result{}, err
@@ -251,6 +253,8 @@ func (r *AzureASOManagedClusterReconciler) reconcileNormal(ctx context.Context, 
 		return ctrl.Result{}, fmt.Errorf("failed to get AzureASOManagedControlPlane %s/%s: %w", asoManagedControlPlane.Namespace, asoManagedControlPlane.Name, err)
 	}
 	asoManagedCluster.Spec.ControlPlaneEndpoint = asoManagedControlPlane.Status.ControlPlaneEndpoint
+
+	asoManagedCluster.Status.Ready = !asoManagedCluster.Spec.ControlPlaneEndpoint.IsZero()
 
 	return ctrl.Result{}, nil
 }

--- a/exp/controllers/azureasomanagedcluster_controller_test.go
+++ b/exp/controllers/azureasomanagedcluster_controller_test.go
@@ -182,6 +182,9 @@ func TestAzureASOManagedClusterReconcile(t *testing.T) {
 					clusterv1.ClusterFinalizer,
 				},
 			},
+			Status: infrav1exp.AzureASOManagedClusterStatus{
+				Ready: true,
+			},
 		}
 		c := fakeClientBuilder().
 			WithObjects(cluster, asoManagedCluster).
@@ -205,6 +208,9 @@ func TestAzureASOManagedClusterReconcile(t *testing.T) {
 		result, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(asoManagedCluster)})
 		g.Expect(err).NotTo(HaveOccurred())
 		g.Expect(result).To(Equal(ctrl.Result{}))
+
+		g.Expect(r.Get(ctx, client.ObjectKeyFromObject(asoManagedCluster), asoManagedCluster)).To(Succeed())
+		g.Expect(asoManagedCluster.Status.Ready).To(BeFalse())
 	})
 
 	t.Run("successfully reconciles normally", func(t *testing.T) {
@@ -239,6 +245,9 @@ func TestAzureASOManagedClusterReconcile(t *testing.T) {
 					clusterv1.ClusterFinalizer,
 				},
 			},
+			Status: infrav1exp.AzureASOManagedClusterStatus{
+				Ready: false,
+			},
 		}
 		asoManagedControlPlane := &infrav1exp.AzureASOManagedControlPlane{
 			ObjectMeta: metav1.ObjectMeta{
@@ -268,6 +277,7 @@ func TestAzureASOManagedClusterReconcile(t *testing.T) {
 
 		g.Expect(c.Get(ctx, client.ObjectKeyFromObject(asoManagedCluster), asoManagedCluster)).To(Succeed())
 		g.Expect(asoManagedCluster.Spec.ControlPlaneEndpoint.Host).To(Equal("endpoint"))
+		g.Expect(asoManagedCluster.Status.Ready).To(BeTrue())
 	})
 
 	t.Run("successfully reconciles pause", func(t *testing.T) {

--- a/exp/controllers/azureasomanagedcontrolplane_controller.go
+++ b/exp/controllers/azureasomanagedcontrolplane_controller.go
@@ -137,6 +137,9 @@ func (r *AzureASOManagedControlPlaneReconciler) Reconcile(ctx context.Context, r
 		}
 	}()
 
+	asoManagedControlPlane.Status.Ready = false
+	asoManagedControlPlane.Status.Initialized = false
+
 	cluster, err := util.GetOwnerCluster(ctx, r.Client, asoManagedControlPlane.ObjectMeta)
 	if err != nil {
 		return ctrl.Result{}, err
@@ -219,6 +222,11 @@ func (r *AzureASOManagedControlPlaneReconciler) reconcileNormal(ctx context.Cont
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to reconcile kubeconfig: %w", err)
 	}
+
+	asoManagedControlPlane.Status.Ready = !asoManagedControlPlane.Status.ControlPlaneEndpoint.IsZero()
+	// The AKS API doesn't allow us to distinguish between CAPI's definitions of "initialized" and "ready" so
+	// we treat them equivalently.
+	asoManagedControlPlane.Status.Initialized = asoManagedControlPlane.Status.Ready
 
 	return ctrl.Result{}, nil
 }

--- a/exp/controllers/azureasomanagedcontrolplane_controller_test.go
+++ b/exp/controllers/azureasomanagedcontrolplane_controller_test.go
@@ -181,6 +181,9 @@ func TestAzureASOManagedControlPlaneReconcile(t *testing.T) {
 					},
 				},
 			},
+			Status: infrav1exp.AzureASOManagedControlPlaneStatus{
+				Ready: true,
+			},
 		}
 		c := fakeClientBuilder().
 			WithObjects(cluster, asoManagedControlPlane).
@@ -204,6 +207,9 @@ func TestAzureASOManagedControlPlaneReconcile(t *testing.T) {
 		result, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(asoManagedControlPlane)})
 		g.Expect(err).NotTo(HaveOccurred())
 		g.Expect(result).To(Equal(ctrl.Result{}))
+
+		g.Expect(c.Get(ctx, client.ObjectKeyFromObject(asoManagedControlPlane), asoManagedControlPlane)).To(Succeed())
+		g.Expect(asoManagedControlPlane.Status.Ready).To(BeFalse())
 	})
 
 	t.Run("successfully reconciles normally", func(t *testing.T) {
@@ -278,6 +284,9 @@ func TestAzureASOManagedControlPlaneReconcile(t *testing.T) {
 					},
 				},
 			},
+			Status: infrav1exp.AzureASOManagedControlPlaneStatus{
+				Ready: false,
+			},
 		}
 		c := fakeClientBuilder().
 			WithObjects(cluster, asoManagedControlPlane, managedCluster, kubeconfig).
@@ -309,6 +318,7 @@ func TestAzureASOManagedControlPlaneReconcile(t *testing.T) {
 		g.Expect(asoManagedControlPlane.Status.ControlPlaneEndpoint.Host).To(Equal("endpoint"))
 		g.Expect(asoManagedControlPlane.Status.Version).To(Equal("vCurrent"))
 		g.Expect(kubeConfigPatched).To(BeTrue())
+		g.Expect(asoManagedControlPlane.Status.Ready).To(BeTrue())
 	})
 
 	t.Run("successfully reconciles pause", func(t *testing.T) {

--- a/exp/controllers/azureasomanagedmachinepool_controller.go
+++ b/exp/controllers/azureasomanagedmachinepool_controller.go
@@ -149,6 +149,8 @@ func (r *AzureASOManagedMachinePoolReconciler) Reconcile(ctx context.Context, re
 		}
 	}()
 
+	asoManagedMachinePool.Status.Ready = false
+
 	machinePool, err := utilexp.GetOwnerMachinePool(ctx, r.Client, asoManagedMachinePool.ObjectMeta)
 	if err != nil {
 		return ctrl.Result{}, err
@@ -273,6 +275,8 @@ func (r *AzureASOManagedMachinePoolReconciler) reconcileNormal(ctx context.Conte
 	slices.Sort(providerIDs)
 	asoManagedMachinePool.Spec.ProviderIDList = providerIDs
 	asoManagedMachinePool.Status.Replicas = int32(ptr.Deref(agentPool.Status.Count, 0))
+
+	asoManagedMachinePool.Status.Ready = true
 
 	return ctrl.Result{}, nil
 }

--- a/exp/controllers/azureasomanagedmachinepool_controller_test.go
+++ b/exp/controllers/azureasomanagedmachinepool_controller_test.go
@@ -239,6 +239,9 @@ func TestAzureASOManagedMachinePoolReconcile(t *testing.T) {
 					},
 				},
 			},
+			Status: infrav1exp.AzureASOManagedMachinePoolStatus{
+				Ready: true,
+			},
 		}
 		machinePool := &expv1.MachinePool{
 			ObjectMeta: metav1.ObjectMeta{
@@ -271,6 +274,9 @@ func TestAzureASOManagedMachinePoolReconcile(t *testing.T) {
 		result, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(asoManagedMachinePool)})
 		g.Expect(err).NotTo(HaveOccurred())
 		g.Expect(result).To(Equal(ctrl.Result{}))
+
+		g.Expect(r.Get(ctx, client.ObjectKeyFromObject(asoManagedMachinePool), asoManagedMachinePool)).To(Succeed())
+		g.Expect(asoManagedMachinePool.Status.Ready).To(BeFalse())
 	})
 
 	t.Run("successfully reconciles normally", func(t *testing.T) {
@@ -336,6 +342,9 @@ func TestAzureASOManagedMachinePoolReconcile(t *testing.T) {
 					},
 				},
 			},
+			Status: infrav1exp.AzureASOManagedMachinePoolStatus{
+				Ready: false,
+			},
 		}
 		machinePool := &expv1.MachinePool{
 			ObjectMeta: metav1.ObjectMeta{
@@ -400,6 +409,7 @@ func TestAzureASOManagedMachinePoolReconcile(t *testing.T) {
 		g.Expect(r.Get(ctx, client.ObjectKeyFromObject(asoManagedMachinePool), asoManagedMachinePool)).To(Succeed())
 		g.Expect(asoManagedMachinePool.Spec.ProviderIDList).To(ConsistOf("azure://node1", "azure://node2"))
 		g.Expect(asoManagedMachinePool.Status.Replicas).To(Equal(int32(3)))
+		g.Expect(asoManagedMachinePool.Status.Ready).To(BeTrue())
 	})
 
 	t.Run("successfully reconciles pause", func(t *testing.T) {


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind feature

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

This PR reconciles the `status.ready` field for each of the ASOAPI types per the CAPI provider contract.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #4713

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [ ] includes documentation
- [X] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
