### PR TITLE
remove sku-specific zonal restrictions

### DIFF
--- a/azure/services/resourceskus/cache.go
+++ b/azure/services/resourceskus/cache.go
@@ -188,21 +188,6 @@ func (c *Cache) GetZones(ctx context.Context, location string) ([]string, error)
 					availableZones[*zone] = true
 				}
 
-				if sku.Restrictions != nil {
-					for _, restriction := range sku.Restrictions {
-						// Can't deploy anything in this subscription in this location. Bail out.
-						if ptr.Deref(restriction.Type, "") == armcompute.ResourceSKURestrictionsTypeLocation {
-							availableZones = nil
-							break
-						}
-
-						// remove restricted zones
-						for _, restrictedZone := range restriction.RestrictionInfo.Zones {
-							delete(availableZones, *restrictedZone)
-						}
-					}
-				}
-
 				// add to global list, if any exist. it's okay for the final list to be empty.
 				// that means the region may not support AZ yet.
 				for zone := range availableZones {


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

/kind bug

**What this PR does / why we need it**:

This PR replaces the existing location-specific zonal getter.

The current implementation does this:

- requires every VM SKU in that location to support a zone in order to allow any VM SKU to use that zone

This new implementation does this:

- Exposes a list of all zones that are supported by any SKU in a location

The former approach has the negative side-effect of disallowing VM SKUs in certain regions from using zonal configuration even though it is supported for that SKU.

The new approach has the negative side-effect of allowing edge-case scenarios to be configured in the `AzureManagedMachinePool` (or `AzureMachineTemplate` in the self-managed scenario) that aren't actually supported for a particular VM SKU in a particular region.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
remove sku-specific zonal restrictions
```
