### PR TITLE
ASOAPI: propagate machinepool values to ManagedClustersAgentPools

### DIFF
--- a/exp/api/v1alpha1/azureasomanagedmachinepool_types.go
+++ b/exp/api/v1alpha1/azureasomanagedmachinepool_types.go
@@ -20,8 +20,13 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// AzureASOManagedMachinePoolKind is the kind for AzureASOManagedMachinePool.
-const AzureASOManagedMachinePoolKind = "AzureASOManagedMachinePool"
+const (
+	// AzureASOManagedMachinePoolKind is the kind for AzureASOManagedMachinePool.
+	AzureASOManagedMachinePoolKind = "AzureASOManagedMachinePool"
+
+	// ReplicasManagedByAKS is the value of the CAPI replica manager annotation that maps to the AKS built-in autoscaler.
+	ReplicasManagedByAKS = "aks"
+)
 
 // AzureASOManagedMachinePoolSpec defines the desired state of AzureASOManagedMachinePool.
 type AzureASOManagedMachinePoolSpec struct {

--- a/exp/controllers/azureasomanagedmachinepool_controller.go
+++ b/exp/controllers/azureasomanagedmachinepool_controller.go
@@ -275,6 +275,9 @@ func (r *AzureASOManagedMachinePoolReconciler) reconcileNormal(ctx context.Conte
 	slices.Sort(providerIDs)
 	asoManagedMachinePool.Spec.ProviderIDList = providerIDs
 	asoManagedMachinePool.Status.Replicas = int32(ptr.Deref(agentPool.Status.Count, 0))
+	if machinePool.Annotations[clusterv1.ReplicasManagedByAnnotation] == infrav1exp.ReplicasManagedByAKS {
+		machinePool.Spec.Replicas = &asoManagedMachinePool.Status.Replicas
+	}
 
 	asoManagedMachinePool.Status.Ready = true
 

--- a/exp/mutators/azureasomanagedmachinepool.go
+++ b/exp/mutators/azureasomanagedmachinepool.go
@@ -1,0 +1,123 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mutators
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	asocontainerservicev1 "github.com/Azure/azure-service-operator/v2/api/containerservice/v1api20231001"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	infrav1exp "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1alpha1"
+	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
+	expv1 "sigs.k8s.io/cluster-api/exp/api/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+// ErrNoManagedClustersAgentPoolDefined describes an AzureASOManagedMachinePool without a ManagedClustersAgentPool.
+var ErrNoManagedClustersAgentPoolDefined = fmt.Errorf("no %s ManagedClustersAgentPools defined in AzureASOManagedMachinePool spec.resources", asocontainerservicev1.GroupVersion.Group)
+
+// SetAgentPoolDefaults propagates config from a MachinePool to an AzureASOManagedMachinePool's defined ManagedClustersAgentPool.
+func SetAgentPoolDefaults(asoManagedMachinePool *infrav1exp.AzureASOManagedMachinePool, machinePool *expv1.MachinePool) ResourcesMutator {
+	return func(ctx context.Context, us []*unstructured.Unstructured) error {
+		ctx, _, done := tele.StartSpanWithLogger(ctx, "mutators.SetAgentPoolDefaults")
+		defer done()
+
+		var agentPool *unstructured.Unstructured
+		var agentPoolPath string
+		for i, u := range us {
+			if u.GroupVersionKind().Group == asocontainerservicev1.GroupVersion.Group &&
+				u.GroupVersionKind().Kind == "ManagedClustersAgentPool" {
+				agentPool = u
+				agentPoolPath = fmt.Sprintf("spec.resources[%d]", i)
+				break
+			}
+		}
+		if agentPool == nil {
+			return reconcile.TerminalError(ErrNoManagedClustersAgentPoolDefined)
+		}
+
+		if err := setAgentPoolOrchestratorVersion(ctx, machinePool, agentPoolPath, agentPool); err != nil {
+			return err
+		}
+
+		if err := setAgentPoolCount(ctx, machinePool, agentPoolPath, agentPool); err != nil {
+			return err
+		}
+
+		return nil
+	}
+}
+
+func setAgentPoolOrchestratorVersion(ctx context.Context, machinePool *expv1.MachinePool, agentPoolPath string, agentPool *unstructured.Unstructured) error {
+	_, log, done := tele.StartSpanWithLogger(ctx, "mutators.setAgentPoolOrchestratorVersion")
+	defer done()
+
+	if machinePool.Spec.Template.Spec.Version == nil {
+		return nil
+	}
+
+	k8sVersionPath := []string{"spec", "orchestratorVersion"}
+	capiK8sVersion := strings.TrimPrefix(*machinePool.Spec.Template.Spec.Version, "v")
+	userK8sVersion, k8sVersionFound, err := unstructured.NestedString(agentPool.UnstructuredContent(), k8sVersionPath...)
+	if err != nil {
+		return err
+	}
+	setK8sVersion := mutation{
+		location: agentPoolPath + "." + strings.Join(k8sVersionPath, "."),
+		val:      capiK8sVersion,
+		reason:   fmt.Sprintf("because MachinePool %s's spec.template.spec.version is %s", machinePool.Name, *machinePool.Spec.Template.Spec.Version),
+	}
+	if k8sVersionFound && userK8sVersion != capiK8sVersion {
+		return Incompatible{
+			mutation: setK8sVersion,
+			userVal:  userK8sVersion,
+		}
+	}
+	logMutation(log, setK8sVersion)
+	return unstructured.SetNestedField(agentPool.UnstructuredContent(), capiK8sVersion, k8sVersionPath...)
+}
+
+func setAgentPoolCount(ctx context.Context, machinePool *expv1.MachinePool, agentPoolPath string, agentPool *unstructured.Unstructured) error {
+	_, log, done := tele.StartSpanWithLogger(ctx, "mutators.setAgentPoolOrchestratorVersion")
+	defer done()
+
+	if machinePool.Spec.Replicas == nil {
+		return nil
+	}
+
+	countPath := []string{"spec", "count"}
+	capiCount := int64(*machinePool.Spec.Replicas)
+	userCount, countFound, err := unstructured.NestedInt64(agentPool.UnstructuredContent(), countPath...)
+	if err != nil {
+		return err
+	}
+	setCount := mutation{
+		location: agentPoolPath + "." + strings.Join(countPath, "."),
+		val:      capiCount,
+		reason:   fmt.Sprintf("because MachinePool %s's spec.replicas is %d", machinePool.Name, capiCount),
+	}
+	if countFound && userCount != capiCount {
+		return Incompatible{
+			mutation: setCount,
+			userVal:  userCount,
+		}
+	}
+	logMutation(log, setCount)
+	return unstructured.SetNestedField(agentPool.UnstructuredContent(), capiCount, countPath...)
+}

--- a/exp/mutators/azureasomanagedmachinepool_test.go
+++ b/exp/mutators/azureasomanagedmachinepool_test.go
@@ -1,0 +1,347 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mutators
+
+import (
+	"context"
+	"testing"
+
+	asocontainerservicev1 "github.com/Azure/azure-service-operator/v2/api/containerservice/v1api20231001"
+	"github.com/google/go-cmp/cmp"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/ptr"
+	infrav1exp "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1alpha1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	expv1 "sigs.k8s.io/cluster-api/exp/api/v1beta1"
+)
+
+func TestSetAgentPoolDefaults(t *testing.T) {
+	ctx := context.Background()
+	g := NewGomegaWithT(t)
+
+	tests := []struct {
+		name                  string
+		asoManagedMachinePool *infrav1exp.AzureASOManagedMachinePool
+		machinePool           *expv1.MachinePool
+		expected              []*unstructured.Unstructured
+		expectedErr           error
+	}{
+		{
+			name: "no ManagedClustersAgentPool",
+			asoManagedMachinePool: &infrav1exp.AzureASOManagedMachinePool{
+				Spec: infrav1exp.AzureASOManagedMachinePoolSpec{
+					AzureASOManagedMachinePoolTemplateResourceSpec: infrav1exp.AzureASOManagedMachinePoolTemplateResourceSpec{
+						Resources: []runtime.RawExtension{},
+					},
+				},
+			},
+			expectedErr: ErrNoManagedClustersAgentPoolDefined,
+		},
+		{
+			name: "success",
+			asoManagedMachinePool: &infrav1exp.AzureASOManagedMachinePool{
+				Spec: infrav1exp.AzureASOManagedMachinePoolSpec{
+					AzureASOManagedMachinePoolTemplateResourceSpec: infrav1exp.AzureASOManagedMachinePoolTemplateResourceSpec{
+						Resources: []runtime.RawExtension{
+							{
+								Raw: apJSON(g, &asocontainerservicev1.ManagedClustersAgentPool{}),
+							},
+						},
+					},
+				},
+			},
+			machinePool: &expv1.MachinePool{
+				Spec: expv1.MachinePoolSpec{
+					Replicas: ptr.To[int32](1),
+					Template: clusterv1.MachineTemplateSpec{
+						Spec: clusterv1.MachineSpec{
+							Version: ptr.To("vcapi k8s version"),
+						},
+					},
+				},
+			},
+			expected: []*unstructured.Unstructured{
+				apUnstructured(g, &asocontainerservicev1.ManagedClustersAgentPool{
+					Spec: asocontainerservicev1.ManagedClusters_AgentPool_Spec{
+						OrchestratorVersion: ptr.To("capi k8s version"),
+						Count:               ptr.To(1),
+					},
+				}),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+
+			mutator := SetAgentPoolDefaults(test.asoManagedMachinePool, test.machinePool)
+			actual, err := ApplyMutators(ctx, test.asoManagedMachinePool.Spec.Resources, mutator)
+			if test.expectedErr != nil {
+				g.Expect(err).To(MatchError(test.expectedErr))
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
+			}
+			g.Expect(cmp.Diff(test.expected, actual)).To(BeEmpty())
+		})
+	}
+}
+
+func TestSetAgentPoolOrchestratorVersion(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name        string
+		machinePool *expv1.MachinePool
+		agentPool   *asocontainerservicev1.ManagedClustersAgentPool
+		expected    *asocontainerservicev1.ManagedClustersAgentPool
+		expectedErr error
+	}{
+		{
+			name: "no CAPI opinion",
+			machinePool: &expv1.MachinePool{
+				Spec: expv1.MachinePoolSpec{
+					Template: clusterv1.MachineTemplateSpec{
+						Spec: clusterv1.MachineSpec{
+							Version: nil,
+						},
+					},
+				},
+			},
+			agentPool: &asocontainerservicev1.ManagedClustersAgentPool{
+				Spec: asocontainerservicev1.ManagedClusters_AgentPool_Spec{
+					OrchestratorVersion: ptr.To("user k8s version"),
+				},
+			},
+			expected: &asocontainerservicev1.ManagedClustersAgentPool{
+				Spec: asocontainerservicev1.ManagedClusters_AgentPool_Spec{
+					OrchestratorVersion: ptr.To("user k8s version"),
+				},
+			},
+		},
+		{
+			name: "set from CAPI opinion",
+			machinePool: &expv1.MachinePool{
+				Spec: expv1.MachinePoolSpec{
+					Template: clusterv1.MachineTemplateSpec{
+						Spec: clusterv1.MachineSpec{
+							Version: ptr.To("vcapi k8s version"),
+						},
+					},
+				},
+			},
+			agentPool: &asocontainerservicev1.ManagedClustersAgentPool{
+				Spec: asocontainerservicev1.ManagedClusters_AgentPool_Spec{
+					OrchestratorVersion: nil,
+				},
+			},
+			expected: &asocontainerservicev1.ManagedClustersAgentPool{
+				Spec: asocontainerservicev1.ManagedClusters_AgentPool_Spec{
+					OrchestratorVersion: ptr.To("capi k8s version"),
+				},
+			},
+		},
+		{
+			name: "user value matching CAPI ok",
+			machinePool: &expv1.MachinePool{
+				Spec: expv1.MachinePoolSpec{
+					Template: clusterv1.MachineTemplateSpec{
+						Spec: clusterv1.MachineSpec{
+							Version: ptr.To("vcapi k8s version"),
+						},
+					},
+				},
+			},
+			agentPool: &asocontainerservicev1.ManagedClustersAgentPool{
+				Spec: asocontainerservicev1.ManagedClusters_AgentPool_Spec{
+					OrchestratorVersion: ptr.To("capi k8s version"),
+				},
+			},
+			expected: &asocontainerservicev1.ManagedClustersAgentPool{
+				Spec: asocontainerservicev1.ManagedClusters_AgentPool_Spec{
+					OrchestratorVersion: ptr.To("capi k8s version"),
+				},
+			},
+		},
+		{
+			name: "incompatible",
+			machinePool: &expv1.MachinePool{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "mp",
+				},
+				Spec: expv1.MachinePoolSpec{
+					Template: clusterv1.MachineTemplateSpec{
+						Spec: clusterv1.MachineSpec{
+							Version: ptr.To("vcapi k8s version"),
+						},
+					},
+				},
+			},
+			agentPool: &asocontainerservicev1.ManagedClustersAgentPool{
+				Spec: asocontainerservicev1.ManagedClusters_AgentPool_Spec{
+					OrchestratorVersion: ptr.To("user k8s version"),
+				},
+			},
+			expectedErr: Incompatible{
+				mutation: mutation{
+					location: ".spec.orchestratorVersion",
+					val:      "capi k8s version",
+					reason:   "because MachinePool mp's spec.template.spec.version is vcapi k8s version",
+				},
+				userVal: "user k8s version",
+			},
+		},
+	}
+
+	s := runtime.NewScheme()
+	NewGomegaWithT(t).Expect(asocontainerservicev1.AddToScheme(s)).To(Succeed())
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+
+			before := test.agentPool.DeepCopy()
+			uap := apUnstructured(g, test.agentPool)
+
+			err := setAgentPoolOrchestratorVersion(ctx, test.machinePool, "", uap)
+			g.Expect(s.Convert(uap, test.agentPool, nil)).To(Succeed())
+			if test.expectedErr != nil {
+				g.Expect(err).To(MatchError(test.expectedErr))
+				g.Expect(cmp.Diff(before, test.agentPool)).To(BeEmpty()) // errors should never modify the resource.
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(cmp.Diff(test.expected, test.agentPool)).To(BeEmpty())
+			}
+		})
+	}
+}
+
+func TestSetAgentPoolCount(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name        string
+		machinePool *expv1.MachinePool
+		agentPool   *asocontainerservicev1.ManagedClustersAgentPool
+		expected    *asocontainerservicev1.ManagedClustersAgentPool
+		expectedErr error
+	}{
+		{
+			name: "no CAPI opinion",
+			machinePool: &expv1.MachinePool{
+				Spec: expv1.MachinePoolSpec{
+					Replicas: nil,
+				},
+			},
+			agentPool: &asocontainerservicev1.ManagedClustersAgentPool{
+				Spec: asocontainerservicev1.ManagedClusters_AgentPool_Spec{
+					Count: ptr.To(2),
+				},
+			},
+			expected: &asocontainerservicev1.ManagedClustersAgentPool{
+				Spec: asocontainerservicev1.ManagedClusters_AgentPool_Spec{
+					Count: ptr.To(2),
+				},
+			},
+		},
+		{
+			name: "set from CAPI opinion",
+			machinePool: &expv1.MachinePool{
+				Spec: expv1.MachinePoolSpec{
+					Replicas: ptr.To[int32](1),
+				},
+			},
+			agentPool: &asocontainerservicev1.ManagedClustersAgentPool{
+				Spec: asocontainerservicev1.ManagedClusters_AgentPool_Spec{
+					OrchestratorVersion: nil,
+				},
+			},
+			expected: &asocontainerservicev1.ManagedClustersAgentPool{
+				Spec: asocontainerservicev1.ManagedClusters_AgentPool_Spec{
+					Count: ptr.To(1),
+				},
+			},
+		},
+		{
+			name: "user value matching CAPI ok",
+			machinePool: &expv1.MachinePool{
+				Spec: expv1.MachinePoolSpec{
+					Replicas: ptr.To[int32](1),
+				},
+			},
+			agentPool: &asocontainerservicev1.ManagedClustersAgentPool{
+				Spec: asocontainerservicev1.ManagedClusters_AgentPool_Spec{
+					Count: ptr.To(1),
+				},
+			},
+			expected: &asocontainerservicev1.ManagedClustersAgentPool{
+				Spec: asocontainerservicev1.ManagedClusters_AgentPool_Spec{
+					Count: ptr.To(1),
+				},
+			},
+		},
+		{
+			name: "incompatible",
+			machinePool: &expv1.MachinePool{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "mp",
+				},
+				Spec: expv1.MachinePoolSpec{
+					Replicas: ptr.To[int32](1),
+				},
+			},
+			agentPool: &asocontainerservicev1.ManagedClustersAgentPool{
+				Spec: asocontainerservicev1.ManagedClusters_AgentPool_Spec{
+					Count: ptr.To(2),
+				},
+			},
+			expectedErr: Incompatible{
+				mutation: mutation{
+					location: ".spec.count",
+					val:      int64(1),
+					reason:   "because MachinePool mp's spec.replicas is 1",
+				},
+				userVal: int64(2),
+			},
+		},
+	}
+
+	s := runtime.NewScheme()
+	NewGomegaWithT(t).Expect(asocontainerservicev1.AddToScheme(s)).To(Succeed())
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+
+			before := test.agentPool.DeepCopy()
+			uap := apUnstructured(g, test.agentPool)
+
+			err := setAgentPoolCount(ctx, test.machinePool, "", uap)
+			g.Expect(s.Convert(uap, test.agentPool, nil)).To(Succeed())
+			if test.expectedErr != nil {
+				g.Expect(err).To(MatchError(test.expectedErr))
+				g.Expect(cmp.Diff(before, test.agentPool)).To(BeEmpty()) // errors should never modify the resource.
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(cmp.Diff(test.expected, test.agentPool)).To(BeEmpty())
+			}
+		})
+	}
+}

--- a/templates/cluster-template-aks-aso.yaml
+++ b/templates/cluster-template-aks-aso.yaml
@@ -95,7 +95,6 @@ spec:
       name: ${CLUSTER_NAME}-pool0
     spec:
       azureName: pool0
-      count: ${WORKER_MACHINE_COUNT:=2}
       mode: System
       owner:
         name: ${CLUSTER_NAME}
@@ -137,7 +136,6 @@ spec:
       name: ${CLUSTER_NAME}-pool1
     spec:
       azureName: pool1
-      count: ${WORKER_MACHINE_COUNT:=2}
       mode: User
       owner:
         name: ${CLUSTER_NAME}

--- a/templates/flavors/aks-aso/cluster-template.yaml
+++ b/templates/flavors/aks-aso/cluster-template.yaml
@@ -97,8 +97,6 @@ spec:
       mode: System
       type: VirtualMachineScaleSets
       vmSize: ${AZURE_NODE_MACHINE_TYPE}
-      # Soon this will be derived from the MachinePool
-      count: ${WORKER_MACHINE_COUNT:=2}
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachinePool
@@ -138,5 +136,3 @@ spec:
       mode: User
       type: VirtualMachineScaleSets
       vmSize: ${AZURE_NODE_MACHINE_TYPE}
-      # Soon this will be derived from the MachinePool
-      count: ${WORKER_MACHINE_COUNT:=2}

--- a/templates/test/ci/cluster-template-prow-aks-aso.yaml
+++ b/templates/test/ci/cluster-template-prow-aks-aso.yaml
@@ -99,7 +99,6 @@ spec:
       name: ${CLUSTER_NAME}-pool0
     spec:
       azureName: pool0
-      count: ${WORKER_MACHINE_COUNT:=2}
       mode: System
       owner:
         name: ${CLUSTER_NAME}
@@ -141,7 +140,6 @@ spec:
       name: ${CLUSTER_NAME}-pool1
     spec:
       azureName: pool1
-      count: ${WORKER_MACHINE_COUNT:=2}
       mode: User
       owner:
         name: ${CLUSTER_NAME}
@@ -183,7 +181,6 @@ spec:
       name: ${CLUSTER_NAME}-pool2
     spec:
       azureName: pool2
-      count: 1
       mode: User
       osType: Windows
       owner:

--- a/templates/test/ci/prow-aks-aso/patches/aks-pool2.yaml
+++ b/templates/test/ci/prow-aks-aso/patches/aks-pool2.yaml
@@ -37,4 +37,3 @@ spec:
       type: VirtualMachineScaleSets
       vmSize: "${AZURE_AKS_NODE_MACHINE_TYPE:=Standard_D2s_v3}"
       osType: Windows
-      count: 1


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

This PR uses the ASOAPI mutator framework to set the Kubernetes version and replica count for ASO agent pools based on its owning MachinePool. It also includes handling for autoscaling AKS node pools.

The first commit in this PR is the same as what's queued up to merge in #4794. It should disappear from this PR automatically once that other PR merges. I'm electing to create this PR now to open up these new changes for feedback in the meantime.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #4713

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [X] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
