### PR TITLE
✨ Add aggregated role support

### DIFF
--- a/config/rbac/aggregation_role.yaml
+++ b/config/rbac/aggregation_role.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: aggregated-manager-role
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      cluster.x-k8s.io/aggregate-to-capz-manager: "true"
+rules: []

--- a/config/rbac/capz_manager_role_patch.yaml
+++ b/config/rbac/capz_manager_role_patch.yaml
@@ -1,0 +1,6 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: manager-role
+  labels:
+    cluster.x-k8s.io/aggregate-to-capz-manager: "true"

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -2,7 +2,11 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - role.yaml
+- aggregation_role.yaml
 - role_binding.yaml
 - service_account.yaml
 - leader_election_role.yaml
 - leader_election_role_binding.yaml
+
+patches:
+- path: capz_manager_role_patch.yaml

--- a/config/rbac/role_binding.yaml
+++ b/config/rbac/role_binding.yaml
@@ -5,7 +5,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: manager-role
+  name: aggregated-manager-role
 subjects:
 - kind: ServiceAccount
   name: manager


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

/kind feature
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

CAPZ provider might need to have an ability to extend default set of RBAC, depending on deployment model or use cases, like with changes proposed in #4931. Splitting this out to test and improve on the changes separately.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
- Added support for aggregation role. Additional RBAC permissions can be included by providing `cluster.x-k8s.io/aggregate-to-capz-manager: "true"` label.
```
