### PR TITLE
Fix Kustomization Warnings

### DIFF
--- a/config/aso/kustomization.yaml
+++ b/config/aso/kustomization.yaml
@@ -7,79 +7,79 @@ resources:
 - settings.yaml
 
 patches:
-  - path: patches/visualizer_label_in_bastionhosts.yaml
-  - path: patches/visualizer_label_in_extensions.yaml
-  - path: patches/visualizer_label_in_fleetmembers.yaml
-  - path: patches/visualizer_label_in_managedclusteragentpools.yaml
-  - path: patches/visualizer_label_in_managed_clusters.yaml
-  - path: patches/visualizer_label_in_natgateways.yaml
-  - path: patches/visualizer_label_in_privateendpoints.yaml
-  - path: patches/visualizer_label_in_resourcegroups.yaml
-  - path: patches/visualizer_label_in_subnets.yaml
-  - path: patches/visualizer_label_in_virtualnetworks.yaml
-  - patch: |- # default kustomization includes a namespace already
-      $patch: delete
-      apiVersion: v1
-      kind: Namespace
-      metadata:
-        name: azureserviceoperator-system
-  - patch: |-
-      - op: test
-        path: /spec/template/spec/containers/0/args/4
-        value: --crd-pattern=
-      - op: replace # Users can specify additional ASO CRDs. CRDs should be appended with ';'
-        path: /spec/template/spec/containers/0/args/4
-        value: --crd-pattern=${ADDITIONAL_ASO_CRDS:= }
-    target:
-      group: apps
-      version: v1
-      kind: Deployment
-      name: azureserviceoperator-controller-manager
+- path: patches/visualizer_label_in_bastionhosts.yaml
+- path: patches/visualizer_label_in_extensions.yaml
+- path: patches/visualizer_label_in_fleetmembers.yaml
+- path: patches/visualizer_label_in_managedclusteragentpools.yaml
+- path: patches/visualizer_label_in_managed_clusters.yaml
+- path: patches/visualizer_label_in_natgateways.yaml
+- path: patches/visualizer_label_in_privateendpoints.yaml
+- path: patches/visualizer_label_in_resourcegroups.yaml
+- path: patches/visualizer_label_in_subnets.yaml
+- path: patches/visualizer_label_in_virtualnetworks.yaml
+- patch: |- # default kustomization includes a namespace already
+    $patch: delete
+    apiVersion: v1
+    kind: Namespace
+    metadata:
+      name: azureserviceoperator-system
+- patch: |-
+    - op: test
+      path: /spec/template/spec/containers/0/args/4
+      value: --crd-pattern=
+    - op: replace # Users can specify additional ASO CRDs. CRDs should be appended with ';'
+      path: /spec/template/spec/containers/0/args/4
+      value: --crd-pattern=${ADDITIONAL_ASO_CRDS:= }
+  target:
+    group: apps
+    kind: Deployment
+    name: azureserviceoperator-controller-manager
+    version: v1
+
   # This implements https://github.com/Azure/azure-service-operator/pull/4011
   # for versions of ASO which don't include that fix.
-  - patch: |-
-      apiVersion: apps/v1
-      kind: Deployment
-      metadata:
-        name: azureserviceoperator-controller-manager
-        namespace: azureserviceoperator-system
-      spec:
-        template:
-          spec:
-            containers:
-              - name: manager
-                env:
-                - name: AZURE_USER_AGENT_SUFFIX
-                  valueFrom:
-                    secretKeyRef:
-                      key: AZURE_USER_AGENT_SUFFIX
-                      name: aso-controller-settings
-                      optional: true
+- patch: |-
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: azureserviceoperator-controller-manager
+      namespace: azureserviceoperator-system
+    spec:
+      template:
+        spec:
+          containers:
+            - name: manager
+              env:
+              - name: AZURE_USER_AGENT_SUFFIX
+                valueFrom:
+                  secretKeyRef:
+                    key: AZURE_USER_AGENT_SUFFIX
+                    name: aso-controller-settings
+                    optional: true
 
 replacements:
-  - source:
-      kind: Certificate
-      group: cert-manager.io
+- source:
+    fieldPath: metadata.namespace
+    group: cert-manager.io
+    kind: Certificate
+    name: azureserviceoperator-serving-cert
+    version: v1
+  targets:
+  - fieldPaths:
+    - metadata.annotations.cert-manager\.io/inject-ca-from
+    options:
+      delimiter: /
+    select:
+      annotationSelector: cert-manager.io/inject-ca-from
       version: v1
+  - fieldPaths:
+    - spec.dnsNames.0
+    - spec.dnsNames.1
+    options:
+      delimiter: .
+      index: 1
+    select:
+      group: cert-manager.io
+      kind: Certificate
       name: azureserviceoperator-serving-cert
-      fieldPath: metadata.namespace
-    targets:
-      - select:
-          version: v1
-          annotationSelector: cert-manager.io/inject-ca-from
-        fieldPaths:
-          - metadata.annotations.cert-manager\.io/inject-ca-from
-        options:
-          delimiter: /
-          index: 0
-      - select:
-          group: cert-manager.io
-          version: v1
-          kind: Certificate
-          name: azureserviceoperator-serving-cert
-        fieldPaths:
-          - spec.dnsNames.0
-          - spec.dnsNames.1
-        options:
-          delimiter: .
-          index: 1
+      version: v1

--- a/config/capz/kustomization.yaml
+++ b/config/capz/kustomization.yaml
@@ -1,5 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 namespace: capz-system
-
 namePrefix: capz-
 
 # Labels to add to all resources and selectors.
@@ -51,7 +52,6 @@ replacements:
       index: 1
     select:
       annotationSelector: cert-manager.io/inject-ca-from
-
 - source: # SERVICE_NAMESPACE
     fieldPath: metadata.namespace
     kind: Service
@@ -79,7 +79,6 @@ replacements:
       name: serving-cert
       namespace: system
       version: v1
-
 - source: # SERVICE_NAME
     kind: Service
     name: webhook-service

--- a/config/certmanager/kustomization.yaml
+++ b/config/certmanager/kustomization.yaml
@@ -1,4 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 resources:
-  - certificate.yaml
+- certificate.yaml
 configurations:
-  - kustomizeconfig.yaml
+- kustomizeconfig.yaml

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -1,79 +1,80 @@
 # This kustomization.yaml is not intended to be run by itself,
 # since it depends on service name and namespace that are out of this kustomize package.
 # It should be run by config/
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 
 resources:
-  - bases/infrastructure.cluster.x-k8s.io_azuremachines.yaml
-  - bases/infrastructure.cluster.x-k8s.io_azureclusters.yaml
-  - bases/infrastructure.cluster.x-k8s.io_azureclustertemplates.yaml
-  - bases/infrastructure.cluster.x-k8s.io_azuremachinetemplates.yaml
-  - bases/infrastructure.cluster.x-k8s.io_azureclusteridentities.yaml
-  - bases/infrastructure.cluster.x-k8s.io_azuremachinepools.yaml
-  - bases/infrastructure.cluster.x-k8s.io_azuremanagedmachinepools.yaml
-  - bases/infrastructure.cluster.x-k8s.io_azuremanagedclusters.yaml
-  - bases/infrastructure.cluster.x-k8s.io_azuremanagedcontrolplanes.yaml
-  - bases/infrastructure.cluster.x-k8s.io_azuremachinepoolmachines.yaml
-  - bases/infrastructure.cluster.x-k8s.io_azuremanagedclustertemplates.yaml
-  - bases/infrastructure.cluster.x-k8s.io_azuremanagedcontrolplanetemplates.yaml
-  - bases/infrastructure.cluster.x-k8s.io_azuremanagedmachinepooltemplates.yaml
-  - bases/infrastructure.cluster.x-k8s.io_azureasomanagedclusters.yaml
-  - bases/infrastructure.cluster.x-k8s.io_azureasomanagedclustertemplates.yaml
-  - bases/infrastructure.cluster.x-k8s.io_azureasomanagedcontrolplanes.yaml
-  - bases/infrastructure.cluster.x-k8s.io_azureasomanagedcontrolplanetemplates.yaml
-  - bases/infrastructure.cluster.x-k8s.io_azureasomanagedmachinepools.yaml
-  - bases/infrastructure.cluster.x-k8s.io_azureasomanagedmachinepooltemplates.yaml
+- bases/infrastructure.cluster.x-k8s.io_azuremachines.yaml
+- bases/infrastructure.cluster.x-k8s.io_azureclusters.yaml
+- bases/infrastructure.cluster.x-k8s.io_azureclustertemplates.yaml
+- bases/infrastructure.cluster.x-k8s.io_azuremachinetemplates.yaml
+- bases/infrastructure.cluster.x-k8s.io_azureclusteridentities.yaml
+- bases/infrastructure.cluster.x-k8s.io_azuremachinepools.yaml
+- bases/infrastructure.cluster.x-k8s.io_azuremanagedmachinepools.yaml
+- bases/infrastructure.cluster.x-k8s.io_azuremanagedclusters.yaml
+- bases/infrastructure.cluster.x-k8s.io_azuremanagedcontrolplanes.yaml
+- bases/infrastructure.cluster.x-k8s.io_azuremachinepoolmachines.yaml
+- bases/infrastructure.cluster.x-k8s.io_azuremanagedclustertemplates.yaml
+- bases/infrastructure.cluster.x-k8s.io_azuremanagedcontrolplanetemplates.yaml
+- bases/infrastructure.cluster.x-k8s.io_azuremanagedmachinepooltemplates.yaml
+- bases/infrastructure.cluster.x-k8s.io_azureasomanagedclusters.yaml
+- bases/infrastructure.cluster.x-k8s.io_azureasomanagedclustertemplates.yaml
+- bases/infrastructure.cluster.x-k8s.io_azureasomanagedcontrolplanes.yaml
+- bases/infrastructure.cluster.x-k8s.io_azureasomanagedcontrolplanetemplates.yaml
+- bases/infrastructure.cluster.x-k8s.io_azureasomanagedmachinepools.yaml
+- bases/infrastructure.cluster.x-k8s.io_azureasomanagedmachinepooltemplates.yaml
 # +kubebuilder:scaffold:crdkustomizeresource
 
-
 patches:
-  # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
-  # patches here are for enabling the conversion webhook for each CRD
-  - path: patches/webhook_in_azuremachines.yaml
-  - path: patches/webhook_in_azureclusters.yaml
-  - path: patches/webhook_in_azureclustertemplates.yaml
-  - path: patches/webhook_in_azureclusteridentities.yaml
-  - path: patches/webhook_in_azuremachinetemplates.yaml
-  - path: patches/webhook_in_azuremachinepools.yaml
-  - path: patches/webhook_in_azuremachinepoolmachines.yaml
-  # - path: patches/webhook_in_azuremanagedmachinepools.yaml
-  # - path: patches/webhook_in_azuremanagedclusters.yaml
-  # - path: patches/webhook_in_azuremanagedcontrolplanes.yaml
-  # +kubebuilder:scaffold:crdkustomizewebhookpatch
+# [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
+# patches here are for enabling the conversion webhook for each CRD
+- path: patches/webhook_in_azuremachines.yaml
+- path: patches/webhook_in_azureclusters.yaml
+- path: patches/webhook_in_azureclustertemplates.yaml
+- path: patches/webhook_in_azureclusteridentities.yaml
+- path: patches/webhook_in_azuremachinetemplates.yaml
+- path: patches/webhook_in_azuremachinepools.yaml
+- path: patches/webhook_in_azuremachinepoolmachines.yaml
+# - path: patches/webhook_in_azuremanagedmachinepools.yaml
+# - path: patches/webhook_in_azuremanagedclusters.yaml
+# - path: patches/webhook_in_azuremanagedcontrolplanes.yaml
+# +kubebuilder:scaffold:crdkustomizewebhookpatch
 
-  # [CERTMANAGER] To enable webhook, uncomment all the sections with [CERTMANAGER] prefix.
-  # patches here are for enabling the CA injection for each CRD
-  - path: patches/cainjection_in_azuremachines.yaml
-  - path: patches/cainjection_in_azureclusters.yaml
-  - path: patches/cainjection_in_azureclustertemplates.yaml
-  - path: patches/cainjection_in_azureclusteridentities.yaml
-  - path: patches/cainjection_in_azuremachinetemplates.yaml
-  - path: patches/cainjection_in_azuremachinepools.yaml
-  - path: patches/cainjection_in_azuremachinepoolmachines.yaml
-  # - path: patches/cainjection_in_azuremanagedmachinepools.yaml
-  # - path: patches/cainjection_in_azuremanagedclusters.yaml
-  # - path: patches/cainjection_in_azuremanagedcontrolplanes.yaml
-  # +kubebuilder:scaffold:crdkustomizecainjectionpatch
+# [CERTMANAGER] To enable webhook, uncomment all the sections with [CERTMANAGER] prefix.
+# patches here are for enabling the CA injection for each CRD
+- path: patches/cainjection_in_azuremachines.yaml
+- path: patches/cainjection_in_azureclusters.yaml
+- path: patches/cainjection_in_azureclustertemplates.yaml
+- path: patches/cainjection_in_azureclusteridentities.yaml
+- path: patches/cainjection_in_azuremachinetemplates.yaml
+- path: patches/cainjection_in_azuremachinepools.yaml
+- path: patches/cainjection_in_azuremachinepoolmachines.yaml
+# - path: patches/cainjection_in_azuremanagedmachinepools.yaml
+# - path: patches/cainjection_in_azuremanagedclusters.yaml
+# - path: patches/cainjection_in_azuremanagedcontrolplanes.yaml
+# +kubebuilder:scaffold:crdkustomizecainjectionpatch
 
-  - path: patches/capicontract_in_azuremachines.yaml
-  - path: patches/capicontract_in_azureclusters.yaml
-  - path: patches/capicontract_in_azureclustertemplates.yaml
-  - path: patches/capicontract_in_azuremachinetemplates.yaml
-  - path: patches/capicontract_in_azureclusteridentities.yaml
-  - path: patches/capicontract_in_azuremachinepools.yaml
-  - path: patches/capicontract_in_azuremanagedmachinepools.yaml
-  - path: patches/capicontract_in_azuremanagedclusters.yaml
-  - path: patches/capicontract_in_azuremanagedcontrolplanes.yaml
-  - path: patches/capicontract_in_azuremachinepoolmachines.yaml
-  - path: patches/capicontract_in_azuremanagedclustertemplates.yaml
-  - path: patches/capicontract_in_azuremanagedcontrolplanetemplates.yaml
-  - path: patches/capicontract_in_azuremanagedmachinepooltemplates.yaml
-  - path: patches/capicontract_in_azureasomanagedclusters.yaml
-  - path: patches/capicontract_in_azureasomanagedclustertemplates.yaml
-  - path: patches/capicontract_in_azureasomanagedcontrolplanes.yaml
-  - path: patches/capicontract_in_azureasomanagedcontrolplanetemplates.yaml
-  - path: patches/capicontract_in_azureasomanagedmachinepools.yaml
-  - path: patches/capicontract_in_azureasomanagedmachinepooltemplates.yaml
+- path: patches/capicontract_in_azuremachines.yaml
+- path: patches/capicontract_in_azureclusters.yaml
+- path: patches/capicontract_in_azureclustertemplates.yaml
+- path: patches/capicontract_in_azuremachinetemplates.yaml
+- path: patches/capicontract_in_azureclusteridentities.yaml
+- path: patches/capicontract_in_azuremachinepools.yaml
+- path: patches/capicontract_in_azuremanagedmachinepools.yaml
+- path: patches/capicontract_in_azuremanagedclusters.yaml
+- path: patches/capicontract_in_azuremanagedcontrolplanes.yaml
+- path: patches/capicontract_in_azuremachinepoolmachines.yaml
+- path: patches/capicontract_in_azuremanagedclustertemplates.yaml
+- path: patches/capicontract_in_azuremanagedcontrolplanetemplates.yaml
+- path: patches/capicontract_in_azuremanagedmachinepooltemplates.yaml
+- path: patches/capicontract_in_azureasomanagedclusters.yaml
+- path: patches/capicontract_in_azureasomanagedclustertemplates.yaml
+- path: patches/capicontract_in_azureasomanagedcontrolplanes.yaml
+- path: patches/capicontract_in_azureasomanagedcontrolplanetemplates.yaml
+- path: patches/capicontract_in_azureasomanagedmachinepools.yaml
+- path: patches/capicontract_in_azureasomanagedmachinepooltemplates.yaml
 
 # the following config is for teaching kustomize how to do kustomization for CRDs.
 configurations:
-  - kustomizeconfig.yaml
+- kustomizeconfig.yaml

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -1,23 +1,25 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 resources:
-  - ../capz
+- ../capz
 
 components:
-  - ../aso
+- ../aso
 
 replacements:
-  - source:
-      kind: Deployment
-      name: capz-controller-manager
-      fieldPath: spec.template.spec.containers.[name=manager].image
-      options:
-        delimiter: ':'
-        index: 1
-    targets:
-      - select:
-          kind: Secret
-          name: aso-controller-settings
-        fieldPaths:
-          - stringData.AZURE_USER_AGENT_SUFFIX
-        options:
-          delimiter: '/'
-          index: 1
+- source:
+    fieldPath: spec.template.spec.containers.[name=manager].image
+    kind: Deployment
+    name: capz-controller-manager
+    options:
+      delimiter: ':'
+      index: 1
+  targets:
+  - fieldPaths:
+    - stringData.AZURE_USER_AGENT_SUFFIX
+    options:
+      delimiter: /
+      index: 1
+    select:
+      kind: Secret
+      name: aso-controller-settings

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,5 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - manager.yaml
-
+- manager.yaml

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -1,8 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - role.yaml
-  - role_binding.yaml
-  - service_account.yaml
-  - leader_election_role.yaml
-  - leader_election_role_binding.yaml
+- role.yaml
+- role_binding.yaml
+- service_account.yaml
+- leader_election_role.yaml
+- leader_election_role_binding.yaml

--- a/config/webhook/kustomization.yaml
+++ b/config/webhook/kustomization.yaml
@@ -1,6 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 resources:
-  - manifests.yaml
-  - service.yaml
+- manifests.yaml
+- service.yaml
 
 configurations:
-  - kustomizeconfig.yaml
+- kustomizeconfig.yaml

--- a/hack/gen-flavors.sh
+++ b/hack/gen-flavors.sh
@@ -29,15 +29,15 @@ ci_dir="${REPO_ROOT}/templates/test/ci/"
 dev_dir="${REPO_ROOT}/templates/test/dev/"
 
 for name in $(find "${flavors_dir}"* -maxdepth 0 -type d -print0 | xargs -0 -I {} basename {} | grep -v base); do
-  ${KUSTOMIZE} build --load-restrictor LoadRestrictionsNone --reorder none "${flavors_dir}${name}" > "${REPO_ROOT}/templates/cluster-template-${name}.yaml"
+  ${KUSTOMIZE} build --load-restrictor LoadRestrictionsNone "${flavors_dir}${name}" > "${REPO_ROOT}/templates/cluster-template-${name}.yaml"
 done
 # move the default template to the default file expected by clusterctl
 mv "${REPO_ROOT}/templates/cluster-template-default.yaml" "${REPO_ROOT}/templates/cluster-template.yaml"
 
 for name in $(find "${ci_dir}"* -maxdepth 0 -type d -print0 | xargs -0 -I {} basename {} | grep -v patches); do
-  ${KUSTOMIZE} build --load-restrictor LoadRestrictionsNone --reorder none "${ci_dir}${name}" > "${ci_dir}cluster-template-${name}.yaml"
+  ${KUSTOMIZE} build --load-restrictor LoadRestrictionsNone "${ci_dir}${name}" > "${ci_dir}cluster-template-${name}.yaml"
 done
 
 for name in $(find "${dev_dir}"* -maxdepth 0 -type d -print0 | xargs -0 -I {} basename {} | grep -v patches); do
-  ${KUSTOMIZE} build --load-restrictor LoadRestrictionsNone --reorder none "${dev_dir}${name}" > "${dev_dir}cluster-template-${name}.yaml"
+  ${KUSTOMIZE} build --load-restrictor LoadRestrictionsNone "${dev_dir}${name}" > "${dev_dir}cluster-template-${name}.yaml"
 done

--- a/hack/observability/kustomization.yaml
+++ b/hack/observability/kustomization.yaml
@@ -1,6 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 resources:
-  - ../../config/default
-  - prometheus
+- ../../config/default
+- prometheus
 
-patchesStrategicMerge:
-  - opentelemetry/controller-manager-patch.yaml
+patches:
+- path: opentelemetry/controller-manager-patch.yaml

--- a/hack/observability/prometheus/kustomization.yaml
+++ b/hack/observability/prometheus/kustomization.yaml
@@ -1,4 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 namespace: capz-system
-
 resources:
-  - resources
+- resources

--- a/hack/observability/prometheus/resources/kustomization.yaml
+++ b/hack/observability/prometheus/resources/kustomization.yaml
@@ -1,4 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 resources:
-  - bundle.yaml
-  - prometheus.yaml
-  - capz_metrics_service.yaml
+- bundle.yaml
+- prometheus.yaml
+- capz_metrics_service.yaml

--- a/templates/addons/azure-cni-v1/kustomization.yaml
+++ b/templates/addons/azure-cni-v1/kustomization.yaml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - https://raw.githubusercontent.com/Azure/azure-container-networking/4034aad0d7085f2a9e96cce6d2b50b81ea9ec900/hack/manifests/cni-installer-v1.yaml
+- https://raw.githubusercontent.com/Azure/azure-container-networking/4034aad0d7085f2a9e96cce6d2b50b81ea9ec900/hack/manifests/cni-installer-v1.yaml

--- a/templates/addons/calico-dual-stack/kustomization.yaml
+++ b/templates/addons/calico-dual-stack/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-    - ../calico-ipv6
-patchesStrategicMerge:
-    - patches/calico-config.yaml
+- ../calico-ipv6
+patches:
+- path: patches/calico-config.yaml

--- a/templates/addons/calico-ipv6/kustomization.yaml
+++ b/templates/addons/calico-ipv6/kustomization.yaml
@@ -1,20 +1,19 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-    - calico-policy-only.yaml
-patchesStrategicMerge:
-    - patches/azure-mtu.yaml
-    - patches/calico-config.yaml
+- calico-policy-only.yaml
 patches:
-- target: 
+- path: patches/calico-node.yaml
+  target:
     group: apps
-    version: v1
     kind: DaemonSet
     name: calico-node
     namespace: kube-system
-  path: patches/calico-node.yaml
+    version: v1
 - path: patches/control-plane-tolerations.yaml
   target:
     kind: Deployment
     name: calico-kube-controllers
     namespace: kube-system
+- path: patches/azure-mtu.yaml
+- path: patches/calico-config.yaml

--- a/templates/addons/calico/kustomization.yaml
+++ b/templates/addons/calico/kustomization.yaml
@@ -1,9 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-    - calico-vxlan.yaml
-patchesStrategicMerge:
-    - patches/azure-mtu.yaml
+- calico-vxlan.yaml
 patches:
 - path: patches/calico-node.yaml
   target:
@@ -13,3 +11,4 @@ patches:
     kind: Deployment
     name: calico-kube-controllers
     namespace: kube-system
+- path: patches/azure-mtu.yaml

--- a/templates/addons/metrics-server/kustomization.yaml
+++ b/templates/addons/metrics-server/kustomization.yaml
@@ -2,14 +2,13 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: kube-system
 resources:
-  - https://github.com/kubernetes-sigs/metrics-server/releases/download/v0.6.3/components.yaml
-patchesStrategicMerge:
-  - patches/control-plane-toleration.yaml
+- https://github.com/kubernetes-sigs/metrics-server/releases/download/v0.6.3/components.yaml
 patches:
-- target:
+- path: patches/temp-use-insecure-https.yaml
+  target:
     group: apps
-    version: v1
     kind: Deployment
     name: metrics-server
     namespace: kube-system
-  path: patches/temp-use-insecure-https.yaml
+    version: v1
+- path: patches/control-plane-toleration.yaml

--- a/templates/azure-cluster-identity/kustomization.yaml
+++ b/templates/azure-cluster-identity/kustomization.yaml
@@ -1,3 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 namespace: default
 resources:
-  - azure-cluster-identity.yaml
+- azure-cluster-identity.yaml

--- a/templates/flavors/aad/kustomization.yaml
+++ b/templates/flavors/aad/kustomization.yaml
@@ -1,8 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 namespace: default
 resources:
-  - ../base
-  - machine-deployment.yaml
-  - ../../azure-cluster-identity
-patchesStrategicMerge:
-  - patches/kubeadm-controlplane.yaml
-  - ../../azure-cluster-identity/azurecluster-identity-ref.yaml
+- ../base
+- machine-deployment.yaml
+- ../../azure-cluster-identity
+patches:
+- path: patches/kubeadm-controlplane.yaml
+- path: ../../azure-cluster-identity/azurecluster-identity-ref.yaml
+
+sortOptions:
+  order: fifo

--- a/templates/flavors/aks-aso-clusterclass/kustomization.yaml
+++ b/templates/flavors/aks-aso-clusterclass/kustomization.yaml
@@ -7,3 +7,6 @@ resources:
 - azure-managed-cluster-template.yaml
 - azure-managed-machinepool-template.yaml
 - kubeadm-config-template.yaml
+
+sortOptions:
+  order: fifo

--- a/templates/flavors/aks-aso-topology/kustomization.yaml
+++ b/templates/flavors/aks-aso-topology/kustomization.yaml
@@ -3,3 +3,6 @@ kind: Kustomization
 namespace: default
 resources:
 - cluster.yaml
+
+sortOptions:
+  order: fifo

--- a/templates/flavors/aks-aso/kustomization.yaml
+++ b/templates/flavors/aks-aso/kustomization.yaml
@@ -3,3 +3,6 @@ kind: Kustomization
 namespace: default
 resources:
 - cluster-template.yaml
+
+sortOptions:
+  order: fifo

--- a/templates/flavors/aks-clusterclass/kustomization.yaml
+++ b/templates/flavors/aks-clusterclass/kustomization.yaml
@@ -8,3 +8,6 @@ resources:
 - azure-managed-machinepool-template.yaml
 - ../../azure-cluster-identity
 - kubeadm-config-template.yaml
+
+sortOptions:
+  order: fifo

--- a/templates/flavors/aks-topology/kustomization.yaml
+++ b/templates/flavors/aks-topology/kustomization.yaml
@@ -3,3 +3,6 @@ kind: Kustomization
 namespace: default
 resources:
 - cluster.yaml
+
+sortOptions:
+  order: fifo

--- a/templates/flavors/aks/kustomization.yaml
+++ b/templates/flavors/aks/kustomization.yaml
@@ -4,5 +4,8 @@ namespace: default
 resources:
 - cluster-template.yaml
 - ../../azure-cluster-identity
-patchesStrategicMerge:
-- ../../azure-cluster-identity/managedazurecluster-identity-ref.yaml
+patches:
+- path: ../../azure-cluster-identity/managedazurecluster-identity-ref.yaml
+
+sortOptions:
+  order: fifo

--- a/templates/flavors/azure-bastion/kustomization.yaml
+++ b/templates/flavors/azure-bastion/kustomization.yaml
@@ -1,5 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 namespace: default
 resources:
-  - ../default
-patchesStrategicMerge:
-  - patches/azure-cluster.yaml
+- ../default
+patches:
+- path: patches/azure-cluster.yaml
+
+sortOptions:
+  order: fifo

--- a/templates/flavors/azure-cni-v1/kustomization.yaml
+++ b/templates/flavors/azure-cni-v1/kustomization.yaml
@@ -1,9 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 namespace: default
 resources:
-  - ../default
-patchesStrategicMerge:
-  - ../../azure-cluster-identity/azurecluster-identity-ref.yaml
-  - patches/azure-machine-template-controlplane.yaml
-  - patches/azure-machine-template.yaml
-  - patches/kubeadm-control-plane.yaml
-  - patches/kubeadm-worker-node.yaml
+- ../default
+patches:
+- path: ../../azure-cluster-identity/azurecluster-identity-ref.yaml
+- path: patches/azure-machine-template-controlplane.yaml
+- path: patches/azure-machine-template.yaml
+- path: patches/kubeadm-control-plane.yaml
+- path: patches/kubeadm-worker-node.yaml
+
+sortOptions:
+  order: fifo

--- a/templates/flavors/base/kustomization.yaml
+++ b/templates/flavors/base/kustomization.yaml
@@ -2,4 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: default
 resources:
-  - cluster-template.yaml
+- cluster-template.yaml
+
+sortOptions:
+  order: fifo

--- a/templates/flavors/clusterclass/kustomization.yaml
+++ b/templates/flavors/clusterclass/kustomization.yaml
@@ -1,9 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 namespace: default
 resources:
-  - clusterclass.yaml
-  - azure-cluster-template.yaml
-  - azure-machine-template-controlplane.yaml
-  - azure-machine-template-worker.yaml
-  - kubeadm-controlplane-template.yaml
-  - kubeadm-config-template.yaml
-  - ../../azure-cluster-identity
+- clusterclass.yaml
+- azure-cluster-template.yaml
+- azure-machine-template-controlplane.yaml
+- azure-machine-template-worker.yaml
+- kubeadm-controlplane-template.yaml
+- kubeadm-config-template.yaml
+- ../../azure-cluster-identity
+
+sortOptions:
+  order: fifo

--- a/templates/flavors/default/kustomization.yaml
+++ b/templates/flavors/default/kustomization.yaml
@@ -1,8 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 namespace: default
 resources:
-  - ../base
-  - machine-deployment.yaml
-  - ../../azure-cluster-identity
+- ../base
+- machine-deployment.yaml
+- ../../azure-cluster-identity
+patches:
+- path: ../../azure-cluster-identity/azurecluster-identity-ref.yaml
 
-patchesStrategicMerge:
-  - ../../azure-cluster-identity/azurecluster-identity-ref.yaml
+sortOptions:
+  order: fifo

--- a/templates/flavors/dual-stack/kustomization.yaml
+++ b/templates/flavors/dual-stack/kustomization.yaml
@@ -1,11 +1,15 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 namespace: default
 resources:
-  - ../base
-  - ../../azure-cluster-identity
-  - machine-deployment.yaml
+- ../base
+- ../../azure-cluster-identity
+- machine-deployment.yaml
+patches:
+- path: patches/dual-stack.yaml
+- path: patches/kubeadm-controlplane.yaml
+- path: patches/controlplane-azuremachinetemplate.yaml
+- path: ../../azure-cluster-identity/azurecluster-identity-ref.yaml
 
-patchesStrategicMerge:
-  - patches/dual-stack.yaml
-  - patches/kubeadm-controlplane.yaml
-  - patches/controlplane-azuremachinetemplate.yaml
-  - ../../azure-cluster-identity/azurecluster-identity-ref.yaml
+sortOptions:
+  order: fifo

--- a/templates/flavors/edgezone/kustomization.yaml
+++ b/templates/flavors/edgezone/kustomization.yaml
@@ -1,7 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 namespace: default
 resources:
-  - ../default
+- ../default
+patches:
+- path: patches/azure-extendedlocation.yaml
+- path: patches/azure-remove-natgateway.yaml
 
-patchesStrategicMerge:
-  - patches/azure-extendedlocation.yaml
-  - patches/azure-remove-natgateway.yaml
+sortOptions:
+  order: fifo

--- a/templates/flavors/ephemeral/kustomization.yaml
+++ b/templates/flavors/ephemeral/kustomization.yaml
@@ -1,17 +1,22 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 namespace: default
 resources:
-  - ../default
+- ../default
 
 patches:
 - path: patches/ephemeral.yaml
   target:
     group: infrastructure.cluster.x-k8s.io
-    version: v1beta1
     kind: AzureMachineTemplate
-    name: ".*-md-0"
+    name: .*-md-0
+    version: v1beta1
 - path: patches/ephemeral.yaml
   target:
     group: infrastructure.cluster.x-k8s.io
-    version: v1beta1
     kind: AzureMachineTemplate
-    name: ".*-control-plane"
+    name: .*-control-plane
+    version: v1beta1
+
+sortOptions:
+  order: fifo

--- a/templates/flavors/flatcar/kustomization.yaml
+++ b/templates/flavors/flatcar/kustomization.yaml
@@ -1,9 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 namespace: default
 resources:
-  - ../base
-  - machine-deployment.yaml
-  - ../../azure-cluster-identity
+- ../base
+- machine-deployment.yaml
+- ../../azure-cluster-identity
+patches:
+- path: patches/kubeadm-controlplane.yaml
+- path: ../../azure-cluster-identity/azurecluster-identity-ref.yaml
 
-patchesStrategicMerge:
-  - patches/kubeadm-controlplane.yaml
-  - ../../azure-cluster-identity/azurecluster-identity-ref.yaml
+sortOptions:
+  order: fifo

--- a/templates/flavors/ipv6/kustomization.yaml
+++ b/templates/flavors/ipv6/kustomization.yaml
@@ -1,11 +1,16 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 namespace: default
 resources:
-  - ../base
-  - ../../azure-cluster-identity
-  - machine-deployment.yaml
+- ../base
+- ../../azure-cluster-identity
+- machine-deployment.yaml
 
-patchesStrategicMerge:
-  - ../../azure-cluster-identity/azurecluster-identity-ref.yaml
-  - patches/ipv6.yaml
-  - patches/kubeadm-controlplane.yaml
-  - patches/controlplane-azuremachinetemplate.yaml
+patches:
+- path: ../../azure-cluster-identity/azurecluster-identity-ref.yaml
+- path: patches/ipv6.yaml
+- path: patches/kubeadm-controlplane.yaml
+- path: patches/controlplane-azuremachinetemplate.yaml
+
+sortOptions:
+  order: fifo

--- a/templates/flavors/machinepool-windows/kustomization.yaml
+++ b/templates/flavors/machinepool-windows/kustomization.yaml
@@ -1,7 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 namespace: default
 resources:
-  - ../machinepool
-  - machine-pool-deployment-windows.yaml
+- ../machinepool
+- machine-pool-deployment-windows.yaml
+patches:
+- path: ../base-windows-containerd/cluster.yaml
 
-patchesStrategicMerge:
-  - ../base-windows-containerd/cluster.yaml
+sortOptions:
+  order: fifo

--- a/templates/flavors/machinepool/kustomization.yaml
+++ b/templates/flavors/machinepool/kustomization.yaml
@@ -1,8 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 namespace: default
 resources:
-  - ../base
-  - machine-pool-deployment.yaml
-  - ../../azure-cluster-identity
+- ../base
+- machine-pool-deployment.yaml
+- ../../azure-cluster-identity
 
-patchesStrategicMerge:
-  - ../../azure-cluster-identity/azurecluster-identity-ref.yaml
+patches:
+- path: ../../azure-cluster-identity/azurecluster-identity-ref.yaml
+
+sortOptions:
+  order: fifo

--- a/templates/flavors/nvidia-gpu/kustomization.yaml
+++ b/templates/flavors/nvidia-gpu/kustomization.yaml
@@ -1,15 +1,20 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 namespace: default
 resources:
-  - ../base
-  - ../../azure-cluster-identity
-  - machine-deployment.yaml
+- ../base
+- ../../azure-cluster-identity
+- machine-deployment.yaml
 
-patchesStrategicMerge:
-  - ../../azure-cluster-identity/azurecluster-identity-ref.yaml
 
 generatorOptions:
+  annotations:
+    note: generated
   disableNameSuffixHash: true
   labels:
     type: generated
-  annotations:
-    note: generated
+patches:
+- path: ../../azure-cluster-identity/azurecluster-identity-ref.yaml
+
+sortOptions:
+  order: fifo

--- a/templates/flavors/private/kustomization.yaml
+++ b/templates/flavors/private/kustomization.yaml
@@ -1,12 +1,16 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 namespace: default
 resources:
-  - ../base
-  - ../default/machine-deployment.yaml
-  - ../../azure-cluster-identity
+- ../base
+- ../default/machine-deployment.yaml
+- ../../azure-cluster-identity
 
-patchesStrategicMerge:
-  - ../../azure-cluster-identity/azurecluster-identity-ref.yaml
-  - patches/private-lb.yaml
-  - patches/apiserver-host-dns.yaml
-  - patches/azure-bastion.yaml
+patches:
+- path: ../../azure-cluster-identity/azurecluster-identity-ref.yaml
+- path: patches/private-lb.yaml
+- path: patches/apiserver-host-dns.yaml
+- path: patches/azure-bastion.yaml
 
+sortOptions:
+  order: fifo

--- a/templates/flavors/topology/kustomization.yaml
+++ b/templates/flavors/topology/kustomization.yaml
@@ -1,3 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 namespace: default
 resources:
 - cluster.yaml
+
+sortOptions:
+  order: fifo

--- a/templates/flavors/windows/kustomization.yaml
+++ b/templates/flavors/windows/kustomization.yaml
@@ -1,8 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 namespace: default
 resources:
-  - ../default
-  - machine-deployment-windows.yaml
+- ../default
+- machine-deployment-windows.yaml
 
-patchesStrategicMerge:
-  - ../base-windows-containerd/cluster.yaml
+patches:
+- path: ../base-windows-containerd/cluster.yaml
 
+sortOptions:
+  order: fifo

--- a/templates/test/ci/prow-aks-aso/kustomization.yaml
+++ b/templates/test/ci/prow-aks-aso/kustomization.yaml
@@ -2,28 +2,31 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: default
 resources:
-  - ../../../flavors/aks-aso
-  - patches/aks-pool2.yaml
+- ../../../flavors/aks-aso
+- patches/aks-pool2.yaml
 
 patches:
-  - patch: |-
-      - op: test
-        path: /spec/resources/0/kind
-        value: ResourceGroup
-      - op: replace
-        path: /spec/resources/0/spec/tags
-        value:
-          jobName: ${JOB_NAME}
-          creationTimestamp: ${TIMESTAMP}
-          buildProvenance: ${BUILD_PROVENANCE}
-    target:
-      kind: AzureASOManagedCluster
-  - patch: |-
-      - op: test
-        path: /spec/resources/0/kind
-        value: ManagedClustersAgentPool
-      - op: replace
-        path: /spec/resources/0/spec/vmSize
-        value: "${AZURE_AKS_NODE_MACHINE_TYPE:=Standard_D2s_v3}"
-    target:
-      kind: AzureASOManagedMachinePool
+- patch: |-
+    - op: test
+      path: /spec/resources/0/kind
+      value: ResourceGroup
+    - op: replace
+      path: /spec/resources/0/spec/tags
+      value:
+        jobName: ${JOB_NAME}
+        creationTimestamp: ${TIMESTAMP}
+        buildProvenance: ${BUILD_PROVENANCE}
+  target:
+    kind: AzureASOManagedCluster
+- patch: |-
+    - op: test
+      path: /spec/resources/0/kind
+      value: ManagedClustersAgentPool
+    - op: replace
+      path: /spec/resources/0/spec/vmSize
+      value: "${AZURE_AKS_NODE_MACHINE_TYPE:=Standard_D2s_v3}"
+  target:
+    kind: AzureASOManagedMachinePool
+
+sortOptions:
+  order: fifo

--- a/templates/test/ci/prow-aks-clusterclass/kustomization.yaml
+++ b/templates/test/ci/prow-aks-clusterclass/kustomization.yaml
@@ -2,13 +2,16 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: default
 resources:
-  - ../../../flavors/aks-clusterclass
-  - ../../../flavors/aks-topology
-patchesStrategicMerge:
-  - patches/tags-aks-clusterclass.yaml
-  - patches/aks-clusterclass-pool0.yaml
-  - patches/aks-clusterclass-pool1.yaml
-  - patches/cluster.yaml
-  - patches/addons.yaml
-  - patches/kubeadm-config-template.yaml
-  - patches.yaml
+- ../../../flavors/aks-clusterclass
+- ../../../flavors/aks-topology
+patches:
+- path: patches/tags-aks-clusterclass.yaml
+- path: patches/aks-clusterclass-pool0.yaml
+- path: patches/aks-clusterclass-pool1.yaml
+- path: patches/cluster.yaml
+- path: patches/addons.yaml
+- path: patches/kubeadm-config-template.yaml
+- path: patches.yaml
+
+sortOptions:
+  order: fifo

--- a/templates/test/ci/prow-aks/kustomization.yaml
+++ b/templates/test/ci/prow-aks/kustomization.yaml
@@ -2,10 +2,13 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: default
 resources:
-  - ../../../flavors/aks
-  - patches/aks-pool2.yaml
-patchesStrategicMerge:
-  - ../patches/tags-aks.yaml
-  - patches/aks-pool0.yaml
-  - patches/aks-pool1.yaml
-  - patches/addons.yaml
+- ../../../flavors/aks
+- patches/aks-pool2.yaml
+patches:
+- path: ../patches/tags-aks.yaml
+- path: patches/aks-pool0.yaml
+- path: patches/aks-pool1.yaml
+- path: patches/addons.yaml
+
+sortOptions:
+  order: fifo

--- a/templates/test/ci/prow-azure-cni-v1/kustomization.yaml
+++ b/templates/test/ci/prow-azure-cni-v1/kustomization.yaml
@@ -2,11 +2,14 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: default
 resources:
-  - ../../../flavors/azure-cni-v1/
-  - ../../../addons/cluster-api-helm/azuredisk-csi-driver.yaml
-  - ../../../addons/cluster-api-helm/cloud-provider-azure.yaml
-  - ../../../addons/cluster-api-helm/cloud-provider-azure-ci.yaml
-patchesStrategicMerge:
-  - ../patches/tags.yaml
-  - ../patches/controller-manager.yaml
-  - ../patches/cluster-label-cloud-provider-azure.yaml
+- ../../../flavors/azure-cni-v1/
+- ../../../addons/cluster-api-helm/azuredisk-csi-driver.yaml
+- ../../../addons/cluster-api-helm/cloud-provider-azure.yaml
+- ../../../addons/cluster-api-helm/cloud-provider-azure-ci.yaml
+patches:
+- path: ../patches/tags.yaml
+- path: ../patches/controller-manager.yaml
+- path: ../patches/cluster-label-cloud-provider-azure.yaml
+
+sortOptions:
+  order: fifo

--- a/templates/test/ci/prow-ci-version-dual-stack/kustomization.yaml
+++ b/templates/test/ci/prow-ci-version-dual-stack/kustomization.yaml
@@ -2,30 +2,32 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: default
 resources:
-  - ../prow-ci-version
-  - ../../../addons/cluster-api-helm/calico-dual-stack.yaml
-patchesStrategicMerge:
-  - ../../../flavors/dual-stack/patches/dual-stack.yaml
-  - ../../../flavors/dual-stack/patches/controlplane-azuremachinetemplate.yaml
-  - ../../../flavors/dual-stack/patches/kubeadm-controlplane.yaml
-  - ../prow-dual-stack/patches/cluster-label-calico-dual-stack.yaml
-  - patches/machine-deployment.yaml
-  - ../patches/windows-addons-disabled.yaml
+- ../prow-ci-version
+- ../../../addons/cluster-api-helm/calico-dual-stack.yaml
 patches:
-  - target:
-      kind: HelmChartProxy
+- patch: |
+    $patch: delete
+    apiVersion: addons.cluster.x-k8s.io/v1alpha1
+    kind: HelmChartProxy
+    metadata:
       name: calico
-    patch: |
-      $patch: delete
-      apiVersion: addons.cluster.x-k8s.io/v1alpha1
-      kind: HelmChartProxy
-      metadata:
-        name: calico
-  - target:
-      name: ".*-win.*"
-    patch: |
-      $patch: delete
-      apiVersion: cluster.x-k8s.io/v1beta1
-      kind: MachineDeployment
-      metadata:
-        name: win
+  target:
+    kind: HelmChartProxy
+    name: calico
+- patch: |
+    $patch: delete
+    apiVersion: cluster.x-k8s.io/v1beta1
+    kind: MachineDeployment
+    metadata:
+      name: win
+  target:
+    name: .*-win.*
+- path: ../../../flavors/dual-stack/patches/dual-stack.yaml
+- path: ../../../flavors/dual-stack/patches/controlplane-azuremachinetemplate.yaml
+- path: ../../../flavors/dual-stack/patches/kubeadm-controlplane.yaml
+- path: ../prow-dual-stack/patches/cluster-label-calico-dual-stack.yaml
+- path: patches/machine-deployment.yaml
+- path: ../patches/windows-addons-disabled.yaml
+
+sortOptions:
+  order: fifo

--- a/templates/test/ci/prow-ci-version-ipv6/kustomization.yaml
+++ b/templates/test/ci/prow-ci-version-ipv6/kustomization.yaml
@@ -2,30 +2,32 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: default
 resources:
-  - ../prow-ci-version
-  - ../../../addons/cluster-api-helm/calico-ipv6.yaml
-patchesStrategicMerge:
-  - ../../../flavors/ipv6/patches/ipv6.yaml
-  - ../../../flavors/ipv6/patches/controlplane-azuremachinetemplate.yaml
-  - ../../../flavors/ipv6/patches/kubeadm-controlplane.yaml
-  - ../prow-ipv6/patches/cluster-label-calico-ipv6.yaml
-  - patches/machine-deployment.yaml
-  - ../patches/windows-addons-disabled.yaml
+- ../prow-ci-version
+- ../../../addons/cluster-api-helm/calico-ipv6.yaml
 patches:
-  - target:
-      kind: HelmChartProxy
+- patch: |
+    $patch: delete
+    apiVersion: addons.cluster.x-k8s.io/v1alpha1
+    kind: HelmChartProxy
+    metadata:
       name: calico
-    patch: |
-      $patch: delete
-      apiVersion: addons.cluster.x-k8s.io/v1alpha1
-      kind: HelmChartProxy
-      metadata:
-        name: calico
-  - target:
-      name: ".*-win.*"
-    patch: |
-      $patch: delete
-      apiVersion: cluster.x-k8s.io/v1beta1
-      kind: MachineDeployment
-      metadata:
-        name: win
+  target:
+    kind: HelmChartProxy
+    name: calico
+- patch: |
+    $patch: delete
+    apiVersion: cluster.x-k8s.io/v1beta1
+    kind: MachineDeployment
+    metadata:
+      name: win
+  target:
+    name: .*-win.*
+- path: ../../../flavors/ipv6/patches/ipv6.yaml
+- path: ../../../flavors/ipv6/patches/controlplane-azuremachinetemplate.yaml
+- path: ../../../flavors/ipv6/patches/kubeadm-controlplane.yaml
+- path: ../prow-ipv6/patches/cluster-label-calico-ipv6.yaml
+- path: patches/machine-deployment.yaml
+- path: ../patches/windows-addons-disabled.yaml
+
+sortOptions:
+  order: fifo

--- a/templates/test/ci/prow-ci-version/kustomization.yaml
+++ b/templates/test/ci/prow-ci-version/kustomization.yaml
@@ -2,70 +2,72 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: default
 resources:
-  - ../prow
-  - ../../../addons/metrics-server/metrics-server-resource-set.yaml
-patchesStrategicMerge:
-  - ../patches/control-plane-image-ci-version.yaml
-  - ../patches/controller-manager.yaml
-  - ../patches/windows-feature-gates.yaml
-  - ../patches/windows-containerd-labels.yaml
-  - ../patches/windows-machine-deployment-replicas.yaml
-  - patches/machine-deployment-ci-version.yaml
-  - patches/machine-deployment-ci-version-windows.yaml
-  - ../patches/metrics-server-enabled-cluster.yaml
-  - ../patches/controller-manager-featuregates.yaml
+- ../prow
+- ../../../addons/metrics-server/metrics-server-resource-set.yaml
 patches:
-- target:
+- path: patches/oot-credential-provider.yaml
+  target:
     group: bootstrap.cluster.x-k8s.io
-    version: v1beta1
     kind: KubeadmConfigTemplate
     name: .*-md-0
     namespace: default
-  path: patches/oot-credential-provider.yaml
-- target:
-    group: bootstrap.cluster.x-k8s.io
     version: v1beta1
+- path: patches/oot-credential-provider-win.yaml
+  target:
+    group: bootstrap.cluster.x-k8s.io
     kind: KubeadmConfigTemplate
     name: .*-md-win
     namespace: default
-  path: patches/oot-credential-provider-win.yaml
-- target:
-    group: controlplane.cluster.x-k8s.io
     version: v1beta1
+- path: patches/oot-credential-provider-kcp.yaml
+  target:
+    group: controlplane.cluster.x-k8s.io
     kind: KubeadmControlPlane
     name: .*-control-plane
-  path: patches/oot-credential-provider-kcp.yaml
-- target:
-    group: bootstrap.cluster.x-k8s.io
     version: v1beta1
+- path: patches/kubeadm-bootstrap.yaml
+  target:
+    group: bootstrap.cluster.x-k8s.io
     kind: KubeadmConfigTemplate
     name: .*-md-0
     namespace: default
-  path: patches/kubeadm-bootstrap.yaml
-- target:
-    group: bootstrap.cluster.x-k8s.io
     version: v1beta1
+- path: patches/kubeadm-bootstrap-windows-k8s-ci-binaries.yaml
+  target:
+    group: bootstrap.cluster.x-k8s.io
     kind: KubeadmConfigTemplate
     name: .*-md-win
     namespace: default
-  path: patches/kubeadm-bootstrap-windows-k8s-ci-binaries.yaml
-- target:
-    group: controlplane.cluster.x-k8s.io
     version: v1beta1
+- path: ../patches/control-plane-kubeadm-boostrap-ci-version.yaml
+  target:
+    group: controlplane.cluster.x-k8s.io
     kind: KubeadmControlPlane
     name: .*-control-plane
-  path: ../patches/control-plane-kubeadm-boostrap-ci-version.yaml
+    version: v1beta1
+- path: ../patches/control-plane-image-ci-version.yaml
+- path: ../patches/controller-manager.yaml
+- path: ../patches/windows-feature-gates.yaml
+- path: ../patches/windows-containerd-labels.yaml
+- path: ../patches/windows-machine-deployment-replicas.yaml
+- path: patches/machine-deployment-ci-version.yaml
+- path: patches/machine-deployment-ci-version-windows.yaml
+- path: ../patches/metrics-server-enabled-cluster.yaml
+- path: ../patches/controller-manager-featuregates.yaml
 configMapGenerator:
-  - name: cni-${CLUSTER_NAME}-calico-windows
-    behavior: merge
-    files:
-      - kube-proxy-patch=../patches/windows-kubeproxy-ci.yaml
-  - name: metrics-server-${CLUSTER_NAME}
-    files:
-      - metrics-server=../../../addons/metrics-server/metrics-server.yaml
+- behavior: merge
+  files:
+  - kube-proxy-patch=../patches/windows-kubeproxy-ci.yaml
+  name: cni-${CLUSTER_NAME}-calico-windows
+- files:
+  - metrics-server=../../../addons/metrics-server/metrics-server.yaml
+  name: metrics-server-${CLUSTER_NAME}
 generatorOptions:
+  annotations:
+    note: generated
   disableNameSuffixHash: true
   labels:
     type: generated
-  annotations:
-    note: generated
+
+sortOptions:
+  order: fifo

--- a/templates/test/ci/prow-clusterclass-ci-default/kustomization.yaml
+++ b/templates/test/ci/prow-clusterclass-ci-default/kustomization.yaml
@@ -2,13 +2,16 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: default
 resources:
-  - ../../../flavors/clusterclass/clusterclass.yaml
-  - ../../../flavors/clusterclass/kubeadm-controlplane-template.yaml
-  - ../../../flavors/clusterclass/azure-cluster-template.yaml
-  - ../../../flavors/clusterclass/azure-machine-template-controlplane.yaml
-  - kubeadm-config-template.yaml
-  - windows.yaml
-  - ../../../azure-cluster-identity
-patchesStrategicMerge:
-  - patches.yaml
-  - variables.yaml
+- ../../../flavors/clusterclass/clusterclass.yaml
+- ../../../flavors/clusterclass/kubeadm-controlplane-template.yaml
+- ../../../flavors/clusterclass/azure-cluster-template.yaml
+- ../../../flavors/clusterclass/azure-machine-template-controlplane.yaml
+- kubeadm-config-template.yaml
+- windows.yaml
+- ../../../azure-cluster-identity
+patches:
+- path: patches.yaml
+- path: variables.yaml
+
+sortOptions:
+  order: fifo

--- a/templates/test/ci/prow-custom-vnet/kustomization.yaml
+++ b/templates/test/ci/prow-custom-vnet/kustomization.yaml
@@ -2,18 +2,21 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: default
 resources:
-  - ../../../flavors/default
-  - ../prow/mhc.yaml
-  - ../../../addons/cluster-api-helm/calico.yaml
-  - ../../../addons/cluster-api-helm/azuredisk-csi-driver.yaml
-  - ../../../addons/cluster-api-helm/cloud-provider-azure.yaml
-  - ../../../addons/cluster-api-helm/cloud-provider-azure-ci.yaml
-patchesStrategicMerge:
-  - ../patches/tags.yaml
-  - ../patches/mhc.yaml
-  - ../patches/controller-manager.yaml
-  - patches/custom-vnet.yaml
-  - ../patches/uami-md-0.yaml
-  - ../patches/uami-control-plane.yaml
-  - ../patches/cluster-label-calico.yaml
-  - ../patches/cluster-label-cloud-provider-azure.yaml
+- ../../../flavors/default
+- ../prow/mhc.yaml
+- ../../../addons/cluster-api-helm/calico.yaml
+- ../../../addons/cluster-api-helm/azuredisk-csi-driver.yaml
+- ../../../addons/cluster-api-helm/cloud-provider-azure.yaml
+- ../../../addons/cluster-api-helm/cloud-provider-azure-ci.yaml
+patches:
+- path: ../patches/tags.yaml
+- path: ../patches/mhc.yaml
+- path: ../patches/controller-manager.yaml
+- path: patches/custom-vnet.yaml
+- path: ../patches/uami-md-0.yaml
+- path: ../patches/uami-control-plane.yaml
+- path: ../patches/cluster-label-calico.yaml
+- path: ../patches/cluster-label-cloud-provider-azure.yaml
+
+sortOptions:
+  order: fifo

--- a/templates/test/ci/prow-dual-stack/kustomization.yaml
+++ b/templates/test/ci/prow-dual-stack/kustomization.yaml
@@ -2,16 +2,19 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: default
 resources:
-  - ../../../flavors/dual-stack
-  - machine-pool-dualstack.yaml
-  - ../../../addons/cluster-api-helm/calico-dual-stack.yaml
-  - ../../../addons/cluster-api-helm/azuredisk-csi-driver.yaml
-  - ../../../addons/cluster-api-helm/cloud-provider-azure.yaml
-  - ../../../addons/cluster-api-helm/cloud-provider-azure-ci.yaml
-patchesStrategicMerge:
-  - ../patches/tags.yaml
-  - ../patches/controller-manager.yaml
-  - patches/azure-machine-template-control-plane.yaml
-  - patches/azure-machine-template.yaml
-  - patches/cluster-label-calico-dual-stack.yaml
-  - ../patches/cluster-label-cloud-provider-azure.yaml
+- ../../../flavors/dual-stack
+- machine-pool-dualstack.yaml
+- ../../../addons/cluster-api-helm/calico-dual-stack.yaml
+- ../../../addons/cluster-api-helm/azuredisk-csi-driver.yaml
+- ../../../addons/cluster-api-helm/cloud-provider-azure.yaml
+- ../../../addons/cluster-api-helm/cloud-provider-azure-ci.yaml
+patches:
+- path: ../patches/tags.yaml
+- path: ../patches/controller-manager.yaml
+- path: patches/azure-machine-template-control-plane.yaml
+- path: patches/azure-machine-template.yaml
+- path: patches/cluster-label-calico-dual-stack.yaml
+- path: ../patches/cluster-label-cloud-provider-azure.yaml
+
+sortOptions:
+  order: fifo

--- a/templates/test/ci/prow-edgezone/kustomization.yaml
+++ b/templates/test/ci/prow-edgezone/kustomization.yaml
@@ -2,21 +2,23 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: default
 resources:
-  - ../../../flavors/edgezone
-  - ../../../addons/cluster-api-helm/calico.yaml
-  - ../../../addons/cluster-api-helm/azuredisk-csi-driver.yaml
-  - ../../../addons/cluster-api-helm/cloud-provider-azure.yaml
-  - ../../../addons/cluster-api-helm/cloud-provider-azure-ci.yaml
-patchesStrategicMerge:
-  - ../patches/tags.yaml
-  - ../patches/controller-manager.yaml
-  - ../patches/apiserver.yaml
-  - ../patches/uami-md-0.yaml
-  - ../patches/uami-control-plane.yaml
-  - patches/azurecluster-edgezone.yaml
-  - patches/standardssd-disk.yaml
-  - patches/machine-type.yaml
-  - patches/kubernetes-version.yaml
-  - ../patches/cluster-label-calico.yaml
-  - ../patches/cluster-label-cloud-provider-azure.yaml
+- ../../../flavors/edgezone
+- ../../../addons/cluster-api-helm/calico.yaml
+- ../../../addons/cluster-api-helm/azuredisk-csi-driver.yaml
+- ../../../addons/cluster-api-helm/cloud-provider-azure.yaml
+- ../../../addons/cluster-api-helm/cloud-provider-azure-ci.yaml
+patches:
+- path: ../patches/tags.yaml
+- path: ../patches/controller-manager.yaml
+- path: ../patches/apiserver.yaml
+- path: ../patches/uami-md-0.yaml
+- path: ../patches/uami-control-plane.yaml
+- path: patches/azurecluster-edgezone.yaml
+- path: patches/standardssd-disk.yaml
+- path: patches/machine-type.yaml
+- path: patches/kubernetes-version.yaml
+- path: ../patches/cluster-label-calico.yaml
+- path: ../patches/cluster-label-cloud-provider-azure.yaml
 
+sortOptions:
+  order: fifo

--- a/templates/test/ci/prow-flatcar/kustomization.yaml
+++ b/templates/test/ci/prow-flatcar/kustomization.yaml
@@ -2,12 +2,15 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: default
 resources:
-  - ../../../flavors/flatcar/
-  - ../../../addons/cluster-api-helm/calico.yaml
-  - ../../../addons/cluster-api-helm/azuredisk-csi-driver.yaml
-  - ../../../addons/cluster-api-helm/cloud-provider-azure-flatcar.yaml
-patchesStrategicMerge:
-  - ../patches/tags.yaml
-  - ../patches/controller-manager.yaml
-  - ../patches/cluster-label-calico.yaml
-  - ../patches/cluster-label-cloud-provider-azure-flatcar.yaml
+- ../../../flavors/flatcar/
+- ../../../addons/cluster-api-helm/calico.yaml
+- ../../../addons/cluster-api-helm/azuredisk-csi-driver.yaml
+- ../../../addons/cluster-api-helm/cloud-provider-azure-flatcar.yaml
+patches:
+- path: ../patches/tags.yaml
+- path: ../patches/controller-manager.yaml
+- path: ../patches/cluster-label-calico.yaml
+- path: ../patches/cluster-label-cloud-provider-azure-flatcar.yaml
+
+sortOptions:
+  order: fifo

--- a/templates/test/ci/prow-ipv6/kustomization.yaml
+++ b/templates/test/ci/prow-ipv6/kustomization.yaml
@@ -2,14 +2,17 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: default
 resources:
-  - ../../../flavors/ipv6
-  - machine-pool-ipv6.yaml
-  - ../../../addons/cluster-api-helm/calico-ipv6.yaml
-  - ../../../addons/cluster-api-helm/azuredisk-csi-driver.yaml
-  - ../../../addons/cluster-api-helm/cloud-provider-azure.yaml
-  - ../../../addons/cluster-api-helm/cloud-provider-azure-ci.yaml
-patchesStrategicMerge:
-  - ../patches/tags.yaml
-  - ../patches/controller-manager.yaml
-  - patches/cluster-label-calico-ipv6.yaml
-  - ../patches/cluster-label-cloud-provider-azure.yaml
+- ../../../flavors/ipv6
+- machine-pool-ipv6.yaml
+- ../../../addons/cluster-api-helm/calico-ipv6.yaml
+- ../../../addons/cluster-api-helm/azuredisk-csi-driver.yaml
+- ../../../addons/cluster-api-helm/cloud-provider-azure.yaml
+- ../../../addons/cluster-api-helm/cloud-provider-azure-ci.yaml
+patches:
+- path: ../patches/tags.yaml
+- path: ../patches/controller-manager.yaml
+- path: patches/cluster-label-calico-ipv6.yaml
+- path: ../patches/cluster-label-cloud-provider-azure.yaml
+
+sortOptions:
+  order: fifo

--- a/templates/test/ci/prow-machine-pool-ci-version/kustomization.yaml
+++ b/templates/test/ci/prow-machine-pool-ci-version/kustomization.yaml
@@ -2,36 +2,38 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: default
 resources:
-  - ../prow-machine-pool
-patchesStrategicMerge:
-  - ../patches/control-plane-image-ci-version.yaml
-  - ../patches/controller-manager.yaml
-  - patches/machine-pool-ci-version.yaml
-  - ../patches/machine-pool-worker-counts.yaml
-  - patches/machine-pool-ci-version-windows.yaml
+- ../prow-machine-pool
 patches:
-- target:
+- path: ../prow-ci-version/patches/oot-credential-provider-kcp.yaml
+  target:
     group: controlplane.cluster.x-k8s.io
-    version: v1beta1
     kind: KubeadmControlPlane
     name: .*-control-plane
-  path: ../prow-ci-version/patches/oot-credential-provider-kcp.yaml
-- target:
-    group: controlplane.cluster.x-k8s.io
     version: v1beta1
+- path: ../patches/control-plane-kubeadm-boostrap-ci-version.yaml
+  target:
+    group: controlplane.cluster.x-k8s.io
     kind: KubeadmControlPlane
     name: .*-control-plane
     namespace: default
-  path: ../patches/control-plane-kubeadm-boostrap-ci-version.yaml
-- target:
-    group: bootstrap.cluster.x-k8s.io
     version: v1beta1
+- path: patches/kubeadm-bootstrap-windows-k8s-ci-binaries.yaml
+  target:
+    group: bootstrap.cluster.x-k8s.io
     kind: KubeadmConfig
     name: .*-mp-win
     namespace: default
-  path: patches/kubeadm-bootstrap-windows-k8s-ci-binaries.yaml
+    version: v1beta1
+- path: ../patches/control-plane-image-ci-version.yaml
+- path: ../patches/controller-manager.yaml
+- path: patches/machine-pool-ci-version.yaml
+- path: ../patches/machine-pool-worker-counts.yaml
+- path: patches/machine-pool-ci-version-windows.yaml
 configMapGenerator:
-  - name: cni-${CLUSTER_NAME}-calico-windows
-    behavior: merge
-    files:
-      - kube-proxy-patch=../patches/windows-kubeproxy-ci.yaml
+- behavior: merge
+  files:
+  - kube-proxy-patch=../patches/windows-kubeproxy-ci.yaml
+  name: cni-${CLUSTER_NAME}-calico-windows
+
+sortOptions:
+  order: fifo

--- a/templates/test/ci/prow-machine-pool-flex/kustomization.yaml
+++ b/templates/test/ci/prow-machine-pool-flex/kustomization.yaml
@@ -2,6 +2,9 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: default
 resources:
-  - ../prow-machine-pool
-patchesStrategicMerge:
-  - patches/vmss-flex.yaml
+- ../prow-machine-pool
+patches:
+- path: patches/vmss-flex.yaml
+
+sortOptions:
+  order: fifo

--- a/templates/test/ci/prow-machine-pool/kustomization.yaml
+++ b/templates/test/ci/prow-machine-pool/kustomization.yaml
@@ -2,36 +2,39 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: default
 resources:
-  - ../../../flavors/machinepool-windows
-  - ../prow/cni-resource-set.yaml
-  - ../../../addons/windows/csi-proxy/csi-proxy-resource-set.yaml
-  - ../../../addons/windows/containerd-logging/containerd-logger-resource-set.yaml
-  - ../../../addons/cluster-api-helm/calico.yaml
-  - ../../../addons/cluster-api-helm/azuredisk-csi-driver.yaml
-  - ../../../addons/cluster-api-helm/cloud-provider-azure.yaml
-  - ../../../addons/cluster-api-helm/cloud-provider-azure-ci.yaml
-patchesStrategicMerge:
-  - ../patches/azuremachinepool-vmextension.yaml
-  - ../patches/tags.yaml
-  - ../patches/controller-manager.yaml
-  - ../patches/machine-pool-worker-counts.yaml
-  - ../patches/windows-containerd-labels.yaml
-  - ../patches/cluster-label-calico.yaml
-  - ../patches/cluster-label-cloud-provider-azure.yaml
+- ../../../flavors/machinepool-windows
+- ../prow/cni-resource-set.yaml
+- ../../../addons/windows/csi-proxy/csi-proxy-resource-set.yaml
+- ../../../addons/windows/containerd-logging/containerd-logger-resource-set.yaml
+- ../../../addons/cluster-api-helm/calico.yaml
+- ../../../addons/cluster-api-helm/azuredisk-csi-driver.yaml
+- ../../../addons/cluster-api-helm/cloud-provider-azure.yaml
+- ../../../addons/cluster-api-helm/cloud-provider-azure-ci.yaml
 configMapGenerator:
-  - name: cni-${CLUSTER_NAME}-calico-windows
-    files:
-      - windows-cni=../../../addons/windows/calico/calico.yaml
-      - proxy=../../../addons/windows/calico/kube-proxy-windows.yaml
-  - name: csi-proxy-addon
-    files:
-      - csi-proxy=../../../addons/windows/csi-proxy/csi-proxy.yaml
-  - name: containerd-logger-${CLUSTER_NAME}
-    files:
-      - containerd-windows-logger=../../../addons/windows/containerd-logging/containerd-logger.yaml
+- files:
+  - windows-cni=../../../addons/windows/calico/calico.yaml
+  - proxy=../../../addons/windows/calico/kube-proxy-windows.yaml
+  name: cni-${CLUSTER_NAME}-calico-windows
+- files:
+  - csi-proxy=../../../addons/windows/csi-proxy/csi-proxy.yaml
+  name: csi-proxy-addon
+- files:
+  - containerd-windows-logger=../../../addons/windows/containerd-logging/containerd-logger.yaml
+  name: containerd-logger-${CLUSTER_NAME}
 generatorOptions:
+  annotations:
+    note: generated
   disableNameSuffixHash: true
   labels:
     type: generated
-  annotations:
-    note: generated
+patches:
+- path: ../patches/azuremachinepool-vmextension.yaml
+- path: ../patches/tags.yaml
+- path: ../patches/controller-manager.yaml
+- path: ../patches/machine-pool-worker-counts.yaml
+- path: ../patches/windows-containerd-labels.yaml
+- path: ../patches/cluster-label-calico.yaml
+- path: ../patches/cluster-label-cloud-provider-azure.yaml
+
+sortOptions:
+  order: fifo

--- a/templates/test/ci/prow-nvidia-gpu/kustomization.yaml
+++ b/templates/test/ci/prow-nvidia-gpu/kustomization.yaml
@@ -2,21 +2,23 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: default
 resources:
-  - ../../../flavors/nvidia-gpu
-  - ../../../addons/cluster-api-helm/calico.yaml
-  - ../../../addons/cluster-api-helm/azuredisk-csi-driver.yaml
-  - ../../../addons/cluster-api-helm/cloud-provider-azure.yaml
-  - ../../../addons/cluster-api-helm/cloud-provider-azure-ci.yaml
-patchesStrategicMerge:
-  - ../patches/tags.yaml
-  - ../patches/controller-manager.yaml
-  - ../patches/azurecluster-gpu.yaml
-  - ../patches/cluster-label-calico.yaml
-  - ../patches/cluster-label-cloud-provider-azure.yaml
+- ../../../flavors/nvidia-gpu
+- ../../../addons/cluster-api-helm/calico.yaml
+- ../../../addons/cluster-api-helm/azuredisk-csi-driver.yaml
+- ../../../addons/cluster-api-helm/cloud-provider-azure.yaml
+- ../../../addons/cluster-api-helm/cloud-provider-azure-ci.yaml
 patches:
 - path: patches/node-storage-type.yaml
   target:
     group: infrastructure.cluster.x-k8s.io
-    version: v1beta1
     kind: AzureMachineTemplate
-    name: ".*-md-0"
+    name: .*-md-0
+    version: v1beta1
+- path: ../patches/tags.yaml
+- path: ../patches/controller-manager.yaml
+- path: ../patches/azurecluster-gpu.yaml
+- path: ../patches/cluster-label-calico.yaml
+- path: ../patches/cluster-label-cloud-provider-azure.yaml
+
+sortOptions:
+  order: fifo

--- a/templates/test/ci/prow-private/kustomization.yaml
+++ b/templates/test/ci/prow-private/kustomization.yaml
@@ -2,32 +2,34 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: default
 resources:
-  - ../../../flavors/private
-  - cni-resource-set.yaml
-  - ../../../addons/cluster-api-helm/calico.yaml
-  - ../../../addons/cluster-api-helm/azuredisk-csi-driver.yaml
-  - ../../../addons/cluster-api-helm/cloud-provider-azure.yaml
-  - ../../../addons/cluster-api-helm/cloud-provider-azure-ci.yaml
-patchesStrategicMerge:
-  - ../patches/tags.yaml
-  - ../patches/controller-manager.yaml
-  - patches/bastion.yaml
-  - patches/vnet-peerings.yaml
-  - ../patches/uami-md-0.yaml
-  - ../patches/uami-control-plane.yaml
-  - ../patches/cluster-label-calico.yaml
-  - ../patches/cluster-label-cloud-provider-azure.yaml
+- ../../../flavors/private
+- cni-resource-set.yaml
+- ../../../addons/cluster-api-helm/calico.yaml
+- ../../../addons/cluster-api-helm/azuredisk-csi-driver.yaml
+- ../../../addons/cluster-api-helm/cloud-provider-azure.yaml
+- ../../../addons/cluster-api-helm/cloud-provider-azure-ci.yaml
 patches:
-  - path: patches/user-assigned.yaml
-    target:
-      kind: AzureClusterIdentity
+- path: patches/user-assigned.yaml
+  target:
+    kind: AzureClusterIdentity
+- path: ../patches/tags.yaml
+- path: ../patches/controller-manager.yaml
+- path: patches/bastion.yaml
+- path: patches/vnet-peerings.yaml
+- path: ../patches/uami-md-0.yaml
+- path: ../patches/uami-control-plane.yaml
+- path: ../patches/cluster-label-calico.yaml
+- path: ../patches/cluster-label-cloud-provider-azure.yaml
 configMapGenerator:
-  - name: cni-${CLUSTER_NAME}-calico
-    files:
-      - resources=../../../addons/calico.yaml
+- files:
+  - resources=../../../addons/calico.yaml
+  name: cni-${CLUSTER_NAME}-calico
 generatorOptions:
+  annotations:
+    note: generated
   disableNameSuffixHash: true
   labels:
     type: generated
-  annotations:
-    note: generated
+
+sortOptions:
+  order: fifo

--- a/templates/test/ci/prow-spot/kustomization.yaml
+++ b/templates/test/ci/prow-spot/kustomization.yaml
@@ -2,18 +2,21 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: default
 resources:
-  - ../../../flavors/default
-  - ../prow/mhc.yaml
-  - ../../../addons/cluster-api-helm/calico.yaml
-  - ../../../addons/cluster-api-helm/azuredisk-csi-driver.yaml
-  - ../../../addons/cluster-api-helm/cloud-provider-azure.yaml
-  - ../../../addons/cluster-api-helm/cloud-provider-azure-ci.yaml
-patchesStrategicMerge:
-  - ../patches/tags.yaml
-  - ../patches/mhc.yaml
-  - ../patches/controller-manager.yaml
-  - patches/spot-vm-options.yaml
-  - ../patches/uami-md-0.yaml
-  - ../patches/uami-control-plane.yaml
-  - ../patches/cluster-label-calico.yaml
-  - ../patches/cluster-label-cloud-provider-azure.yaml
+- ../../../flavors/default
+- ../prow/mhc.yaml
+- ../../../addons/cluster-api-helm/calico.yaml
+- ../../../addons/cluster-api-helm/azuredisk-csi-driver.yaml
+- ../../../addons/cluster-api-helm/cloud-provider-azure.yaml
+- ../../../addons/cluster-api-helm/cloud-provider-azure-ci.yaml
+patches:
+- path: ../patches/tags.yaml
+- path: ../patches/mhc.yaml
+- path: ../patches/controller-manager.yaml
+- path: patches/spot-vm-options.yaml
+- path: ../patches/uami-md-0.yaml
+- path: ../patches/uami-control-plane.yaml
+- path: ../patches/cluster-label-calico.yaml
+- path: ../patches/cluster-label-cloud-provider-azure.yaml
+
+sortOptions:
+  order: fifo

--- a/templates/test/ci/prow-topology/kustomization.yaml
+++ b/templates/test/ci/prow-topology/kustomization.yaml
@@ -2,29 +2,32 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: default
 resources:
-  - ../../../flavors/topology/cluster.yaml
-  - cni-resource-set.yaml
-  - ../../../addons/windows/csi-proxy/csi-proxy-resource-set.yaml
-  - ../../../addons/cluster-api-helm/calico.yaml
-  - ../../../addons/cluster-api-helm/azuredisk-csi-driver.yaml
-  - ../../../addons/cluster-api-helm/cloud-provider-azure.yaml
-  - ../../../addons/cluster-api-helm/cloud-provider-azure-ci.yaml
-patchesStrategicMerge:
-  - ../patches/windows-containerd-labels.yaml
-  - cluster.yaml
-  - ../patches/cluster-label-calico.yaml
-  - ../patches/cluster-label-cloud-provider-azure.yaml
+- ../../../flavors/topology/cluster.yaml
+- cni-resource-set.yaml
+- ../../../addons/windows/csi-proxy/csi-proxy-resource-set.yaml
+- ../../../addons/cluster-api-helm/calico.yaml
+- ../../../addons/cluster-api-helm/azuredisk-csi-driver.yaml
+- ../../../addons/cluster-api-helm/cloud-provider-azure.yaml
+- ../../../addons/cluster-api-helm/cloud-provider-azure-ci.yaml
 configMapGenerator:
-  - name: cni-${CLUSTER_NAME}-calico-windows
-    files:
-      - windows-cni=../../../addons/windows/calico/calico.yaml
-      - proxy=../../../addons/windows/calico/kube-proxy-windows.yaml
-  - name: csi-proxy-addon
-    files:
-      - csi-proxy=../../../addons/windows/csi-proxy/csi-proxy.yaml
+- files:
+  - windows-cni=../../../addons/windows/calico/calico.yaml
+  - proxy=../../../addons/windows/calico/kube-proxy-windows.yaml
+  name: cni-${CLUSTER_NAME}-calico-windows
+- files:
+  - csi-proxy=../../../addons/windows/csi-proxy/csi-proxy.yaml
+  name: csi-proxy-addon
 generatorOptions:
+  annotations:
+    note: generated
   disableNameSuffixHash: true
   labels:
     type: generated
-  annotations:
-    note: generated
+patches:
+- path: ../patches/windows-containerd-labels.yaml
+- path: cluster.yaml
+- path: ../patches/cluster-label-calico.yaml
+- path: ../patches/cluster-label-cloud-provider-azure.yaml
+
+sortOptions:
+  order: fifo

--- a/templates/test/ci/prow-workload-identity/kustomization.yaml
+++ b/templates/test/ci/prow-workload-identity/kustomization.yaml
@@ -2,18 +2,20 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: default
 resources:
-  - ../../../flavors/default
-  - ../../../addons/cluster-api-helm/calico.yaml
-  - ../../../addons/cluster-api-helm/azuredisk-csi-driver.yaml
-  - ../../../addons/cluster-api-helm/cloud-provider-azure.yaml
-  - ../../../addons/cluster-api-helm/cloud-provider-azure-ci.yaml
-patchesStrategicMerge:
-  - ../patches/azureclusteridentity-azwi.yaml
-  - ../patches/tags.yaml
-  - ../patches/controller-manager.yaml
-  - ../patches/apiserver.yaml
-  - ../patches/uami-md-0.yaml
-  - ../patches/uami-control-plane.yaml
-  - ../patches/cluster-label-calico.yaml
-  - ../patches/cluster-label-cloud-provider-azure.yaml
+- ../../../flavors/default
+- ../../../addons/cluster-api-helm/calico.yaml
+- ../../../addons/cluster-api-helm/azuredisk-csi-driver.yaml
+- ../../../addons/cluster-api-helm/cloud-provider-azure.yaml
+- ../../../addons/cluster-api-helm/cloud-provider-azure-ci.yaml
+patches:
+- path: ../patches/azureclusteridentity-azwi.yaml
+- path: ../patches/tags.yaml
+- path: ../patches/controller-manager.yaml
+- path: ../patches/apiserver.yaml
+- path: ../patches/uami-md-0.yaml
+- path: ../patches/uami-control-plane.yaml
+- path: ../patches/cluster-label-calico.yaml
+- path: ../patches/cluster-label-cloud-provider-azure.yaml
 
+sortOptions:
+  order: fifo

--- a/templates/test/ci/prow/kustomization.yaml
+++ b/templates/test/ci/prow/kustomization.yaml
@@ -2,66 +2,68 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: default
 resources:
-  - ../../../flavors/base
-  - ../../../flavors/default/machine-deployment.yaml
-  - ../../../flavors/windows/machine-deployment-windows.yaml
-  - mhc.yaml
-  - cni-resource-set.yaml
-  - ../../../azure-cluster-identity
-  - ../../../addons/windows/csi-proxy/csi-proxy-resource-set.yaml
-  - ../../../addons/windows/containerd-logging/containerd-logger-resource-set.yaml
-  - ../../../addons/cluster-api-helm/calico.yaml
-  - ../../../addons/cluster-api-helm/azuredisk-csi-driver.yaml
-  - ../../../addons/cluster-api-helm/cloud-provider-azure.yaml
-  - ../../../addons/cluster-api-helm/cloud-provider-azure-ci.yaml
-patchesStrategicMerge:
-  - ../patches/tags.yaml
-  - ../patches/mhc.yaml
-  - ../patches/controller-manager.yaml
-  - ../patches/windows-machine-deployment-replicas.yaml
-  - ../../../azure-cluster-identity/azurecluster-identity-ref.yaml
-  - ../patches/azuremachinetemplate-vmextension.yaml
-  - ../patches/windows-feature-gates.yaml
-  - ../patches/windows-containerd-labels.yaml
-  - ../patches/windows-server-version.yaml
-  - ../patches/cluster-label-calico.yaml
-  - ../patches/cluster-label-cloud-provider-azure.yaml
+- ../../../flavors/base
+- ../../../flavors/default/machine-deployment.yaml
+- ../../../flavors/windows/machine-deployment-windows.yaml
+- mhc.yaml
+- cni-resource-set.yaml
+- ../../../azure-cluster-identity
+- ../../../addons/windows/csi-proxy/csi-proxy-resource-set.yaml
+- ../../../addons/windows/containerd-logging/containerd-logger-resource-set.yaml
+- ../../../addons/cluster-api-helm/calico.yaml
+- ../../../addons/cluster-api-helm/azuredisk-csi-driver.yaml
+- ../../../addons/cluster-api-helm/cloud-provider-azure.yaml
+- ../../../addons/cluster-api-helm/cloud-provider-azure-ci.yaml
 patches:
-- target:
+- path: ../patches/windows-tmp-folder.yaml
+  target:
     group: bootstrap.cluster.x-k8s.io
-    version: v1beta1
     kind: KubeadmConfigTemplate
     name: .*-md-win
     namespace: default
-  path: ../patches/windows-tmp-folder.yaml
-- target:
-    group: bootstrap.cluster.x-k8s.io
     version: v1beta1
+- path: ../patches/kubeadm-bootstrap-windows-containerd.yaml
+  target:
+    group: bootstrap.cluster.x-k8s.io
     kind: KubeadmConfigTemplate
     name: .*-md-win
     namespace: default
-  path: ../patches/kubeadm-bootstrap-windows-containerd.yaml
-- target:
-    group: bootstrap.cluster.x-k8s.io
     version: v1beta1
+- path: ../patches/windows-collect-hns-crashes.yaml
+  target:
+    group: bootstrap.cluster.x-k8s.io
     kind: KubeadmConfigTemplate
     name: .*-md-win
     namespace: default
-  path: ../patches/windows-collect-hns-crashes.yaml
+    version: v1beta1
+- path: ../patches/tags.yaml
+- path: ../patches/mhc.yaml
+- path: ../patches/controller-manager.yaml
+- path: ../patches/windows-machine-deployment-replicas.yaml
+- path: ../../../azure-cluster-identity/azurecluster-identity-ref.yaml
+- path: ../patches/azuremachinetemplate-vmextension.yaml
+- path: ../patches/windows-feature-gates.yaml
+- path: ../patches/windows-containerd-labels.yaml
+- path: ../patches/windows-server-version.yaml
+- path: ../patches/cluster-label-calico.yaml
+- path: ../patches/cluster-label-cloud-provider-azure.yaml
 configMapGenerator:
-  - name: cni-${CLUSTER_NAME}-calico-windows
-    files:
-      - windows-cni=../../../addons/windows/calico/calico.yaml
-      - proxy=../../../addons/windows/calico/kube-proxy-windows.yaml
-  - name: csi-proxy-addon
-    files:
-      - csi-proxy=../../../addons/windows/csi-proxy/csi-proxy.yaml
-  - name: containerd-logger-${CLUSTER_NAME}
-    files:
-      - containerd-windows-logger=../../../addons/windows/containerd-logging/containerd-logger.yaml
+- files:
+  - windows-cni=../../../addons/windows/calico/calico.yaml
+  - proxy=../../../addons/windows/calico/kube-proxy-windows.yaml
+  name: cni-${CLUSTER_NAME}-calico-windows
+- files:
+  - csi-proxy=../../../addons/windows/csi-proxy/csi-proxy.yaml
+  name: csi-proxy-addon
+- files:
+  - containerd-windows-logger=../../../addons/windows/containerd-logging/containerd-logger.yaml
+  name: containerd-logger-${CLUSTER_NAME}
 generatorOptions:
+  annotations:
+    note: generated
   disableNameSuffixHash: true
   labels:
     type: generated
-  annotations:
-    note: generated
+
+sortOptions:
+  order: fifo

--- a/templates/test/dev/custom-builds-machine-pool/kustomization.yaml
+++ b/templates/test/dev/custom-builds-machine-pool/kustomization.yaml
@@ -1,32 +1,35 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 namespace: default
 resources:
-  - ../../../test/ci/prow-machine-pool
-patchesStrategicMerge:
-  - ../patches/control-plane-custom-builds.yaml
-  - patches/machine-pool-deployment-pr-version-windows.yaml
-  - patches/custom-builds.yaml
+- ../../../test/ci/prow-machine-pool
 patches:
-  - target:
-      group: controlplane.cluster.x-k8s.io
-      version: v1beta1
-      kind: KubeadmControlPlane
-      name: .*-control-plane
-    path: ../../../test/ci/prow-ci-version/patches/oot-credential-provider-kcp.yaml
-  - target:
-      group: bootstrap.cluster.x-k8s.io
-      version: v1beta1
-      kind: KubeadmConfig
-      name: .*-mp-win
-      namespace: default
-    path: patches/kubeadm-bootstrap-machine-pool-windows-k8s-pr-binaries.yaml
+- path: ../patches/control-plane-custom-builds.yaml
+- path: patches/machine-pool-deployment-pr-version-windows.yaml
+- path: patches/custom-builds.yaml
+- path: ../../../test/ci/prow-ci-version/patches/oot-credential-provider-kcp.yaml
+  target:
+    group: controlplane.cluster.x-k8s.io
+    kind: KubeadmControlPlane
+    name: .*-control-plane
+    version: v1beta1
+- path: patches/kubeadm-bootstrap-machine-pool-windows-k8s-pr-binaries.yaml
+  target:
+    group: bootstrap.cluster.x-k8s.io
+    kind: KubeadmConfig
+    name: .*-mp-win
+    namespace: default
+    version: v1beta1
 configMapGenerator:
-  - name: cni-${CLUSTER_NAME}-calico-windows
-    behavior: merge
-    files:
-      - kube-proxy-patch=../../../test/ci/patches/windows-kubeproxy-ci.yaml
+- behavior: merge
+  files:
+    - kube-proxy-patch=../../../test/ci/patches/windows-kubeproxy-ci.yaml
+  name: cni-${CLUSTER_NAME}-calico-windows
 generatorOptions:
+  annotations:
+    note: generated
   disableNameSuffixHash: true
   labels:
     type: generated
-  annotations:
-    note: generated
+sortOptions:
+  order: fifo

--- a/templates/test/dev/custom-builds/kustomization.yaml
+++ b/templates/test/dev/custom-builds/kustomization.yaml
@@ -1,67 +1,70 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 namespace: default
 resources:
-  - ../../../test/ci/prow
-  - ../../../addons/metrics-server/metrics-server-resource-set.yaml
-patchesStrategicMerge:
-  - patches/machine-deployment-pr-version.yaml
-  - patches/machine-deployment-pr-version-windows.yaml
-  - ../../../test/ci/patches/windows-feature-gates.yaml
-  - ../../../test/ci/patches/windows-containerd-labels.yaml
-  - ../../../test/ci/patches/windows-machine-deployment-replicas.yaml
-  - ../../../test/ci/patches/metrics-server-enabled-cluster.yaml
-  - ../../../test/ci/patches/controller-manager-featuregates.yaml
+- ../../../test/ci/prow
+- ../../../addons/metrics-server/metrics-server-resource-set.yaml
 patches:
-- target:
+- path: ../../../test/ci/prow-ci-version/patches/oot-credential-provider.yaml
+  target:
     group: bootstrap.cluster.x-k8s.io
-    version: v1beta1
     kind: KubeadmConfigTemplate
     name: .*-md-0
     namespace: default
-  path: ../../../test/ci/prow-ci-version/patches/oot-credential-provider.yaml
-- target:
-    group: bootstrap.cluster.x-k8s.io
     version: v1beta1
+- path: ../../../test/ci/prow-ci-version/patches/oot-credential-provider-win.yaml
+  target:
+    group: bootstrap.cluster.x-k8s.io
     kind: KubeadmConfigTemplate
     name: .*-md-win
     namespace: default
-  path: ../../../test/ci/prow-ci-version/patches/oot-credential-provider-win.yaml
-- target:
-    group: controlplane.cluster.x-k8s.io
     version: v1beta1
+- path: ../../../test/ci/prow-ci-version/patches/oot-credential-provider-kcp.yaml
+  target:
+    group: controlplane.cluster.x-k8s.io
     kind: KubeadmControlPlane
     name: .*-control-plane
-  path: ../../../test/ci/prow-ci-version/patches/oot-credential-provider-kcp.yaml
-- target:
-    group: bootstrap.cluster.x-k8s.io
     version: v1beta1
+- path: patches/kubeadm-bootstrap.yaml
+  target:
+    group: bootstrap.cluster.x-k8s.io
     kind: KubeadmConfigTemplate
     name: .*-md-0
     namespace: default
-  path: patches/kubeadm-bootstrap.yaml
-- target:
-    group: controlplane.cluster.x-k8s.io
     version: v1beta1
+- path: patches/kubeadm-controlplane-bootstrap.yaml
+  target:
+    group: controlplane.cluster.x-k8s.io
     kind: KubeadmControlPlane
     name: .*-control-plane
-  path: patches/kubeadm-controlplane-bootstrap.yaml
-- target:
-    group: bootstrap.cluster.x-k8s.io
     version: v1beta1
+- path: patches/kubeadm-bootstrap-windows-k8s-pr-binaries.yaml
+  target:
+    group: bootstrap.cluster.x-k8s.io
     kind: KubeadmConfigTemplate
     name: .*-md-win
     namespace: default
-  path: patches/kubeadm-bootstrap-windows-k8s-pr-binaries.yaml
+    version: v1beta1
+- path: patches/machine-deployment-pr-version.yaml
+- path: patches/machine-deployment-pr-version-windows.yaml
+- path: ../../../test/ci/patches/windows-feature-gates.yaml
+- path: ../../../test/ci/patches/windows-containerd-labels.yaml
+- path: ../../../test/ci/patches/windows-machine-deployment-replicas.yaml
+- path: ../../../test/ci/patches/metrics-server-enabled-cluster.yaml
+- path: ../../../test/ci/patches/controller-manager-featuregates.yaml
 configMapGenerator:
-  - name: cni-${CLUSTER_NAME}-calico-windows
-    behavior: merge
-    files:
-      - kube-proxy-patch=../../../test/ci/patches/windows-kubeproxy-ci.yaml
-  - name: metrics-server-${CLUSTER_NAME}
-    files:
-      - metrics-server=../../../addons/metrics-server/metrics-server.yaml
+- behavior: merge
+  files:
+  - kube-proxy-patch=../../../test/ci/patches/windows-kubeproxy-ci.yaml
+  name: cni-${CLUSTER_NAME}-calico-windows
+- files:
+  - metrics-server=../../../addons/metrics-server/metrics-server.yaml
+  name: metrics-server-${CLUSTER_NAME}
 generatorOptions:
+  annotations:
+    note: generated
   disableNameSuffixHash: true
   labels:
     type: generated
-  annotations:
-    note: generated
+sortOptions:
+  order: fifo

--- a/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-kcp-remediation/kustomization.yaml
+++ b/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-kcp-remediation/kustomization.yaml
@@ -1,4 +1,6 @@
-bases:
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
 - ../bases/cluster-with-kcp.yaml
 - ../bases/md.yaml
 - mhc.yaml
@@ -7,7 +9,6 @@ bases:
 - ../../../../../../templates/addons/cluster-api-helm/azuredisk-csi-driver.yaml
 - ../../../../../../templates/addons/cluster-api-helm/cloud-provider-azure.yaml
 - ../../../../../../templates/addons/cluster-api-helm/cloud-provider-azure-ci.yaml
-
-patchesStrategicMerge:
-- ../../../../../../templates/azure-cluster-identity/azurecluster-identity-ref.yaml
-- ../../../../../../templates/test/ci/patches/cluster-label-calico.yaml
+patches:
+- path: ../../../../../../templates/azure-cluster-identity/azurecluster-identity-ref.yaml
+- path: ../../../../../../templates/test/ci/patches/cluster-label-calico.yaml

--- a/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-kcp-scale-in/kustomization.yaml
+++ b/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-kcp-scale-in/kustomization.yaml
@@ -1,4 +1,6 @@
-bases:
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
 - ../bases/cluster-with-kcp.yaml
 - ../bases/md.yaml
 - ../../../../../../templates/azure-cluster-identity/azure-cluster-identity.yaml
@@ -6,9 +8,8 @@ bases:
 - ../../../../../../templates/addons/cluster-api-helm/azuredisk-csi-driver.yaml
 - ../../../../../../templates/addons/cluster-api-helm/cloud-provider-azure.yaml
 - ../../../../../../templates/addons/cluster-api-helm/cloud-provider-azure-ci.yaml
-
-patchesStrategicMerge:
-- ./cluster-with-kcp.yaml
-- ../../../../../../templates/azure-cluster-identity/azurecluster-identity-ref.yaml
-- ../../../../../../templates/test/ci/patches/cluster-label-calico.yaml
-- ../../../../../../templates/test/ci/patches/cluster-label-cloud-provider-azure.yaml
+patches:
+- path: ./cluster-with-kcp.yaml
+- path: ../../../../../../templates/azure-cluster-identity/azurecluster-identity-ref.yaml
+- path: ../../../../../../templates/test/ci/patches/cluster-label-calico.yaml
+- path: ../../../../../../templates/test/ci/patches/cluster-label-cloud-provider-azure.yaml

--- a/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-machine-pool/kustomization.yaml
+++ b/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-machine-pool/kustomization.yaml
@@ -1,3 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 resources:
 - ../bases/cluster-with-kcp.yaml
 - ../bases/mp.yaml
@@ -6,8 +8,7 @@ resources:
 - ../../../../../../templates/addons/cluster-api-helm/azuredisk-csi-driver.yaml
 - ../../../../../../templates/addons/cluster-api-helm/cloud-provider-azure.yaml
 - ../../../../../../templates/addons/cluster-api-helm/cloud-provider-azure-ci.yaml
-
-patchesStrategicMerge:
-- ../../../../../../templates/azure-cluster-identity/azurecluster-identity-ref.yaml
-- ../../../../../../templates/test/ci/patches/cluster-label-calico.yaml
-- ../../../../../../templates/test/ci/patches/cluster-label-cloud-provider-azure.yaml
+patches:
+- path: ../../../../../../templates/azure-cluster-identity/azurecluster-identity-ref.yaml
+- path: ../../../../../../templates/test/ci/patches/cluster-label-calico.yaml
+- path: ../../../../../../templates/test/ci/patches/cluster-label-cloud-provider-azure.yaml

--- a/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-md-remediation/kustomization.yaml
+++ b/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-md-remediation/kustomization.yaml
@@ -1,4 +1,6 @@
-bases:
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
 - ../bases/cluster-with-kcp.yaml
 - ../bases/md.yaml
 - mhc.yaml
@@ -7,9 +9,8 @@ bases:
 - ../../../../../../templates/addons/cluster-api-helm/azuredisk-csi-driver.yaml
 - ../../../../../../templates/addons/cluster-api-helm/cloud-provider-azure.yaml
 - ../../../../../../templates/addons/cluster-api-helm/cloud-provider-azure-ci.yaml
-
-patchesStrategicMerge:
-- ./md.yaml
-- ../../../../../../templates/azure-cluster-identity/azurecluster-identity-ref.yaml
-- ../../../../../../templates/test/ci/patches/cluster-label-calico.yaml
-- ../../../../../../templates/test/ci/patches/cluster-label-cloud-provider-azure.yaml
+patches:
+- path: ./md.yaml
+- path: ../../../../../../templates/azure-cluster-identity/azurecluster-identity-ref.yaml
+- path: ../../../../../../templates/test/ci/patches/cluster-label-calico.yaml
+- path: ../../../../../../templates/test/ci/patches/cluster-label-cloud-provider-azure.yaml

--- a/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-node-drain/kustomization.yaml
+++ b/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-node-drain/kustomization.yaml
@@ -1,4 +1,6 @@
-bases:
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
 - ../bases/cluster-with-kcp.yaml
 - ../bases/md.yaml
 - ../../../../../../templates/azure-cluster-identity/azure-cluster-identity.yaml
@@ -6,10 +8,9 @@ bases:
 - ../../../../../../templates/addons/cluster-api-helm/azuredisk-csi-driver.yaml
 - ../../../../../../templates/addons/cluster-api-helm/cloud-provider-azure.yaml
 - ../../../../../../templates/addons/cluster-api-helm/cloud-provider-azure-ci.yaml
-
-patchesStrategicMerge:
-- ./md.yaml
-- ./cluster-with-kcp.yaml
-- ../../../../../../templates/azure-cluster-identity/azurecluster-identity-ref.yaml
-- ../../../../../../templates/test/ci/patches/cluster-label-calico.yaml
-- ../../../../../../templates/test/ci/patches/cluster-label-cloud-provider-azure.yaml
+patches:
+- path: ./md.yaml
+- path: ./cluster-with-kcp.yaml
+- path: ../../../../../../templates/azure-cluster-identity/azurecluster-identity-ref.yaml
+- path: ../../../../../../templates/test/ci/patches/cluster-label-calico.yaml
+- path: ../../../../../../templates/test/ci/patches/cluster-label-cloud-provider-azure.yaml

--- a/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-upgrades/kustomization.yaml
+++ b/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-upgrades/kustomization.yaml
@@ -1,8 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 resources:
-  - ../bases/cluster-with-kcp.yaml
-  - ../bases/md.yaml
-  - ../bases/mp.yaml
-  - ../../../../../../templates/azure-cluster-identity/azure-cluster-identity.yaml
-
-patchesStrategicMerge:
-  - ../../../../../../templates/azure-cluster-identity/azurecluster-identity-ref.yaml
+- ../bases/cluster-with-kcp.yaml
+- ../bases/md.yaml
+- ../bases/mp.yaml
+- ../../../../../../templates/azure-cluster-identity/azure-cluster-identity.yaml
+patches:
+- path: ../../../../../../templates/azure-cluster-identity/azurecluster-identity-ref.yaml

--- a/test/e2e/data/infrastructure-azure/v1beta1/cluster-template/kustomization.yaml
+++ b/test/e2e/data/infrastructure-azure/v1beta1/cluster-template/kustomization.yaml
@@ -1,4 +1,6 @@
-bases:
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
 - ../bases/cluster-with-kcp.yaml
 - ../bases/md.yaml
 - ../../../../../../templates/azure-cluster-identity/azure-cluster-identity.yaml
@@ -6,8 +8,7 @@ bases:
 - ../../../../../../templates/addons/cluster-api-helm/azuredisk-csi-driver.yaml
 - ../../../../../../templates/addons/cluster-api-helm/cloud-provider-azure.yaml
 - ../../../../../../templates/addons/cluster-api-helm/cloud-provider-azure-ci.yaml
-
-patchesStrategicMerge:
-- ../../../../../../templates/azure-cluster-identity/azurecluster-identity-ref.yaml
-- ../../../../../../templates/test/ci/patches/cluster-label-calico.yaml
-- ../../../../../../templates/test/ci/patches/cluster-label-cloud-provider-azure.yaml
+patches:
+- path: ../../../../../../templates/azure-cluster-identity/azurecluster-identity-ref.yaml
+- path: ../../../../../../templates/test/ci/patches/cluster-label-calico.yaml
+- path: ../../../../../../templates/test/ci/patches/cluster-label-cloud-provider-azure.yaml


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind cleanup

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
This PR is intended to fix Kustomization warnings seen on running `make generate`.
The warnings I see are 
- `# Warning: 'patchesStrategicMerge' is deprecated. Please use 'patches' instead. Run 'kustomize edit fix' to update your Kustomization automatically.`
- `Flag --reorder has been deprecated, use the new 'sortOptions' field in kustomization.yaml instead.`

**Which issue(s) this PR fixes**:

Fixes #4752

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
