### PR TITLE
Don't reuse windows cnm image if it has os.version set

### DIFF
--- a/scripts/ci-build-azure-ccm.sh
+++ b/scripts/ci-build-azure-ccm.sh
@@ -95,6 +95,12 @@ can_reuse_artifacts() {
         echo "false" && return
     fi
 
+    # Do not reuse the image if there is a Windows image built with older version of this script that did not
+    # build the images as host-process-container images. Those images cannot be pulled on mis-matched Windows Server versions.
+    if docker manifest inspect "${REGISTRY}/${CNM_IMAGE_NAME}:${IMAGE_TAG_CNM}" | grep -q "\"os.version\": \"10.0."; then
+        echo "false" && return
+    fi
+
     for BINARY in azure-acr-credential-provider azure-acr-credential-provider.exe credential-provider-config.yaml credential-provider-config-win.yaml; do
         if [[ "$(az storage blob exists --container-name "${AZURE_BLOB_CONTAINER_NAME}" --name "${IMAGE_TAG_ACR_CREDENTIAL_PROVIDER}/${BINARY}" --query exists --output tsv)" == "false" ]]; then
             echo "false" && return


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind feature

/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/4890 updated this script to build the windows cloud-node-manger image as a host-process container.

This PR updates the logic used to determine if we need to rebuild the cloud-node-manager image because we started running into some issues in CI where some test passes were building the image as host-process containers and some weren't.
This causes issues because if the image was build as a non-hpc image for Windows Server 2019 (because that test pass was using an older version of this script), and then we run a test pass against Windows Server 2022 that build the image as a host-process container, the image pull will fail because the `os.version` from the older / non-hpc image will cause some image-version checks to fail in contianerd.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
