### PR TITLE
Add release 1.16 to metadata.yaml

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -62,3 +62,6 @@ releaseSeries:
   - major: 1
     minor: 15
     contract: v1beta1
+  - major: 1
+    minor: 16
+    contract: v1beta1


### PR DESCRIPTION
/kind cleanup

**What this PR does / why we need it**:

Adds the impending 1.16 release series to metadata.yaml so its API version is found, and all that good stuff.

**Which issue(s) this PR fixes**:

N/A, but see #4821 for prior art.

**Special notes for your reviewer**:


- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:

```release-note
NONE
```
