### PR TITLE
ASOAPI: truncate expected node label values at max length

### DIFF
--- a/controllers/azureasomanagedmachinepool_controller.go
+++ b/controllers/azureasomanagedmachinepool_controller.go
@@ -25,6 +25,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/utils/ptr"
 	infrav1alpha "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha1"
 	"sigs.k8s.io/cluster-api-provider-azure/pkg/mutators"
@@ -285,6 +286,12 @@ func (r *AzureASOManagedMachinePoolReconciler) reconcileNormal(ctx context.Conte
 }
 
 func expectedNodeLabels(poolName, nodeRG string) map[string]string {
+	if len(poolName) > validation.LabelValueMaxLength {
+		poolName = poolName[:validation.LabelValueMaxLength]
+	}
+	if len(nodeRG) > validation.LabelValueMaxLength {
+		nodeRG = nodeRG[:validation.LabelValueMaxLength]
+	}
 	return map[string]string{
 		"kubernetes.azure.com/agentpool": poolName,
 		"kubernetes.azure.com/cluster":   nodeRG,


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

This PR updates the labels used to map workload cluster Nodes to AzureASOManagedMachinePools to account for when the expected label values are longer than the 63 character max by truncating to fit within that limit.

This run shows that the actual Node has a label of `kubernetes.azure.com/cluster=MC_capz-e2e-bfd5ks-asoapi_capz-e2e-bfd5ks-asoapi_switzerlandnor` where CAPZ was looking for a value which includes the truncated `th`: https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_cluster-api-provider-azure/5055/pull-cluster-api-provider-azure-e2e-aks/1820510315842899968
 
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [X] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixed a bug with AzureASOManagedMachinePools preventing it from mapping Nodes when the AKS node resource group is more than 63 characters long.
```
