### PR TITLE
ASOAPI: add resource mutator framework

### DIFF
--- a/exp/controllers/azureasomanagedcontrolplane_controller.go
+++ b/exp/controllers/azureasomanagedcontrolplane_controller.go
@@ -180,7 +180,7 @@ func (r *AzureASOManagedControlPlaneReconciler) reconcileNormal(ctx context.Cont
 		return ctrl.Result{Requeue: true}, nil
 	}
 
-	resources, err := mutators.ApplyMutators(ctx, asoManagedControlPlane.Spec.Resources, mutators.SetManagedClusterDefaults(asoManagedControlPlane))
+	resources, err := mutators.ApplyMutators(ctx, asoManagedControlPlane.Spec.Resources, mutators.SetManagedClusterDefaults(asoManagedControlPlane, cluster))
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/exp/controllers/azureasomanagedcontrolplane_controller.go
+++ b/exp/controllers/azureasomanagedcontrolplane_controller.go
@@ -180,7 +180,7 @@ func (r *AzureASOManagedControlPlaneReconciler) reconcileNormal(ctx context.Cont
 		return ctrl.Result{Requeue: true}, nil
 	}
 
-	resources, err := mutators.ApplyMutators(ctx, asoManagedControlPlane.Spec.Resources)
+	resources, err := mutators.ApplyMutators(ctx, asoManagedControlPlane.Spec.Resources, mutators.SetManagedClusterDefaults(asoManagedControlPlane))
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -194,7 +194,7 @@ func (r *AzureASOManagedControlPlaneReconciler) reconcileNormal(ctx context.Cont
 		}
 	}
 	if managedClusterName == "" {
-		return ctrl.Result{}, reconcile.TerminalError(fmt.Errorf("no %s ManagedCluster defined in AzureASOManagedControlPlane spec.resources", asocontainerservicev1.GroupVersion.Group))
+		return ctrl.Result{}, reconcile.TerminalError(mutators.ErrNoManagedClusterDefined)
 	}
 
 	resourceReconciler := r.newResourceReconciler(asoManagedControlPlane, resources)

--- a/exp/controllers/azureasomanagedcontrolplane_controller.go
+++ b/exp/controllers/azureasomanagedcontrolplane_controller.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	infracontroller "sigs.k8s.io/cluster-api-provider-azure/controllers"
 	infrav1exp "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1alpha1"
+	"sigs.k8s.io/cluster-api-provider-azure/exp/mutators"
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/controllers/external"
@@ -179,13 +180,13 @@ func (r *AzureASOManagedControlPlaneReconciler) reconcileNormal(ctx context.Cont
 		return ctrl.Result{Requeue: true}, nil
 	}
 
-	us, err := resourcesToUnstructured(asoManagedControlPlane.Spec.Resources)
+	resources, err := mutators.ApplyMutators(ctx, asoManagedControlPlane.Spec.Resources)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
 
 	var managedClusterName string
-	for _, resource := range us {
+	for _, resource := range resources {
 		if resource.GroupVersionKind().Group == asocontainerservicev1.GroupVersion.Group &&
 			resource.GroupVersionKind().Kind == "ManagedCluster" {
 			managedClusterName = resource.GetName()
@@ -196,7 +197,7 @@ func (r *AzureASOManagedControlPlaneReconciler) reconcileNormal(ctx context.Cont
 		return ctrl.Result{}, reconcile.TerminalError(fmt.Errorf("no %s ManagedCluster defined in AzureASOManagedControlPlane spec.resources", asocontainerservicev1.GroupVersion.Group))
 	}
 
-	resourceReconciler := r.newResourceReconciler(asoManagedControlPlane, us)
+	resourceReconciler := r.newResourceReconciler(asoManagedControlPlane, resources)
 	err = resourceReconciler.Reconcile(ctx)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to reconcile resources: %w", err)
@@ -295,11 +296,11 @@ func (r *AzureASOManagedControlPlaneReconciler) reconcileDelete(ctx context.Cont
 	defer done()
 	log.V(4).Info("reconciling delete")
 
-	us, err := resourcesToUnstructured(asoManagedControlPlane.Spec.Resources)
+	resources, err := mutators.ToUnstructured(ctx, asoManagedControlPlane.Spec.Resources)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
-	resourceReconciler := r.newResourceReconciler(asoManagedControlPlane, us)
+	resourceReconciler := r.newResourceReconciler(asoManagedControlPlane, resources)
 	err = resourceReconciler.Delete(ctx)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to reconcile resources: %w", err)

--- a/exp/mutators/azureasomanagedcontrolplane.go
+++ b/exp/mutators/azureasomanagedcontrolplane.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mutators
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	asocontainerservicev1 "github.com/Azure/azure-service-operator/v2/api/containerservice/v1api20231001"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	infrav1exp "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1alpha1"
+	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+var (
+	// ErrNoManagedClusterDefined describes an AzureASOManagedControlPlane without a ManagedCluster.
+	ErrNoManagedClusterDefined = fmt.Errorf("no %s ManagedCluster defined in AzureASOManagedControlPlane spec.resources", asocontainerservicev1.GroupVersion.Group)
+)
+
+// SetManagedClusterDefaults propagates values defined by Cluster API to an ASO ManagedCluster.
+func SetManagedClusterDefaults(asoManagedControlPlane *infrav1exp.AzureASOManagedControlPlane) ResourcesMutator {
+	return func(ctx context.Context, us []*unstructured.Unstructured) error {
+		ctx, _, done := tele.StartSpanWithLogger(ctx, "mutators.SetManagedClusterDefaults")
+		defer done()
+
+		var managedCluster *unstructured.Unstructured
+		var managedClusterPath string
+		for i, u := range us {
+			if u.GroupVersionKind().Group == asocontainerservicev1.GroupVersion.Group &&
+				u.GroupVersionKind().Kind == "ManagedCluster" {
+				managedCluster = u
+				managedClusterPath = fmt.Sprintf("spec.resources[%d]", i)
+				break
+			}
+		}
+		if managedCluster == nil {
+			return reconcile.TerminalError(ErrNoManagedClusterDefined)
+		}
+
+		if err := setManagedClusterKubernetesVersion(ctx, asoManagedControlPlane, managedClusterPath, managedCluster); err != nil {
+			return err
+		}
+
+		return nil
+	}
+}
+
+func setManagedClusterKubernetesVersion(ctx context.Context, asoManagedControlPlane *infrav1exp.AzureASOManagedControlPlane, managedClusterPath string, managedCluster *unstructured.Unstructured) error {
+	_, log, done := tele.StartSpanWithLogger(ctx, "mutators.setManagedClusterKubernetesVersion")
+	defer done()
+
+	capzK8sVersion := strings.TrimPrefix(asoManagedControlPlane.Spec.Version, "v")
+	if capzK8sVersion == "" {
+		// When the CAPI contract field isn't set, any value for version in the embedded ASO resource may be specified.
+		return nil
+	}
+
+	k8sVersionPath := []string{"spec", "kubernetesVersion"}
+	userK8sVersion, k8sVersionFound, err := unstructured.NestedString(managedCluster.UnstructuredContent(), k8sVersionPath...)
+	if err != nil {
+		return err
+	}
+	setK8sVersion := mutation{
+		location: managedClusterPath + "." + strings.Join(k8sVersionPath, "."),
+		val:      capzK8sVersion,
+		reason:   "because spec.version is set to " + asoManagedControlPlane.Spec.Version,
+	}
+	if k8sVersionFound && userK8sVersion != capzK8sVersion {
+		return Incompatible{
+			mutation: setK8sVersion,
+			userVal:  userK8sVersion,
+		}
+	}
+	logMutation(log, setK8sVersion)
+	return unstructured.SetNestedField(managedCluster.UnstructuredContent(), capzK8sVersion, k8sVersionPath...)
+}

--- a/exp/mutators/azureasomanagedcontrolplane_test.go
+++ b/exp/mutators/azureasomanagedcontrolplane_test.go
@@ -1,0 +1,215 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mutators
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	asocontainerservicev1 "github.com/Azure/azure-service-operator/v2/api/containerservice/v1api20231001"
+	"github.com/google/go-cmp/cmp"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/ptr"
+	infrav1exp "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1alpha1"
+)
+
+func TestSetManagedClusterDefaults(t *testing.T) {
+	ctx := context.Background()
+	g := NewGomegaWithT(t)
+
+	tests := []struct {
+		name                   string
+		asoManagedControlPlane *infrav1exp.AzureASOManagedControlPlane
+		expected               []*unstructured.Unstructured
+		expectedErr            error
+	}{
+		{
+			name: "no ManagedCluster",
+			asoManagedControlPlane: &infrav1exp.AzureASOManagedControlPlane{
+				Spec: infrav1exp.AzureASOManagedControlPlaneSpec{
+					AzureASOManagedControlPlaneTemplateResourceSpec: infrav1exp.AzureASOManagedControlPlaneTemplateResourceSpec{
+						Resources: []runtime.RawExtension{},
+					},
+				},
+			},
+			expectedErr: ErrNoManagedClusterDefined,
+		},
+		{
+			name: "success",
+			asoManagedControlPlane: &infrav1exp.AzureASOManagedControlPlane{
+				Spec: infrav1exp.AzureASOManagedControlPlaneSpec{
+					AzureASOManagedControlPlaneTemplateResourceSpec: infrav1exp.AzureASOManagedControlPlaneTemplateResourceSpec{
+						Version: "vCAPI k8s version",
+						Resources: []runtime.RawExtension{
+							{
+								Raw: mcJSON(g, &asocontainerservicev1.ManagedCluster{}),
+							},
+						},
+					},
+				},
+			},
+			expected: []*unstructured.Unstructured{
+				mcUnstructured(g, &asocontainerservicev1.ManagedCluster{
+					Spec: asocontainerservicev1.ManagedCluster_Spec{
+						KubernetesVersion: ptr.To("CAPI k8s version"),
+					},
+				}),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+
+			mutator := SetManagedClusterDefaults(test.asoManagedControlPlane)
+			actual, err := ApplyMutators(ctx, test.asoManagedControlPlane.Spec.Resources, mutator)
+			if test.expectedErr != nil {
+				g.Expect(err).To(MatchError(test.expectedErr))
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
+			}
+			g.Expect(cmp.Diff(test.expected, actual)).To(BeEmpty())
+		})
+	}
+}
+
+func TestSetManagedClusterKubernetesVersion(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name                   string
+		asoManagedControlPlane *infrav1exp.AzureASOManagedControlPlane
+		managedCluster         *asocontainerservicev1.ManagedCluster
+		expected               *asocontainerservicev1.ManagedCluster
+		expectedErr            error
+	}{
+		{
+			name:                   "no CAPI opinion",
+			asoManagedControlPlane: &infrav1exp.AzureASOManagedControlPlane{},
+			managedCluster: &asocontainerservicev1.ManagedCluster{
+				Spec: asocontainerservicev1.ManagedCluster_Spec{
+					KubernetesVersion: ptr.To("user k8s version"),
+				},
+			},
+			expected: &asocontainerservicev1.ManagedCluster{
+				Spec: asocontainerservicev1.ManagedCluster_Spec{
+					KubernetesVersion: ptr.To("user k8s version"),
+				},
+			},
+		},
+		{
+			name: "set from CAPI opinion",
+			asoManagedControlPlane: &infrav1exp.AzureASOManagedControlPlane{
+				Spec: infrav1exp.AzureASOManagedControlPlaneSpec{
+					AzureASOManagedControlPlaneTemplateResourceSpec: infrav1exp.AzureASOManagedControlPlaneTemplateResourceSpec{
+						Version: "vCAPI k8s version",
+					},
+				},
+			},
+			managedCluster: &asocontainerservicev1.ManagedCluster{},
+			expected: &asocontainerservicev1.ManagedCluster{
+				Spec: asocontainerservicev1.ManagedCluster_Spec{
+					KubernetesVersion: ptr.To("CAPI k8s version"),
+				},
+			},
+		},
+		{
+			name: "user value matching CAPI ok",
+			asoManagedControlPlane: &infrav1exp.AzureASOManagedControlPlane{
+				Spec: infrav1exp.AzureASOManagedControlPlaneSpec{
+					AzureASOManagedControlPlaneTemplateResourceSpec: infrav1exp.AzureASOManagedControlPlaneTemplateResourceSpec{
+						Version: "vCAPI k8s version",
+					},
+				},
+			},
+			managedCluster: &asocontainerservicev1.ManagedCluster{
+				Spec: asocontainerservicev1.ManagedCluster_Spec{
+					KubernetesVersion: ptr.To("CAPI k8s version"),
+				},
+			},
+			expected: &asocontainerservicev1.ManagedCluster{
+				Spec: asocontainerservicev1.ManagedCluster_Spec{
+					KubernetesVersion: ptr.To("CAPI k8s version"),
+				},
+			},
+		},
+		{
+			name: "incompatible",
+			asoManagedControlPlane: &infrav1exp.AzureASOManagedControlPlane{
+				Spec: infrav1exp.AzureASOManagedControlPlaneSpec{
+					AzureASOManagedControlPlaneTemplateResourceSpec: infrav1exp.AzureASOManagedControlPlaneTemplateResourceSpec{
+						Version: "vCAPI k8s version",
+					},
+				},
+			},
+			managedCluster: &asocontainerservicev1.ManagedCluster{
+				Spec: asocontainerservicev1.ManagedCluster_Spec{
+					KubernetesVersion: ptr.To("user k8s version"),
+				},
+			},
+			expectedErr: Incompatible{
+				mutation: mutation{
+					location: ".spec.kubernetesVersion",
+					val:      "CAPI k8s version",
+					reason:   "because spec.version is set to vCAPI k8s version",
+				},
+				userVal: "user k8s version",
+			},
+		},
+	}
+
+	s := runtime.NewScheme()
+	NewGomegaWithT(t).Expect(asocontainerservicev1.AddToScheme(s)).To(Succeed())
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+
+			before := test.managedCluster.DeepCopy()
+			umc := mcUnstructured(g, test.managedCluster)
+
+			err := setManagedClusterKubernetesVersion(ctx, test.asoManagedControlPlane, "", umc)
+			g.Expect(s.Convert(umc, test.managedCluster, nil)).To(Succeed())
+			if test.expectedErr != nil {
+				g.Expect(err).To(MatchError(test.expectedErr))
+				g.Expect(cmp.Diff(before, test.managedCluster)).To(BeEmpty()) // errors should never modify the resource.
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(cmp.Diff(test.expected, test.managedCluster)).To(BeEmpty())
+			}
+		})
+	}
+}
+
+func mcJSON(g Gomega, mc *asocontainerservicev1.ManagedCluster) []byte {
+	mc.SetGroupVersionKind(asocontainerservicev1.GroupVersion.WithKind("ManagedCluster"))
+	j, err := json.Marshal(mc)
+	g.Expect(err).NotTo(HaveOccurred())
+	return j
+}
+
+func mcUnstructured(g Gomega, mc *asocontainerservicev1.ManagedCluster) *unstructured.Unstructured {
+	s := runtime.NewScheme()
+	g.Expect(asocontainerservicev1.AddToScheme(s)).To(Succeed())
+	u := &unstructured.Unstructured{}
+	g.Expect(s.Convert(mc, u, nil)).To(Succeed())
+	return u
+}

--- a/exp/mutators/mutator.go
+++ b/exp/mutators/mutator.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mutators
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+// ResourcesMutator mutates in-place a slice of ASO resources to be reconciled. These mutations make only the
+// changes strictly necessary for CAPZ resources to play nice with Cluster API. Any mutations should be logged
+// and mutations that conflict with user-defined values should be rejected by returning Incompatible.
+type ResourcesMutator func(context.Context, []*unstructured.Unstructured) error
+
+type mutation struct {
+	location string
+	val      any
+	reason   string
+}
+
+// Incompatible describes an error where a piece of user-defined configuration does not match what CAPZ
+// requires.
+type Incompatible struct {
+	mutation
+	userVal any
+}
+
+func (e Incompatible) Error() string {
+	return fmt.Sprintf("incompatible value: value at %s set by user to %v but CAPZ must set it to %v %s. The user-defined value must not be defined, or must match CAPZ's desired value.", e.location, e.userVal, e.val, e.reason)
+}
+
+// ApplyMutators applies the given mutators to the given resources.
+func ApplyMutators(ctx context.Context, resources []runtime.RawExtension, mutators ...ResourcesMutator) ([]*unstructured.Unstructured, error) {
+	us := []*unstructured.Unstructured{}
+	for _, resource := range resources {
+		u := &unstructured.Unstructured{}
+		if err := u.UnmarshalJSON(resource.Raw); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal resource JSON: %w", err)
+		}
+		us = append(us, u)
+	}
+	for _, mutator := range mutators {
+		if err := mutator(ctx, us); err != nil {
+			err = fmt.Errorf("failed to run mutator: %w", err)
+			if errors.As(err, &Incompatible{}) {
+				err = reconcile.TerminalError(err)
+			}
+			return nil, err
+		}
+	}
+	return us, nil
+}
+
+// ToUnstructured converts the given resources to Unstructured.
+func ToUnstructured(ctx context.Context, resources []runtime.RawExtension) ([]*unstructured.Unstructured, error) {
+	return ApplyMutators(ctx, resources)
+}

--- a/exp/mutators/mutator.go
+++ b/exp/mutators/mutator.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -35,6 +36,10 @@ type mutation struct {
 	location string
 	val      any
 	reason   string
+}
+
+func logMutation(log logr.Logger, mutation mutation) {
+	log.V(4).Info(fmt.Sprintf("setting %s to %v %s", mutation.location, mutation.val, mutation.reason))
 }
 
 // Incompatible describes an error where a piece of user-defined configuration does not match what CAPZ

--- a/exp/mutators/mutator_test.go
+++ b/exp/mutators/mutator_test.go
@@ -1,0 +1,118 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mutators
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func TestApplyMutators(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name        string
+		resources   []runtime.RawExtension
+		mutators    []ResourcesMutator
+		expected    []*unstructured.Unstructured
+		expectedErr error
+	}{
+		{
+			name: "no mutators",
+			resources: []runtime.RawExtension{
+				{Raw: []byte(`{"apiVersion": "v1", "kind": "SomeObject"}`)},
+			},
+			expected: []*unstructured.Unstructured{
+				{Object: map[string]interface{}{"apiVersion": "v1", "kind": "SomeObject"}},
+			},
+		},
+		{
+			name: "mutators apply in order",
+			resources: []runtime.RawExtension{
+				{Raw: []byte(`{"apiVersion": "v1", "kind": "SomeObject"}`)},
+			},
+			mutators: []ResourcesMutator{
+				func(_ context.Context, us []*unstructured.Unstructured) error {
+					us[0].Object["f1"] = "3"
+					us[0].Object["f2"] = "3"
+					us[0].Object["f3"] = "3"
+					return nil
+				},
+				func(_ context.Context, us []*unstructured.Unstructured) error {
+					us[0].Object["f1"] = "2"
+					us[0].Object["f2"] = "2"
+					return nil
+				},
+				func(_ context.Context, us []*unstructured.Unstructured) error {
+					us[0].Object["f1"] = "1"
+					return nil
+				},
+			},
+			expected: []*unstructured.Unstructured{
+				{
+					Object: map[string]interface{}{
+						"apiVersion": "v1",
+						"kind":       "SomeObject",
+						"f1":         "1",
+						"f2":         "2",
+						"f3":         "3",
+					},
+				},
+			},
+		},
+		{
+			name:      "error",
+			resources: []runtime.RawExtension{},
+			mutators: []ResourcesMutator{
+				func(_ context.Context, us []*unstructured.Unstructured) error {
+					return errors.New("mutator err")
+				},
+			},
+			expectedErr: errors.New("mutator err"),
+		},
+		{
+			name:      "incompatible is terminal",
+			resources: []runtime.RawExtension{},
+			mutators: []ResourcesMutator{
+				func(_ context.Context, us []*unstructured.Unstructured) error {
+					return Incompatible{}
+				},
+			},
+			expectedErr: reconcile.TerminalError(Incompatible{}),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+
+			actual, err := ApplyMutators(ctx, test.resources, test.mutators...)
+			if test.expectedErr != nil {
+				g.Expect(err).To(MatchError(test.expectedErr))
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
+			}
+			g.Expect(actual).To(Equal(test.expected))
+		})
+	}
+}


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

The main gap in the ASOAPI implementations at the moment is that certain parts of the CAPI API that map to Azure resource parameters, like MachinePool spec.replicas -> ManagedClustersAgentPool spec.count, are not ultimately propagated to ASO. This PR adds a framework for making those kinds of transformations and a few examples.

The way this works is roughly:
- Before the `spec.resources` are reconciled, some functions can be run to inject/modify values to the ASO resources (`mutators.ApplyMutators()`).
  - These dynamic values are \*not\* persisted back to the CAPZ resource because the ClusterClass controller will start to fight with CAPZ, to prevent duplicate data from appearing in CAPZ specs (e.g. AzureASOManagedControlPlane's `spec.version` and an embeddedManagedCluster's `spec.kubernetesVersion`), and to maintain the philosophy that `spec` is what's defined by the user.
- For each individual mutated field, CAPZ will return an error if the user defines a value that's different from what CAPZ needs to set. The error instructs the user to either match CAPZ or remove that field from their ASO resource embedded in the CAPZ spec.
- When optional CAPI fields, like MachinePool's `spec.template.spec.version`,  are nil, CAPZ will allow users to define the equivalent field on the ASO resource (ManagedClustersAgentPool's `spec.orchestratorVersion`) to any value allowed by Azure. In this context of a node pool's Kubernetes version, this allows users to leverage the AKS API's flexibility to define only MAJOR.MINOR versions which aren't allowed in the MachinePool API (#4111).
- Mutations are performed on unstructured representations of resources to reduce our dependence on knowledge of individual AKS API versions.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #4713

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [X] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
