### PR TITLE
restore manager bootstrap creds for subscription ID

### DIFF
--- a/config/capz/credentials.yaml
+++ b/config/capz/credentials.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: manager-bootstrap-credentials
+  namespace: system
+type: Opaque
+data:
+  subscription-id: ${AZURE_SUBSCRIPTION_ID_B64:=""}

--- a/config/capz/kustomization.yaml
+++ b/config/capz/kustomization.yaml
@@ -10,6 +10,7 @@ labels:
 
 resources:
 - namespace.yaml
+- credentials.yaml
 - ../crd
 - ../rbac
 - ../manager
@@ -19,6 +20,7 @@ resources:
 patches:
 - path: manager_image_patch.yaml
 - path: manager_pull_policy.yaml
+- path: manager_credentials_patch.yaml
 - path: manager_webhook_patch.yaml
 - path: validatingwebhookcainjection_patch.yaml
 - path: mutatingwebhookcainjection_patch.yaml

--- a/config/capz/manager_credentials_patch.yaml
+++ b/config/capz/manager_credentials_patch.yaml
@@ -1,0 +1,16 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        env:
+          - name: AZURE_SUBSCRIPTION_ID
+            valueFrom:
+              secretKeyRef:
+                name: manager-bootstrap-credentials
+                key: subscription-id


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

When we required AzureClusterIdentity starting in #3793, we removed the authentication environment variables from the CAPZ controller manager Pod, including `AZURE_SUBSCRIPTION_ID`. That value cannot be defined in an AzureClusterIdentity and is instead an optional field on AzureCluster and AzureManagedControlPlane. That "optional" qualifier requires that users are able to specify a subscription ID some other way. This PR restores the `AZURE_SUBSCRIPTION_ID` variable for the controller manager Pod and can be set when CAPZ is installed the same way it could have been in CAPZ v1.10 and earlier.

This is a near-term, backwards compatible fix to help us flesh out how we might want to modify the subscriptionID field longer-term in #4612.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4557

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [X] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
A regression making `spec.subsciptionID` required on AzureCluster and AzureManagedControlPlane has been fixed. Users can specify a global subscription ID with the `AZURE_SUBSCRIPTION_ID_B64` environment variable when CAPZ is installed as was possible in CAPZ v1.10 and earlier.
```
