### PR TITLE
Validate identity type on user-assigned identities

### DIFF
--- a/api/v1beta1/azuremachine_default_test.go
+++ b/api/v1beta1/azuremachine_default_test.go
@@ -596,6 +596,13 @@ func createMachineWithUserAssignedIdentities(identitiesList []UserAssignedIdenti
 	return machine
 }
 
+func createMachineWithUserAssignedIdentitiesWithBadIdentity(identitiesList []UserAssignedIdentity) *AzureMachine {
+	machine := hardcodedAzureMachineWithSSHKey(generateSSHPublicKey(true))
+	machine.Spec.Identity = VMIdentitySystemAssigned
+	machine.Spec.UserAssignedIdentities = identitiesList
+	return machine
+}
+
 func hardcodedAzureMachineWithSSHKey(sshPublicKey string) *AzureMachine {
 	return &AzureMachine{
 		ObjectMeta: metav1.ObjectMeta{

--- a/api/v1beta1/azuremachine_validation.go
+++ b/api/v1beta1/azuremachine_validation.go
@@ -138,6 +138,10 @@ func ValidateSystemAssignedIdentity(identityType VMIdentity, oldIdentity, newIde
 func ValidateUserAssignedIdentity(identityType VMIdentity, userAssignedIdentities []UserAssignedIdentity, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
+	if len(userAssignedIdentities) > 0 && identityType != VMIdentityUserAssigned {
+		allErrs = append(allErrs, field.Invalid(fldPath, identityType, "must be set to 'UserAssigned' when assigning any user identity to the machine"))
+	}
+
 	if identityType == VMIdentityUserAssigned {
 		if len(userAssignedIdentities) == 0 {
 			allErrs = append(allErrs, field.Required(fldPath, "must be specified for the 'UserAssigned' identity type"))
@@ -160,7 +164,7 @@ func ValidateSystemAssignedIdentityRole(identityType VMIdentity, roleAssignmentN
 	if roleAssignmentName != "" && role != nil && role.Name != "" {
 		allErrs = append(allErrs, field.Invalid(fldPath, role.Name, "cannot set both roleAssignmentName and systemAssignedIdentityRole.name"))
 	}
-	if identityType == VMIdentitySystemAssigned {
+	if identityType == VMIdentitySystemAssigned && role != nil {
 		if role.DefinitionID == "" {
 			allErrs = append(allErrs, field.Invalid(field.NewPath("spec", "systemAssignedIdentityRole", "definitionID"), role.DefinitionID, "the definitionID field cannot be empty"))
 		}

--- a/api/v1beta1/azuremachine_webhook_test.go
+++ b/api/v1beta1/azuremachine_webhook_test.go
@@ -96,6 +96,14 @@ func TestAzureMachine_ValidateCreate(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "azuremachine with list of user-assigned identities with wrong identity type",
+			machine: createMachineWithUserAssignedIdentitiesWithBadIdentity([]UserAssignedIdentity{
+				{ProviderID: "azure:///subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/my-resource-group/providers/Microsoft.Compute/virtualMachines/default-12345-control-plane-9d5x5"},
+				{ProviderID: "azure:///subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/my-resource-group/providers/Microsoft.Compute/virtualMachines/default-12345-control-plane-a1b2c"},
+			}),
+			wantErr: true,
+		},
+		{
 			name:    "azuremachine with empty list of user-assigned identities",
 			machine: createMachineWithUserAssignedIdentities([]UserAssignedIdentity{}),
 			wantErr: true,


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
Validate the identity type is 'UserAssigned' when using user-assigned identities.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Identity type is required to be 'UserAssigned' when using user-assigned identities.
```
