### PR TITLE
use managed identity for CAPI self-hosted e2e test

### DIFF
--- a/azure/scope/identity.go
+++ b/azure/scope/identity.go
@@ -41,6 +41,7 @@ type CredentialsProvider interface {
 	GetClientSecret(ctx context.Context) (string, error)
 	GetTenantID() string
 	GetTokenCredential(ctx context.Context, resourceManagerEndpoint, activeDirectoryEndpoint, tokenAudience string) (azcore.TokenCredential, error)
+	Type() infrav1.IdentityType
 }
 
 // AzureCredentialsProvider represents a credential provider with azure cluster identity.
@@ -226,6 +227,11 @@ func (p *AzureCredentialsProvider) GetClientSecret(ctx context.Context) (string,
 // GetTenantID returns the Tenant ID associated with the AzureCredentialsProvider's Identity.
 func (p *AzureCredentialsProvider) GetTenantID() string {
 	return p.Identity.Spec.TenantID
+}
+
+// Type returns the auth mechanism used.
+func (p *AzureCredentialsProvider) Type() infrav1.IdentityType {
+	return p.Identity.Spec.Type
 }
 
 // hasClientSecret returns true if the identity has a Service Principal Client Secret.

--- a/test/e2e/data/infrastructure-azure/v1beta1/cluster-template.yaml
+++ b/test/e2e/data/infrastructure-azure/v1beta1/cluster-template.yaml
@@ -284,10 +284,13 @@ spec:
       - diskSizeGB: 256
         lun: 0
         nameSuffix: etcddisk
+      identity: UserAssigned
       osDisk:
         diskSizeGB: 128
         osType: Linux
       sshPublicKey: ${AZURE_SSH_PUBLIC_KEY_B64:=""}
+      userAssignedIdentities:
+      - providerID: /subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${CI_RG:=capz-ci}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER_IDENTITY:=cloud-provider-user-identity}
       vmSize: ${AZURE_CONTROL_PLANE_MACHINE_TYPE}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
@@ -298,10 +301,13 @@ metadata:
 spec:
   template:
     spec:
+      identity: UserAssigned
       osDisk:
         diskSizeGB: 128
         managedDisk:
           storageAccountType: Premium_LRS
         osType: Linux
       sshPublicKey: ${AZURE_SSH_PUBLIC_KEY_B64:=""}
+      userAssignedIdentities:
+      - providerID: /subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${CI_RG:=capz-ci}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER_IDENTITY:=cloud-provider-user-identity}
       vmSize: ${AZURE_NODE_MACHINE_TYPE}

--- a/test/e2e/data/infrastructure-azure/v1beta1/cluster-template/kustomization.yaml
+++ b/test/e2e/data/infrastructure-azure/v1beta1/cluster-template/kustomization.yaml
@@ -12,3 +12,5 @@ patches:
 - path: ../../../../../../templates/azure-cluster-identity/azurecluster-identity-ref.yaml
 - path: ../../../../../../templates/test/ci/patches/cluster-label-calico.yaml
 - path: ../../../../../../templates/test/ci/patches/cluster-label-cloud-provider-azure.yaml
+- path: ../../../../../../templates/test/ci/patches/uami-control-plane.yaml
+- path: ../../../../../../templates/test/ci/patches/uami-md-0.yaml


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind failing-test

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

This PR fixes the failing self-hosted e2e test by recreating the AzureClusterIdentity after the move with UserAssignedMSI credentials.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #5002

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [X] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
