### PR TITLE
workaround ASO User-Agent not getting set

### DIFF
--- a/config/aso/kustomization.yaml
+++ b/config/aso/kustomization.yaml
@@ -35,6 +35,26 @@ patches:
       version: v1
       kind: Deployment
       name: azureserviceoperator-controller-manager
+  # This implements https://github.com/Azure/azure-service-operator/pull/4011
+  # for versions of ASO which don't include that fix.
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: azureserviceoperator-controller-manager
+        namespace: azureserviceoperator-system
+      spec:
+        template:
+          spec:
+            containers:
+              - name: manager
+                env:
+                - name: AZURE_USER_AGENT_SUFFIX
+                  valueFrom:
+                    secretKeyRef:
+                      key: AZURE_USER_AGENT_SUFFIX
+                      name: aso-controller-settings
+                      optional: true
 
 replacements:
   - source:


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

There is a bug in ASO's deployment template preventing the `AZURE_USER_AGENT_SUFFIX` setting from being honored. That fix is upstreamed (https://github.com/Azure/azure-service-operator/pull/4011) but reimplemented here so we don't have to update our ASO for that fix.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [X] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
