### PR TITLE
Bump CAPI to v1.7.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -300,7 +300,7 @@ create-management-cluster: $(KUSTOMIZE) $(ENVSUBST) $(KUBECTL) $(KIND) ## Create
 	./hack/create-custom-cloud-provider-config.sh
 
 	# Deploy CAPI
-	timeout --foreground 300 bash -c "until curl --retry $(CURL_RETRIES) -sSL https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.7.1/cluster-api-components.yaml | $(ENVSUBST) | $(KUBECTL) apply -f -; do sleep 5; done"
+	timeout --foreground 300 bash -c "until curl --retry $(CURL_RETRIES) -sSL https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.7.2/cluster-api-components.yaml | $(ENVSUBST) | $(KUBECTL) apply -f -; do sleep 5; done"
 
 	# Deploy CAAPH
 	timeout --foreground 300 bash -c "until curl --retry $(CURL_RETRIES) -sSL https://github.com/kubernetes-sigs/cluster-api-addon-provider-helm/releases/download/v0.1.0-alpha.10/addon-components.yaml | $(ENVSUBST) | $(KUBECTL) apply -f -; do sleep 5; done"

--- a/Tiltfile
+++ b/Tiltfile
@@ -20,7 +20,7 @@ settings = {
     "deploy_cert_manager": True,
     "preload_images_for_kind": True,
     "kind_cluster_name": "capz",
-    "capi_version": "v1.7.1",
+    "capi_version": "v1.7.2",
     "caaph_version": "v0.2.1",
     "cert_manager_version": "v1.14.4",
     "kubernetes_version": "v1.28.3",

--- a/Tiltfile
+++ b/Tiltfile
@@ -22,7 +22,7 @@ settings = {
     "kind_cluster_name": "capz",
     "capi_version": "v1.7.2",
     "caaph_version": "v0.2.1",
-    "cert_manager_version": "v1.14.4",
+    "cert_manager_version": "v1.14.5",
     "kubernetes_version": "v1.28.3",
     "aks_kubernetes_version": "v1.28.3",
     "flatcar_version": "3374.2.1",

--- a/go.mod
+++ b/go.mod
@@ -52,8 +52,8 @@ require (
 	k8s.io/kubectl v0.29.3
 	k8s.io/utils v0.0.0-20240102154912-e7106e64919e
 	sigs.k8s.io/cloud-provider-azure v1.29.3
-	sigs.k8s.io/cluster-api v1.7.1
-	sigs.k8s.io/cluster-api/test v1.7.1
+	sigs.k8s.io/cluster-api v1.7.2
+	sigs.k8s.io/cluster-api/test v1.7.2
 	sigs.k8s.io/controller-runtime v0.17.3
 	sigs.k8s.io/kind v0.22.0
 )
@@ -216,7 +216,7 @@ require (
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
 
-replace sigs.k8s.io/cluster-api => sigs.k8s.io/cluster-api v1.7.1
+replace sigs.k8s.io/cluster-api => sigs.k8s.io/cluster-api v1.7.2
 
 // kube-openapi should match the version imported by CAPI.
 replace k8s.io/kube-openapi => k8s.io/kube-openapi v0.0.0-20231010175941-2dd684a91f00

--- a/go.sum
+++ b/go.sum
@@ -722,10 +722,10 @@ sigs.k8s.io/cloud-provider-azure/pkg/azclient v0.0.2 h1:9Zp+uWnxdUOoy/FaQK1DjPfL
 sigs.k8s.io/cloud-provider-azure/pkg/azclient v0.0.2/go.mod h1:JKWYkoOyET3wsN0Kk9WxA+zpopkuCy+v4+mrnJ60Yyk=
 sigs.k8s.io/cloud-provider-azure/pkg/azclient/configloader v0.0.1 h1:Lp0nALZmvMJoiVeVV6XjnZv1uClfArnThhuDAjaqE5A=
 sigs.k8s.io/cloud-provider-azure/pkg/azclient/configloader v0.0.1/go.mod h1:pPkJPx/eMVWP3R+LhPoOYGoY7lywcMJev5L2uSfH+Jo=
-sigs.k8s.io/cluster-api v1.7.1 h1:JkMAbAMzBM+WBHxXLTJXTiCisv1PAaHRzld/3qrmLYY=
-sigs.k8s.io/cluster-api v1.7.1/go.mod h1:V9ZhKLvQtsDODwjXOKgbitjyCmC71yMBwDcMyNNIov0=
-sigs.k8s.io/cluster-api/test v1.7.1 h1:QDru2586ZjIFBTW1Z7VVXVtauzR/yANm4tglUNLm9iE=
-sigs.k8s.io/cluster-api/test v1.7.1/go.mod h1:yG0g5Mdq73fMn9JP4akgRQPSne973L+Qx6iVH+LjtSM=
+sigs.k8s.io/cluster-api v1.7.2 h1:bRE8zoao7ajuLC0HijqfZVcubKQCPlZ04HMgcA53FGE=
+sigs.k8s.io/cluster-api v1.7.2/go.mod h1:V9ZhKLvQtsDODwjXOKgbitjyCmC71yMBwDcMyNNIov0=
+sigs.k8s.io/cluster-api/test v1.7.2 h1:muacGu5G/DGz2uTv3CUxml2QLi8fxbIra4CxA2S31KE=
+sigs.k8s.io/cluster-api/test v1.7.2/go.mod h1:yG0g5Mdq73fMn9JP4akgRQPSne973L+Qx6iVH+LjtSM=
 sigs.k8s.io/controller-runtime v0.17.3 h1:65QmN7r3FWgTxDMz9fvGnO1kbf2nu+acg9p2R9oYYYk=
 sigs.k8s.io/controller-runtime v0.17.3/go.mod h1:N0jpP5Lo7lMTF9aL56Z/B2oWBJjey6StQM0jRbKQXtY=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd h1:EDPBXCAspyGV4jQlpZSudPeMmr1bNJefnuqLsRAsHZo=

--- a/hack/install-cert-manager.sh
+++ b/hack/install-cert-manager.sh
@@ -54,7 +54,7 @@ source "${REPO_ROOT}/hack/common-vars.sh"
 make --directory="${REPO_ROOT}" "${KUBECTL##*/}"
 
 ## Install cert manager and wait for availability
-"${KUBECTL}" apply -f https://github.com/jetstack/cert-manager/releases/download/v1.14.4/cert-manager.yaml
+"${KUBECTL}" apply -f https://github.com/jetstack/cert-manager/releases/download/v1.14.5/cert-manager.yaml
 "${KUBECTL}" wait --for=condition=Available --timeout=5m -n cert-manager deployment/cert-manager
 "${KUBECTL}" wait --for=condition=Available --timeout=5m -n cert-manager deployment/cert-manager-cainjector
 "${KUBECTL}" wait --for=condition=Available --timeout=5m -n cert-manager deployment/cert-manager-webhook

--- a/test/e2e/config/azure-dev.yaml
+++ b/test/e2e/config/azure-dev.yaml
@@ -3,11 +3,11 @@ managementClusterName: capz-e2e
 images:
   - name: ${MANAGER_IMAGE}
     loadBehavior: mustLoad
-  - name: registry.k8s.io/cluster-api/cluster-api-controller:v1.7.1
+  - name: registry.k8s.io/cluster-api/cluster-api-controller:v1.7.2
     loadBehavior: tryLoad
-  - name: registry.k8s.io/cluster-api/kubeadm-bootstrap-controller:v1.7.1
+  - name: registry.k8s.io/cluster-api/kubeadm-bootstrap-controller:v1.7.2
     loadBehavior: tryLoad
-  - name: registry.k8s.io/cluster-api/kubeadm-control-plane-controller:v1.7.1
+  - name: registry.k8s.io/cluster-api/kubeadm-control-plane-controller:v1.7.2
     loadBehavior: tryLoad
   - name: registry.k8s.io/cluster-api-helm/cluster-api-helm-controller:v0.1.1-alpha.1
     loadBehavior: tryLoad
@@ -25,8 +25,8 @@ providers:
           new: --metrics-addr=:8080
       files:
         - sourcePath: "../data/shared/v1beta1/metadata.yaml"
-    - name: v1.7.1
-      value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.7.1/core-components.yaml
+    - name: v1.7.2
+      value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.7.2/core-components.yaml
       type: url
       contract: v1beta1
       files:
@@ -48,8 +48,8 @@ providers:
           new: --metrics-addr=:8080
       files:
         - sourcePath: "../data/shared/v1beta1/metadata.yaml"
-    - name: v1.7.1
-      value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.7.1/bootstrap-components.yaml
+    - name: v1.7.2
+      value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.7.2/bootstrap-components.yaml
       type: url
       contract: v1beta1
       files:
@@ -70,8 +70,8 @@ providers:
           new: --metrics-addr=:8080
       files:
         - sourcePath: "../data/shared/v1beta1/metadata.yaml"
-    - name: v1.7.1
-      value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.7.1/control-plane-components.yaml
+    - name: v1.7.2
+      value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.7.2/control-plane-components.yaml
       type: url
       contract: v1beta1
       files:
@@ -227,7 +227,7 @@ variables:
   SECURITY_SCAN_CONTAINER: "${SECURITY_SCAN_CONTAINER:-quay.io/armosec/kubescape:v2.0.167}"
   AZURE_CNI_V1_MANIFEST_PATH: "${PWD}/templates/addons/azure-cni-v1.yaml"
   OLD_CAPI_UPGRADE_VERSION: "v1.6.4"
-  LATEST_CAPI_UPGRADE_VERSION: "v1.7.1"
+  LATEST_CAPI_UPGRADE_VERSION: "v1.7.2"
   OLD_PROVIDER_UPGRADE_VERSION: "v1.14.4"
   LATEST_PROVIDER_UPGRADE_VERSION: "v1.15.0"
   OLD_CAAPH_UPGRADE_VERSION: "v0.1.0-alpha.10"


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Updates CAPI to [v1.7.2](https://github.com/kubernetes-sigs/cluster-api/releases/tag/v1.7.2).

**Which issue(s) this PR fixes**:

N/A, but see #4767 for prior art.

**Special notes for your reviewer**:

- [x] cherry-pick candidate

**TODOs**:

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:

```release-note
Bump CAPI to v1.7.2
```
