### PR TITLE
reduce to one credential provider implementation

### DIFF
--- a/azure/scope/cluster.go
+++ b/azure/scope/cluster.go
@@ -77,7 +77,7 @@ func NewClusterScope(ctx context.Context, params ClusterScopeParams) (*ClusterSc
 		return nil, errors.New("failed to generate new scope from nil AzureCluster")
 	}
 
-	credentialsProvider, err := NewAzureClusterCredentialsProvider(ctx, params.Client, params.AzureCluster)
+	credentialsProvider, err := NewAzureCredentialsProvider(ctx, params.Client, params.AzureCluster.Spec.IdentityRef, params.AzureCluster.Namespace)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to init credentials provider")
 	}

--- a/azure/scope/cluster_test.go
+++ b/azure/scope/cluster_test.go
@@ -3642,7 +3642,8 @@ func TestVNetPeerings(t *testing.T) {
 					AzureClusterClassSpec: infrav1.AzureClusterClassSpec{
 						SubscriptionID: tc.subscriptionID,
 						IdentityRef: &corev1.ObjectReference{
-							Kind: infrav1.AzureClusterIdentityKind,
+							Kind:      infrav1.AzureClusterIdentityKind,
+							Namespace: clusterNamespace,
 						},
 					},
 					NetworkSpec: infrav1.NetworkSpec{

--- a/azure/scope/identity.go
+++ b/azure/scope/identity.go
@@ -50,87 +50,31 @@ type AzureCredentialsProvider struct {
 	Identity *infrav1.AzureClusterIdentity
 }
 
-// AzureClusterCredentialsProvider wraps AzureCredentialsProvider with AzureCluster.
-type AzureClusterCredentialsProvider struct {
-	AzureCredentialsProvider
-	AzureCluster *infrav1.AzureCluster
-}
-
-// ManagedControlPlaneCredentialsProvider wraps AzureCredentialsProvider with AzureManagedControlPlane.
-type ManagedControlPlaneCredentialsProvider struct {
-	AzureCredentialsProvider
-	AzureManagedControlPlane *infrav1.AzureManagedControlPlane
-}
-
-var _ CredentialsProvider = (*AzureClusterCredentialsProvider)(nil)
-var _ CredentialsProvider = (*ManagedControlPlaneCredentialsProvider)(nil)
-
-// NewAzureClusterCredentialsProvider creates a new AzureClusterCredentialsProvider from the supplied inputs.
-func NewAzureClusterCredentialsProvider(ctx context.Context, kubeClient client.Client, azureCluster *infrav1.AzureCluster) (*AzureClusterCredentialsProvider, error) {
-	if azureCluster.Spec.IdentityRef == nil {
+// NewAzureCredentialsProvider creates a new AzureClusterCredentialsProvider from the supplied inputs.
+func NewAzureCredentialsProvider(ctx context.Context, kubeClient client.Client, identityRef *corev1.ObjectReference, defaultNamespace string) (*AzureCredentialsProvider, error) {
+	if identityRef == nil {
 		return nil, errors.New("failed to generate new AzureClusterCredentialsProvider from empty identityName")
 	}
 
-	ref := azureCluster.Spec.IdentityRef
 	// if the namespace isn't specified then assume it's in the same namespace as the AzureCluster
-	namespace := ref.Namespace
+	namespace := identityRef.Namespace
 	if namespace == "" {
-		namespace = azureCluster.Namespace
+		namespace = defaultNamespace
 	}
 	identity := &infrav1.AzureClusterIdentity{}
-	key := client.ObjectKey{Name: ref.Name, Namespace: namespace}
+	key := client.ObjectKey{Name: identityRef.Name, Namespace: namespace}
 	if err := kubeClient.Get(ctx, key, identity); err != nil {
 		return nil, errors.Errorf("failed to retrieve AzureClusterIdentity external object %q/%q: %v", key.Namespace, key.Name, err)
 	}
 
-	return &AzureClusterCredentialsProvider{
-		AzureCredentialsProvider{
-			Client:   kubeClient,
-			Identity: identity,
-		},
-		azureCluster,
+	return &AzureCredentialsProvider{
+		Client:   kubeClient,
+		Identity: identity,
 	}, nil
 }
 
 // GetTokenCredential returns an Azure TokenCredential based on the provided azure identity.
-func (p *AzureClusterCredentialsProvider) GetTokenCredential(ctx context.Context, resourceManagerEndpoint, activeDirectoryEndpoint, tokenAudience string) (azcore.TokenCredential, error) {
-	return p.AzureCredentialsProvider.GetTokenCredential(ctx, resourceManagerEndpoint, activeDirectoryEndpoint, tokenAudience, p.AzureCluster.ObjectMeta)
-}
-
-// NewManagedControlPlaneCredentialsProvider creates a new ManagedControlPlaneCredentialsProvider from the supplied inputs.
-func NewManagedControlPlaneCredentialsProvider(ctx context.Context, kubeClient client.Client, managedControlPlane *infrav1.AzureManagedControlPlane) (*ManagedControlPlaneCredentialsProvider, error) {
-	if managedControlPlane.Spec.IdentityRef == nil {
-		return nil, errors.New("failed to generate new ManagedControlPlaneCredentialsProvider from empty identityName")
-	}
-
-	ref := managedControlPlane.Spec.IdentityRef
-	// if the namespace isn't specified then assume it's in the same namespace as the AzureManagedControlPlane
-	namespace := ref.Namespace
-	if namespace == "" {
-		namespace = managedControlPlane.Namespace
-	}
-	identity := &infrav1.AzureClusterIdentity{}
-	key := client.ObjectKey{Name: ref.Name, Namespace: namespace}
-	if err := kubeClient.Get(ctx, key, identity); err != nil {
-		return nil, errors.Errorf("failed to retrieve AzureClusterIdentity external object %q/%q: %v", key.Namespace, key.Name, err)
-	}
-
-	return &ManagedControlPlaneCredentialsProvider{
-		AzureCredentialsProvider{
-			Client:   kubeClient,
-			Identity: identity,
-		},
-		managedControlPlane,
-	}, nil
-}
-
-// GetTokenCredential returns an Azure TokenCredential based on the provided azure identity.
-func (p *ManagedControlPlaneCredentialsProvider) GetTokenCredential(ctx context.Context, resourceManagerEndpoint, activeDirectoryEndpoint, tokenAudience string) (azcore.TokenCredential, error) {
-	return p.AzureCredentialsProvider.GetTokenCredential(ctx, resourceManagerEndpoint, activeDirectoryEndpoint, tokenAudience, p.AzureManagedControlPlane.ObjectMeta)
-}
-
-// GetTokenCredential returns an Azure TokenCredential based on the provided azure identity.
-func (p *AzureCredentialsProvider) GetTokenCredential(ctx context.Context, resourceManagerEndpoint, activeDirectoryEndpoint, tokenAudience string, clusterMeta metav1.ObjectMeta) (azcore.TokenCredential, error) {
+func (p *AzureCredentialsProvider) GetTokenCredential(ctx context.Context, resourceManagerEndpoint, activeDirectoryEndpoint, tokenAudience string) (azcore.TokenCredential, error) {
 	ctx, log, done := tele.StartSpanWithLogger(ctx, "azure.scope.AzureCredentialsProvider.GetTokenCredential")
 	defer done()
 

--- a/azure/scope/identity_test.go
+++ b/azure/scope/identity_test.go
@@ -351,7 +351,7 @@ func TestGetTokenCredential(t *testing.T) {
 				initObjects = append(initObjects, tt.secret)
 			}
 			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(initObjects...).Build()
-			provider, err := NewAzureClusterCredentialsProvider(context.Background(), fakeClient, tt.cluster)
+			provider, err := NewAzureCredentialsProvider(context.Background(), fakeClient, tt.cluster.Spec.IdentityRef, "")
 			g.Expect(err).NotTo(HaveOccurred())
 			cred, err := provider.GetTokenCredential(context.Background(), "", tt.ActiveDirectoryAuthorityHost, "")
 			g.Expect(err).NotTo(HaveOccurred())

--- a/azure/scope/managedcontrolplane.go
+++ b/azure/scope/managedcontrolplane.go
@@ -90,7 +90,7 @@ func NewManagedControlPlaneScope(ctx context.Context, params ManagedControlPlane
 		return nil, errors.New("failed to generate new scope from nil ControlPlane")
 	}
 
-	credentialsProvider, err := NewManagedControlPlaneCredentialsProvider(ctx, params.Client, params.ControlPlane)
+	credentialsProvider, err := NewAzureCredentialsProvider(ctx, params.Client, params.ControlPlane.Spec.IdentityRef, params.ControlPlane.Namespace)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to init credentials provider")
 	}


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind cleanup

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

Currently there are separate flows to get an `scope.CredentialsProvider` for an AzureCluster and for an AzureManagedControlPlane that aren't actually meaningfully different. This change reduces both implementations into one.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [X] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
