### PR TITLE
Set cluster name label for pre-existing kubeconfig

### DIFF
--- a/controllers/azuremanagedcontrolplane_reconciler.go
+++ b/controllers/azuremanagedcontrolplane_reconciler.go
@@ -33,6 +33,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-azure/azure/services/subnets"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/services/virtualnetworks"
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/util/secret"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -136,6 +137,15 @@ func (r *azureManagedControlPlaneService) reconcileKubeconfig(ctx context.Contex
 		if _, err := controllerutil.CreateOrUpdate(ctx, r.kubeclient, &kubeConfigSecret, func() error {
 			kubeConfigSecret.Data = map[string][]byte{
 				secret.KubeconfigDataName: kubeConfigData,
+			}
+
+			// When upgrading from an older version of CAPI, the kubeconfig secret may not have the required
+			// cluster name label. Add it here to avoid kubeconfig issues during upgrades.
+			if _, ok := kubeConfigSecret.Labels[clusterv1.ClusterNameLabel]; !ok {
+				if kubeConfigSecret.Labels == nil {
+					kubeConfigSecret.Labels = make(map[string]string)
+				}
+				kubeConfigSecret.Labels[clusterv1.ClusterNameLabel] = r.scope.ClusterName()
 			}
 			return nil
 		}); err != nil {


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
This PR adds a fix for clusters upgrading from before CAPI v1.5 to a newer version. v1.5 introduced a new requirement for the ClusterNameLabel to be added to kubeconfig secrets: https://cluster-api.sigs.k8s.io/developer/providers/migrations/v1.4-to-v1.5#other

CAPZ handles this for newly created kubeconfigs, but not pre-existing ones. This PR handles that case.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4738 

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [x] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Set cluster name label for pre-existing kubeconfig
```
