### PR TITLE
Add DisableExtensionOperations field

### DIFF
--- a/api/v1beta1/azuremachine_types.go
+++ b/api/v1beta1/azuremachine_types.go
@@ -132,6 +132,12 @@ type AzureMachineSpec struct {
 	// +optional
 	DNSServers []string `json:"dnsServers,omitempty"`
 
+	// DisableExtensionOperations specifies whether extension operations should be disabled on the virtual machine.
+	// Use this setting only if VMExtensions are not supported by your image, as it disables CAPZ bootstrapping extension used for detecting Kubernetes bootstrap failure.
+	// This may only be set to True when no extensions are configured on the virtual machine.
+	// +optional
+	DisableExtensionOperations *bool `json:"disableExtensionOperations,omitempty"`
+
 	// VMExtensions specifies a list of extensions to be added to the virtual machine.
 	// +optional
 	VMExtensions []VMExtension `json:"vmExtensions,omitempty"`

--- a/api/v1beta1/azuremachine_webhook.go
+++ b/api/v1beta1/azuremachine_webhook.go
@@ -213,6 +213,13 @@ func (mw *azureMachineWebhook) ValidateUpdate(ctx context.Context, oldObj, newOb
 		allErrs = append(allErrs, err)
 	}
 
+	if err := webhookutils.ValidateImmutable(
+		field.NewPath("spec", "disableExtensionOperations"),
+		old.Spec.DisableExtensionOperations,
+		m.Spec.DisableExtensionOperations); err != nil {
+		allErrs = append(allErrs, err)
+	}
+
 	if len(allErrs) == 0 {
 		return nil, nil
 	}

--- a/api/v1beta1/azuremachine_webhook_test.go
+++ b/api/v1beta1/azuremachine_webhook_test.go
@@ -230,6 +230,16 @@ func TestAzureMachine_ValidateCreate(t *testing.T) {
 			machine: createMachineWithCapacityReservaionGroupID("invalid-capacity-group-id"),
 			wantErr: true,
 		},
+		{
+			name:    "azuremachine with DisableExtensionOperations true and without VMExtensions",
+			machine: createMachineWithDisableExtenionOperations(),
+			wantErr: false,
+		},
+		{
+			name:    "azuremachine with DisableExtensionOperations true and with VMExtension",
+			machine: createMachineWithDisableExtenionOperationsAndHasExtension(),
+			wantErr: true,
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -779,6 +789,34 @@ func TestAzureMachine_ValidateUpdate(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "invalidTest: azuremachine.spec.disableExtensionOperations is immutable",
+			oldMachine: &AzureMachine{
+				Spec: AzureMachineSpec{
+					DisableExtensionOperations: ptr.To(true),
+				},
+			},
+			newMachine: &AzureMachine{
+				Spec: AzureMachineSpec{
+					DisableExtensionOperations: ptr.To(false),
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "validTest: azuremachine.spec.disableExtensionOperations is immutable",
+			oldMachine: &AzureMachine{
+				Spec: AzureMachineSpec{
+					DisableExtensionOperations: ptr.To(true),
+				},
+			},
+			newMachine: &AzureMachine{
+				Spec: AzureMachineSpec{
+					DisableExtensionOperations: ptr.To(true),
+				},
+			},
+			wantErr: false,
+		},
+		{
 			name: "validTest: azuremachine.spec.networkInterfaces is immutable",
 			oldMachine: &AzureMachine{
 				Spec: AzureMachineSpec{
@@ -1151,6 +1189,31 @@ func createMachineWithCapacityReservaionGroupID(capacityReservationGroupID strin
 			SSHPublicKey:               validSSHPublicKey,
 			OSDisk:                     validOSDisk,
 			CapacityReservationGroupID: strPtr,
+		},
+	}
+}
+
+func createMachineWithDisableExtenionOperationsAndHasExtension() *AzureMachine {
+	return &AzureMachine{
+		Spec: AzureMachineSpec{
+			SSHPublicKey:               validSSHPublicKey,
+			OSDisk:                     validOSDisk,
+			DisableExtensionOperations: ptr.To(true),
+			VMExtensions: []VMExtension{{
+				Name:      "test-extension",
+				Publisher: "test-publiher",
+				Version:   "v0.0.1-test",
+			}},
+		},
+	}
+}
+
+func createMachineWithDisableExtenionOperations() *AzureMachine {
+	return &AzureMachine{
+		Spec: AzureMachineSpec{
+			SSHPublicKey:               validSSHPublicKey,
+			OSDisk:                     validOSDisk,
+			DisableExtensionOperations: ptr.To(true),
 		},
 	}
 }

--- a/api/v1beta1/azuremachinetemplate_webhook.go
+++ b/api/v1beta1/azuremachinetemplate_webhook.go
@@ -24,6 +24,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/cluster-api/util/topology"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
@@ -83,6 +84,10 @@ func (r *AzureMachineTemplate) ValidateCreate(ctx context.Context, obj runtime.O
 		if networkInterface.PrivateIPConfigs < 1 {
 			allErrs = append(allErrs, field.Invalid(field.NewPath("AzureMachineTemplate", "spec", "template", "spec", "networkInterfaces", "privateIPConfigs"), r.Spec.Template.Spec.NetworkInterfaces[i].PrivateIPConfigs, "networkInterface privateIPConfigs must be set to a minimum value of 1"))
 		}
+	}
+
+	if ptr.Deref(r.Spec.Template.Spec.DisableExtensionOperations, false) && len(r.Spec.Template.Spec.VMExtensions) > 0 {
+		allErrs = append(allErrs, field.Forbidden(field.NewPath("AzureMachineTemplate", "spec", "template", "spec", "VMExtensions"), "VMExtensions must be empty when DisableExtensionOperations is true"))
 	}
 
 	if len(allErrs) == 0 {

--- a/api/v1beta1/azuremachinetemplate_webhook_test.go
+++ b/api/v1beta1/azuremachinetemplate_webhook_test.go
@@ -144,6 +144,16 @@ func TestAzureMachineTemplate_ValidateCreate(t *testing.T) {
 			wantErr:         true,
 		},
 		{
+			name:            "azuremachinetemplate with DisableExtensionOperations true and without VMExtensions",
+			machineTemplate: createAzureMachineTemplateFromMachine(createMachineWithDisableExtenionOperations()),
+			wantErr:         false,
+		},
+		{
+			name:            "azuremachinetempalte with DisableExtensionOperations true and with VMExtension",
+			machineTemplate: createAzureMachineTemplateFromMachine(createMachineWithDisableExtenionOperationsAndHasExtension()),
+			wantErr:         true,
+		},
+		{
 			name:            "azuremachinetemplate without RoleAssignmentName",
 			machineTemplate: createAzureMachineTemplateFromMachine(createMachineWithoutRoleAssignmentName()),
 			wantErr:         false,

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -934,6 +934,11 @@ func (in *AzureMachineSpec) DeepCopyInto(out *AzureMachineSpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.DisableExtensionOperations != nil {
+		in, out := &in.DisableExtensionOperations, &out.DisableExtensionOperations
+		*out = new(bool)
+		**out = **in
+	}
 	if in.VMExtensions != nil {
 		in, out := &in.VMExtensions, &out.VMExtensions
 		*out = make([]VMExtension, len(*in))

--- a/azure/scope/machine.go
+++ b/azure/scope/machine.go
@@ -178,6 +178,7 @@ func (m *MachineScope) VMSpec() azure.ResourceSpecGetter {
 		SpotVMOptions:              m.AzureMachine.Spec.SpotVMOptions,
 		SecurityProfile:            m.AzureMachine.Spec.SecurityProfile,
 		DiagnosticsProfile:         m.AzureMachine.Spec.Diagnostics,
+		DisableExtensionOperations: ptr.Deref(m.AzureMachine.Spec.DisableExtensionOperations, false),
 		AdditionalTags:             m.AdditionalTags(),
 		AdditionalCapabilities:     m.AzureMachine.Spec.AdditionalCapabilities,
 		CapacityReservationGroupID: m.GetCapacityReservationGroupID(),
@@ -374,6 +375,10 @@ func (m *MachineScope) HasSystemAssignedIdentity() bool {
 
 // VMExtensionSpecs returns the VM extension specs.
 func (m *MachineScope) VMExtensionSpecs() []azure.ResourceSpecGetter {
+	if ptr.Deref(m.AzureMachine.Spec.DisableExtensionOperations, false) {
+		return []azure.ResourceSpecGetter{}
+	}
+
 	var extensionSpecs = []azure.ResourceSpecGetter{}
 	for _, extension := range m.AzureMachine.Spec.VMExtensions {
 		extensionSpecs = append(extensionSpecs, &vmextensions.VMExtensionSpec{

--- a/azure/scope/machine_test.go
+++ b/azure/scope/machine_test.go
@@ -599,6 +599,44 @@ func TestMachineScope_VMExtensionSpecs(t *testing.T) {
 			},
 		},
 		{
+			name: "If OS type is Linux and cloud is AzurePublicCloud and DisableExtensionOperations is true, it returns empty",
+			machineScope: MachineScope{
+				Machine: &clusterv1.Machine{},
+				AzureMachine: &infrav1.AzureMachine{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "machine-name",
+					},
+					Spec: infrav1.AzureMachineSpec{
+						DisableExtensionOperations: ptr.To(true),
+						OSDisk: infrav1.OSDisk{
+							OSType: "Linux",
+						},
+					},
+				},
+				ClusterScoper: &ClusterScope{
+					AzureClients: AzureClients{
+						EnvironmentSettings: auth.EnvironmentSettings{
+							Environment: azureautorest.Environment{
+								Name: azureautorest.PublicCloud.Name,
+							},
+						},
+					},
+					AzureCluster: &infrav1.AzureCluster{
+						Spec: infrav1.AzureClusterSpec{
+							ResourceGroup: "my-rg",
+							AzureClusterClassSpec: infrav1.AzureClusterClassSpec{
+								Location: "westus",
+							},
+						},
+					},
+				},
+				cache: &MachineCache{
+					VMSKU: resourceskus.SKU{},
+				},
+			},
+			want: []azure.ResourceSpecGetter{},
+		},
+		{
 			name: "If OS type is Linux and cloud is not AzurePublicCloud, it returns empty",
 			machineScope: MachineScope{
 				Machine: &clusterv1.Machine{},

--- a/azure/services/virtualmachines/spec.go
+++ b/azure/services/virtualmachines/spec.go
@@ -53,6 +53,7 @@ type VMSpec struct {
 	AdditionalTags             infrav1.Tags
 	AdditionalCapabilities     *infrav1.AdditionalCapabilities
 	DiagnosticsProfile         *infrav1.Diagnostics
+	DisableExtensionOperations bool
 	CapacityReservationGroupID string
 	SKU                        resourceskus.SKU
 	Image                      *infrav1.Image
@@ -263,9 +264,10 @@ func (s *VMSpec) generateOSProfile() (*armcompute.OSProfile, error) {
 	}
 
 	osProfile := &armcompute.OSProfile{
-		ComputerName:  ptr.To(s.Name),
-		AdminUsername: ptr.To(azure.DefaultUserName),
-		CustomData:    ptr.To(s.BootstrapData),
+		ComputerName:             ptr.To(s.Name),
+		AdminUsername:            ptr.To(azure.DefaultUserName),
+		CustomData:               ptr.To(s.BootstrapData),
+		AllowExtensionOperations: ptr.To(!s.DisableExtensionOperations),
 	}
 
 	switch s.OSDisk.OSType {

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremachines.yaml
@@ -238,6 +238,12 @@ spec:
                     - storageAccountType
                     type: object
                 type: object
+              disableExtensionOperations:
+                description: |-
+                  DisableExtensionOperations specifies whether extension operations should be disabled on the virtual machine.
+                  Use this setting only if VMExtensions are not supported by your image, as it disables CAPZ bootstrapping extension used for detecting Kubernetes bootstrap failure.
+                  This may only be set to True when no extensions are configured on the virtual machine.
+                type: boolean
               dnsServers:
                 description: DNSServers adds a list of DNS Server IP addresses to
                   the VM NICs.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremachinetemplates.yaml
@@ -253,6 +253,12 @@ spec:
                             - storageAccountType
                             type: object
                         type: object
+                      disableExtensionOperations:
+                        description: |-
+                          DisableExtensionOperations specifies whether extension operations should be disabled on the virtual machine.
+                          Use this setting only if VMExtensions are not supported by your image, as it disables CAPZ bootstrapping extension used for detecting Kubernetes bootstrap failure.
+                          This may only be set to True when no extensions are configured on the virtual machine.
+                        type: boolean
                       dnsServers:
                         description: DNSServers adds a list of DNS Server IP addresses
                           to the VM NICs.


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

/kind feature
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
This PR adds a new field to machine spec DisableExtensionOperations that when set to true ensures that no VMExtensions are configured on the machine by preventing users to add values to VMExtensions field in machine template and setting AllowExtensionOperations false in the instance osProfile.
Setting DisableExtensionOperations also disables the bootstrap failure detection VMExtension.

The intent of this change is to provide a way to create VMs that use images without the capability of running VMExtensions. Currently, these machines get stuck waiting for the bootstrapping VMExtension to get installed.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [ ] includes documentation
- [X] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add option DisableExtensionOperations to disable VMExtensions
```

/cc @damdo @JoelSpeed 
