### PR TITLE
remove westeurope from test regions

### DIFF
--- a/hack/util.sh
+++ b/hack/util.sh
@@ -63,7 +63,7 @@ capz::util::should_build_ccm() {
 
 # all test regions must support AvailabilityZones
 capz::util::get_random_region() {
-    local REGIONS=("canadacentral" "eastus" "eastus2" "northeurope" "uksouth" "westeurope" "westus2" "westus3")
+    local REGIONS=("canadacentral" "eastus" "eastus2" "northeurope" "uksouth" "westus2" "westus3")
     echo "${REGIONS[${RANDOM} % ${#REGIONS[@]}]}"
 }
 # all regions below must have GPU availability for the chosen GPU VM SKU


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind flake

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

e2e test runs that land in westeurope are exceedingly flaky when provisioning AKS clusters and often fail with this kind of error:
```
(AKSCapacityError) Creating a free tier cluster is unavailable at this time in region westeurope.
```
This triage link shows recent failures: https://storage.googleapis.com/k8s-triage/index.html?pr=1&text=Timed%20out%20waiting%20for%20Cluster&job=cluster-api-provider-azure&test=%5C%5BManaged%20Kubernetes%5C%5D

SIG Windows tests are also affected which use this script to pick a region, e.g. https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-kubernetes-e2e-capz-windows-1-28/1805594677622083584

This PR removes westeurope from the list of regions to avoid running tests there. If we merge this, I'll open an issue to track adding the region back when we're more confident it won't flake.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [X] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
