### PR TITLE
eliminate unnecessary tag updates to VMSS resources

### DIFF
--- a/azure/scope/machinepool.go
+++ b/azure/scope/machinepool.go
@@ -210,7 +210,7 @@ func (m *MachinePoolScope) ScaleSetSpec(ctx context.Context) azure.ResourceSpecG
 		SubscriptionID:               m.SubscriptionID(),
 		HasReplicasExternallyManaged: m.HasReplicasExternallyManaged(ctx),
 		ClusterName:                  m.ClusterName(),
-		AdditionalTags:               m.AzureMachinePool.Spec.AdditionalTags,
+		AdditionalTags:               m.AdditionalTags(),
 		PlatformFaultDomainCount:     m.AzureMachinePool.Spec.PlatformFaultDomainCount,
 		ZoneBalance:                  m.AzureMachinePool.Spec.ZoneBalance,
 	}


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

This PR fixes an issue pointed out by @mweibel in https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/5020#issuecomment-2260796524 where tags on VMSS resources converge, but take more API calls than necessary because the `scalesets` and `tags` services were using different sets of `AdditionalTags`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [X] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixed a bug causing unnecessary updates to tags to VMSS resources.
```
