### PR TITLE
Use workload identity for azure cli when Federated token file is present

### DIFF
--- a/hack/ensure-acr-login.sh
+++ b/hack/ensure-acr-login.sh
@@ -22,16 +22,11 @@ set +o xtrace
 REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 cd "${REPO_ROOT}" || exit 1
 
-if [[ "${REGISTRY:-}" =~ capzci\.azurecr\.io ]]; then
+if [[ "${REGISTRY:-}" =~ \.azurecr\.io ]]; then
     # if we are using the prow Azure Container Registry, login.
     "${REPO_ROOT}/hack/ensure-azcli.sh"
     : "${AZURE_SUBSCRIPTION_ID:?Environment variable empty or not defined.}"
     az account set -s "${AZURE_SUBSCRIPTION_ID}"
-    az acr login --name capzci
-    # TODO(mainred): When using ACR, `az acr login` impacts the authentication of `docker buildx build --push` when the
-    # ACR, capzci in our case, has anonymous pull enabled.
-    # Use `docker login` as a suggested workaround and remove this target when the issue is resolved.
-    # Issue link: https://github.com/Azure/acr/issues/582
-    # Failed building link: https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_cloud-provider-azure/974/pull-cloud-provider-azure-e2e-ccm-capz/1480459040440979456
-    docker login -u "${AZURE_CLIENT_ID}" -p "${AZURE_CLIENT_SECRET}" capzci.azurecr.io
+    acrname="${REGISTRY%%.*}"
+    az acr login --name "$acrname"
 fi

--- a/hack/ensure-azcli.sh
+++ b/hack/ensure-azcli.sh
@@ -25,5 +25,16 @@ if [[ -z "$(command -v az)" ]]; then
   AZ_REPO=$(lsb_release -cs)
   echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ ${AZ_REPO} main" | tee /etc/apt/sources.list.d/azure-cli.list
   apt-get update && apt-get install -y azure-cli
-  az login --service-principal -u "${AZURE_CLIENT_ID}" -p "${AZURE_CLIENT_SECRET}" --tenant "${AZURE_TENANT_ID}" > /dev/null
+
+  if [[ -n "${AZURE_FEDERATED_TOKEN_FILE:-}" ]]; then
+    # AZURE_CLIENT_ID has been overloaded with Azure Workload ID in the preset-azure-cred-wi.
+    # This is done to avoid exporting Azure Workload ID as AZURE_CLIENT_ID in the test scenarios.
+    az login --service-principal -u "${AZURE_CLIENT_ID}" -t "${AZURE_TENANT_ID}" --federated-token "$(cat "${AZURE_FEDERATED_TOKEN_FILE}")" > /dev/null
+
+    # Use --auth-mode "login" in az storage commands.
+    ENABLE_AUTH_MODE_LOGIN="true"
+    export ENABLE_AUTH_MODE_LOGIN
+  else
+    az login --service-principal -u "${AZURE_CLIENT_ID}" -p "${AZURE_CLIENT_SECRET}" --tenant "${AZURE_TENANT_ID}" > /dev/null
+  fi
 fi

--- a/scripts/ci-build-kubernetes.sh
+++ b/scripts/ci-build-kubernetes.sh
@@ -33,7 +33,6 @@ source "${REPO_ROOT}/hack/parse-prow-creds.sh"
 source "${REPO_ROOT}/hack/util.sh"
 
 : "${AZURE_STORAGE_ACCOUNT:?Environment variable empty or not defined.}"
-: "${AZURE_STORAGE_KEY:?Environment variable empty or not defined.}"
 : "${REGISTRY:?Environment variable empty or not defined.}"
 
 declare -a BINARIES=("kubeadm" "kubectl" "kubelet" "e2e.test")
@@ -80,10 +79,10 @@ setup() {
 }
 
 main() {
-    if [[ "$(az storage container exists --name "${AZURE_BLOB_CONTAINER_NAME}" --query exists --output tsv)" == "false" ]]; then
+    if [[ "$(az storage container exists ${ENABLE_AUTH_MODE_LOGIN:+"--auth-mode login"} --name "${AZURE_BLOB_CONTAINER_NAME}" --query exists --output tsv)" == "false" ]]; then
         echo "Creating ${AZURE_BLOB_CONTAINER_NAME} storage container"
-        az storage container create --name "${AZURE_BLOB_CONTAINER_NAME}" > /dev/null
-        az storage container set-permission --name "${AZURE_BLOB_CONTAINER_NAME}" --public-access container > /dev/null
+        az storage container ${ENABLE_AUTH_MODE_LOGIN:+"--auth-mode login"} create --name "${AZURE_BLOB_CONTAINER_NAME}" > /dev/null
+        az storage container ${ENABLE_AUTH_MODE_LOGIN:+"--auth-mode login"} set-permission --name "${AZURE_BLOB_CONTAINER_NAME}" --public-access container > /dev/null
     fi
 
     if [[ "${KUBE_BUILD_CONFORMANCE:-}" =~ [yY] ]]; then
@@ -116,7 +115,7 @@ main() {
         for BINARY in "${BINARIES[@]}"; do
             BIN_PATH="${KUBE_GIT_VERSION}/bin/linux/amd64/${BINARY}"
             echo "uploading ${BIN_PATH}"
-            az storage blob upload --overwrite --container-name "${AZURE_BLOB_CONTAINER_NAME}" --file "${KUBE_ROOT}/_output/dockerized/bin/linux/amd64/${BINARY}" --name "${BIN_PATH}"
+            az storage blob upload ${ENABLE_AUTH_MODE_LOGIN:+"--auth-mode login"} --overwrite --container-name "${AZURE_BLOB_CONTAINER_NAME}" --file "${KUBE_ROOT}/_output/dockerized/bin/linux/amd64/${BINARY}" --name "${BIN_PATH}"
         done
 
         if [[ "${TEST_WINDOWS:-}" == "true" ]]; then
@@ -129,7 +128,7 @@ main() {
             for BINARY in "${WINDOWS_BINARIES[@]}"; do
                 BIN_PATH="${KUBE_GIT_VERSION}/bin/windows/amd64/${BINARY}.exe"
                 echo "uploading ${BIN_PATH}"
-                az storage blob upload --overwrite --container-name "${AZURE_BLOB_CONTAINER_NAME}" --file "${KUBE_ROOT}/_output/dockerized/bin/windows/amd64/${BINARY}.exe" --name "${BIN_PATH}"
+                az storage blob upload ${ENABLE_AUTH_MODE_LOGIN:+"--auth-mode login"} --overwrite --container-name "${AZURE_BLOB_CONTAINER_NAME}" --file "${KUBE_ROOT}/_output/dockerized/bin/windows/amd64/${BINARY}.exe" --name "${BIN_PATH}"
             done
         fi
     fi
@@ -144,14 +143,14 @@ can_reuse_artifacts() {
     done
 
     for BINARY in "${BINARIES[@]}"; do
-        if [[ "$(az storage blob exists --container-name "${AZURE_BLOB_CONTAINER_NAME}" --name "${KUBE_GIT_VERSION}/bin/linux/amd64/${BINARY}" --query exists --output tsv)" == "false" ]]; then
+        if [[ "$(az storage blob exists ${ENABLE_AUTH_MODE_LOGIN:+"--auth-mode login"} --container-name "${AZURE_BLOB_CONTAINER_NAME}" --name "${KUBE_GIT_VERSION}/bin/linux/amd64/${BINARY}" --query exists --output tsv)" == "false" ]]; then
             echo "false" && return
         fi
     done
 
     if [[ "${TEST_WINDOWS:-}" == "true" ]]; then
         for BINARY in "${WINDOWS_BINARIES[@]}"; do
-            if [[ "$(az storage blob exists --container-name "${AZURE_BLOB_CONTAINER_NAME}" --name "${KUBE_GIT_VERSION}/bin/windows/amd64/${BINARY}.exe" --query exists --output tsv)" == "false" ]]; then
+            if [[ "$(az storage blob exists ${ENABLE_AUTH_MODE_LOGIN:+"--auth-mode login"} --container-name "${AZURE_BLOB_CONTAINER_NAME}" --name "${KUBE_GIT_VERSION}/bin/windows/amd64/${BINARY}.exe" --query exists --output tsv)" == "false" ]]; then
                 echo "false" && return
             fi
         done


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
- `ensure-azcli.sh` will log in using `AZURE_WORKLOAD_ID` and `--federated-token` when `AZURE_FEDERATED_TOKEN_FILE` is available in the env.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
POC as part of https://github.com/kubernetes/test-infra/blob/master/docs/job-migration-todo.md and https://github.com/kubernetes-sigs/cluster-api-provider-azure/issues/4976

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->
- Once this PR merges
	- We should be updating CAPZ test jobs with `preset-azure-cred-wi: "true"` preset and dropping any unrelated credential presets.
	- Migrate other test jobs to use WI.


- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
`ensure-azcli.sh` will log in using `AZURE_WORKLOAD_ID` if `AZURE_FEDERATED_TOKEN_FILE` is available in the env.
```
