### PR TITLE
remove user-defined MP count from aks-aso-clusterclass template

### DIFF
--- a/templates/cluster-template-aks-aso-clusterclass.yaml
+++ b/templates/cluster-template-aks-aso-clusterclass.yaml
@@ -87,8 +87,6 @@ spec:
                 mode: System
                 type: VirtualMachineScaleSets
                 vmSize: ${AZURE_NODE_MACHINE_TYPE}
-                # Soon this will be derived from the MachinePool
-                count: ${WORKER_MACHINE_COUNT:=2}
       selector:
         apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
         kind: AzureASOManagedMachinePoolTemplate
@@ -117,8 +115,6 @@ spec:
                 mode: User
                 type: VirtualMachineScaleSets
                 vmSize: ${AZURE_NODE_MACHINE_TYPE}
-                # Soon this will be derived from the MachinePool
-                count: ${WORKER_MACHINE_COUNT:=2}
       selector:
         apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
         kind: AzureASOManagedMachinePoolTemplate

--- a/templates/flavors/aks-aso-clusterclass/clusterclass.yaml
+++ b/templates/flavors/aks-aso-clusterclass/clusterclass.yaml
@@ -124,8 +124,6 @@ spec:
                 mode: System
                 type: VirtualMachineScaleSets
                 vmSize: ${AZURE_NODE_MACHINE_TYPE}
-                # Soon this will be derived from the MachinePool
-                count: ${WORKER_MACHINE_COUNT:=2}
   - name: azureasomanagedmachinepool-pool1-spec
     definitions:
     - selector:
@@ -154,6 +152,4 @@ spec:
                 mode: User
                 type: VirtualMachineScaleSets
                 vmSize: ${AZURE_NODE_MACHINE_TYPE}
-                # Soon this will be derived from the MachinePool
-                count: ${WORKER_MACHINE_COUNT:=2}
 


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

This PR removes the `spec.count` defined on ManagedClustersAgentPools in AzureASOManagedMachinePools based on the aks-aso-clusterclass template which has been derived from the owning MachinePool's `spec.replicas` since #4798. This fixes an issue where scaling the machine pools as defined in a Cluster's `spec.topology` would get stuck.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [X] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
