### PR TITLE
deprecate AzureClusterIdentity spec.resourceID

### DIFF
--- a/api/v1beta1/azureclusteridentity_types.go
+++ b/api/v1beta1/azureclusteridentity_types.go
@@ -48,6 +48,9 @@ type AzureClusterIdentitySpec struct {
 	Type IdentityType `json:"type"`
 	// ResourceID is the Azure resource ID for the User Assigned MSI resource.
 	// Only applicable when type is UserAssignedMSI.
+	//
+	// Deprecated: This field no longer has any effect.
+	//
 	// +optional
 	ResourceID string `json:"resourceID,omitempty"`
 	// ClientID is the service principal client ID.

--- a/api/v1beta1/azureclusteridentity_validation.go
+++ b/api/v1beta1/azureclusteridentity_validation.go
@@ -24,9 +24,7 @@ import (
 
 func (c *AzureClusterIdentity) validateClusterIdentity() (admission.Warnings, error) {
 	var allErrs field.ErrorList
-	if c.Spec.Type == UserAssignedMSI && c.Spec.ResourceID == "" {
-		allErrs = append(allErrs, field.Required(field.NewPath("spec", "resourceID"), c.Spec.ResourceID))
-	} else if c.Spec.Type != UserAssignedMSI && c.Spec.ResourceID != "" {
+	if c.Spec.Type != UserAssignedMSI && c.Spec.ResourceID != "" {
 		allErrs = append(allErrs, field.Forbidden(field.NewPath("spec", "resourceID"), c.Spec.ResourceID))
 	}
 	if len(allErrs) == 0 {

--- a/api/v1beta1/azureclusteridentity_webhook_test.go
+++ b/api/v1beta1/azureclusteridentity_webhook_test.go
@@ -76,7 +76,7 @@ func TestAzureClusterIdentity_ValidateCreate(t *testing.T) {
 					TenantID: fakeTenantID,
 				},
 			},
-			wantErr: true,
+			wantErr: false,
 		},
 	}
 

--- a/azure/scope/identity_test.go
+++ b/azure/scope/identity_test.go
@@ -143,8 +143,7 @@ func TestHasClientSecret(t *testing.T) {
 			name: "user assigned identity",
 			identity: &infrav1.AzureClusterIdentity{
 				Spec: infrav1.AzureClusterIdentitySpec{
-					Type:       infrav1.UserAssignedMSI,
-					ResourceID: "my-resource-id",
+					Type: infrav1.UserAssignedMSI,
 				},
 			},
 			want: false,

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azureclusteridentities.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azureclusteridentities.yaml
@@ -144,6 +144,9 @@ spec:
                 description: |-
                   ResourceID is the Azure resource ID for the User Assigned MSI resource.
                   Only applicable when type is UserAssignedMSI.
+
+
+                  Deprecated: This field no longer has any effect.
                 type: string
               tenantID:
                 description: TenantID is the service principal primary tenant id.

--- a/docs/book/src/topics/identities.md
+++ b/docs/book/src/topics/identities.md
@@ -155,7 +155,6 @@ spec:
   type: UserAssignedMSI
   tenantID: <azure-tenant-id>
   clientID: <client-id-of-user-assigned-identity>
-  resourceID: <resource-id-of-user-assigned-identity>
   allowedNamespaces:
     list:
     - <cluster-namespace>

--- a/templates/test/ci/cluster-template-prow-private.yaml
+++ b/templates/test/ci/cluster-template-prow-private.yaml
@@ -248,7 +248,6 @@ metadata:
 spec:
   allowedNamespaces: {}
   clientID: ${UAMI_CLIENT_ID}
-  resourceID: /subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${CI_RG:=capz-ci}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER_IDENTITY:=cloud-provider-user-identity}
   tenantID: ${AZURE_TENANT_ID}
   type: UserAssignedMSI
 ---

--- a/templates/test/ci/prow-private/patches/user-assigned.yaml
+++ b/templates/test/ci/prow-private/patches/user-assigned.yaml
@@ -3,9 +3,6 @@
   value: UserAssignedMSI
 - op: remove
   path: /spec/clientSecret
-- op: add
-  path: /spec/resourceID
-  value: /subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${CI_RG:=capz-ci}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER_IDENTITY:=cloud-provider-user-identity}
 - op: replace
   path: /spec/clientID
   value: ${UAMI_CLIENT_ID}


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind cleanup

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

The `spec.resourceID` field is no longer used in any meaningful way, I think since we eliminated our use of AAD Pod Identity. This change removes the requirement that this field be specified for UserAssignedMSI AzureClusterIdentities and marks the field deprecated to at least make the linter hold us accountable if we ever start to reference it again.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
The `spec.resourceID` field for AzureClusterIdentity is deprecated as it no longer has any effect.
```
