### PR TITLE
Make dependabot ignore major and minor Prometheus go mod bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,6 +40,8 @@ updates:
     - dependency-name: "sigs.k8s.io/controller-runtime"
     # Ignore k8s and its transitives modules as they are upgraded manually together with controller-runtime.
     - dependency-name: "k8s.io/*"
+    - dependency-name: "github.com/prometheus/*"
+      update-types: [ "version-update:semver-major", "version-update:semver-minor"] # Consume only patch updates.
     - dependency-name: "go.etcd.io/*"
     - dependency-name: "google.golang.org/grpc"
     - dependency-name: "sigs.k8s.io/cloud-provider-azure"


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind cleanup

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

This mirrors the change CAPI made to get around compile errors due to a breaking change in a transient dependency: https://github.com/kubernetes-sigs/cluster-api/blob/a7a32ed5705d991af0332d856f61dbcdd54abd94/.github/dependabot.yaml#L40-L41

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Related to #4860

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
