### PR TITLE
WIP: Update docs on updating clusterctl API version upgrade tests

### DIFF
--- a/docs/book/src/developers/releasing.md
+++ b/docs/book/src/developers/releasing.md
@@ -201,7 +201,9 @@ Additionally, we need to update the `type: InfrastructureProvider` spec in [azur
 
 #### Update clusterctl API version upgrade tests
 
-Update the [API version upgrade tests](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/v1.12.1/test/e2e/capi_test.go#L214) to use the oldest supported release versions of CAPI and CAPZ after the release is cut as "Init" provider versions. See [this PR](https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/4433) for more details.
+Update the provider versions for the [API version upgrade tests](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/v1.16.0/test/e2e/common.go#L94-L95) to use the latest patch release of the previous two minor releases. See [this PR](https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/4873) for more details.
+
+The two versioned prow templates within `test/e2e/data/infrastructure-azure` should be updated to `templates/test/ci/cluster-template-prow.yaml` at the respective version. For example, if we're updating `v1.14.4` to `v1.14.5`, then `cluster-template-prow.yaml` should be moved from `test/e2e/data/infrastructure-azure/v1.14.4` to `test/e2e/data/infrastructure-azure/v1.14.5`, and contain the same contents as `templates/test/ci/cluster-template-prow.yaml`. 
 
 ### Update Upstream Tests (skip for patch releases)
 


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind documentation

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
This PR updates documentation on how to update the clusterctl API version upgrade tests on a new release. Previously the docs were pointing to the wrong place for updating versions, as well as not including guidance on how to update the `cluster-template-prow.yaml` that the test was using.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
