### PR TITLE
remove predefined availabilityZones from AKS e2e templates

### DIFF
--- a/templates/test/ci/cluster-template-prow-aks-clusterclass.yaml
+++ b/templates/test/ci/cluster-template-prow-aks-clusterclass.yaml
@@ -106,11 +106,7 @@ metadata:
 spec:
   template:
     spec:
-      availabilityZones:
-      - "1"
-      - "2"
       enableNodePublicIP: false
-      enableUltraSSD: true
       maxPods: 30
       mode: System
       name: pool0

--- a/templates/test/ci/cluster-template-prow-aks.yaml
+++ b/templates/test/ci/cluster-template-prow-aks.yaml
@@ -76,11 +76,7 @@ metadata:
   name: ${CLUSTER_NAME}-pool0
   namespace: default
 spec:
-  availabilityZones:
-  - "1"
-  - "2"
   enableNodePublicIP: false
-  enableUltraSSD: true
   maxPods: 30
   mode: System
   name: pool0

--- a/templates/test/ci/prow-aks-clusterclass/patches/aks-clusterclass-pool0.yaml
+++ b/templates/test/ci/prow-aks-clusterclass/patches/aks-clusterclass-pool0.yaml
@@ -9,7 +9,5 @@ spec:
       osDiskType: "Managed"
       osDiskSizeGB: 30
       enableNodePublicIP: false
-      enableUltraSSD: true
-      availabilityZones: ["1", "2"]
       name: pool0
       sku: "${AZURE_AKS_NODE_MACHINE_TYPE:=Standard_D2s_v3}"

--- a/templates/test/ci/prow-aks/patches/aks-pool0.yaml
+++ b/templates/test/ci/prow-aks/patches/aks-pool0.yaml
@@ -7,7 +7,5 @@ spec:
   osDiskType: "Managed"
   osDiskSizeGB: 30
   enableNodePublicIP: false
-  enableUltraSSD: true
-  availabilityZones: ["1", "2"]
   name: pool0
   sku: "${AZURE_AKS_NODE_MACHINE_TYPE:=Standard_D2s_v3}"


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind flake

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

This is a workaround for #5033 for the AKS e2e tests. Availability zones may dynamically have restrictions placed on them at a subscription level so we can't always depend on a specific set of zones to be available to all regions.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [X] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
