### PR TITLE
ASOAPI: aggregate agentPoolProfiles for ManagedCluster create

### DIFF
--- a/main.go
+++ b/main.go
@@ -26,9 +26,12 @@ import (
 	"time"
 
 	// +kubebuilder:scaffold:imports
+	asocontainerservicev1api20210501 "github.com/Azure/azure-service-operator/v2/api/containerservice/v1api20210501"
+	asocontainerservicev1api20230201 "github.com/Azure/azure-service-operator/v2/api/containerservice/v1api20230201"
 	asocontainerservicev1api20230202preview "github.com/Azure/azure-service-operator/v2/api/containerservice/v1api20230202preview"
 	asocontainerservicev1api20230315preview "github.com/Azure/azure-service-operator/v2/api/containerservice/v1api20230315preview"
-	asocontainerservicev1 "github.com/Azure/azure-service-operator/v2/api/containerservice/v1api20231001"
+	asocontainerservicev1api20231001 "github.com/Azure/azure-service-operator/v2/api/containerservice/v1api20231001"
+	asocontainerservicev1api20231102preview "github.com/Azure/azure-service-operator/v2/api/containerservice/v1api20231102preview"
 	asokubernetesconfigurationv1 "github.com/Azure/azure-service-operator/v2/api/kubernetesconfiguration/v1api20230501"
 	asonetworkv1api20201101 "github.com/Azure/azure-service-operator/v2/api/network/v1api20201101"
 	asonetworkv1api20220701 "github.com/Azure/azure-service-operator/v2/api/network/v1api20220701"
@@ -82,11 +85,14 @@ func init() {
 	_ = expv1.AddToScheme(scheme)
 	_ = kubeadmv1.AddToScheme(scheme)
 	_ = asoresourcesv1.AddToScheme(scheme)
-	_ = asocontainerservicev1.AddToScheme(scheme)
+	_ = asocontainerservicev1api20210501.AddToScheme(scheme)
+	_ = asocontainerservicev1api20230201.AddToScheme(scheme)
+	_ = asocontainerservicev1api20231001.AddToScheme(scheme)
 	_ = asonetworkv1api20220701.AddToScheme(scheme)
 	_ = asonetworkv1api20201101.AddToScheme(scheme)
 	_ = asocontainerservicev1api20230202preview.AddToScheme(scheme)
 	_ = asocontainerservicev1api20230315preview.AddToScheme(scheme)
+	_ = asocontainerservicev1api20231102preview.AddToScheme(scheme)
 	_ = asokubernetesconfigurationv1.AddToScheme(scheme)
 	// +kubebuilder:scaffold:scheme
 }

--- a/templates/cluster-template-aks-aso-clusterclass.yaml
+++ b/templates/cluster-template-aks-aso-clusterclass.yaml
@@ -66,13 +66,6 @@ spec:
                     adminCredentials:
                       name: "{{ .builtin.cluster.name }}-kubeconfig"
                       key: value
-                # This agent pool only exists to avoid having to aggregate definitions
-                # from AzureASOManagedMachinePools. That will be done soon.
-                agentPoolProfiles:
-                - name: stub
-                  vmSize: ${AZURE_NODE_MACHINE_TYPE}
-                  mode: System
-                  count: 1
       selector:
         apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
         kind: AzureASOManagedControlPlaneTemplate

--- a/templates/cluster-template-aks-aso.yaml
+++ b/templates/cluster-template-aks-aso.yaml
@@ -27,11 +27,6 @@ spec:
         serviceoperator.azure.com/credential-from: ${ASO_CREDENTIAL_SECRET_NAME}
       name: ${CLUSTER_NAME}
     spec:
-      agentPoolProfiles:
-      - count: 1
-        mode: System
-        name: stub
-        vmSize: ${AZURE_NODE_MACHINE_TYPE}
       dnsPrefix: ${CLUSTER_NAME}
       identity:
         type: SystemAssigned

--- a/templates/flavors/aks-aso-clusterclass/clusterclass.yaml
+++ b/templates/flavors/aks-aso-clusterclass/clusterclass.yaml
@@ -101,13 +101,6 @@ spec:
                     adminCredentials:
                       name: "{{ .builtin.cluster.name }}-kubeconfig"
                       key: value
-                # This agent pool only exists to avoid having to aggregate definitions
-                # from AzureASOManagedMachinePools. That will be done soon.
-                agentPoolProfiles:
-                - name: stub
-                  vmSize: ${AZURE_NODE_MACHINE_TYPE}
-                  mode: System
-                  count: 1
   - name: azureasomanagedmachinepool-pool0-spec
     definitions:
     - selector:

--- a/templates/flavors/aks-aso/cluster-template.yaml
+++ b/templates/flavors/aks-aso/cluster-template.yaml
@@ -43,13 +43,6 @@ spec:
           adminCredentials:
             name: ${CLUSTER_NAME}-kubeconfig
             key: value
-      # This agent pool only exists to avoid having to aggregate definitions
-      # from AzureASOManagedMachinePools. That will be done soon.
-      agentPoolProfiles:
-      - name: stub
-        vmSize: ${AZURE_NODE_MACHINE_TYPE}
-        mode: System
-        count: 1
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
 kind: AzureASOManagedCluster

--- a/templates/test/ci/cluster-template-prow-aks-aso.yaml
+++ b/templates/test/ci/cluster-template-prow-aks-aso.yaml
@@ -27,11 +27,6 @@ spec:
         serviceoperator.azure.com/credential-from: ${ASO_CREDENTIAL_SECRET_NAME}
       name: ${CLUSTER_NAME}
     spec:
-      agentPoolProfiles:
-      - count: 1
-        mode: System
-        name: stub
-        vmSize: ${AZURE_NODE_MACHINE_TYPE}
       dnsPrefix: ${CLUSTER_NAME}
       identity:
         type: SystemAssigned


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

This PR leverages the mutator framework added in #4793 to aggregate the `spec.agentPoolProfiles` to be created alongside an ASO ManagedCluster to fulfill AKS's requirement that ManagedClusters must be created with at least one node pool. This is modeled after how CAPZ already handles this for AzureManagedControlPlanes.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #4713

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [ ] includes documentation
- [X] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
