### PR TITLE
Skip MEC e2e test

### DIFF
--- a/test/e2e/azure_test.go
+++ b/test/e2e/azure_test.go
@@ -1112,6 +1112,7 @@ var _ = Describe("Workload cluster creation", func() {
 	// the `AZURE_EDGEZONE_CONTROL_PLANE_MACHINE_TYPE` and `AZURE_EDGEZONE_NODE_MACHINE_TYPE` environment variables.
 	Context("Creating clusters on public MEC [OPTIONAL]", func() {
 		It("with 1 control plane nodes and 1 worker node", func() {
+			Skip("Skipping public MEC test until a new edgezone is available")
 			By("using user-assigned identity")
 			clusterName = getClusterName(clusterNamePrefix, "edgezone")
 			clusterctl.ApplyClusterTemplateAndWait(ctx, createApplyClusterTemplateInput(


### PR DESCRIPTION
**What type of PR is this?**

/kind failing-test

**What this PR does / why we need it**:

The edgezone this test depended on is being decommissioned, so it began failing. Since we know it won't pass, let's skip it for now until the Edge Zone team has had time to set up another edgezone with CAPZ reference images.

This is to get useful green signal for the `-optional` tests on PRs and on [testgrid](https://testgrid.k8s.io/sig-cluster-lifecycle-cluster-api-provider-azure#capz-periodic-e2e-main).

**Which issue(s) this PR fixes**:

Refs #4885

**Special notes for your reviewer**:

- [x] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:

```release-note
NONE
```
