### PR TITLE
handle non-native autoscalers for AzureASOManagedMachinePool

### DIFF
--- a/exp/controllers/azureasomanagedmachinepool_controller.go
+++ b/exp/controllers/azureasomanagedmachinepool_controller.go
@@ -209,7 +209,7 @@ func (r *AzureASOManagedMachinePoolReconciler) reconcileNormal(ctx context.Conte
 		return ctrl.Result{Requeue: true}, nil
 	}
 
-	resources, err := mutators.ApplyMutators(ctx, asoManagedMachinePool.Spec.Resources, mutators.SetAgentPoolDefaults(asoManagedMachinePool, machinePool))
+	resources, err := mutators.ApplyMutators(ctx, asoManagedMachinePool.Spec.Resources, mutators.SetAgentPoolDefaults(r.Client, machinePool))
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -276,7 +276,7 @@ func (r *AzureASOManagedMachinePoolReconciler) reconcileNormal(ctx context.Conte
 	slices.Sort(providerIDs)
 	asoManagedMachinePool.Spec.ProviderIDList = providerIDs
 	asoManagedMachinePool.Status.Replicas = int32(ptr.Deref(agentPool.Status.Count, 0))
-	if machinePool.Annotations[clusterv1.ReplicasManagedByAnnotation] == infrav1exp.ReplicasManagedByAKS {
+	if _, autoscaling := machinePool.Annotations[clusterv1.ReplicasManagedByAnnotation]; autoscaling {
 		machinePool.Spec.Replicas = &asoManagedMachinePool.Status.Replicas
 	}
 

--- a/exp/mutators/azureasomanagedcontrolplane.go
+++ b/exp/mutators/azureasomanagedcontrolplane.go
@@ -25,7 +25,6 @@ import (
 	asocontainerservicev1 "github.com/Azure/azure-service-operator/v2/api/containerservice/v1api20231001"
 	asocontainerservicev1hub "github.com/Azure/azure-service-operator/v2/api/containerservice/v1api20231001/storage"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
 	infrav1exp "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1alpha1"
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
@@ -270,7 +269,7 @@ func agentPoolsFromManagedMachinePools(ctx context.Context, ctrlClient client.Cl
 		}
 
 		resources, err := ApplyMutators(ctx, asoManagedMachinePool.Spec.Resources,
-			SetAgentPoolDefaults(ptr.To(asoManagedMachinePool), machinePool),
+			SetAgentPoolDefaults(ctrlClient, machinePool),
 		)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

Currently, AzureASOManagedMachinePool only handles autoscaled machine pools when the autoscaler is AKS's built-in cluster-autoscaler exposed through the AKS API. This change fixes an issue where using a non-`"aks"` autoscaler defined in a MachinePool's `cluster.x-k8s.io/replicas-managed-by` annotation would cause CAPZ/ASO and the autoscaler to fight over the replica count.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [X] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [ ] includes documentation
- [X] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixed a bug causing ASO and non-AKS-native autoscalers to fight over the replica count of an AzureASOManagedMachinePool
```
