### PR TITLE
Skip optional GPU-enabled test since sub has no quota

### DIFF
--- a/test/e2e/azure_test.go
+++ b/test/e2e/azure_test.go
@@ -560,6 +560,7 @@ var _ = Describe("Workload cluster creation", func() {
 	// See https://azure.microsoft.com/en-us/pricing/details/virtual-machines/linux/ for pricing.
 	Context("Creating a GPU-enabled cluster [OPTIONAL]", func() {
 		It("with a single control plane node and 1 node", func() {
+			Skip("Skipping since the e2e subscription has no quota for GPU SKUs")
 			clusterName = getClusterName(clusterNamePrefix, "gpu")
 			clusterctl.ApplyClusterTemplateAndWait(ctx, createApplyClusterTemplateInput(
 				specName,


### PR DESCRIPTION

/kind failing-test


**What this PR does / why we need it**:

Disables the optional GPU-based test, as the new community subscription has no quota for these SKUs and it will fail.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

- [x] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:

```release-note
NONE
```
