### PR TITLE
[WIP] Default to Azure Linux images

### DIFF
--- a/azure/scope/machine.go
+++ b/azure/scope/machine.go
@@ -723,7 +723,7 @@ func (m *MachineScope) GetVMImage(ctx context.Context) (*infrav1.Image, error) {
 	}
 
 	log.Info("No image specified for machine, using default Linux Image", "machine", m.AzureMachine.GetName())
-	return svc.GetDefaultUbuntuImage(ctx, m.Location(), ptr.Deref(m.Machine.Spec.Version, ""))
+	return svc.GetDefaultLinuxImage(ctx, m.Location(), ptr.Deref(m.Machine.Spec.Version, ""))
 }
 
 // SetSubnetName defaults the AzureMachine subnet name to the name of one the subnets with the machine role when there is only one of them.

--- a/azure/scope/machine_test.go
+++ b/azure/scope/machine_test.go
@@ -1740,7 +1740,7 @@ func TestMachineScope_GetVMImage(t *testing.T) {
 				ClusterScoper: clusterMock,
 			},
 			want: func() *infrav1.Image {
-				image, _ := svc.GetDefaultUbuntuImage(context.TODO(), "", "1.20.1")
+				image, _ := svc.GetDefaultLinuxImage(context.TODO(), "", "1.20.1")
 				return image
 			}(),
 			expectedErr: "",

--- a/azure/scope/machinepool.go
+++ b/azure/scope/machinepool.go
@@ -772,7 +772,7 @@ func (m *MachinePoolScope) GetVMImage(ctx context.Context) (*infrav1.Image, erro
 		log.V(4).Info("No image specified for machine, using default Windows Image", "machine", m.MachinePool.GetName(), "runtime", runtime, "windowsServerVersion", windowsServerVersion)
 		defaultImage, err = svc.GetDefaultWindowsImage(ctx, m.Location(), ptr.Deref(m.MachinePool.Spec.Template.Spec.Version, ""), runtime, windowsServerVersion)
 	} else {
-		defaultImage, err = svc.GetDefaultUbuntuImage(ctx, m.Location(), ptr.Deref(m.MachinePool.Spec.Template.Spec.Version, ""))
+		defaultImage, err = svc.GetDefaultLinuxImage(ctx, m.Location(), ptr.Deref(m.MachinePool.Spec.Template.Spec.Version, ""))
 	}
 
 	if err != nil {

--- a/azure/scope/machinepool_test.go
+++ b/azure/scope/machinepool_test.go
@@ -423,7 +423,7 @@ func TestMachinePoolScope_GetVMImage(t *testing.T) {
 						ImagePlan: infrav1.ImagePlan{
 							Publisher: "cncf-upstream",
 							Offer:     "capi",
-							SKU:       "k8s-1dot19dot11-ubuntu-1804",
+							SKU:       "k8s-1dot19dot11-azurelinux-3",
 						},
 						Version:         "latest",
 						ThirdPartyImage: false,

--- a/templates/addons/cluster-api-helm/cloud-provider-azure-ci.yaml
+++ b/templates/addons/cluster-api-helm/cloud-provider-azure-ci.yaml
@@ -22,6 +22,7 @@ spec:
       logVerbosity: ${CCM_LOG_VERBOSITY:-4}
       replicas: ${CCM_COUNT:-1}
       enableDynamicReloading: ${ENABLE_DYNAMIC_RELOADING:-false}
+      caCertDir: ${CCM_CA_CERT_DIR:-/etc/pki/tls}
     cloudNodeManager:
       imageName: "${CNM_IMAGE_NAME:-""}"
       imageRepository: "${IMAGE_REGISTRY:-""}"

--- a/templates/addons/cluster-api-helm/cloud-provider-azure.yaml
+++ b/templates/addons/cluster-api-helm/cloud-provider-azure.yaml
@@ -15,3 +15,4 @@ spec:
     cloudControllerManager:
       clusterCIDR: {{ .Cluster.spec.clusterNetwork.pods.cidrBlocks | join "," }}
       logVerbosity: 4
+      caCertDir: ${CCM_CA_CERT_DIR:-/etc/pki/tls}

--- a/templates/test/ci/cluster-template-prow-azure-cni-v1.yaml
+++ b/templates/test/ci/cluster-template-prow-azure-cni-v1.yaml
@@ -258,6 +258,7 @@ spec:
     cloudControllerManager:
       clusterCIDR: {{ .Cluster.spec.clusterNetwork.pods.cidrBlocks | join "," }}
       logVerbosity: 4
+      caCertDir: ${CCM_CA_CERT_DIR:-/etc/pki/tls}
 ---
 apiVersion: addons.cluster.x-k8s.io/v1alpha1
 kind: HelmChartProxy
@@ -284,6 +285,7 @@ spec:
       logVerbosity: ${CCM_LOG_VERBOSITY:-4}
       replicas: ${CCM_COUNT:-1}
       enableDynamicReloading: ${ENABLE_DYNAMIC_RELOADING:-false}
+      caCertDir: ${CCM_CA_CERT_DIR:-/etc/pki/tls}
     cloudNodeManager:
       imageName: "${CNM_IMAGE_NAME:-""}"
       imageRepository: "${IMAGE_REGISTRY:-""}"

--- a/templates/test/ci/cluster-template-prow-ci-version-dual-stack.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version-dual-stack.yaml
@@ -524,6 +524,7 @@ spec:
     cloudControllerManager:
       clusterCIDR: {{ .Cluster.spec.clusterNetwork.pods.cidrBlocks | join "," }}
       logVerbosity: 4
+      caCertDir: ${CCM_CA_CERT_DIR:-/etc/pki/tls}
 ---
 apiVersion: addons.cluster.x-k8s.io/v1alpha1
 kind: HelmChartProxy
@@ -550,6 +551,7 @@ spec:
       logVerbosity: ${CCM_LOG_VERBOSITY:-4}
       replicas: ${CCM_COUNT:-1}
       enableDynamicReloading: ${ENABLE_DYNAMIC_RELOADING:-false}
+      caCertDir: ${CCM_CA_CERT_DIR:-/etc/pki/tls}
     cloudNodeManager:
       imageName: "${CNM_IMAGE_NAME:-""}"
       imageRepository: "${IMAGE_REGISTRY:-""}"

--- a/templates/test/ci/cluster-template-prow-ci-version-ipv6.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version-ipv6.yaml
@@ -542,6 +542,7 @@ spec:
     cloudControllerManager:
       clusterCIDR: {{ .Cluster.spec.clusterNetwork.pods.cidrBlocks | join "," }}
       logVerbosity: 4
+      caCertDir: ${CCM_CA_CERT_DIR:-/etc/pki/tls}
 ---
 apiVersion: addons.cluster.x-k8s.io/v1alpha1
 kind: HelmChartProxy
@@ -568,6 +569,7 @@ spec:
       logVerbosity: ${CCM_LOG_VERBOSITY:-4}
       replicas: ${CCM_COUNT:-1}
       enableDynamicReloading: ${ENABLE_DYNAMIC_RELOADING:-false}
+      caCertDir: ${CCM_CA_CERT_DIR:-/etc/pki/tls}
     cloudNodeManager:
       imageName: "${CNM_IMAGE_NAME:-""}"
       imageRepository: "${IMAGE_REGISTRY:-""}"

--- a/templates/test/ci/cluster-template-prow-ci-version.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version.yaml
@@ -724,6 +724,7 @@ spec:
     cloudControllerManager:
       clusterCIDR: {{ .Cluster.spec.clusterNetwork.pods.cidrBlocks | join "," }}
       logVerbosity: 4
+      caCertDir: ${CCM_CA_CERT_DIR:-/etc/pki/tls}
 ---
 apiVersion: addons.cluster.x-k8s.io/v1alpha1
 kind: HelmChartProxy
@@ -750,6 +751,7 @@ spec:
       logVerbosity: ${CCM_LOG_VERBOSITY:-4}
       replicas: ${CCM_COUNT:-1}
       enableDynamicReloading: ${ENABLE_DYNAMIC_RELOADING:-false}
+      caCertDir: ${CCM_CA_CERT_DIR:-/etc/pki/tls}
     cloudNodeManager:
       imageName: "${CNM_IMAGE_NAME:-""}"
       imageRepository: "${IMAGE_REGISTRY:-""}"

--- a/templates/test/ci/cluster-template-prow-custom-vnet.yaml
+++ b/templates/test/ci/cluster-template-prow-custom-vnet.yaml
@@ -311,6 +311,7 @@ spec:
     cloudControllerManager:
       clusterCIDR: {{ .Cluster.spec.clusterNetwork.pods.cidrBlocks | join "," }}
       logVerbosity: 4
+      caCertDir: ${CCM_CA_CERT_DIR:-/etc/pki/tls}
 ---
 apiVersion: addons.cluster.x-k8s.io/v1alpha1
 kind: HelmChartProxy
@@ -337,6 +338,7 @@ spec:
       logVerbosity: ${CCM_LOG_VERBOSITY:-4}
       replicas: ${CCM_COUNT:-1}
       enableDynamicReloading: ${ENABLE_DYNAMIC_RELOADING:-false}
+      caCertDir: ${CCM_CA_CERT_DIR:-/etc/pki/tls}
     cloudNodeManager:
       imageName: "${CNM_IMAGE_NAME:-""}"
       imageRepository: "${IMAGE_REGISTRY:-""}"

--- a/templates/test/ci/cluster-template-prow-dual-stack.yaml
+++ b/templates/test/ci/cluster-template-prow-dual-stack.yaml
@@ -384,6 +384,7 @@ spec:
     cloudControllerManager:
       clusterCIDR: {{ .Cluster.spec.clusterNetwork.pods.cidrBlocks | join "," }}
       logVerbosity: 4
+      caCertDir: ${CCM_CA_CERT_DIR:-/etc/pki/tls}
 ---
 apiVersion: addons.cluster.x-k8s.io/v1alpha1
 kind: HelmChartProxy
@@ -410,6 +411,7 @@ spec:
       logVerbosity: ${CCM_LOG_VERBOSITY:-4}
       replicas: ${CCM_COUNT:-1}
       enableDynamicReloading: ${ENABLE_DYNAMIC_RELOADING:-false}
+      caCertDir: ${CCM_CA_CERT_DIR:-/etc/pki/tls}
     cloudNodeManager:
       imageName: "${CNM_IMAGE_NAME:-""}"
       imageRepository: "${IMAGE_REGISTRY:-""}"

--- a/templates/test/ci/cluster-template-prow-edgezone.yaml
+++ b/templates/test/ci/cluster-template-prow-edgezone.yaml
@@ -294,6 +294,7 @@ spec:
     cloudControllerManager:
       clusterCIDR: {{ .Cluster.spec.clusterNetwork.pods.cidrBlocks | join "," }}
       logVerbosity: 4
+      caCertDir: ${CCM_CA_CERT_DIR:-/etc/pki/tls}
 ---
 apiVersion: addons.cluster.x-k8s.io/v1alpha1
 kind: HelmChartProxy
@@ -320,6 +321,7 @@ spec:
       logVerbosity: ${CCM_LOG_VERBOSITY:-4}
       replicas: ${CCM_COUNT:-1}
       enableDynamicReloading: ${ENABLE_DYNAMIC_RELOADING:-false}
+      caCertDir: ${CCM_CA_CERT_DIR:-/etc/pki/tls}
     cloudNodeManager:
       imageName: "${CNM_IMAGE_NAME:-""}"
       imageRepository: "${IMAGE_REGISTRY:-""}"

--- a/templates/test/ci/cluster-template-prow-ipv6.yaml
+++ b/templates/test/ci/cluster-template-prow-ipv6.yaml
@@ -404,6 +404,7 @@ spec:
     cloudControllerManager:
       clusterCIDR: {{ .Cluster.spec.clusterNetwork.pods.cidrBlocks | join "," }}
       logVerbosity: 4
+      caCertDir: ${CCM_CA_CERT_DIR:-/etc/pki/tls}
 ---
 apiVersion: addons.cluster.x-k8s.io/v1alpha1
 kind: HelmChartProxy
@@ -430,6 +431,7 @@ spec:
       logVerbosity: ${CCM_LOG_VERBOSITY:-4}
       replicas: ${CCM_COUNT:-1}
       enableDynamicReloading: ${ENABLE_DYNAMIC_RELOADING:-false}
+      caCertDir: ${CCM_CA_CERT_DIR:-/etc/pki/tls}
     cloudNodeManager:
       imageName: "${CNM_IMAGE_NAME:-""}"
       imageRepository: "${IMAGE_REGISTRY:-""}"

--- a/templates/test/ci/cluster-template-prow-machine-pool-ci-version.yaml
+++ b/templates/test/ci/cluster-template-prow-machine-pool-ci-version.yaml
@@ -658,6 +658,7 @@ spec:
     cloudControllerManager:
       clusterCIDR: {{ .Cluster.spec.clusterNetwork.pods.cidrBlocks | join "," }}
       logVerbosity: 4
+      caCertDir: ${CCM_CA_CERT_DIR:-/etc/pki/tls}
 ---
 apiVersion: addons.cluster.x-k8s.io/v1alpha1
 kind: HelmChartProxy
@@ -684,6 +685,7 @@ spec:
       logVerbosity: ${CCM_LOG_VERBOSITY:-4}
       replicas: ${CCM_COUNT:-1}
       enableDynamicReloading: ${ENABLE_DYNAMIC_RELOADING:-false}
+      caCertDir: ${CCM_CA_CERT_DIR:-/etc/pki/tls}
     cloudNodeManager:
       imageName: "${CNM_IMAGE_NAME:-""}"
       imageRepository: "${IMAGE_REGISTRY:-""}"

--- a/templates/test/ci/cluster-template-prow-machine-pool-flex.yaml
+++ b/templates/test/ci/cluster-template-prow-machine-pool-flex.yaml
@@ -423,6 +423,7 @@ spec:
     cloudControllerManager:
       clusterCIDR: {{ .Cluster.spec.clusterNetwork.pods.cidrBlocks | join "," }}
       logVerbosity: 4
+      caCertDir: ${CCM_CA_CERT_DIR:-/etc/pki/tls}
 ---
 apiVersion: addons.cluster.x-k8s.io/v1alpha1
 kind: HelmChartProxy
@@ -449,6 +450,7 @@ spec:
       logVerbosity: ${CCM_LOG_VERBOSITY:-4}
       replicas: ${CCM_COUNT:-1}
       enableDynamicReloading: ${ENABLE_DYNAMIC_RELOADING:-false}
+      caCertDir: ${CCM_CA_CERT_DIR:-/etc/pki/tls}
     cloudNodeManager:
       imageName: "${CNM_IMAGE_NAME:-""}"
       imageRepository: "${IMAGE_REGISTRY:-""}"

--- a/templates/test/ci/cluster-template-prow-machine-pool.yaml
+++ b/templates/test/ci/cluster-template-prow-machine-pool.yaml
@@ -417,6 +417,7 @@ spec:
     cloudControllerManager:
       clusterCIDR: {{ .Cluster.spec.clusterNetwork.pods.cidrBlocks | join "," }}
       logVerbosity: 4
+      caCertDir: ${CCM_CA_CERT_DIR:-/etc/pki/tls}
 ---
 apiVersion: addons.cluster.x-k8s.io/v1alpha1
 kind: HelmChartProxy
@@ -443,6 +444,7 @@ spec:
       logVerbosity: ${CCM_LOG_VERBOSITY:-4}
       replicas: ${CCM_COUNT:-1}
       enableDynamicReloading: ${ENABLE_DYNAMIC_RELOADING:-false}
+      caCertDir: ${CCM_CA_CERT_DIR:-/etc/pki/tls}
     cloudNodeManager:
       imageName: "${CNM_IMAGE_NAME:-""}"
       imageRepository: "${IMAGE_REGISTRY:-""}"

--- a/templates/test/ci/cluster-template-prow-nvidia-gpu.yaml
+++ b/templates/test/ci/cluster-template-prow-nvidia-gpu.yaml
@@ -284,6 +284,7 @@ spec:
     cloudControllerManager:
       clusterCIDR: {{ .Cluster.spec.clusterNetwork.pods.cidrBlocks | join "," }}
       logVerbosity: 4
+      caCertDir: ${CCM_CA_CERT_DIR:-/etc/pki/tls}
 ---
 apiVersion: addons.cluster.x-k8s.io/v1alpha1
 kind: HelmChartProxy
@@ -310,6 +311,7 @@ spec:
       logVerbosity: ${CCM_LOG_VERBOSITY:-4}
       replicas: ${CCM_COUNT:-1}
       enableDynamicReloading: ${ENABLE_DYNAMIC_RELOADING:-false}
+      caCertDir: ${CCM_CA_CERT_DIR:-/etc/pki/tls}
     cloudNodeManager:
       imageName: "${CNM_IMAGE_NAME:-""}"
       imageRepository: "${IMAGE_REGISTRY:-""}"

--- a/templates/test/ci/cluster-template-prow-private.yaml
+++ b/templates/test/ci/cluster-template-prow-private.yaml
@@ -336,6 +336,7 @@ spec:
     cloudControllerManager:
       clusterCIDR: {{ .Cluster.spec.clusterNetwork.pods.cidrBlocks | join "," }}
       logVerbosity: 4
+      caCertDir: ${CCM_CA_CERT_DIR:-/etc/pki/tls}
 ---
 apiVersion: addons.cluster.x-k8s.io/v1alpha1
 kind: HelmChartProxy
@@ -362,6 +363,7 @@ spec:
       logVerbosity: ${CCM_LOG_VERBOSITY:-4}
       replicas: ${CCM_COUNT:-1}
       enableDynamicReloading: ${ENABLE_DYNAMIC_RELOADING:-false}
+      caCertDir: ${CCM_CA_CERT_DIR:-/etc/pki/tls}
     cloudNodeManager:
       imageName: "${CNM_IMAGE_NAME:-""}"
       imageRepository: "${IMAGE_REGISTRY:-""}"

--- a/templates/test/ci/cluster-template-prow-spot.yaml
+++ b/templates/test/ci/cluster-template-prow-spot.yaml
@@ -307,6 +307,7 @@ spec:
     cloudControllerManager:
       clusterCIDR: {{ .Cluster.spec.clusterNetwork.pods.cidrBlocks | join "," }}
       logVerbosity: 4
+      caCertDir: ${CCM_CA_CERT_DIR:-/etc/pki/tls}
 ---
 apiVersion: addons.cluster.x-k8s.io/v1alpha1
 kind: HelmChartProxy
@@ -333,6 +334,7 @@ spec:
       logVerbosity: ${CCM_LOG_VERBOSITY:-4}
       replicas: ${CCM_COUNT:-1}
       enableDynamicReloading: ${ENABLE_DYNAMIC_RELOADING:-false}
+      caCertDir: ${CCM_CA_CERT_DIR:-/etc/pki/tls}
     cloudNodeManager:
       imageName: "${CNM_IMAGE_NAME:-""}"
       imageRepository: "${IMAGE_REGISTRY:-""}"

--- a/templates/test/ci/cluster-template-prow-topology.yaml
+++ b/templates/test/ci/cluster-template-prow-topology.yaml
@@ -152,6 +152,7 @@ spec:
     cloudControllerManager:
       clusterCIDR: {{ .Cluster.spec.clusterNetwork.pods.cidrBlocks | join "," }}
       logVerbosity: 4
+      caCertDir: ${CCM_CA_CERT_DIR:-/etc/pki/tls}
 ---
 apiVersion: addons.cluster.x-k8s.io/v1alpha1
 kind: HelmChartProxy
@@ -178,6 +179,7 @@ spec:
       logVerbosity: ${CCM_LOG_VERBOSITY:-4}
       replicas: ${CCM_COUNT:-1}
       enableDynamicReloading: ${ENABLE_DYNAMIC_RELOADING:-false}
+      caCertDir: ${CCM_CA_CERT_DIR:-/etc/pki/tls}
     cloudNodeManager:
       imageName: "${CNM_IMAGE_NAME:-""}"
       imageRepository: "${IMAGE_REGISTRY:-""}"

--- a/templates/test/ci/cluster-template-prow.yaml
+++ b/templates/test/ci/cluster-template-prow.yaml
@@ -484,6 +484,7 @@ spec:
     cloudControllerManager:
       clusterCIDR: {{ .Cluster.spec.clusterNetwork.pods.cidrBlocks | join "," }}
       logVerbosity: 4
+      caCertDir: ${CCM_CA_CERT_DIR:-/etc/pki/tls}
 ---
 apiVersion: addons.cluster.x-k8s.io/v1alpha1
 kind: HelmChartProxy
@@ -510,6 +511,7 @@ spec:
       logVerbosity: ${CCM_LOG_VERBOSITY:-4}
       replicas: ${CCM_COUNT:-1}
       enableDynamicReloading: ${ENABLE_DYNAMIC_RELOADING:-false}
+      caCertDir: ${CCM_CA_CERT_DIR:-/etc/pki/tls}
     cloudNodeManager:
       imageName: "${CNM_IMAGE_NAME:-""}"
       imageRepository: "${IMAGE_REGISTRY:-""}"

--- a/templates/test/dev/cluster-template-custom-builds-machine-pool.yaml
+++ b/templates/test/dev/cluster-template-custom-builds-machine-pool.yaml
@@ -600,6 +600,7 @@ spec:
     cloudControllerManager:
       clusterCIDR: {{ .Cluster.spec.clusterNetwork.pods.cidrBlocks | join "," }}
       logVerbosity: 4
+      caCertDir: ${CCM_CA_CERT_DIR:-/etc/pki/tls}
 ---
 apiVersion: addons.cluster.x-k8s.io/v1alpha1
 kind: HelmChartProxy
@@ -626,6 +627,7 @@ spec:
       logVerbosity: ${CCM_LOG_VERBOSITY:-4}
       replicas: ${CCM_COUNT:-1}
       enableDynamicReloading: ${ENABLE_DYNAMIC_RELOADING:-false}
+      caCertDir: ${CCM_CA_CERT_DIR:-/etc/pki/tls}
     cloudNodeManager:
       imageName: "${CNM_IMAGE_NAME:-""}"
       imageRepository: "${IMAGE_REGISTRY:-""}"

--- a/templates/test/dev/cluster-template-custom-builds.yaml
+++ b/templates/test/dev/cluster-template-custom-builds.yaml
@@ -693,6 +693,7 @@ spec:
     cloudControllerManager:
       clusterCIDR: {{ .Cluster.spec.clusterNetwork.pods.cidrBlocks | join "," }}
       logVerbosity: 4
+      caCertDir: ${CCM_CA_CERT_DIR:-/etc/pki/tls}
 ---
 apiVersion: addons.cluster.x-k8s.io/v1alpha1
 kind: HelmChartProxy
@@ -719,6 +720,7 @@ spec:
       logVerbosity: ${CCM_LOG_VERBOSITY:-4}
       replicas: ${CCM_COUNT:-1}
       enableDynamicReloading: ${ENABLE_DYNAMIC_RELOADING:-false}
+      caCertDir: ${CCM_CA_CERT_DIR:-/etc/pki/tls}
     cloudNodeManager:
       imageName: "${CNM_IMAGE_NAME:-""}"
       imageRepository: "${IMAGE_REGISTRY:-""}"

--- a/test/e2e/cloud-provider-azure.go
+++ b/test/e2e/cloud-provider-azure.go
@@ -69,6 +69,8 @@ func EnsureCNIAndCloudProviderAzureHelmChart(ctx context.Context, input clusterc
 
 		if strings.Contains(input.ClusterName, "flatcar") {
 			options.StringValues = append(options.StringValues, "cloudControllerManager.caCertDir=/usr/share/ca-certificates")
+		} else {
+			options.StringValues = append(options.StringValues, fmt.Sprintf("cloudControllerManager.caCertDir=%s", os.Getenv("CCM_CA_CERT_DIR")))
 		}
 
 		InstallHelmChart(ctx, clusterProxy, defaultNamespace, cloudProviderAzureHelmRepoURL, cloudProviderAzureChartName, cloudProviderAzureHelmReleaseName, options, "")

--- a/test/e2e/config/azure-dev.yaml
+++ b/test/e2e/config/azure-dev.yaml
@@ -199,6 +199,7 @@ variables:
   KUBERNETES_VERSION_UPGRADE_FROM: "${KUBERNETES_VERSION_UPGRADE_FROM:-stable-1.28}"
   CNI: "${PWD}/templates/addons/calico.yaml"
   ADDONS_PATH: "${PWD}/templates/addons"
+  CCM_CA_CERT_DIR: "${CCM_CA_CERT_DIR:-/etc/pki/tls}"
   REDACT_LOG_SCRIPT: "${PWD}/hack/log/redact.sh"
   EXP_AKS_RESOURCE_HEALTH: "true"
   EXP_MACHINE_POOL: "true"

--- a/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-kcp-remediation.yaml
+++ b/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-kcp-remediation.yaml
@@ -66,6 +66,7 @@ spec:
     cloudControllerManager:
       clusterCIDR: {{ .Cluster.spec.clusterNetwork.pods.cidrBlocks | join "," }}
       logVerbosity: 4
+      caCertDir: ${CCM_CA_CERT_DIR:-/etc/pki/tls}
 ---
 apiVersion: addons.cluster.x-k8s.io/v1alpha1
 kind: HelmChartProxy
@@ -91,6 +92,7 @@ spec:
       logVerbosity: ${CCM_LOG_VERBOSITY:-4}
       replicas: ${CCM_COUNT:-1}
       enableDynamicReloading: ${ENABLE_DYNAMIC_RELOADING:-false}
+      caCertDir: ${CCM_CA_CERT_DIR:-/etc/pki/tls}
     cloudNodeManager:
       imageName: "${CNM_IMAGE_NAME:-""}"
       imageRepository: "${IMAGE_REGISTRY:-""}"

--- a/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-kcp-scale-in.yaml
+++ b/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-kcp-scale-in.yaml
@@ -66,6 +66,7 @@ spec:
     cloudControllerManager:
       clusterCIDR: {{ .Cluster.spec.clusterNetwork.pods.cidrBlocks | join "," }}
       logVerbosity: 4
+      caCertDir: ${CCM_CA_CERT_DIR:-/etc/pki/tls}
 ---
 apiVersion: addons.cluster.x-k8s.io/v1alpha1
 kind: HelmChartProxy
@@ -91,6 +92,7 @@ spec:
       logVerbosity: ${CCM_LOG_VERBOSITY:-4}
       replicas: ${CCM_COUNT:-1}
       enableDynamicReloading: ${ENABLE_DYNAMIC_RELOADING:-false}
+      caCertDir: ${CCM_CA_CERT_DIR:-/etc/pki/tls}
     cloudNodeManager:
       imageName: "${CNM_IMAGE_NAME:-""}"
       imageRepository: "${IMAGE_REGISTRY:-""}"

--- a/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-machine-pool.yaml
+++ b/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-machine-pool.yaml
@@ -66,6 +66,7 @@ spec:
     cloudControllerManager:
       clusterCIDR: {{ .Cluster.spec.clusterNetwork.pods.cidrBlocks | join "," }}
       logVerbosity: 4
+      caCertDir: ${CCM_CA_CERT_DIR:-/etc/pki/tls}
 ---
 apiVersion: addons.cluster.x-k8s.io/v1alpha1
 kind: HelmChartProxy
@@ -91,6 +92,7 @@ spec:
       logVerbosity: ${CCM_LOG_VERBOSITY:-4}
       replicas: ${CCM_COUNT:-1}
       enableDynamicReloading: ${ENABLE_DYNAMIC_RELOADING:-false}
+      caCertDir: ${CCM_CA_CERT_DIR:-/etc/pki/tls}
     cloudNodeManager:
       imageName: "${CNM_IMAGE_NAME:-""}"
       imageRepository: "${IMAGE_REGISTRY:-""}"

--- a/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-md-remediation.yaml
+++ b/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-md-remediation.yaml
@@ -66,6 +66,7 @@ spec:
     cloudControllerManager:
       clusterCIDR: {{ .Cluster.spec.clusterNetwork.pods.cidrBlocks | join "," }}
       logVerbosity: 4
+      caCertDir: ${CCM_CA_CERT_DIR:-/etc/pki/tls}
 ---
 apiVersion: addons.cluster.x-k8s.io/v1alpha1
 kind: HelmChartProxy
@@ -91,6 +92,7 @@ spec:
       logVerbosity: ${CCM_LOG_VERBOSITY:-4}
       replicas: ${CCM_COUNT:-1}
       enableDynamicReloading: ${ENABLE_DYNAMIC_RELOADING:-false}
+      caCertDir: ${CCM_CA_CERT_DIR:-/etc/pki/tls}
     cloudNodeManager:
       imageName: "${CNM_IMAGE_NAME:-""}"
       imageRepository: "${IMAGE_REGISTRY:-""}"

--- a/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-node-drain.yaml
+++ b/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-node-drain.yaml
@@ -66,6 +66,7 @@ spec:
     cloudControllerManager:
       clusterCIDR: {{ .Cluster.spec.clusterNetwork.pods.cidrBlocks | join "," }}
       logVerbosity: 4
+      caCertDir: ${CCM_CA_CERT_DIR:-/etc/pki/tls}
 ---
 apiVersion: addons.cluster.x-k8s.io/v1alpha1
 kind: HelmChartProxy
@@ -91,6 +92,7 @@ spec:
       logVerbosity: ${CCM_LOG_VERBOSITY:-4}
       replicas: ${CCM_COUNT:-1}
       enableDynamicReloading: ${ENABLE_DYNAMIC_RELOADING:-false}
+      caCertDir: ${CCM_CA_CERT_DIR:-/etc/pki/tls}
     cloudNodeManager:
       imageName: "${CNM_IMAGE_NAME:-""}"
       imageRepository: "${IMAGE_REGISTRY:-""}"

--- a/test/e2e/data/infrastructure-azure/v1beta1/cluster-template.yaml
+++ b/test/e2e/data/infrastructure-azure/v1beta1/cluster-template.yaml
@@ -66,6 +66,7 @@ spec:
     cloudControllerManager:
       clusterCIDR: {{ .Cluster.spec.clusterNetwork.pods.cidrBlocks | join "," }}
       logVerbosity: 4
+      caCertDir: ${CCM_CA_CERT_DIR:-/etc/pki/tls}
 ---
 apiVersion: addons.cluster.x-k8s.io/v1alpha1
 kind: HelmChartProxy
@@ -91,6 +92,7 @@ spec:
       logVerbosity: ${CCM_LOG_VERBOSITY:-4}
       replicas: ${CCM_COUNT:-1}
       enableDynamicReloading: ${ENABLE_DYNAMIC_RELOADING:-false}
+      caCertDir: ${CCM_CA_CERT_DIR:-/etc/pki/tls}
     cloudNodeManager:
       imageName: "${CNM_IMAGE_NAME:-""}"
       imageRepository: "${IMAGE_REGISTRY:-""}"


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Changes the default node image selection logic to prefer Azure Linux (aka Mariner) images, falling back to Ubuntu if no AL image is found for the Kubernetes version required.

This should speed up provisioning a bit, as well as align CAPZ better with Azure service recommendations and security intitiatives.

**Which issue(s) this PR fixes**:

Fixes #4828
See also kubernetes-sigs/image-builder#1465

**Special notes for your reviewer**:

- [ ] cherry-pick candidate

**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests – this does need some for the new funcs!
- [ ] update the "mariner-2" string after republishing recent images

**Release note**:

```release-note
Default to Azure Linux images
```
