### PR TITLE
set AZURE_CLIENT_ID_USER_ASSIGNED_IDENTITY for create-custom-cloud-provider-config.sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -308,6 +308,7 @@ create-management-cluster: $(KUSTOMIZE) $(ENVSUBST) $(KUBECTL) $(KIND) ## Create
 	./hack/install-cert-manager.sh
 
 	# Create customized cloud provider configs
+	AZURE_CLIENT_ID_USER_ASSIGNED_IDENTITY="$${AZURE_CLIENT_ID_USER_ASSIGNED_IDENTITY:-$$(cat $(AZURE_IDENTITY_ID_FILEPATH))}" \
 	./hack/create-custom-cloud-provider-config.sh
 
 	# Deploy CAPI

--- a/hack/create-custom-cloud-provider-config.sh
+++ b/hack/create-custom-cloud-provider-config.sh
@@ -31,7 +31,6 @@ if [[ -n "${CUSTOM_CLOUD_PROVIDER_CONFIG:-}" ]]; then
   CLOUD_PROVIDER_CONFIG="${CUSTOM_CLOUD_PROVIDER_CONFIG:-}"
 fi
 
-echo "curling ${CLOUD_PROVIDER_CONFIG}"
 curl --retry 3 -sL -o tmp_azure_json "${CLOUD_PROVIDER_CONFIG}"
 "${ENVSUBST}" < tmp_azure_json > azure_json
 "${KUBECTL}" delete secret "${CLUSTER_NAME}-control-plane-azure-json" -n default || true


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind failing-test

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

This PR passes the `AZURE_CLIENT_ID_USER_ASSIGNED_IDENTITY` environment variable onto the create-custom-cloud-provider-config.sh script so it can be used when constructing a custom cloud provider azure.json.

This was passing our ci-entrypoint test before while authenticating with system-assigned identity:
```
I0802 01:53:21.430273       1 azure_auth.go:313] Using AzurePublicCloud environment
I0802 01:53:21.430474       1 azure_auth.go:106] "Setup ARM general resource token provider" logger="GetServicePrincipalToken" method="msi"
I0802 01:53:21.430571       1 azure_auth.go:128] "Setup with system assigned managed identity" logger="GetServicePrincipalToken"
```

This PR now correctly authenticates with a user-assigned identity:
```
I0802 20:05:02.938256       1 azure_auth.go:313] Using AzurePublicCloud environment
I0802 20:05:02.940903       1 azure_auth.go:106] "Setup ARM general resource token provider" logger="GetServicePrincipalToken" method="msi"
I0802 20:05:02.941011       1 azure_auth.go:112] "Parsing user assigned managed identity" logger="GetServicePrincipalToken"
I0802 20:05:02.941130       1 azure_auth.go:123] "Setup with user assigned managed identity" logger="GetServicePrincipalToken" id-type="client_id"
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [X] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
