### PR TITLE
Use envtest binaries from controller-tools repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,11 @@ CODESPELL_BIN := codespell
 CODESPELL_DIST_DIR := codespell_dist
 CODESPELL := $(TOOLS_BIN_DIR)/$(CODESPELL_DIST_DIR)/$(CODESPELL_BIN)
 
-SETUP_ENVTEST_VER := v0.0.0-20231012212722-e25aeebc7846
+# This is a commit from CR main (22.05.2024).
+# Intentionally using a commit from main to use a setup-envtest version
+# that uses binaries from controller-tools, not GCS.
+# CR PR: https://github.com/kubernetes-sigs/controller-runtime/pull/2811
+SETUP_ENVTEST_VER := v0.0.0-20240522175850-2e9781e9fc60
 SETUP_ENVTEST_BIN := setup-envtest
 SETUP_ENVTEST := $(abspath $(TOOLS_BIN_DIR)/$(SETUP_ENVTEST_BIN)-$(SETUP_ENVTEST_VER))
 SETUP_ENVTEST_PKG := sigs.k8s.io/controller-runtime/tools/setup-envtest


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Updates `setup-envtest` to a commit on `main` that fetches `envtest` binaries from the GitHub release on the [controller-tools](https://github.com/kubernetes-sigs/controller-tools) repo. This is to move away from using GCP resource buckets.

**Which issue(s) this PR fixes**:
None, but see 
- kubernetes-sigs/cluster-api#10569
- kubernetes-sigs/controller-runtime#2811
- kubernetes/k8s.io#2647

**Special notes for your reviewer**:

- [x] cherry-pick candidate

**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:

```release-note
NONE
```

Thanks @sbueringer for always being on top of things like this!