### PR TITLE
Add omitempty to SSHPublicKey

### DIFF
--- a/api/v1beta1/azuremachine_types.go
+++ b/api/v1beta1/azuremachine_types.go
@@ -84,7 +84,7 @@ type AzureMachineSpec struct {
 	// SSHPublicKey is the SSH public key string, base64-encoded to add to a Virtual Machine. Linux only.
 	// Refer to documentation on how to set up SSH access on Windows instances.
 	// +optional
-	SSHPublicKey string `json:"sshPublicKey"`
+	SSHPublicKey string `json:"sshPublicKey,omitempty"`
 
 	// AdditionalTags is an optional set of tags to add to an instance, in addition to the ones added by default by the
 	// Azure provider. If both the AzureCluster and the AzureMachine specify the same tag name with different values, the


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Adds omitempty to SSHPublicKey since this field is optional. If a value is not set for this field, the value is set to "". This causes the following error:
```
        --------------------------------------------------------------------------------
        RESPONSE 400: 400 Bad Request
        ERROR CODE: InvalidParameter
        --------------------------------------------------------------------------------
        {
          "error": {
            "code": "InvalidParameter",
            "message": "The value of parameter linuxConfiguration.ssh.publicKeys.keyData is invalid.",
            "target": "linuxConfiguration.ssh.publicKeys.keyData"
          }
        }
        --------------------------------------------------------------------------------
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
