### PR TITLE
Check UserManaged is not nil in azure/converters/diagnostics

### DIFF
--- a/azure/converters/diagnostics.go
+++ b/azure/converters/diagnostics.go
@@ -39,11 +39,13 @@ func GetDiagnosticsProfile(diagnostics *infrav1.Diagnostics) *armcompute.Diagnos
 				},
 			}
 		case infrav1.UserManagedDiagnosticsStorage:
-			return &armcompute.DiagnosticsProfile{
-				BootDiagnostics: &armcompute.BootDiagnostics{
-					Enabled:    ptr.To(true),
-					StorageURI: &diagnostics.Boot.UserManaged.StorageAccountURI,
-				},
+			if diagnostics.Boot.UserManaged != nil {
+				return &armcompute.DiagnosticsProfile{
+					BootDiagnostics: &armcompute.BootDiagnostics{
+						Enabled:    ptr.To(true),
+						StorageURI: &diagnostics.Boot.UserManaged.StorageAccountURI,
+					},
+				}
 			}
 		}
 	}

--- a/azure/converters/diagnostics_test.go
+++ b/azure/converters/diagnostics_test.go
@@ -81,6 +81,16 @@ func TestGetDiagnosticsProfile(t *testing.T) {
 			},
 			want: nil,
 		},
+		{
+			name: "nil diagnostics boot user managed",
+			diagnostics: &infrav1.Diagnostics{
+				Boot: &infrav1.BootDiagnostics{
+					StorageAccountType: infrav1.UserManagedDiagnosticsStorage,
+					UserManaged:        nil,
+				},
+			},
+			want: nil,
+		},
 	}
 	for _, tt := range tests {
 		tt := tt


### PR DESCRIPTION
**What this PR does / why we need it**: Adds nil check for UserManagedDiagnosticsStorage in azure/converters/diagnostics.go . This prevents a crash in the case that the StorageAccountURI provided is empty.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [x] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Adds nil check for UserManagedDiagnosticsStorage in azure/converters/diagnostics.go 
```
