### PR TITLE
fix: panic in MachinePool log

### DIFF
--- a/azure/scope/machinepool.go
+++ b/azure/scope/machinepool.go
@@ -533,7 +533,7 @@ func (m *MachinePoolScope) DeleteMachine(ctx context.Context, ampm infrav1exp.Az
 		return errors.Wrapf(err, "error getting owner Machine for AzureMachinePoolMachine %s/%s", ampm.Namespace, ampm.Name)
 	}
 	if machine == nil {
-		log.V(2).Info("No owner Machine exists for AzureMachinePoolMachine", ampm, klog.KObj(&ampm))
+		log.V(2).Info("No owner Machine exists for AzureMachinePoolMachine", "ampm", klog.KObj(&ampm))
 		// If the AzureMachinePoolMachine does not have an owner Machine, do not attempt to delete the AzureMachinePoolMachine as the MachinePool controller will create the
 		// Machine and we want to let it catch up. If we are too hasty to delete, that introduces a race condition where the AzureMachinePoolMachine could be deleted
 		// just as the Machine comes online.


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Fixes a panic when trying to delete a machine where there is no OwnerMachine available anymore. The log statement was wrong in that it didn't specify a key for the value. 

**Special notes for your reviewer**:
partial panic log - note, the line numbers are a bit off since I'm running on a fork containing multiple changes which will be submitted as separate PRs today

```

panic: runtime error: hash of unhashable type v1beta1.AzureMachinePoolMachine [recovered]
       panic: runtime error: hash of unhashable type v1beta1.AzureMachinePoolMachine
manager
goroutine 623 [running]:
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile.func1()
       /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.17.3/pkg/internal/controller/controller.go:116 +0x1e5
panic({0x2c8dae0?, 0xc001f6ad70?})
       /usr/local/go/src/runtime/panic.go:914 +0x21f
k8s.io/klog/v2/internal/serialize.MergeKVs({0xc002170120, 0x12, 0x0?}, {0xc009c69cc0, 0x2, 0xc0023c4cf0?})
       /go/pkg/mod/k8s.io/klog/v2@v2.120.1/internal/serialize/keyvalues.go:82 +0x134
k8s.io/klog/v2.(*klogger).Info(0xc00088d740, 0x2, {0x328e1ca, 0x33}, {0xc009c69cc0?, 0x40e578?, 0x2cd9ae0?})
       /go/pkg/mod/k8s.io/klog/v2@v2.120.1/klogr.go:56 +0x5a
sigs.k8s.io/cluster-api-provider-azure/util/tele.(*compositeLogSink).Info.func1(...)
       /workspace/util/tele/composite_logger.go:54
sigs.k8s.io/cluster-api-provider-azure/util/tele.(*compositeLogSink).iter(...)
       /workspace/util/tele/composite_logger.go:48
sigs.k8s.io/cluster-api-provider-azure/util/tele.(*compositeLogSink).Info(0xc000079000?, 0x2, {0x328e1ca, 0x33}, {0xc009c69cc0, 0x2, 0x2})
       /workspace/util/tele/composite_logger.go:53 +0x69
github.com/go-logr/logr.Logger.Info({{0x36a7338?, 0xc00a631da0?}, 0x0?}, {0x328e1ca, 0x33}, {0xc009c69cc0, 0x2, 0x2})
       /go/pkg/mod/github.com/go-logr/logr@v1.4.2/logr.go:280 +0xdc
sigs.k8s.io/cluster-api-provider-azure/azure/scope.(*MachinePoolScope).DeleteMachine(_, {_, _}, {{{0x29501e6, 0x17}, {0xc00213ced0, 0x27}}, {{0xc000dd2470, 0x9}, {0x0, ...}, ...}, ...})
       /workspace/azure/scope/machinepool.go:552 +0x45f
sigs.k8s.io/cluster-api-provider-azure/exp/controllers.(*AzureMachinePoolReconciler).reconcileDelete(0xc0005a54a0, {0x36a0b70?, 0xc0003b9ce0?}, 0xc0006cdef0, {0x36e00d8, 0xc006dd2000})
       /workspace/exp/controllers/azuremachinepool_controller.go:413 +0x850
sigs.k8s.io/cluster-api-provider-azure/exp/controllers.(*AzureMachinePoolReconciler).Reconcile(0xc0005a54a0, {0x36a0ac8?, 0xc008ef0210?}, {{{0xc000caaa40?, 0xa?}, {0xc000caaab7?, 0x0?}}})
       /workspace/exp/controllers/azuremachinepool_controller.go:254 +0xb45
sigs.k8s.io/cluster-api-provider-azure/pkg/coalescing.(*reconciler).Reconcile(0xc0003ea400, {0x36a0ac8?, 0xc008ef0150?}, {{{0xc000caaa40?, 0x0?}, {0xc000caaab7?, 0xc001c77d08?}}})
       /workspace/pkg/coalescing/reconciler.go:109 +0x3eb
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile(0x36a6298?, {0x36a0ac8?, 0xc008ef0150?}, {{{0xc000caaa40?, 0xb?}, {0xc000caaab7?, 0x0?}}})
       /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.17.3/pkg/internal/controller/controller.go:119 +0xb7

```

- [x] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
```release-note
NONE
```
