### PR TITLE
Bump CAAPH to v0.2.5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -315,7 +315,7 @@ create-management-cluster: $(KUSTOMIZE) $(ENVSUBST) $(KUBECTL) $(KIND) ## Create
 	timeout --foreground 300 bash -c "until curl --retry $(CURL_RETRIES) -sSL https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.7.5/cluster-api-components.yaml | $(ENVSUBST) | $(KUBECTL) apply -f -; do sleep 5; done"
 
 	# Deploy CAAPH
-	timeout --foreground 300 bash -c "until curl --retry $(CURL_RETRIES) -sSL https://github.com/kubernetes-sigs/cluster-api-addon-provider-helm/releases/download/v0.1.0-alpha.10/addon-components.yaml | $(ENVSUBST) | $(KUBECTL) apply -f -; do sleep 5; done"
+	timeout --foreground 300 bash -c "until curl --retry $(CURL_RETRIES) -sSL https://github.com/kubernetes-sigs/cluster-api-addon-provider-helm/releases/download/v0.2.5/addon-components.yaml | $(ENVSUBST) | $(KUBECTL) apply -f -; do sleep 5; done"
 
 	# Deploy CAPZ
 	$(KIND) load docker-image $(CONTROLLER_IMG)-$(ARCH):$(TAG) --name=$(KIND_CLUSTER_NAME)

--- a/Tiltfile
+++ b/Tiltfile
@@ -21,7 +21,7 @@ settings = {
     "preload_images_for_kind": True,
     "kind_cluster_name": "capz",
     "capi_version": "v1.7.5",
-    "caaph_version": "v0.2.1",
+    "caaph_version": "v0.2.5",
     "cert_manager_version": "v1.15.2",
     "kubernetes_version": "v1.28.3",
     "aks_kubernetes_version": "v1.28.3",

--- a/test/e2e/config/azure-dev.yaml
+++ b/test/e2e/config/azure-dev.yaml
@@ -9,7 +9,7 @@ images:
     loadBehavior: tryLoad
   - name: registry.k8s.io/cluster-api/kubeadm-control-plane-controller:v1.7.5
     loadBehavior: tryLoad
-  - name: registry.k8s.io/cluster-api-helm/cluster-api-helm-controller:v0.1.1-alpha.1
+  - name: registry.k8s.io/cluster-api-helm/cluster-api-helm-controller:v0.2.5
     loadBehavior: tryLoad
 
 providers:
@@ -176,8 +176,8 @@ providers:
       replacements:
       - old: "imagePullPolicy: Always"
         new: "imagePullPolicy: IfNotPresent"
-    - name: v0.1.1-alpha.1
-      value: https://github.com/kubernetes-sigs/cluster-api-addon-provider-helm/releases/download/v0.1.1-alpha.1/addon-components.yaml
+    - name: v0.2.5
+      value: https://github.com/kubernetes-sigs/cluster-api-addon-provider-helm/releases/download/v0.2.5/addon-components.yaml
       type: url
       contract: v1beta1
       files:
@@ -228,7 +228,7 @@ variables:
   OLD_PROVIDER_UPGRADE_VERSION: "v1.15.3"
   LATEST_PROVIDER_UPGRADE_VERSION: "v1.16.0"
   OLD_CAAPH_UPGRADE_VERSION: "v0.1.0-alpha.10"
-  LATEST_CAAPH_UPGRADE_VERSION: "v0.1.1-alpha.1"
+  LATEST_CAAPH_UPGRADE_VERSION: "v0.2.5"
   CI_RG: capz-ci
   USER_IDENTITY: cloud-provider-user-identity
 

--- a/test/e2e/data/shared/v1beta1_addon_provider/metadata.yaml
+++ b/test/e2e/data/shared/v1beta1_addon_provider/metadata.yaml
@@ -1,5 +1,8 @@
 apiVersion: clusterctl.cluster.x-k8s.io/v1alpha3
 releaseSeries:
   - major: 0
+    minor: 2
+    contract: v1beta1
+  - major: 0
     minor: 1
     contract: v1beta1


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Updates [CAAPH](https://github.com/kubernetes-sigs/cluster-api-addon-provider-helm) in tests to the current release [v0.2.5](https://github.com/kubernetes-sigs/cluster-api-addon-provider-helm/releases/tag/v0.2.5).

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

- [ ] cherry-pick candidate

**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:

```release-note
NONE
```
