### PR TITLE
[release-1.15] add namespace to identity secret kubectl commands

### DIFF
--- a/hack/create-identity-secret.sh
+++ b/hack/create-identity-secret.sh
@@ -28,8 +28,8 @@ make --directory="${REPO_ROOT}" "${KUBECTL##*/}"
 # shellcheck source=hack/parse-prow-creds.sh
 source "${REPO_ROOT}/hack/parse-prow-creds.sh"
 
-if ! "${KUBECTL}" get secret "${AZURE_CLUSTER_IDENTITY_SECRET_NAME}" > /dev/null; then
-  "${KUBECTL}" create secret generic "${AZURE_CLUSTER_IDENTITY_SECRET_NAME}" --from-literal=clientSecret="${AZURE_CLIENT_SECRET}"
+if ! "${KUBECTL}" get secret -n default "${AZURE_CLUSTER_IDENTITY_SECRET_NAME}" > /dev/null; then
+  "${KUBECTL}" create secret generic -n default "${AZURE_CLUSTER_IDENTITY_SECRET_NAME}" --from-literal=clientSecret="${AZURE_CLIENT_SECRET}"
 fi
 
-"${KUBECTL}" label secret "${AZURE_CLUSTER_IDENTITY_SECRET_NAME}" "clusterctl.cluster.x-k8s.io/move-hierarchy=true" --overwrite=true
+"${KUBECTL}" label secret -n default "${AZURE_CLUSTER_IDENTITY_SECRET_NAME}" "clusterctl.cluster.x-k8s.io/move-hierarchy=true" --overwrite=true


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind failing-test

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

This is a follow up to #4993 to add `-n default` to the kubectl commands which create the AzureClusterIdentity Secret which I missed in the other PR because that script had already been removed from main. This should fix failures like https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/capz-release-azure-disk-master/1813846064134885376

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
