### PR TITLE
[release-1.13] Don't allow fleetsMembers to have capital letters. Default spec.group.

### DIFF
--- a/api/v1beta1/azuremanagedcontrolplane_default.go
+++ b/api/v1beta1/azuremanagedcontrolplane_default.go
@@ -101,8 +101,13 @@ func (m *AzureManagedControlPlane) setDefaultSubnet() {
 // setDefaultFleetsMember sets the default FleetsMember for an AzureManagedControlPlane.
 func setDefaultFleetsMember(fleetsMember *FleetsMember, labels map[string]string) *FleetsMember {
 	result := fleetsMember.DeepCopy()
-	if clusterName, ok := labels[clusterv1.ClusterNameLabel]; ok && fleetsMember != nil && fleetsMember.Name == "" {
-		result.Name = clusterName
+	if fleetsMember != nil {
+		if clusterName, ok := labels[clusterv1.ClusterNameLabel]; ok && fleetsMember.Name == "" {
+			result.Name = clusterName
+		}
+		if fleetsMember.Group == "" {
+			result.Group = "default"
+		}
 	}
 	return result
 }

--- a/api/v1beta1/azuremanagedcontrolplane_webhook.go
+++ b/api/v1beta1/azuremanagedcontrolplane_webhook.go
@@ -261,7 +261,7 @@ func (mw *azureManagedControlPlaneWebhook) ValidateUpdate(ctx context.Context, o
 		allErrs = append(allErrs, errs...)
 	}
 
-	if errs := m.validateFleetsMember(old); len(errs) > 0 {
+	if errs := m.validateFleetsMemberUpdate(old); len(errs) > 0 {
 		allErrs = append(allErrs, errs...)
 	}
 
@@ -315,6 +315,8 @@ func (m *AzureManagedControlPlane) Validate(cli client.Client) error {
 	allErrs = append(allErrs, validateAutoScalerProfile(m.Spec.AutoScalerProfile, field.NewPath("spec").Child("AutoScalerProfile"))...)
 
 	allErrs = append(allErrs, validateAMCPVirtualNetwork(m.Spec.VirtualNetwork, field.NewPath("spec").Child("VirtualNetwork"))...)
+
+	allErrs = append(allErrs, validateFleetsMember(m.Spec.FleetsMember, field.NewPath("spec").Child("FleetsMember"))...)
 
 	return allErrs.ToAggregate()
 }
@@ -428,6 +430,25 @@ func validateAMCPVirtualNetwork(virtualNetwork ManagedControlPlaneVirtualNetwork
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("CIDRBlock"), virtualNetwork.CIDRBlock, "pre-existing virtual networks CIDR block should contain the subnet CIDR block"))
 		}
 	}
+	return allErrs
+}
+
+func validateFleetsMember(fleetsMember *FleetsMember, fldPath *field.Path) field.ErrorList {
+	var allErrs field.ErrorList
+
+	if fleetsMember != nil && fleetsMember.Name != "" {
+		match, _ := regexp.MatchString(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`, fleetsMember.Name)
+		if !match {
+			allErrs = append(allErrs,
+				field.Invalid(
+					fldPath.Child("Name"),
+					fleetsMember.Name,
+					"Name must match ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+				),
+			)
+		}
+	}
+
 	return allErrs
 }
 
@@ -714,8 +735,8 @@ func (m *AzureManagedControlPlane) validateOIDCIssuerProfileUpdate(old *AzureMan
 	return allErrs
 }
 
-// validateFleetsMember validates a FleetsMember.
-func (m *AzureManagedControlPlane) validateFleetsMember(old *AzureManagedControlPlane) field.ErrorList {
+// validateFleetsMemberUpdate validates a FleetsMember.
+func (m *AzureManagedControlPlane) validateFleetsMemberUpdate(old *AzureManagedControlPlane) field.ErrorList {
 	var allErrs field.ErrorList
 
 	if old.Spec.FleetsMember == nil || m.Spec.FleetsMember == nil {


### PR DESCRIPTION
This is a manual cherry-pick of #4800

```release-note
Don't allow fleetsMembers to have capital letters. Default fleet spec.group.
```
