### PR TITLE
Group dependabot updates together for GitHub actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,9 @@ updates:
     time: "09:00"
     # Use America/New_York Standard Time (UTC -05:00)
     timezone: "America/New_York"
+  groups:
+    all-github-actions:
+      patterns: [ "*" ]
   commit-message:
     prefix: "dependabot"
     include: scope


### PR DESCRIPTION
/kind cleanup

**What this PR does / why we need it**:

Groups the weekly updates to GitHub Actions into a single PR, instead of one per changed action.

This should reduce the CI effort somewhat, but seems unlikely to introduce conflicts since CAPZ generally approves all GH action updates.

**Which issue(s) this PR fixes**:

None, but see kubernetes-sigs/cluster-api#10571 for the inspiration.

**Special notes for your reviewer**:

- [ ] cherry-pick candidate

**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:

```release-note
NONE
```
