### PR TITLE
add user-assigned identity to worker nodes for CI version templates

### DIFF
--- a/templates/test/ci/cluster-template-prow-ci-version-dual-stack.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version-dual-stack.yaml
@@ -296,6 +296,7 @@ spec:
   template:
     spec:
       enableIPForwarding: true
+      identity: UserAssigned
       image:
         marketplace:
           offer: capi
@@ -306,6 +307,8 @@ spec:
         diskSizeGB: 128
         osType: Linux
       sshPublicKey: ${AZURE_SSH_PUBLIC_KEY_B64:=""}
+      userAssignedIdentities:
+      - providerID: /subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${CI_RG:=capz-ci}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER_IDENTITY:=cloud-provider-user-identity}
       vmExtensions:
       - name: CustomScript
         protectedSettings:

--- a/templates/test/ci/cluster-template-prow-ci-version-ipv6.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version-ipv6.yaml
@@ -303,6 +303,7 @@ spec:
   template:
     spec:
       enableIPForwarding: true
+      identity: UserAssigned
       image:
         marketplace:
           offer: capi
@@ -313,6 +314,8 @@ spec:
         diskSizeGB: 128
         osType: Linux
       sshPublicKey: ${AZURE_SSH_PUBLIC_KEY_B64:=""}
+      userAssignedIdentities:
+      - providerID: /subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${CI_RG:=capz-ci}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER_IDENTITY:=cloud-provider-user-identity}
       vmExtensions:
       - name: CustomScript
         protectedSettings:

--- a/templates/test/ci/cluster-template-prow-ci-version.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version.yaml
@@ -273,6 +273,7 @@ metadata:
 spec:
   template:
     spec:
+      identity: UserAssigned
       image:
         marketplace:
           offer: capi
@@ -283,6 +284,8 @@ spec:
         diskSizeGB: 128
         osType: Linux
       sshPublicKey: ${AZURE_SSH_PUBLIC_KEY_B64:=""}
+      userAssignedIdentities:
+      - providerID: /subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${CI_RG:=capz-ci}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER_IDENTITY:=cloud-provider-user-identity}
       vmExtensions:
       - name: CustomScript
         protectedSettings:

--- a/templates/test/ci/cluster-template-prow-machine-pool-ci-version.yaml
+++ b/templates/test/ci/cluster-template-prow-machine-pool-ci-version.yaml
@@ -265,6 +265,7 @@ metadata:
   name: ${CLUSTER_NAME}-mp-0
   namespace: default
 spec:
+  identity: UserAssigned
   location: ${AZURE_LOCATION}
   strategy:
     rollingUpdate:
@@ -295,6 +296,8 @@ spec:
       publisher: Microsoft.Azure.Extensions
       version: "2.1"
     vmSize: ${AZURE_NODE_MACHINE_TYPE}
+  userAssignedIdentities:
+  - providerID: /subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${CI_RG:=capz-ci}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER_IDENTITY:=cloud-provider-user-identity}
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfig

--- a/templates/test/ci/prow-ci-version/kustomization.yaml
+++ b/templates/test/ci/prow-ci-version/kustomization.yaml
@@ -55,6 +55,7 @@ patches:
 - path: patches/machine-deployment-ci-version-control-plane.yaml
 - path: ../patches/metrics-server-enabled-cluster.yaml
 - path: ../patches/controller-manager-featuregates.yaml
+- path: ../patches/uami-md-0.yaml
 configMapGenerator:
 - behavior: merge
   files:

--- a/templates/test/ci/prow-machine-pool-ci-version/kustomization.yaml
+++ b/templates/test/ci/prow-machine-pool-ci-version/kustomization.yaml
@@ -29,6 +29,7 @@ patches:
 - path: patches/machine-pool-ci-version.yaml
 - path: ../patches/machine-pool-worker-counts.yaml
 - path: patches/machine-pool-ci-version-windows.yaml
+- path: ../patches/uami-mp-0.yaml
 configMapGenerator:
 - behavior: merge
   files:


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

In the wake of #4765 I noticed the Azure File/Azure Disk CSI driver tests were failing and it looks like because cloud-provider auth isn't working: https://testgrid.k8s.io/provider-azure-master-signal. This PR adds the user-assigned identity to worker nodes for the templates used by those tests so the CSI drivers which invoke cloud-provider from worker nodes can work as expected.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
