### PR TITLE
ci-entrypoint: don't reset kind cluster before getting logs

### DIFF
--- a/hack/create-dev-cluster.sh
+++ b/hack/create-dev-cluster.sh
@@ -82,12 +82,10 @@ create_cluster() {
     make create-cluster
 }
 
-setup
-
 retries=$CLUSTER_CREATE_ATTEMPTS
 while ((retries > 0)); do
-    create_cluster && break
     setup
+    create_cluster && break
     sleep 5
     ((retries --))
 done


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

When creating a cluster with ci-entrypoint.sh fails, the bootstrap kind cluster gets deleted here: https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/f2976c03051e5044cc63a256e8f3c9cac5b631a6/hack/create-dev-cluster.sh#L90

before ci-entrypoint can collect logs here: https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/f2976c03051e5044cc63a256e8f3c9cac5b631a6/scripts/ci-entrypoint.sh#L224-L239

As a result, no logs whatsoever get collected for failed ci-entrypoint runs, like this one: https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_cloud-provider-azure/6638/pull-cloud-provider-azure-e2e-ccm-vmss-capz-eks-test/1815555949386010624

This PR only deletes the kind bootstrap cluster in between tries, leaving it around after all tries fail so logs can be collected like when a try succeeds.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [X] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
