### PR TITLE
don't rollout VMSS model updates when tags change

### DIFF
--- a/azure/const.go
+++ b/azure/const.go
@@ -23,6 +23,12 @@ const (
 	// for annotation formatting rules.
 	VMTagsLastAppliedAnnotation = "sigs.k8s.io/cluster-api-provider-azure-last-applied-tags-vm"
 
+	// VMSSTagsLastAppliedAnnotation is the key for the machine object annotation
+	// which tracks the AdditionalTags in the MachinePool Provider Config.
+	// See https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+	// for annotation formatting rules.
+	VMSSTagsLastAppliedAnnotation = "sigs.k8s.io/cluster-api-provider-azure-last-applied-tags-vmss"
+
 	// RGTagsLastAppliedAnnotation is the key for the Azure Cluster object annotation
 	// which tracks the AdditionalTags for Resource Group which is part in the Azure Cluster.
 	// See https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/

--- a/azure/defaults.go
+++ b/azure/defaults.go
@@ -217,6 +217,11 @@ func VMID(subscriptionID, resourceGroup, vmName string) string {
 	return fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/virtualMachines/%s", subscriptionID, resourceGroup, vmName)
 }
 
+// VMSSID returns the azure resource ID for a given VMSS.
+func VMSSID(subscriptionID, resourceGroup, vmssName string) string {
+	return fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/virtualMachineScaleSets/%s", subscriptionID, resourceGroup, vmssName)
+}
+
 // VNetID returns the azure resource ID for a given VNet.
 func VNetID(subscriptionID, resourceGroup, vnetName string) string {
 	return fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/virtualNetworks/%s", subscriptionID, resourceGroup, vnetName)

--- a/azure/types.go
+++ b/azure/types.go
@@ -126,7 +126,6 @@ func (vmss VMSS) HasModelChanges(other VMSS) bool {
 	equal := cmp.Equal(vmss.Image, other.Image) &&
 		cmp.Equal(vmss.Identity, other.Identity) &&
 		cmp.Equal(vmss.Zones, other.Zones) &&
-		cmp.Equal(vmss.Tags, other.Tags) &&
 		cmp.Equal(vmss.Sku, other.Sku)
 	return !equal
 }

--- a/azure/types_test.go
+++ b/azure/types_test.go
@@ -124,18 +124,6 @@ func TestVMSS_HasModelChanges(t *testing.T) {
 			},
 			HasModelChanges: true,
 		},
-		{
-			Name: "with different Tags",
-			Factory: func() (VMSS, VMSS) {
-				l := getDefaultVMSSForModelTesting()
-				l.Tags = infrav1.Tags{
-					"bin": "baz",
-				}
-				r := getDefaultVMSSForModelTesting()
-				return r, l
-			},
-			HasModelChanges: true,
-		},
 	}
 
 	for _, c := range cases {

--- a/exp/controllers/azuremachinepool_reconciler.go
+++ b/exp/controllers/azuremachinepool_reconciler.go
@@ -25,6 +25,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-azure/azure/services/resourceskus"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/services/roleassignments"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/services/scalesets"
+	"sigs.k8s.io/cluster-api-provider-azure/azure/services/tags"
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
 )
 
@@ -49,12 +50,17 @@ func newAzureMachinePoolService(machinePoolScope *scope.MachinePoolScope) (*azur
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create a scalesets service")
 	}
+	tagsSvc, err := tags.New(machinePoolScope)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed creating tags service")
+	}
 
 	return &azureMachinePoolService{
 		scope: machinePoolScope,
 		services: []azure.ServiceReconciler{
 			scaleSetsSvc,
 			roleAssignmentsSvc,
+			tagsSvc,
 		},
 		skuCache: cache,
 	}, nil


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

This PR wires up AzureMachinePool to the `tags` service which manages resource tags in Azure and can gracefully handle tags applied by external actors like Azure Policy.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes the functional part of #5019

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [X] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixed a bug causing AzureMachinePool to endlessly reconcile when a tag is applied to a VMSS by an external actor like Azure Policy
```
