### PR TITLE
Move webhook registration behind feature gate flag

### DIFF
--- a/api/v1beta1/azuremanagedcluster_webhook.go
+++ b/api/v1beta1/azuremanagedcluster_webhook.go
@@ -18,13 +18,9 @@ package v1beta1
 
 import (
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/validation/field"
-	capifeature "sigs.k8s.io/cluster-api/feature"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
-
-	"sigs.k8s.io/cluster-api-provider-azure/feature"
 )
 
 // SetupWebhookWithManager sets up and registers the webhook with the manager.
@@ -40,14 +36,6 @@ var _ webhook.Validator = &AzureManagedCluster{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
 func (r *AzureManagedCluster) ValidateCreate() (admission.Warnings, error) {
-	// NOTE: AzureManagedCluster relies upon MachinePools, which is behind a feature gate flag.
-	// The webhook must prevent creating new objects in case the feature flag is disabled.
-	if !feature.Gates.Enabled(capifeature.MachinePool) {
-		return nil, field.Forbidden(
-			field.NewPath("spec"),
-			"can be set only if the Cluster API 'MachinePool' feature flag is enabled",
-		)
-	}
 	return nil, nil
 }
 

--- a/api/v1beta1/azuremanagedcluster_webhook_test.go
+++ b/api/v1beta1/azuremanagedcluster_webhook_test.go
@@ -22,7 +22,6 @@ import (
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilfeature "k8s.io/component-base/featuregate/testing"
-	"k8s.io/utils/ptr"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	capifeature "sigs.k8s.io/cluster-api/feature"
 
@@ -142,12 +141,6 @@ func TestAzureManagedCluster_ValidateCreateFailure(t *testing.T) {
 		featureGateEnabled *bool
 		expectError        bool
 	}{
-		{
-			name:               "feature gate explicitly disabled",
-			amc:                getKnownValidAzureManagedCluster(),
-			featureGateEnabled: ptr.To(false),
-			expectError:        true,
-		},
 		{
 			name:               "feature gate implicitly enabled",
 			amc:                getKnownValidAzureManagedCluster(),

--- a/api/v1beta1/azuremanagedclustertemplate_webhook.go
+++ b/api/v1beta1/azuremanagedclustertemplate_webhook.go
@@ -18,13 +18,9 @@ package v1beta1
 
 import (
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/validation/field"
-	capifeature "sigs.k8s.io/cluster-api/feature"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
-
-	"sigs.k8s.io/cluster-api-provider-azure/feature"
 )
 
 // SetupWebhookWithManager sets up and registers the webhook with the manager.
@@ -40,14 +36,6 @@ var _ webhook.Validator = &AzureManagedClusterTemplate{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
 func (r *AzureManagedClusterTemplate) ValidateCreate() (admission.Warnings, error) {
-	// NOTE: AzureManagedClusterTemplate relies upon MachinePools, which is behind a feature gate flag.
-	// The webhook must prevent creating new objects in case the feature flag is disabled.
-	if !feature.Gates.Enabled(capifeature.MachinePool) {
-		return nil, field.Forbidden(
-			field.NewPath("spec"),
-			"cannot be set if the Cluster API 'MachinePool' feature flag is not enabled",
-		)
-	}
 	return nil, nil
 }
 

--- a/api/v1beta1/azuremanagedcontrolplane_webhook.go
+++ b/api/v1beta1/azuremanagedcontrolplane_webhook.go
@@ -31,12 +31,10 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/utils/ptr"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
-	capifeature "sigs.k8s.io/cluster-api/feature"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
-	"sigs.k8s.io/cluster-api-provider-azure/feature"
 	"sigs.k8s.io/cluster-api-provider-azure/util/versions"
 	webhookutils "sigs.k8s.io/cluster-api-provider-azure/util/webhook"
 )
@@ -110,14 +108,6 @@ func (mw *azureManagedControlPlaneWebhook) ValidateCreate(_ context.Context, obj
 	m, ok := obj.(*AzureManagedControlPlane)
 	if !ok {
 		return nil, apierrors.NewBadRequest("expected an AzureManagedControlPlane")
-	}
-	// NOTE: AzureManagedControlPlane relies upon MachinePools, which is behind a feature gate flag.
-	// The webhook must prevent creating new objects in case the feature flag is disabled.
-	if !feature.Gates.Enabled(capifeature.MachinePool) {
-		return nil, field.Forbidden(
-			field.NewPath("spec"),
-			"can be set only if the Cluster API 'MachinePool' feature flag is enabled",
-		)
 	}
 
 	return nil, m.Validate(mw.Client)

--- a/api/v1beta1/azuremanagedcontrolplane_webhook_test.go
+++ b/api/v1beta1/azuremanagedcontrolplane_webhook_test.go
@@ -1665,12 +1665,6 @@ func TestAzureManagedControlPlane_ValidateCreateFailure(t *testing.T) {
 		expectError        bool
 	}{
 		{
-			name:               "feature gate explicitly disabled",
-			amcp:               getKnownValidAzureManagedControlPlane(),
-			featureGateEnabled: ptr.To(false),
-			expectError:        true,
-		},
-		{
 			name:               "feature gate implicitly enabled",
 			amcp:               getKnownValidAzureManagedControlPlane(),
 			featureGateEnabled: nil,

--- a/api/v1beta1/azuremanagedcontrolplanetemplate_webhook.go
+++ b/api/v1beta1/azuremanagedcontrolplanetemplate_webhook.go
@@ -23,12 +23,10 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	capifeature "sigs.k8s.io/cluster-api/feature"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
-	"sigs.k8s.io/cluster-api-provider-azure/feature"
 	"sigs.k8s.io/cluster-api-provider-azure/util/versions"
 	webhookutils "sigs.k8s.io/cluster-api-provider-azure/util/webhook"
 )
@@ -65,14 +63,6 @@ func (mcpw *azureManagedControlPlaneTemplateWebhook) ValidateCreate(_ context.Co
 	mcp, ok := obj.(*AzureManagedControlPlaneTemplate)
 	if !ok {
 		return nil, apierrors.NewBadRequest("expected an AzureManagedControlPlaneTemplate")
-	}
-	// NOTE: AzureManagedControlPlaneTemplate relies upon MachinePools, which is behind a feature gate flag.
-	// The webhook must prevent creating new objects in case the feature flag is disabled.
-	if !feature.Gates.Enabled(capifeature.MachinePool) {
-		return nil, field.Forbidden(
-			field.NewPath("spec"),
-			"can be set only if the Cluster API 'MachinePool' feature flag is enabled",
-		)
 	}
 
 	return nil, mcp.validateManagedControlPlaneTemplate(mcpw.Client)

--- a/api/v1beta1/azuremanagedmachinepool_webhook.go
+++ b/api/v1beta1/azuremanagedmachinepool_webhook.go
@@ -32,12 +32,10 @@ import (
 	"k8s.io/utils/ptr"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	clusterctlv1alpha3 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
-	capifeature "sigs.k8s.io/cluster-api/feature"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
-	"sigs.k8s.io/cluster-api-provider-azure/feature"
 	azureutil "sigs.k8s.io/cluster-api-provider-azure/util/azure"
 	webhookutils "sigs.k8s.io/cluster-api-provider-azure/util/webhook"
 )
@@ -90,14 +88,6 @@ func (mw *azureManagedMachinePoolWebhook) ValidateCreate(_ context.Context, obj 
 	m, ok := obj.(*AzureManagedMachinePool)
 	if !ok {
 		return nil, apierrors.NewBadRequest("expected an AzureManagedMachinePool")
-	}
-	// NOTE: AzureManagedMachinePool relies upon MachinePools, which is behind a feature gate flag.
-	// The webhook must prevent creating new objects in case the feature flag is disabled.
-	if !feature.Gates.Enabled(capifeature.MachinePool) {
-		return nil, field.Forbidden(
-			field.NewPath("spec"),
-			"can be set only if the Cluster API 'MachinePool' feature flag is enabled",
-		)
 	}
 
 	var errs []error

--- a/api/v1beta1/azuremanagedmachinepool_webhook_test.go
+++ b/api/v1beta1/azuremanagedmachinepool_webhook_test.go
@@ -1313,12 +1313,6 @@ func TestAzureManagedMachinePool_ValidateCreateFailure(t *testing.T) {
 		expectError        bool
 	}{
 		{
-			name:               "feature gate explicitly disabled",
-			ammp:               getKnownValidAzureManagedMachinePool(),
-			featureGateEnabled: ptr.To(false),
-			expectError:        true,
-		},
-		{
 			name:               "feature gate implicitly enabled",
 			ammp:               getKnownValidAzureManagedMachinePool(),
 			featureGateEnabled: nil,

--- a/api/v1beta1/azuremanagedmachinepooltemplate_webhook.go
+++ b/api/v1beta1/azuremanagedmachinepooltemplate_webhook.go
@@ -25,12 +25,10 @@ import (
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/utils/ptr"
-	capifeature "sigs.k8s.io/cluster-api/feature"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
-	"sigs.k8s.io/cluster-api-provider-azure/feature"
 	webhookutils "sigs.k8s.io/cluster-api-provider-azure/util/webhook"
 )
 
@@ -77,13 +75,6 @@ func (mpw *azureManagedMachinePoolTemplateWebhook) ValidateCreate(_ context.Cont
 	mp, ok := obj.(*AzureManagedMachinePoolTemplate)
 	if !ok {
 		return nil, apierrors.NewBadRequest("expected an AzureManagedMachinePoolTemplate")
-	}
-
-	if !feature.Gates.Enabled(capifeature.MachinePool) {
-		return nil, field.Forbidden(
-			field.NewPath("spec"),
-			"can be set only if the Cluster API 'MachinePool' feature flag is enabled",
-		)
 	}
 
 	var errs []error

--- a/exp/api/v1beta1/azuremachinepool_webhook.go
+++ b/exp/api/v1beta1/azuremachinepool_webhook.go
@@ -29,13 +29,11 @@ import (
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	capifeature "sigs.k8s.io/cluster-api/feature"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
-	"sigs.k8s.io/cluster-api-provider-azure/feature"
 	azureutil "sigs.k8s.io/cluster-api-provider-azure/util/azure"
 )
 
@@ -73,14 +71,7 @@ func (ampw *azureMachinePoolWebhook) ValidateCreate(_ context.Context, obj runti
 	if !ok {
 		return nil, apierrors.NewBadRequest("expected an AzureMachinePool")
 	}
-	// NOTE: AzureMachinePool is behind MachinePool feature gate flag; the webhook
-	// must prevent creating new objects in case the feature flag is disabled.
-	if !feature.Gates.Enabled(capifeature.MachinePool) {
-		return nil, field.Forbidden(
-			field.NewPath("spec"),
-			"can be set only if the MachinePool feature flag is enabled",
-		)
-	}
+
 	return nil, amp.Validate(nil, ampw.Client)
 }
 

--- a/exp/api/v1beta1/azuremachinepool_webhook_test.go
+++ b/exp/api/v1beta1/azuremachinepool_webhook_test.go
@@ -707,12 +707,6 @@ func TestAzureMachinePool_ValidateCreateFailure(t *testing.T) {
 		expectError        bool
 	}{
 		{
-			name:               "feature gate explicitly disabled",
-			amp:                getKnownValidAzureMachinePool(),
-			featureGateEnabled: ptr.To(false),
-			expectError:        true,
-		},
-		{
 			name:               "feature gate implicitly enabled",
 			amp:                getKnownValidAzureMachinePool(),
 			featureGateEnabled: nil,

--- a/exp/api/v1beta1/azuremachinepoolmachine_webhook.go
+++ b/exp/api/v1beta1/azuremachinepoolmachine_webhook.go
@@ -19,13 +19,9 @@ package v1beta1
 import (
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/validation/field"
-	capifeature "sigs.k8s.io/cluster-api/feature"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
-
-	"sigs.k8s.io/cluster-api-provider-azure/feature"
 )
 
 // SetupWebhookWithManager sets up and registers the webhook with the manager.
@@ -46,15 +42,6 @@ func (ampm *AzureMachinePoolMachine) ValidateCreate() (admission.Warnings, error
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
 func (ampm *AzureMachinePoolMachine) ValidateUpdate(old runtime.Object) (admission.Warnings, error) {
-	// NOTE: AzureMachinePoolMachine is behind MachinePool feature gate flag; the webhook
-	// must prevent creating new objects new case the feature flag is disabled.
-	if !feature.Gates.Enabled(capifeature.MachinePool) {
-		return nil, field.Forbidden(
-			field.NewPath("spec"),
-			"can be set only if the MachinePool feature flag is enabled",
-		)
-	}
-
 	oldMachine, ok := old.(*AzureMachinePoolMachine)
 	if !ok {
 		return nil, errors.New("expected and AzureMachinePoolMachine")

--- a/main.go
+++ b/main.go
@@ -593,6 +593,11 @@ func registerWebhooks(mgr manager.Manager) {
 		os.Exit(1)
 	}
 
+	if err := infrav1.SetupAzureMachineWebhookWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create webhook", "webhook", "AzureMachine")
+		os.Exit(1)
+	}
+
 	if err := (&infrav1.AzureMachineTemplate{}).SetupWebhookWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create webhook", "webhook", "AzureMachineTemplate")
 		os.Exit(1)
@@ -603,66 +608,63 @@ func registerWebhooks(mgr manager.Manager) {
 		os.Exit(1)
 	}
 
-	if err := (&infrav1exp.AzureMachinePoolMachine{}).SetupWebhookWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create webhook", "webhook", "AzureMachinePoolMachine")
-		os.Exit(1)
+	if feature.Gates.Enabled(capifeature.MachinePool) {
+		if err := infrav1exp.SetupAzureMachinePoolWebhookWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create webhook", "webhook", "AzureMachinePool")
+			os.Exit(1)
+		}
+
+		if err := (&infrav1exp.AzureMachinePoolMachine{}).SetupWebhookWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create webhook", "webhook", "AzureMachinePoolMachine")
+			os.Exit(1)
+		}
+
+		if err := infrav1.SetupAzureManagedMachinePoolWebhookWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create webhook", "webhook", "AzureManagedMachinePool")
+			os.Exit(1)
+		}
+
+		if err := infrav1.SetupAzureManagedMachinePoolTemplateWebhookWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create webhook", "webhook", "AzureManagedMachinePoolTemplate")
+			os.Exit(1)
+		}
+
+		if err := (&infrav1.AzureManagedCluster{}).SetupWebhookWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create webhook", "webhook", "AzureManagedCluster")
+			os.Exit(1)
+		}
+
+		if err := (&infrav1.AzureManagedClusterTemplate{}).SetupWebhookWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create webhook", "webhook", "AzureManagedClusterTemplate")
+			os.Exit(1)
+		}
+
+		if err := infrav1.SetupAzureManagedControlPlaneWebhookWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create webhook", "webhook", "AzureManagedControlPlane")
+			os.Exit(1)
+		}
+
+		if err := infrav1.SetupAzureManagedControlPlaneTemplateWebhookWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create webhook", "webhook", "AzureManagedControlPlaneTemplate")
+			os.Exit(1)
+		}
 	}
 
-	// NOTE: AzureManagedCluster is behind AKS feature gate flag; the webhook
-	// is going to prevent creating or updating new objects in case the feature flag is disabled
-	if err := (&infrav1.AzureManagedCluster{}).SetupWebhookWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create webhook", "webhook", "AzureManagedCluster")
-		os.Exit(1)
-	}
+	if feature.Gates.Enabled(feature.ASOAPI) {
+		if err := infrav1alpha.SetupAzureASOManagedClusterWebhookWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create webhook", "webhook", "AzureASOManagedCluster")
+			os.Exit(1)
+		}
 
-	if err := (&infrav1.AzureManagedClusterTemplate{}).SetupWebhookWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create webhook", "webhook", "AzureManagedClusterTemplate")
-		os.Exit(1)
-	}
+		if err := infrav1alpha.SetupAzureASOManagedControlPlaneWebhookWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create webhook", "webhook", "AzureASOManagedControlPlane")
+			os.Exit(1)
+		}
 
-	if err := infrav1exp.SetupAzureMachinePoolWebhookWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create webhook", "webhook", "AzureMachinePool")
-		os.Exit(1)
-	}
-
-	if err := infrav1.SetupAzureMachineWebhookWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create webhook", "webhook", "AzureMachine")
-		os.Exit(1)
-	}
-
-	if err := infrav1.SetupAzureManagedMachinePoolWebhookWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create webhook", "webhook", "AzureManagedMachinePool")
-		os.Exit(1)
-	}
-
-	if err := infrav1.SetupAzureManagedMachinePoolTemplateWebhookWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create webhook", "webhook", "AzureManagedMachinePoolTemplate")
-		os.Exit(1)
-	}
-
-	if err := infrav1.SetupAzureManagedControlPlaneWebhookWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create webhook", "webhook", "AzureManagedControlPlane")
-		os.Exit(1)
-	}
-
-	if err := infrav1.SetupAzureManagedControlPlaneTemplateWebhookWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create webhook", "webhook", "AzureManagedControlPlaneTemplate")
-		os.Exit(1)
-	}
-
-	if err := infrav1alpha.SetupAzureASOManagedClusterWebhookWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create webhook", "webhook", "AzureASOManagedCluster")
-		os.Exit(1)
-	}
-
-	if err := infrav1alpha.SetupAzureASOManagedControlPlaneWebhookWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create webhook", "webhook", "AzureASOManagedControlPlane")
-		os.Exit(1)
-	}
-
-	if err := infrav1alpha.SetupAzureASOManagedMachinePoolWebhookWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create webhook", "webhook", "AzureASOManagedMachinePool")
-		os.Exit(1)
+		if err := infrav1alpha.SetupAzureASOManagedMachinePoolWebhookWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create webhook", "webhook", "AzureASOManagedMachinePool")
+			os.Exit(1)
+		}
 	}
 
 	if err := mgr.AddReadyzCheck("webhook", mgr.GetWebhookServer().StartedChecker()); err != nil {


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
Move webhook registration behind feature gate flags similar to controller registration.

Without this PR, from a self-managed / externally managed infrastructure perspective, if you want to exclude the CRDs behind the MachinePool and ASOAPI feature flags, you'll get an error because the webhook for them is still registered.
```
E0828 10:05:27.972237       1 kind.go:63] "if kind is a CRD, it should be installed before calling Start" err="failed to get restmapping: no matches for kind \"AzureManagedControlPlane\" in group \"infrastructure.cluster.x-k8s.io\"" logger="controller-runtime.source.EventHandler" kind="AzureManagedControlPlane.infrastructure.cluster.x-k8s.io"
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Moves webhook registration behind feature gate flags like controller registration already does.
```
