### PR TITLE
use windows-2022 image by default

### DIFF
--- a/azure/defaults.go
+++ b/azure/defaults.go
@@ -71,7 +71,7 @@ const (
 const (
 	// DefaultWindowsOsAndVersion is the default Windows Server version to use when
 	// generating default images for Windows nodes.
-	DefaultWindowsOsAndVersion = "windows-2019"
+	DefaultWindowsOsAndVersion = "windows-2022"
 )
 
 const (

--- a/azure/services/virtualmachineimages/images_test.go
+++ b/azure/services/virtualmachineimages/images_test.go
@@ -275,7 +275,7 @@ func TestGetDefaultWindowsImage(t *testing.T) {
 			k8sVersion:  "v1.21.4",
 			runtime:     "",
 			osVersion:   "",
-			expectedSKU: "k8s-1dot21dot4-windows-2019",
+			expectedSKU: "k8s-1dot21dot4-windows-2022",
 			expectedErr: "",
 		},
 		{
@@ -283,7 +283,7 @@ func TestGetDefaultWindowsImage(t *testing.T) {
 			k8sVersion:  "v1.21.4",
 			runtime:     "dockershim",
 			osVersion:   "",
-			expectedSKU: "k8s-1dot21dot4-windows-2019",
+			expectedSKU: "k8s-1dot21dot4-windows-2022",
 			expectedErr: "",
 		},
 		{
@@ -299,7 +299,7 @@ func TestGetDefaultWindowsImage(t *testing.T) {
 			k8sVersion:  "v1.23.2",
 			runtime:     "containerd",
 			osVersion:   "",
-			expectedSKU: "k8s-1dot23dot2-windows-2019-containerd",
+			expectedSKU: "k8s-1dot23dot2-windows-2022-containerd",
 			expectedErr: "",
 		},
 		{

--- a/docs/book/src/developers/development.md
+++ b/docs/book/src/developers/development.md
@@ -539,7 +539,7 @@ With the following environment variables defined, you can build a CAPZ cluster f
 | ------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `E2E_ARGS`                | `-kubetest.use-ci-artifacts`                                                                                                                                                                             |
 | `KUBERNETES_VERSION`      | `latest` - extract Kubernetes version from https://dl.k8s.io/ci/latest.txt (main's HEAD)<br>`latest-1.<MINOR>` - extract Kubernetes version from dl.k8s.io/ci/latest-1.<MINOR>.txt (release branch's HEAD) |
-| `WINDOWS_SERVER_VERSION`  | Optional, can be `windows-2019` (default) or `windows-2022`                                                                                                                                              |
+| `WINDOWS_SERVER_VERSION`  | Optional, can be `windows-2022` (default) or `windows-2019`                                                                                                                                              |
 | `KUBETEST_WINDOWS_CONFIG` | Optional, can be `upstream-windows-serial-slow.yaml`, when not specified `upstream-windows.yaml` is used                                                                                                 |
 | `WINDOWS_CONTAINERD_URL`  | Optional, can be any url to a `tar.gz` file containing binaries for containerd in the same format as upstream package                                                                                    |
 

--- a/templates/test/ci/cluster-template-prow-ci-version.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version.yaml
@@ -441,7 +441,7 @@ spec:
         marketplace:
           offer: capi-windows
           publisher: cncf-upstream
-          sku: ${WINDOWS_SERVER_VERSION:=windows-2019}-containerd-gen1
+          sku: ${WINDOWS_SERVER_VERSION:=windows-2022}-containerd-gen1
           version: latest
       osDisk:
         diskSizeGB: 128

--- a/templates/test/ci/cluster-template-prow-machine-pool-ci-version.yaml
+++ b/templates/test/ci/cluster-template-prow-machine-pool-ci-version.yaml
@@ -453,7 +453,7 @@ spec:
       marketplace:
         offer: capi-windows
         publisher: cncf-upstream
-        sku: ${WINDOWS_SERVER_VERSION:=windows-2019}-containerd-gen1
+        sku: ${WINDOWS_SERVER_VERSION:=windows-2022}-containerd-gen1
         version: latest
     osDisk:
       diskSizeGB: 128

--- a/templates/test/ci/prow-ci-version/patches/machine-deployment-ci-version-windows.yaml
+++ b/templates/test/ci/prow-ci-version/patches/machine-deployment-ci-version-windows.yaml
@@ -11,5 +11,5 @@ spec:
         marketplace:
           publisher: cncf-upstream
           offer: capi-windows
-          sku: ${WINDOWS_SERVER_VERSION:=windows-2019}-containerd-gen1
+          sku: ${WINDOWS_SERVER_VERSION:=windows-2022}-containerd-gen1
           version: "latest"

--- a/templates/test/ci/prow-machine-pool-ci-version/patches/machine-pool-ci-version-windows.yaml
+++ b/templates/test/ci/prow-machine-pool-ci-version/patches/machine-pool-ci-version-windows.yaml
@@ -11,5 +11,5 @@ spec:
       marketplace:
         publisher: cncf-upstream
         offer: capi-windows
-        sku: ${WINDOWS_SERVER_VERSION:=windows-2019}-containerd-gen1
+        sku: ${WINDOWS_SERVER_VERSION:=windows-2022}-containerd-gen1
         version: latest

--- a/templates/test/dev/cluster-template-custom-builds-machine-pool.yaml
+++ b/templates/test/dev/cluster-template-custom-builds-machine-pool.yaml
@@ -400,7 +400,7 @@ spec:
       marketplace:
         offer: capi-windows
         publisher: cncf-upstream
-        sku: ${WINDOWS_SERVER_VERSION:=windows-2019}-containerd-gen1
+        sku: ${WINDOWS_SERVER_VERSION:=windows-2022}-containerd-gen1
         version: latest
     osDisk:
       diskSizeGB: 128

--- a/templates/test/dev/cluster-template-custom-builds.yaml
+++ b/templates/test/dev/cluster-template-custom-builds.yaml
@@ -397,7 +397,7 @@ spec:
         marketplace:
           offer: capi-windows
           publisher: cncf-upstream
-          sku: ${WINDOWS_SERVER_VERSION:=windows-2019}-containerd-gen1
+          sku: ${WINDOWS_SERVER_VERSION:=windows-2022}-containerd-gen1
           version: latest
       osDisk:
         diskSizeGB: 128

--- a/templates/test/dev/custom-builds-machine-pool/patches/machine-pool-deployment-pr-version-windows.yaml
+++ b/templates/test/dev/custom-builds-machine-pool/patches/machine-pool-deployment-pr-version-windows.yaml
@@ -10,5 +10,5 @@ spec:
       marketplace:
         publisher: cncf-upstream
         offer: capi-windows
-        sku: ${WINDOWS_SERVER_VERSION:=windows-2019}-containerd-gen1
+        sku: ${WINDOWS_SERVER_VERSION:=windows-2022}-containerd-gen1
         version: latest

--- a/templates/test/dev/custom-builds/patches/machine-deployment-pr-version-windows.yaml
+++ b/templates/test/dev/custom-builds/patches/machine-deployment-pr-version-windows.yaml
@@ -15,5 +15,5 @@ spec:
         marketplace:
           publisher: cncf-upstream
           offer: capi-windows
-          sku: ${WINDOWS_SERVER_VERSION:=windows-2019}-containerd-gen1
+          sku: ${WINDOWS_SERVER_VERSION:=windows-2022}-containerd-gen1
           version: latest

--- a/test/e2e/conformance_test.go
+++ b/test/e2e/conformance_test.go
@@ -127,6 +127,7 @@ var _ = Describe("Conformance Tests", func() {
 			flavor += "-dual-stack"
 			kubetestConfigFilePath = strings.Replace(kubetestConfigFilePath, ".yaml", "-dual-stack.yaml", 1)
 		}
+		By(fmt.Sprintf("Using the %s cluster template flavor", flavor))
 
 		// Starting with Kubernetes v1.25, the kubetest config file needs to be compatible with Ginkgo V2.
 		v125 := semver.MustParse("1.25.0-alpha.0.0")


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

/kind cleanup

**What this PR does / why we need it**:

This PR updates our default Windows image configuration to 2022 for Windows CI and tests and inherit the default image.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
