### PR TITLE
[release-1.15] Use Standard tier SKU for AKS e2e tests

### DIFF
--- a/hack/util.sh
+++ b/hack/util.sh
@@ -63,7 +63,7 @@ capz::util::should_build_ccm() {
 
 # all test regions must support AvailabilityZones
 capz::util::get_random_region() {
-    local REGIONS=("canadacentral" "eastus" "eastus2" "northeurope" "uksouth" "westus2" "westus3")
+    local REGIONS=("canadacentral" "eastus" "eastus2" "northeurope" "uksouth" "westeurope" "westus2" "westus3")
     echo "${REGIONS[${RANDOM} % ${#REGIONS[@]}]}"
 }
 # all regions below must have GPU availability for the chosen GPU VM SKU

--- a/templates/test/ci/cluster-template-prow-aks-aso.yaml
+++ b/templates/test/ci/cluster-template-prow-aks-aso.yaml
@@ -37,6 +37,9 @@ spec:
         name: ${CLUSTER_NAME}
       servicePrincipalProfile:
         clientId: msi
+      sku:
+        name: Base
+        tier: Standard
       tags:
         buildProvenance: ${BUILD_PROVENANCE}
         creationTimestamp: ${TIMESTAMP}

--- a/templates/test/ci/cluster-template-prow-aks-clusterclass.yaml
+++ b/templates/test/ci/cluster-template-prow-aks-clusterclass.yaml
@@ -84,6 +84,8 @@ spec:
         kind: AzureClusterIdentity
         name: ${CLUSTER_IDENTITY_NAME}
       location: ${AZURE_LOCATION}
+      sku:
+        tier: Standard
       subscriptionID: ${AZURE_SUBSCRIPTION_ID}
       version: ${KUBERNETES_VERSION}
 ---

--- a/templates/test/ci/cluster-template-prow-aks.yaml
+++ b/templates/test/ci/cluster-template-prow-aks.yaml
@@ -38,6 +38,8 @@ spec:
   oidcIssuerProfile:
     enabled: true
   resourceGroupName: ${AZURE_RESOURCE_GROUP:=${CLUSTER_NAME}}
+  sku:
+    tier: Standard
   sshPublicKey: ${AZURE_SSH_PUBLIC_KEY_B64:=""}
   subscriptionID: ${AZURE_SUBSCRIPTION_ID}
   version: ${KUBERNETES_VERSION}

--- a/templates/test/ci/prow-aks-aso/kustomization.yaml
+++ b/templates/test/ci/prow-aks-aso/kustomization.yaml
@@ -28,6 +28,11 @@ patches:
           jobName: ${JOB_NAME}
           creationTimestamp: ${TIMESTAMP}
           buildProvenance: ${BUILD_PROVENANCE}
+      - op: replace
+        path: /spec/resources/0/spec/sku
+        value:
+          name: Base
+          tier: Standard
     target:
       kind: AzureASOManagedControlPlane
   - patch: |-

--- a/templates/test/ci/prow-aks-clusterclass/kustomization.yaml
+++ b/templates/test/ci/prow-aks-clusterclass/kustomization.yaml
@@ -12,3 +12,4 @@ patchesStrategicMerge:
   - patches/addons.yaml
   - patches/kubeadm-config-template.yaml
   - patches.yaml
+  - patches/sku.yaml

--- a/templates/test/ci/prow-aks-clusterclass/patches/sku.yaml
+++ b/templates/test/ci/prow-aks-clusterclass/patches/sku.yaml
@@ -1,0 +1,10 @@
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: AzureManagedControlPlaneTemplate
+metadata:
+  name: ${CLUSTER_NAME}-control-plane
+  namespace: default
+spec:
+  template:
+    spec:
+      sku:
+        tier: Standard

--- a/templates/test/ci/prow-aks/kustomization.yaml
+++ b/templates/test/ci/prow-aks/kustomization.yaml
@@ -9,3 +9,4 @@ patchesStrategicMerge:
   - patches/aks-pool0.yaml
   - patches/aks-pool1.yaml
   - patches/addons.yaml
+  - patches/sku.yaml

--- a/templates/test/ci/prow-aks/patches/sku.yaml
+++ b/templates/test/ci/prow-aks/patches/sku.yaml
@@ -1,0 +1,8 @@
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: AzureManagedControlPlane
+metadata:
+  name: ${CLUSTER_NAME}
+  namespace: default
+spec:
+  sku:
+    tier: Standard


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind flake

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

Manual cherry-pick of #4962:

> This PR updates the CI templates to specify "Standard" tier AKS clusters instead of the default "Free" which was resulting in errors in some regions where AKS would fail to provision free clusters: https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/directory/pull-cluster-api-provider-azure-e2e-aks/1803862127094534144

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
