### PR TITLE
AzureMachinePoolMachine remove finalizer and avoid recreation if VMSS is deleting

### DIFF
--- a/azure/scope/machinepool.go
+++ b/azure/scope/machinepool.go
@@ -412,6 +412,10 @@ func (m *MachinePoolScope) applyAzureMachinePoolMachines(ctx context.Context) er
 	// determine which machines need to be created to reflect the current state in Azure
 	azureMachinesByProviderID := m.vmssState.InstancesByProviderID(m.AzureMachinePool.Spec.OrchestrationMode)
 	for key, val := range azureMachinesByProviderID {
+		if val.State == infrav1.Deleting || val.State == infrav1.Deleted {
+			log.V(4).Info("not recreating AzureMachinePoolMachine because VMSS VM is deleting", "providerID", key)
+			continue
+		}
 		if _, ok := existingMachinesByProviderID[key]; !ok {
 			log.V(4).Info("creating AzureMachinePoolMachine", "providerID", key)
 			if err := m.createMachine(ctx, val); err != nil {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR fixes the issues related to deleting MachinePools with VMSS still existing. Copying from the linked issue:

1. MachinePool delete deletes the VMSS
2. [Finalizer on AzureMachinePoolMachine gets removed because AzureMachinePool's deletionTimestamp is non zero](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/c304ddc1290377cb014d06cca3cabc67873c6e9f/exp/controllers/azuremachinepoolmachine_controller.go#L335-L340)
3. Machine gets deleted because dependant AMPM was deleted due to removing the finalizer
4. At this point however, the VMSS VM still exists
5. Next reconcile of the AzureMachinePool [recreates the AzureMachinePoolMachine again](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/c304ddc1290377cb014d06cca3cabc67873c6e9f/azure/scope/machinepool.go#L413-L422)
6. Now there is no Machine anymore for that AzureMachinePoolMachine and it can't get reconciled/deleted anymore

This PR fixes point 5 by avoiding to recreate the VMSS VM when it's already in Deleting/Deleted state. Additionally it fixes Point 6 (more as a safeguard) by removing a finalizer on an AMPM early on when the AzureMachinePool is deleting and the Machine does not exist. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4955

**Special notes for your reviewer**:
possibly @Jont828 could review this.

- [x] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests

**Release note**:

```release-note
fixes a few edge cases related to deleting a MachinePool
```
