### PR TITLE
Remove kubeadm dependency when machinepool enabled

### DIFF
--- a/exp/controllers/azuremachinepool_controller.go
+++ b/exp/controllers/azuremachinepool_controller.go
@@ -35,18 +35,15 @@ import (
 	"sigs.k8s.io/cluster-api-provider-azure/util/reconciler"
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
-	kubeadmv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1beta1"
 	capierrors "sigs.k8s.io/cluster-api/errors"
 	expv1 "sigs.k8s.io/cluster-api/exp/api/v1beta1"
 	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/cluster-api/util/annotations"
 	"sigs.k8s.io/cluster-api/util/predicates"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
-	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
@@ -126,12 +123,6 @@ func (ampr *AzureMachinePoolReconciler) SetupWithManager(ctx context.Context, mg
 		Watches(
 			&infrav1.AzureManagedControlPlane{},
 			handler.EnqueueRequestsFromMapFunc(azureManagedControlPlaneMapper),
-		).
-		// watch for changes in KubeadmConfig to sync bootstrap token
-		Watches(
-			&kubeadmv1.KubeadmConfig{},
-			handler.EnqueueRequestsFromMapFunc(KubeadmConfigToInfrastructureMapFunc(ctx, ampr.Client, log)),
-			builder.WithPredicates(predicate.ResourceVersionChangedPredicate{}),
 		).
 		Build(r)
 	if err != nil {


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:

When installing the provider with the `MachinePool` feature enabled, the controller watches Kubeadm resources which forces the user to exclusively use Kubeadm as a bootstrap provider. As specified in https://github.com/kubernetes-sigs/cluster-api-provider-azure/issues/4854, users may need to use any bootstrap providers of their choice. Other infrastructure providers, such as CAPA [don't have this dependency on Kubeadm](https://github.com/kubernetes-sigs/cluster-api-provider-aws/blob/main/exp/controllers/awsmachinepool_controller.go). Unless there is a specific need for this watcher, I suggest we remove this dependency.

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes-sigs/cluster-api-provider-azure/issues/4854

**Special notes for your reviewer**:

**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
kubeadm is no longer required when enabling `MachinePool`
```
