### PR TITLE
fix: delete Machine instead of AzureMachinePoolMachine if VMSS VM is failed

### DIFF
--- a/exp/controllers/azuremachinepoolmachine_controller.go
+++ b/exp/controllers/azuremachinepoolmachine_controller.go
@@ -297,8 +297,9 @@ func (ampmr *AzureMachinePoolMachineController) reconcileNormal(ctx context.Cont
 		machineScope.SetFailureReason(capierrors.UpdateMachineError)
 		machineScope.SetFailureMessage(errors.Errorf("Azure VM state is %s", state))
 	case infrav1.Deleting:
-		if err := ampmr.Client.Delete(ctx, machineScope.AzureMachinePoolMachine); err != nil {
-			return reconcile.Result{}, errors.Wrap(err, "machine pool machine failed to be deleted when deleting")
+		log.V(4).Info("deleting machine because state is Deleting", "machine", machineScope.Name())
+		if err := ampmr.Client.Delete(ctx, machineScope.Machine); err != nil {
+			return reconcile.Result{}, errors.Wrap(err, "machine failed to be deleted when deleting")
 		}
 	}
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
As explained in the linked issue, the problem appears when the VMSS VM is in Deleting state (e.g. if MachinePool gets removed, or a node gets evicted). If we delete the AMPM, the Machine will stay in Failed state and not get cleaned up. Instead, we delete the Machine in this case and let the deletion propagate down to the AMPM. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4940

**Special notes for your reviewer**:

- [x] cherry-pick candidate

**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests

**Release note**:

```release-note
NONE
```
