### PR TITLE
ASOAPI: delete resources removed from spec

### DIFF
--- a/exp/api/v1alpha1/azureasomanagedcluster_types.go
+++ b/exp/api/v1alpha1/azureasomanagedcluster_types.go
@@ -78,7 +78,12 @@ type AzureASOManagedCluster struct {
 	Status AzureASOManagedClusterStatus `json:"status,omitempty"`
 }
 
-// SetResourceStatuses returns the status of resources.
+// GetResourceStatuses returns the status of resources.
+func (a *AzureASOManagedCluster) GetResourceStatuses() []ResourceStatus {
+	return a.Status.Resources
+}
+
+// SetResourceStatuses sets the status of resources.
 func (a *AzureASOManagedCluster) SetResourceStatuses(r []ResourceStatus) {
 	a.Status.Resources = r
 }

--- a/exp/api/v1alpha1/azureasomanagedcontrolplane_types.go
+++ b/exp/api/v1alpha1/azureasomanagedcontrolplane_types.go
@@ -66,7 +66,12 @@ type AzureASOManagedControlPlane struct {
 	Status AzureASOManagedControlPlaneStatus `json:"status,omitempty"`
 }
 
-// SetResourceStatuses returns the status of resources.
+// GetResourceStatuses returns the status of resources.
+func (a *AzureASOManagedControlPlane) GetResourceStatuses() []ResourceStatus {
+	return a.Status.Resources
+}
+
+// SetResourceStatuses sets the status of resources.
 func (a *AzureASOManagedControlPlane) SetResourceStatuses(r []ResourceStatus) {
 	a.Status.Resources = r
 }

--- a/exp/api/v1alpha1/azureasomanagedmachinepool_types.go
+++ b/exp/api/v1alpha1/azureasomanagedmachinepool_types.go
@@ -61,7 +61,12 @@ type AzureASOManagedMachinePool struct {
 	Status AzureASOManagedMachinePoolStatus `json:"status,omitempty"`
 }
 
-// SetResourceStatuses returns the status of resources.
+// GetResourceStatuses returns the status of resources.
+func (a *AzureASOManagedMachinePool) GetResourceStatuses() []ResourceStatus {
+	return a.Status.Resources
+}
+
+// SetResourceStatuses sets the status of resources.
 func (a *AzureASOManagedMachinePool) SetResourceStatuses(r []ResourceStatus) {
 	a.Status.Resources = r
 }


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind feature

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

This PR adds the logic for ASOAPI resources to delete resources that are removed from `spec.resources` through an update like we did for the existing CAPZ APIs in #4506.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #4713

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [ ] includes documentation
- [X] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
