### PR TITLE
ASOAPI: basic automated adoption

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -58,12 +58,24 @@ rules:
   - cluster.x-k8s.io
   resources:
   - clusters
+  verbs:
+  - create
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - clusters
   - clusters/status
   verbs:
   - get
   - list
   - patch
   - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - machinepools
+  verbs:
+  - create
 - apiGroups:
   - cluster.x-k8s.io
   resources:

--- a/exp/controllers/agentpooladopt_controller.go
+++ b/exp/controllers/agentpooladopt_controller.go
@@ -1,0 +1,202 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"fmt"
+
+	asocontainerservicev1 "github.com/Azure/azure-service-operator/v2/api/containerservice/v1api20231001"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/ptr"
+	infrav1exp "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1alpha1"
+	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	expv1 "sigs.k8s.io/cluster-api/exp/api/v1beta1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+// AgentPoolAdoptReconciler adopts ASO ManagedClustersAgentPool resources into a CAPI Cluster.
+type AgentPoolAdoptReconciler struct {
+	client.Client
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *AgentPoolAdoptReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {
+	_, err := ctrl.NewControllerManagedBy(mgr).
+		For(&asocontainerservicev1.ManagedClustersAgentPool{}).
+		WithEventFilter(predicate.Funcs{
+			UpdateFunc: func(ev event.UpdateEvent) bool {
+				return ev.ObjectOld.GetAnnotations()[adoptAnnotation] != ev.ObjectNew.GetAnnotations()[adoptAnnotation]
+			},
+			DeleteFunc: func(_ event.DeleteEvent) bool { return false },
+		}).
+		Build(r)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// +kubebuilder:rbac:groups=cluster.x-k8s.io,resources=machinepools,verbs=create
+
+// Reconcile reconciles an AzureASOManagedCluster.
+func (r *AgentPoolAdoptReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, resultErr error) {
+	ctx, log, done := tele.StartSpanWithLogger(ctx,
+		"controllers.AgentPoolAdoptReconciler.Reconcile",
+		tele.KVP("namespace", req.Namespace),
+		tele.KVP("name", req.Name),
+		tele.KVP("kind", "ManagedCluster"),
+	)
+	defer done()
+
+	agentPool := &asocontainerservicev1.ManagedClustersAgentPool{}
+	err := r.Get(ctx, req.NamespacedName, agentPool)
+	if err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	if agentPool.GetAnnotations()[adoptAnnotation] != "true" {
+		return ctrl.Result{}, nil
+	}
+
+	for _, owner := range agentPool.GetOwnerReferences() {
+		if owner.APIVersion == infrav1exp.GroupVersion.Identifier() &&
+			owner.Kind == infrav1exp.AzureASOManagedMachinePoolKind {
+			return ctrl.Result{}, nil
+		}
+	}
+
+	log.Info("adopting")
+
+	namespace := agentPool.Namespace
+
+	// filter down to what will be persisted in the AzureASOManagedMachinePool
+	agentPool = &asocontainerservicev1.ManagedClustersAgentPool{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: asocontainerservicev1.GroupVersion.Identifier(),
+			Kind:       "ManagedClustersAgentPool",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: agentPool.Name,
+		},
+		Spec: agentPool.Spec,
+	}
+
+	var replicas *int32
+	if agentPool.Spec.Count != nil {
+		replicas = ptr.To(int32(*agentPool.Spec.Count))
+		agentPool.Spec.Count = nil
+	}
+
+	managedCluster := &asocontainerservicev1.ManagedCluster{}
+	if agentPool.Owner() == nil {
+		return ctrl.Result{}, fmt.Errorf("agent pool %s/%s has no owner", namespace, agentPool.Name)
+	}
+	managedClusterKey := client.ObjectKey{
+		Namespace: namespace,
+		Name:      agentPool.Owner().Name,
+	}
+	err = r.Get(ctx, managedClusterKey, managedCluster)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to get ManagedCluster %s: %w", managedClusterKey, err)
+	}
+	var managedControlPlaneOwner *metav1.OwnerReference
+	for _, owner := range managedCluster.GetOwnerReferences() {
+		if owner.APIVersion == infrav1exp.GroupVersion.Identifier() &&
+			owner.Kind == infrav1exp.AzureASOManagedControlPlaneKind &&
+			owner.Name == agentPool.Owner().Name {
+			managedControlPlaneOwner = ptr.To(owner)
+			break
+		}
+	}
+	if managedControlPlaneOwner == nil {
+		return ctrl.Result{}, fmt.Errorf("ManagedCluster %s is not owned by any AzureASOManagedControlPlane", managedClusterKey)
+	}
+	asoManagedControlPlane := &infrav1exp.AzureASOManagedControlPlane{}
+	managedControlPlaneKey := client.ObjectKey{
+		Namespace: namespace,
+		Name:      managedControlPlaneOwner.Name,
+	}
+	err = r.Get(ctx, managedControlPlaneKey, asoManagedControlPlane)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to get AzureASOManagedControlPlane %s: %w", managedControlPlaneKey, err)
+	}
+	clusterName := asoManagedControlPlane.Labels[clusterv1.ClusterNameLabel]
+
+	asoManagedMachinePool := &infrav1exp.AzureASOManagedMachinePool{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      agentPool.Name,
+		},
+		Spec: infrav1exp.AzureASOManagedMachinePoolSpec{
+			AzureASOManagedMachinePoolTemplateResourceSpec: infrav1exp.AzureASOManagedMachinePoolTemplateResourceSpec{
+				Resources: []runtime.RawExtension{
+					{Object: agentPool},
+				},
+			},
+		},
+	}
+
+	machinePool := &expv1.MachinePool{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      agentPool.Name,
+		},
+		Spec: expv1.MachinePoolSpec{
+			ClusterName: clusterName,
+			Replicas:    replicas,
+			Template: clusterv1.MachineTemplateSpec{
+				Spec: clusterv1.MachineSpec{
+					Bootstrap: clusterv1.Bootstrap{
+						DataSecretName: ptr.To(""),
+					},
+					ClusterName: clusterName,
+					InfrastructureRef: corev1.ObjectReference{
+						APIVersion: infrav1exp.GroupVersion.Identifier(),
+						Kind:       infrav1exp.AzureASOManagedMachinePoolKind,
+						Name:       asoManagedMachinePool.Name,
+					},
+				},
+			},
+		},
+	}
+
+	if ptr.Deref(agentPool.Spec.EnableAutoScaling, false) {
+		machinePool.Annotations = map[string]string{
+			clusterv1.ReplicasManagedByAnnotation: infrav1exp.ReplicasManagedByAKS,
+		}
+	}
+
+	err = r.Create(ctx, machinePool)
+	if client.IgnoreAlreadyExists(err) != nil {
+		return ctrl.Result{}, err
+	}
+
+	err = r.Create(ctx, asoManagedMachinePool)
+	if client.IgnoreAlreadyExists(err) != nil {
+		return ctrl.Result{}, err
+	}
+
+	return ctrl.Result{}, nil
+}

--- a/exp/controllers/managedclusteradopt_controller.go
+++ b/exp/controllers/managedclusteradopt_controller.go
@@ -1,0 +1,196 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"fmt"
+
+	asocontainerservicev1 "github.com/Azure/azure-service-operator/v2/api/containerservice/v1api20231001"
+	asoresourcesv1 "github.com/Azure/azure-service-operator/v2/api/resources/v1api20200601"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	infrav1exp "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1alpha1"
+	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+const adoptAnnotation = "sigs.k8s.io/cluster-api-provider-azure-adopt"
+
+// ManagedClusterAdoptReconciler adopts ASO ManagedCluster resources into a CAPI Cluster.
+type ManagedClusterAdoptReconciler struct {
+	client.Client
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *ManagedClusterAdoptReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {
+	_, err := ctrl.NewControllerManagedBy(mgr).
+		For(&asocontainerservicev1.ManagedCluster{}).
+		WithEventFilter(predicate.Funcs{
+			UpdateFunc: func(ev event.UpdateEvent) bool {
+				return ev.ObjectOld.GetAnnotations()[adoptAnnotation] != ev.ObjectNew.GetAnnotations()[adoptAnnotation]
+			},
+			DeleteFunc: func(_ event.DeleteEvent) bool { return false },
+		}).
+		Build(r)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// +kubebuilder:rbac:groups=cluster.x-k8s.io,resources=clusters,verbs=create
+
+// Reconcile reconciles an AzureASOManagedCluster.
+func (r *ManagedClusterAdoptReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, resultErr error) {
+	ctx, log, done := tele.StartSpanWithLogger(ctx,
+		"controllers.ManagedClusterAdoptReconciler.Reconcile",
+		tele.KVP("namespace", req.Namespace),
+		tele.KVP("name", req.Name),
+		tele.KVP("kind", "ManagedCluster"),
+	)
+	defer done()
+
+	managedCluster := &asocontainerservicev1.ManagedCluster{}
+	err := r.Get(ctx, req.NamespacedName, managedCluster)
+	if err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	if managedCluster.GetAnnotations()[adoptAnnotation] != "true" {
+		return ctrl.Result{}, nil
+	}
+
+	for _, owner := range managedCluster.GetOwnerReferences() {
+		if owner.APIVersion == infrav1exp.GroupVersion.Identifier() &&
+			owner.Kind == infrav1exp.AzureASOManagedControlPlaneKind {
+			return ctrl.Result{}, nil
+		}
+	}
+
+	log.Info("adopting")
+
+	cluster := &clusterv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: managedCluster.Namespace,
+			Name:      managedCluster.Name,
+		},
+		Spec: clusterv1.ClusterSpec{
+			InfrastructureRef: &corev1.ObjectReference{
+				APIVersion: infrav1exp.GroupVersion.Identifier(),
+				Kind:       infrav1exp.AzureASOManagedClusterKind,
+				Name:       managedCluster.Name,
+			},
+			ControlPlaneRef: &corev1.ObjectReference{
+				APIVersion: infrav1exp.GroupVersion.Identifier(),
+				Kind:       infrav1exp.AzureASOManagedControlPlaneKind,
+				Name:       managedCluster.Name,
+			},
+		},
+	}
+	err = r.Create(ctx, cluster)
+	if client.IgnoreAlreadyExists(err) != nil {
+		return ctrl.Result{}, err
+	}
+
+	resourceGroup := &asoresourcesv1.ResourceGroup{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: managedCluster.Namespace,
+			Name:      managedCluster.Owner().Name,
+		},
+	}
+
+	err = r.Get(ctx, client.ObjectKeyFromObject(resourceGroup), resourceGroup)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("error getting ResourceGroup %s: %w", client.ObjectKeyFromObject(resourceGroup), err)
+	}
+
+	// filter down to what will be persisted in the AzureASOManagedCluster
+	resourceGroup = &asoresourcesv1.ResourceGroup{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: asoresourcesv1.GroupVersion.Identifier(),
+			Kind:       "ResourceGroup",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: resourceGroup.Name,
+		},
+		Spec: resourceGroup.Spec,
+	}
+
+	asoManagedCluster := &infrav1exp.AzureASOManagedCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: managedCluster.Namespace,
+			Name:      managedCluster.Name,
+		},
+		Spec: infrav1exp.AzureASOManagedClusterSpec{
+			AzureASOManagedClusterTemplateResourceSpec: infrav1exp.AzureASOManagedClusterTemplateResourceSpec{
+				Resources: []runtime.RawExtension{
+					{Object: resourceGroup},
+				},
+			},
+		},
+	}
+	err = r.Create(ctx, asoManagedCluster)
+	if client.IgnoreAlreadyExists(err) != nil {
+		return ctrl.Result{}, err
+	}
+
+	// agent pools are defined by AzureASOManagedMachinePools. Remove them from this resource.
+	managedClusterBefore := managedCluster.DeepCopy()
+	managedCluster.Spec.AgentPoolProfiles = nil
+	err = r.Patch(ctx, managedCluster, client.MergeFrom(managedClusterBefore))
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	managedCluster = &asocontainerservicev1.ManagedCluster{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: asocontainerservicev1.GroupVersion.Identifier(),
+			Kind:       "ManagedCluster",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: managedCluster.Name,
+		},
+		Spec: managedCluster.Spec,
+	}
+
+	asoManagedControlPlane := &infrav1exp.AzureASOManagedControlPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: cluster.Namespace,
+			Name:      managedCluster.Name,
+		},
+		Spec: infrav1exp.AzureASOManagedControlPlaneSpec{
+			AzureASOManagedControlPlaneTemplateResourceSpec: infrav1exp.AzureASOManagedControlPlaneTemplateResourceSpec{
+				Resources: []runtime.RawExtension{
+					{Object: managedCluster},
+				},
+			},
+		},
+	}
+	err = r.Create(ctx, asoManagedControlPlane)
+	if client.IgnoreAlreadyExists(err) != nil {
+		return ctrl.Result{}, err
+	}
+
+	return ctrl.Result{}, nil
+}

--- a/exp/mutators/azureasomanagedcontrolplane_test.go
+++ b/exp/mutators/azureasomanagedcontrolplane_test.go
@@ -23,6 +23,7 @@ import (
 
 	asocontainerservicev1preview "github.com/Azure/azure-service-operator/v2/api/containerservice/v1api20230202preview"
 	asocontainerservicev1 "github.com/Azure/azure-service-operator/v2/api/containerservice/v1api20231001"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	"github.com/google/go-cmp/cmp"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -32,6 +33,7 @@ import (
 	infrav1exp "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1alpha1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	expv1 "sigs.k8s.io/cluster-api/exp/api/v1beta1"
+	"sigs.k8s.io/cluster-api/util/secret"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/conversion"
 )
@@ -73,6 +75,9 @@ func TestSetManagedClusterDefaults(t *testing.T) {
 				},
 			},
 			cluster: &clusterv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cluster",
+				},
 				Spec: clusterv1.ClusterSpec{
 					ClusterNetwork: &clusterv1.ClusterNetwork{
 						Pods: &clusterv1.NetworkRanges{
@@ -91,6 +96,14 @@ func TestSetManagedClusterDefaults(t *testing.T) {
 						NetworkProfile: &asocontainerservicev1.ContainerServiceNetworkProfile{
 							ServiceCidr: ptr.To("svc-0"),
 							PodCidr:     ptr.To("pod-0"),
+						},
+						OperatorSpec: &asocontainerservicev1.ManagedClusterOperatorSpec{
+							Secrets: &asocontainerservicev1.ManagedClusterOperatorSecrets{
+								AdminCredentials: &genruntime.SecretDestination{
+									Name: secret.Name("cluster", secret.Kubeconfig),
+									Key:  secret.KubeconfigDataName,
+								},
+							},
 						},
 					},
 				}),

--- a/main.go
+++ b/main.go
@@ -556,6 +556,20 @@ func registerControllers(ctx context.Context, mgr manager.Manager) {
 			setupLog.Error(err, "unable to create controller", "controller", "AzureASOManagedMachinePool")
 			os.Exit(1)
 		}
+
+		if err := (&infrav1controllersexp.ManagedClusterAdoptReconciler{
+			Client: mgr.GetClient(),
+		}).SetupWithManager(ctx, mgr); err != nil {
+			setupLog.Error(err, "unable to create controller", "controller", "ManagedCluster")
+			os.Exit(1)
+		}
+
+		if err := (&infrav1controllersexp.AgentPoolAdoptReconciler{
+			Client: mgr.GetClient(),
+		}).SetupWithManager(ctx, mgr); err != nil {
+			setupLog.Error(err, "unable to create controller", "controller", "AgentPool")
+			os.Exit(1)
+		}
 	}
 }
 

--- a/templates/cluster-template-aks-aso-clusterclass.yaml
+++ b/templates/cluster-template-aks-aso-clusterclass.yaml
@@ -61,11 +61,6 @@ spec:
                   clientId: msi
                 networkProfile:
                   networkPlugin: azure
-                operatorSpec:
-                  secrets:
-                    adminCredentials:
-                      name: "{{ .builtin.cluster.name }}-kubeconfig"
-                      key: value
       selector:
         apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
         kind: AzureASOManagedControlPlaneTemplate

--- a/templates/cluster-template-aks-aso.yaml
+++ b/templates/cluster-template-aks-aso.yaml
@@ -33,11 +33,6 @@ spec:
       location: ${AZURE_LOCATION}
       networkProfile:
         networkPlugin: azure
-      operatorSpec:
-        secrets:
-          adminCredentials:
-            key: value
-            name: ${CLUSTER_NAME}-kubeconfig
       owner:
         name: ${CLUSTER_NAME}
       servicePrincipalProfile:

--- a/templates/flavors/aks-aso-clusterclass/clusterclass.yaml
+++ b/templates/flavors/aks-aso-clusterclass/clusterclass.yaml
@@ -96,11 +96,6 @@ spec:
                   clientId: msi
                 networkProfile:
                   networkPlugin: azure
-                operatorSpec:
-                  secrets:
-                    adminCredentials:
-                      name: "{{ .builtin.cluster.name }}-kubeconfig"
-                      key: value
   - name: azureasomanagedmachinepool-pool0-spec
     definitions:
     - selector:

--- a/templates/flavors/aks-aso/cluster-template.yaml
+++ b/templates/flavors/aks-aso/cluster-template.yaml
@@ -38,11 +38,6 @@ spec:
         clientId: msi
       networkProfile:
         networkPlugin: azure
-      operatorSpec:
-        secrets:
-          adminCredentials:
-            name: ${CLUSTER_NAME}-kubeconfig
-            key: value
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
 kind: AzureASOManagedCluster

--- a/templates/test/ci/cluster-template-prow-aks-aso.yaml
+++ b/templates/test/ci/cluster-template-prow-aks-aso.yaml
@@ -33,11 +33,6 @@ spec:
       location: ${AZURE_LOCATION}
       networkProfile:
         networkPlugin: azure
-      operatorSpec:
-        secrets:
-          adminCredentials:
-            key: value
-            name: ${CLUSTER_NAME}-kubeconfig
       owner:
         name: ${CLUSTER_NAME}
       servicePrincipalProfile:


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind feature

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

This PR implements an automated adoption mechanism for ASOAPI-based clusters. It works by watching ASO ManagedClusters and ManagedClustersAgentPools with a sentinel `sigs.k8s.io/cluster-api-provider-azure-adopt=true` annotation and scaffolds the CAPZ/CAPI resources around them required to represent a full Cluster API Cluster. It's designed to work in conjunction with [`asoctl import azure-resource`](https://azure.github.io/azure-service-operator/tools/asoctl/#import-azure-resource) in order to work with any pre-existing AKS cluster, though any ASO YAML should work.

This PR currently includes the changes from #4798 in the first two commits, but I'll merge `main` into this branch after that merges to keep this PR diff clean.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #4713 and related to #1173

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
