### PR TITLE
remove surge from MachinePool test templates

### DIFF
--- a/templates/test/ci/cluster-template-prow-machine-pool-ci-version.yaml
+++ b/templates/test/ci/cluster-template-prow-machine-pool-ci-version.yaml
@@ -270,8 +270,8 @@ spec:
   strategy:
     rollingUpdate:
       deletePolicy: Oldest
-      maxSurge: 25%
-      maxUnavailable: 1
+      maxSurge: 0
+      maxUnavailable: 10
     type: RollingUpdate
   template:
     image:
@@ -452,6 +452,10 @@ metadata:
 spec:
   identity: UserAssigned
   location: ${AZURE_LOCATION}
+  strategy:
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 10
   template:
     image:
       marketplace:

--- a/templates/test/ci/cluster-template-prow-machine-pool.yaml
+++ b/templates/test/ci/cluster-template-prow-machine-pool.yaml
@@ -174,8 +174,8 @@ spec:
   strategy:
     rollingUpdate:
       deletePolicy: Oldest
-      maxSurge: 25%
-      maxUnavailable: 1
+      maxSurge: 0
+      maxUnavailable: 10
     type: RollingUpdate
   template:
     osDisk:
@@ -260,6 +260,10 @@ metadata:
   namespace: default
 spec:
   location: ${AZURE_LOCATION}
+  strategy:
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 10
   template:
     osDisk:
       diskSizeGB: 128

--- a/templates/test/ci/patches/azuremachinepool-surge.yaml
+++ b/templates/test/ci/patches/azuremachinepool-surge.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: AzureMachinePool
+metadata:
+  name: ${CLUSTER_NAME}-mp-0
+  namespace: default
+spec:
+  strategy:
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 10
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: AzureMachinePool
+metadata:
+  name: "${CLUSTER_NAME}-mp-win"
+  namespace: default
+spec:
+  strategy:
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 10

--- a/templates/test/ci/prow-machine-pool/kustomization.yaml
+++ b/templates/test/ci/prow-machine-pool/kustomization.yaml
@@ -35,6 +35,7 @@ patches:
 - path: ../patches/windows-containerd-labels.yaml
 - path: ../patches/cluster-label-calico.yaml
 - path: ../patches/cluster-label-cloud-provider-azure.yaml
+- path: ../patches/azuremachinepool-surge.yaml
 
 sortOptions:
   order: fifo

--- a/templates/test/dev/cluster-template-custom-builds-machine-pool.yaml
+++ b/templates/test/dev/cluster-template-custom-builds-machine-pool.yaml
@@ -260,8 +260,8 @@ spec:
   strategy:
     rollingUpdate:
       deletePolicy: Oldest
-      maxSurge: 25%
-      maxUnavailable: 1
+      maxSurge: 0
+      maxUnavailable: 10
     type: RollingUpdate
   template:
     image:
@@ -395,6 +395,10 @@ metadata:
   namespace: default
 spec:
   location: ${AZURE_LOCATION}
+  strategy:
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 10
   template:
     image:
       marketplace:


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind failing-test

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

This PR removes the max surge config on AzureMachinePools used in test templates to work around VMSS instances in the new community subscription from endlessly cycling due to an Azure Policy adding a tag on the resource that CAPZ endlessly tries to reconcile.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [X] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
