### PR TITLE
ASOAPI: add CI tags to ManagedCluster resource

### DIFF
--- a/templates/test/ci/cluster-template-prow-aks-aso.yaml
+++ b/templates/test/ci/cluster-template-prow-aks-aso.yaml
@@ -37,6 +37,10 @@ spec:
         name: ${CLUSTER_NAME}
       servicePrincipalProfile:
         clientId: msi
+      tags:
+        buildProvenance: ${BUILD_PROVENANCE}
+        creationTimestamp: ${TIMESTAMP}
+        jobName: ${JOB_NAME}
   version: ${KUBERNETES_VERSION}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1

--- a/templates/test/ci/prow-aks-aso/kustomization.yaml
+++ b/templates/test/ci/prow-aks-aso/kustomization.yaml
@@ -21,6 +21,18 @@ patches:
 - patch: |-
     - op: test
       path: /spec/resources/0/kind
+      value: ManagedCluster
+    - op: replace
+      path: /spec/resources/0/spec/tags
+      value:
+        jobName: ${JOB_NAME}
+        creationTimestamp: ${TIMESTAMP}
+        buildProvenance: ${BUILD_PROVENANCE}
+  target:
+    kind: AzureASOManagedControlPlane
+- patch: |-
+    - op: test
+      path: /spec/resources/0/kind
       value: ManagedClustersAgentPool
     - op: replace
       path: /spec/resources/0/spec/vmSize


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind flake

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

This PR adds the regular slew of CI Azure tags to the ManagedCluster resource created in ASOAPI tests to prevent our regular resource group cleanup job from garbage collecting the `MC_` resource group for the cluster, which inherits tags from the AKS resource.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes flakes like https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_cluster-api-provider-azure/4874/pull-cluster-api-provider-azure-e2e-aks/1793427287857696768

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [X] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
