### PR TITLE
Set default values in API rather than in webhooks

### DIFF
--- a/api/v1beta1/azuremachine_default.go
+++ b/api/v1beta1/azuremachine_default.go
@@ -49,13 +49,6 @@ func (s *AzureMachineSpec) SetDefaultSSHPublicKey() error {
 	return nil
 }
 
-// SetDefaultCachingType sets the default cache type for an AzureMachine.
-func (s *AzureMachineSpec) SetDefaultCachingType() {
-	if s.OSDisk.CachingType == "" {
-		s.OSDisk.CachingType = "None"
-	}
-}
-
 // SetDataDisksDefaults sets the data disk defaults for an AzureMachine.
 func (s *AzureMachineSpec) SetDataDisksDefaults() {
 	set := make(map[int32]struct{})
@@ -245,7 +238,6 @@ func (m *AzureMachine) SetDefaults(client client.Client) error {
 		errs = append(errs, errors.Wrapf(err, "failed to fetch subscription ID for AzureMachine %s/%s", m.Namespace, m.Name))
 	}
 
-	m.Spec.SetDefaultCachingType()
 	m.Spec.SetDataDisksDefaults()
 	m.Spec.SetIdentityDefaults(subscriptionID)
 	m.Spec.SetSpotEvictionPolicyDefaults()

--- a/api/v1beta1/azuremachine_webhook_test.go
+++ b/api/v1beta1/azuremachine_webhook_test.go
@@ -988,11 +988,6 @@ func TestAzureMachine_Default(t *testing.T) {
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(publicKeyNotExistTest.machine.Spec.SSHPublicKey).To(Not(BeEmpty()))
 
-	cacheTypeNotSpecifiedTest := test{machine: &AzureMachine{ObjectMeta: testObjectMeta, Spec: AzureMachineSpec{OSDisk: OSDisk{CachingType: ""}}}}
-	err = mw.Default(context.Background(), cacheTypeNotSpecifiedTest.machine)
-	g.Expect(err).NotTo(HaveOccurred())
-	g.Expect(cacheTypeNotSpecifiedTest.machine.Spec.OSDisk.CachingType).To(Equal("None"))
-
 	for _, possibleCachingType := range armcompute.PossibleCachingTypesValues() {
 		cacheTypeSpecifiedTest := test{machine: &AzureMachine{ObjectMeta: testObjectMeta, Spec: AzureMachineSpec{OSDisk: OSDisk{CachingType: string(possibleCachingType)}}}}
 		err = mw.Default(context.Background(), cacheTypeSpecifiedTest.machine)

--- a/api/v1beta1/azuremachinetemplate_webhook.go
+++ b/api/v1beta1/azuremachinetemplate_webhook.go
@@ -152,7 +152,6 @@ func (r *AzureMachineTemplate) Default(_ context.Context, obj runtime.Object) er
 	if err := t.Spec.Template.Spec.SetDefaultSSHPublicKey(); err != nil {
 		ctrl.Log.WithName("SetDefault").Error(err, "SetDefaultSSHPublicKey failed")
 	}
-	t.Spec.Template.Spec.SetDefaultCachingType()
 	t.Spec.Template.Spec.SetDataDisksDefaults()
 	t.Spec.Template.Spec.SetNetworkInterfacesDefaults()
 	return nil

--- a/api/v1beta1/azuremachinetemplate_webhook_test.go
+++ b/api/v1beta1/azuremachinetemplate_webhook_test.go
@@ -347,53 +347,6 @@ func TestAzureMachineTemplate_ValidateUpdate(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "AzureMachineTemplate with default mismatch",
-			oldTemplate: &AzureMachineTemplate{
-				Spec: AzureMachineTemplateSpec{
-					Template: AzureMachineTemplateResource{
-						Spec: AzureMachineSpec{
-							VMSize:        "size",
-							FailureDomain: &failureDomain,
-							OSDisk: OSDisk{
-								OSType:      "type",
-								DiskSizeGB:  ptr.To[int32](11),
-								CachingType: "",
-							},
-							DataDisks:    []DataDisk{},
-							SSHPublicKey: "",
-						},
-					},
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "OldTemplate",
-				},
-			},
-			template: &AzureMachineTemplate{
-				Spec: AzureMachineTemplateSpec{
-					Template: AzureMachineTemplateResource{
-						Spec: AzureMachineSpec{
-							VMSize:        "size",
-							FailureDomain: &failureDomain,
-							OSDisk: OSDisk{
-								OSType:      "type",
-								DiskSizeGB:  ptr.To[int32](11),
-								CachingType: "None",
-							},
-							DataDisks:    []DataDisk{},
-							SSHPublicKey: "fake ssh key",
-							NetworkInterfaces: []NetworkInterface{{
-								PrivateIPConfigs: 1,
-							}},
-						},
-					},
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "NewTemplate",
-				},
-			},
-			wantErr: false,
-		},
-		{
 			name: "AzureMachineTemplate ssh key removed",
 			oldTemplate: &AzureMachineTemplate{
 				Spec: AzureMachineTemplateSpec{

--- a/api/v1beta1/azuremanagedcontrolplane_default.go
+++ b/api/v1beta1/azuremanagedcontrolplane_default.go
@@ -106,9 +106,6 @@ func setDefaultFleetsMember(fleetsMember *FleetsMember, labels map[string]string
 		if clusterName, ok := labels[clusterv1.ClusterNameLabel]; ok && fleetsMember.Name == "" {
 			result.Name = clusterName
 		}
-		if fleetsMember.Group == "" {
-			result.Group = "default"
-		}
 	}
 	return result
 }
@@ -133,78 +130,9 @@ func setDefaultVersion(version string) string {
 	return version
 }
 
-func setDefaultAutoScalerProfile(autoScalerProfile *AutoScalerProfile) *AutoScalerProfile {
-	if autoScalerProfile == nil {
-		return nil
-	}
-
-	result := autoScalerProfile.DeepCopy()
-
-	// Default values are from https://learn.microsoft.com/en-us/azure/aks/cluster-autoscaler#using-the-autoscaler-profile
-	// If any values are set, they all need to be set.
-	if autoScalerProfile.BalanceSimilarNodeGroups == nil {
-		result.BalanceSimilarNodeGroups = (*BalanceSimilarNodeGroups)(ptr.To(string(BalanceSimilarNodeGroupsFalse)))
-	}
-	if autoScalerProfile.Expander == nil {
-		result.Expander = (*Expander)(ptr.To(string(ExpanderRandom)))
-	}
-	if autoScalerProfile.MaxEmptyBulkDelete == nil {
-		result.MaxEmptyBulkDelete = ptr.To("10")
-	}
-	if autoScalerProfile.MaxGracefulTerminationSec == nil {
-		result.MaxGracefulTerminationSec = ptr.To("600")
-	}
-	if autoScalerProfile.MaxNodeProvisionTime == nil {
-		result.MaxNodeProvisionTime = ptr.To("15m")
-	}
-	if autoScalerProfile.MaxTotalUnreadyPercentage == nil {
-		result.MaxTotalUnreadyPercentage = ptr.To("45")
-	}
-	if autoScalerProfile.NewPodScaleUpDelay == nil {
-		result.NewPodScaleUpDelay = ptr.To("0s")
-	}
-	if autoScalerProfile.OkTotalUnreadyCount == nil {
-		result.OkTotalUnreadyCount = ptr.To("3")
-	}
-	if autoScalerProfile.ScanInterval == nil {
-		result.ScanInterval = ptr.To("10s")
-	}
-	if autoScalerProfile.ScaleDownDelayAfterAdd == nil {
-		result.ScaleDownDelayAfterAdd = ptr.To("10m")
-	}
-	if autoScalerProfile.ScaleDownDelayAfterDelete == nil {
-		// Default is the same as the ScanInterval so default to that same value if it isn't set
-		result.ScaleDownDelayAfterDelete = result.ScanInterval
-	}
-	if autoScalerProfile.ScaleDownDelayAfterFailure == nil {
-		result.ScaleDownDelayAfterFailure = ptr.To("3m")
-	}
-	if autoScalerProfile.ScaleDownUnneededTime == nil {
-		result.ScaleDownUnneededTime = ptr.To("10m")
-	}
-	if autoScalerProfile.ScaleDownUnreadyTime == nil {
-		result.ScaleDownUnreadyTime = ptr.To("20m")
-	}
-	if autoScalerProfile.ScaleDownUtilizationThreshold == nil {
-		result.ScaleDownUtilizationThreshold = ptr.To("0.5")
-	}
-	if autoScalerProfile.SkipNodesWithLocalStorage == nil {
-		result.SkipNodesWithLocalStorage = (*SkipNodesWithLocalStorage)(ptr.To(string(SkipNodesWithLocalStorageFalse)))
-	}
-	if autoScalerProfile.SkipNodesWithSystemPods == nil {
-		result.SkipNodesWithSystemPods = (*SkipNodesWithSystemPods)(ptr.To(string(SkipNodesWithSystemPodsTrue)))
-	}
-
-	return result
-}
-
 func (m *AzureManagedControlPlane) setDefaultOIDCIssuerProfile() {
 	if m.Spec.OIDCIssuerProfile == nil {
 		m.Spec.OIDCIssuerProfile = &OIDCIssuerProfile{}
-	}
-
-	if m.Spec.OIDCIssuerProfile.Enabled == nil {
-		m.Spec.OIDCIssuerProfile.Enabled = ptr.To(false)
 	}
 }
 
@@ -218,9 +146,6 @@ func (m *AzureManagedControlPlane) setDefaultAKSExtensions() {
 	for _, extension := range m.Spec.Extensions {
 		if extension.Plan != nil && extension.Plan.Name == "" {
 			extension.Plan.Name = fmt.Sprintf("%s-%s", m.Name, extension.Plan.Product)
-		}
-		if extension.AutoUpgradeMinorVersion == nil {
-			extension.AutoUpgradeMinorVersion = ptr.To(true)
 		}
 	}
 }

--- a/api/v1beta1/azuremanagedcontrolplane_default_test.go
+++ b/api/v1beta1/azuremanagedcontrolplane_default_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	. "github.com/onsi/gomega"
-	"k8s.io/utils/ptr"
 )
 
 func TestAzureManagedControlPlane_SetDefaultSSHPublicKey(t *testing.T) {
@@ -53,88 +52,4 @@ func hardcodedAzureManagedControlPlaneWithSSHKey(sshPublicKey string) *AzureMana
 			SSHPublicKey: &sshPublicKey,
 		},
 	}
-}
-
-func TestSetDefaultAutoScalerProfile(t *testing.T) {
-	g := NewWithT(t)
-
-	type test struct {
-		amcp *AzureManagedControlPlane
-	}
-
-	defaultAMP := &AzureManagedControlPlane{
-		Spec: AzureManagedControlPlaneSpec{
-			AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
-				AutoScalerProfile: &AutoScalerProfile{
-					BalanceSimilarNodeGroups:      (*BalanceSimilarNodeGroups)(ptr.To(string(BalanceSimilarNodeGroupsFalse))),
-					Expander:                      (*Expander)(ptr.To(string(ExpanderRandom))),
-					MaxEmptyBulkDelete:            ptr.To("10"),
-					MaxGracefulTerminationSec:     ptr.To("600"),
-					MaxNodeProvisionTime:          ptr.To("15m"),
-					MaxTotalUnreadyPercentage:     ptr.To("45"),
-					NewPodScaleUpDelay:            ptr.To("0s"),
-					OkTotalUnreadyCount:           ptr.To("3"),
-					ScanInterval:                  ptr.To("10s"),
-					ScaleDownDelayAfterAdd:        ptr.To("10m"),
-					ScaleDownDelayAfterDelete:     ptr.To("10s"),
-					ScaleDownDelayAfterFailure:    ptr.To("3m"),
-					ScaleDownUnneededTime:         ptr.To("10m"),
-					ScaleDownUnreadyTime:          ptr.To("20m"),
-					ScaleDownUtilizationThreshold: ptr.To("0.5"),
-					SkipNodesWithLocalStorage:     (*SkipNodesWithLocalStorage)(ptr.To(string(SkipNodesWithLocalStorageFalse))),
-					SkipNodesWithSystemPods:       (*SkipNodesWithSystemPods)(ptr.To(string(SkipNodesWithSystemPodsTrue))),
-				},
-			},
-		},
-	}
-
-	allFieldsAreNilTest := test{amcp: &AzureManagedControlPlane{
-		Spec: AzureManagedControlPlaneSpec{
-			AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
-				AutoScalerProfile: &AutoScalerProfile{},
-			},
-		},
-	}}
-
-	allFieldsAreNilTest.amcp.Spec.AutoScalerProfile = setDefaultAutoScalerProfile(allFieldsAreNilTest.amcp.Spec.AutoScalerProfile)
-
-	g.Expect(allFieldsAreNilTest.amcp.Spec.AutoScalerProfile).To(Equal(defaultAMP.Spec.AutoScalerProfile))
-
-	expectedNotNil := &AzureManagedControlPlane{
-		Spec: AzureManagedControlPlaneSpec{
-			AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
-				AutoScalerProfile: &AutoScalerProfile{
-					BalanceSimilarNodeGroups:      (*BalanceSimilarNodeGroups)(ptr.To(string(BalanceSimilarNodeGroupsTrue))),
-					Expander:                      (*Expander)(ptr.To(string(ExpanderLeastWaste))),
-					MaxEmptyBulkDelete:            ptr.To("5"),
-					MaxGracefulTerminationSec:     ptr.To("300"),
-					MaxNodeProvisionTime:          ptr.To("10m"),
-					MaxTotalUnreadyPercentage:     ptr.To("30"),
-					NewPodScaleUpDelay:            ptr.To("30s"),
-					OkTotalUnreadyCount:           ptr.To("5"),
-					ScanInterval:                  ptr.To("20s"),
-					ScaleDownDelayAfterAdd:        ptr.To("5m"),
-					ScaleDownDelayAfterDelete:     ptr.To("1m"),
-					ScaleDownDelayAfterFailure:    ptr.To("2m"),
-					ScaleDownUnneededTime:         ptr.To("5m"),
-					ScaleDownUnreadyTime:          ptr.To("10m"),
-					ScaleDownUtilizationThreshold: ptr.To("0.4"),
-					SkipNodesWithLocalStorage:     (*SkipNodesWithLocalStorage)(ptr.To(string(SkipNodesWithLocalStorageTrue))),
-					SkipNodesWithSystemPods:       (*SkipNodesWithSystemPods)(ptr.To(string(SkipNodesWithSystemPodsFalse))),
-				},
-			},
-		},
-	}
-
-	allFieldsAreNotNilTest := test{amcp: &AzureManagedControlPlane{
-		Spec: AzureManagedControlPlaneSpec{
-			AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
-				AutoScalerProfile: ptr.To(*expectedNotNil.Spec.AutoScalerProfile),
-			},
-		},
-	}}
-
-	allFieldsAreNotNilTest.amcp.Spec.AutoScalerProfile = setDefaultAutoScalerProfile(allFieldsAreNotNilTest.amcp.Spec.AutoScalerProfile)
-
-	g.Expect(allFieldsAreNotNilTest.amcp.Spec.AutoScalerProfile).To(Equal(expectedNotNil.Spec.AutoScalerProfile))
 }

--- a/api/v1beta1/azuremanagedcontrolplane_types.go
+++ b/api/v1beta1/azuremanagedcontrolplane_types.go
@@ -327,6 +327,7 @@ const (
 // AKSSku - AKS SKU.
 type AKSSku struct {
 	// Tier - Tier of an AKS cluster.
+	// +kubebuilder:default:="Free"
 	Tier AzureManagedControlPlaneSkuTier `json:"tier"`
 }
 
@@ -383,7 +384,9 @@ type ManagedControlPlaneVirtualNetwork struct {
 
 // ManagedControlPlaneSubnet describes a subnet for an AKS cluster.
 type ManagedControlPlaneSubnet struct {
-	Name      string `json:"name"`
+	Name string `json:"name"`
+
+	// +kubebuilder:default:="10.240.0.0/16"
 	CIDRBlock string `json:"cidrBlock"`
 
 	// ServiceEndpoints is a slice of Virtual Network service endpoints to enable for the subnets.
@@ -442,72 +445,90 @@ type OIDCIssuerProfileStatus struct {
 //
 // [AKS doc]: https://learn.microsoft.com/azure/aks/cluster-autoscaler#use-the-cluster-autoscaler-profile
 // [K8s doc]: https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#what-are-the-parameters-to-ca
+// Default values are from https://learn.microsoft.com/azure/aks/cluster-autoscaler#using-the-autoscaler-profile
 type AutoScalerProfile struct {
 	// BalanceSimilarNodeGroups - Valid values are 'true' and 'false'. The default is false.
 	// +kubebuilder:validation:Enum="true";"false"
+	// +kubebuilder:default:="false"
 	// +optional
 	BalanceSimilarNodeGroups *BalanceSimilarNodeGroups `json:"balanceSimilarNodeGroups,omitempty"`
 	// Expander - If not specified, the default is 'random'. See [expanders](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#what-are-expanders) for more information.
 	// +kubebuilder:validation:Enum=least-waste;most-pods;priority;random
+	// +kubebuilder:default:="random"
 	// +optional
 	Expander *Expander `json:"expander,omitempty"`
 	// MaxEmptyBulkDelete - The default is 10.
+	// +kubebuilder:default:="10"
 	// +optional
 	MaxEmptyBulkDelete *string `json:"maxEmptyBulkDelete,omitempty"`
 	// MaxGracefulTerminationSec - The default is 600.
 	// +kubebuilder:validation:Pattern=`^(\d+)$`
+	// +kubebuilder:default:="600"
 	// +optional
 	MaxGracefulTerminationSec *string `json:"maxGracefulTerminationSec,omitempty"`
 	// MaxNodeProvisionTime - The default is '15m'. Values must be an integer followed by an 'm'. No unit of time other than minutes (m) is supported.
 	// +kubebuilder:validation:Pattern=`^(\d+)m$`
+	// +kubebuilder:default:="15m"
 	// +optional
 	MaxNodeProvisionTime *string `json:"maxNodeProvisionTime,omitempty"`
 	// MaxTotalUnreadyPercentage - The default is 45. The maximum is 100 and the minimum is 0.
 	// +kubebuilder:validation:Pattern=`^(\d+)$`
 	// +kubebuilder:validation:MaxLength=3
 	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:default:="45"
 	// +optional
 	MaxTotalUnreadyPercentage *string `json:"maxTotalUnreadyPercentage,omitempty"`
 	// NewPodScaleUpDelay - For scenarios like burst/batch scale where you don't want CA to act before the kubernetes scheduler could schedule all the pods, you can tell CA to ignore unscheduled pods before they're a certain age. The default is '0s'. Values must be an integer followed by a unit ('s' for seconds, 'm' for minutes, 'h' for hours, etc).
 	// +optional
+	// +kubebuilder:default:="0s"
 	NewPodScaleUpDelay *string `json:"newPodScaleUpDelay,omitempty"`
 	// OkTotalUnreadyCount - This must be an integer. The default is 3.
 	// +kubebuilder:validation:Pattern=`^(\d+)$`
+	// +kubebuilder:default:="3"
 	// +optional
 	OkTotalUnreadyCount *string `json:"okTotalUnreadyCount,omitempty"`
 	// ScanInterval - How often cluster is reevaluated for scale up or down. The default is '10s'.
 	// +kubebuilder:validation:Pattern=`^(\d+)s$`
+	// +kubebuilder:default:="10s"
 	// +optional
 	ScanInterval *string `json:"scanInterval,omitempty"`
 	// ScaleDownDelayAfterAdd - The default is '10m'. Values must be an integer followed by an 'm'. No unit of time other than minutes (m) is supported.
 	// +kubebuilder:validation:Pattern=`^(\d+)m$`
+	// +kubebuilder:default:="10m"
 	// +optional
 	ScaleDownDelayAfterAdd *string `json:"scaleDownDelayAfterAdd,omitempty"`
 	// ScaleDownDelayAfterDelete - The default is the scan-interval. Values must be an integer followed by an 's'. No unit of time other than seconds (s) is supported.
 	// +kubebuilder:validation:Pattern=`^(\d+)s$`
+	// +kubebuilder:default:="10s"
 	// +optional
 	ScaleDownDelayAfterDelete *string `json:"scaleDownDelayAfterDelete,omitempty"`
 	// ScaleDownDelayAfterFailure - The default is '3m'. Values must be an integer followed by an 'm'. No unit of time other than minutes (m) is supported.
 	// +kubebuilder:validation:Pattern=`^(\d+)m$`
+	// +kubebuilder:default:="3m"
 	// +optional
 	ScaleDownDelayAfterFailure *string `json:"scaleDownDelayAfterFailure,omitempty"`
 	// ScaleDownUnneededTime - The default is '10m'. Values must be an integer followed by an 'm'. No unit of time other than minutes (m) is supported.
 	// +kubebuilder:validation:Pattern=`^(\d+)m$`
+	// +kubebuilder:default:="10m"
 	// +optional
 	ScaleDownUnneededTime *string `json:"scaleDownUnneededTime,omitempty"`
 	// ScaleDownUnreadyTime - The default is '20m'. Values must be an integer followed by an 'm'. No unit of time other than minutes (m) is supported.
 	// +kubebuilder:validation:Pattern=`^(\d+)m$`
+	// +kubebuilder:default:="20m"
 	// +optional
 	ScaleDownUnreadyTime *string `json:"scaleDownUnreadyTime,omitempty"`
 	// ScaleDownUtilizationThreshold - The default is '0.5'.
+	// +kubebuilder:default:="0.5"
 	// +optional
 	ScaleDownUtilizationThreshold *string `json:"scaleDownUtilizationThreshold,omitempty"`
 	// SkipNodesWithLocalStorage - The default is false.
 	// +kubebuilder:validation:Enum="true";"false"
+	// +kubebuilder:default:="false"
 	// +optional
 	SkipNodesWithLocalStorage *SkipNodesWithLocalStorage `json:"skipNodesWithLocalStorage,omitempty"`
 	// SkipNodesWithSystemPods - The default is true.
 	// +kubebuilder:validation:Enum="true";"false"
+	// +kubebuilder:default:="true"
 	// +optional
 	SkipNodesWithSystemPods *SkipNodesWithSystemPods `json:"skipNodesWithSystemPods,omitempty"`
 }
@@ -563,6 +584,7 @@ const (
 type Identity struct {
 	// Type - The Identity type to use.
 	// +kubebuilder:validation:Enum=SystemAssigned;UserAssigned
+	// +kubebuilder:default:=SystemAssigned
 	// +optional
 	Type ManagedControlPlaneIdentityType `json:"type,omitempty"`
 
@@ -577,6 +599,7 @@ type Identity struct {
 // [AKS doc]: https://learn.microsoft.com/en-us/azure/aks/use-oidc-issuer
 type OIDCIssuerProfile struct {
 	// Enabled is whether the OIDC issuer is enabled.
+	// +kubebuilder:default:=false
 	// +optional
 	Enabled *bool `json:"enabled,omitempty"`
 }

--- a/api/v1beta1/azuremanagedcontrolplane_webhook.go
+++ b/api/v1beta1/azuremanagedcontrolplane_webhook.go
@@ -72,20 +72,9 @@ func (mw *azureManagedControlPlaneWebhook) Default(_ context.Context, obj runtim
 	if !ok {
 		return apierrors.NewBadRequest("expected an AzureManagedControlPlane")
 	}
-	if m.Spec.NetworkPlugin == nil {
-		networkPlugin := AzureNetworkPluginName
-		m.Spec.NetworkPlugin = &networkPlugin
-	}
 
-	setDefault[*string](&m.Spec.NetworkPlugin, ptr.To(AzureNetworkPluginName))
-	setDefault[*string](&m.Spec.LoadBalancerSKU, ptr.To("Standard"))
-	setDefault[*Identity](&m.Spec.Identity, &Identity{
-		Type: ManagedControlPlaneIdentityTypeSystemAssigned,
-	})
-	setDefault[*bool](&m.Spec.EnablePreviewFeatures, ptr.To(false))
 	m.Spec.Version = setDefaultVersion(m.Spec.Version)
 	m.Spec.SKU = setDefaultSku(m.Spec.SKU)
-	m.Spec.AutoScalerProfile = setDefaultAutoScalerProfile(m.Spec.AutoScalerProfile)
 	m.Spec.FleetsMember = setDefaultFleetsMember(m.Spec.FleetsMember, m.Labels)
 
 	if err := m.setDefaultSSHPublicKey(); err != nil {

--- a/api/v1beta1/azuremanagedcontrolplane_webhook_test.go
+++ b/api/v1beta1/azuremanagedcontrolplane_webhook_test.go
@@ -55,6 +55,7 @@ func TestDefaultingWebhook(t *testing.T) {
 						},
 					},
 				},
+				SKU: &AKSSku{},
 			},
 			SSHPublicKey: ptr.To(""),
 		},
@@ -63,23 +64,14 @@ func TestDefaultingWebhook(t *testing.T) {
 	err := mcpw.Default(context.Background(), amcp)
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(amcp.Spec.ResourceGroupName).To(Equal("fooCluster"))
-	g.Expect(amcp.Spec.NetworkPlugin).To(Equal(ptr.To(AzureNetworkPluginName)))
-	g.Expect(amcp.Spec.LoadBalancerSKU).To(Equal(ptr.To("Standard")))
 	g.Expect(amcp.Spec.Version).To(Equal("v1.17.5"))
 	g.Expect(*amcp.Spec.SSHPublicKey).NotTo(BeEmpty())
 	g.Expect(amcp.Spec.NodeResourceGroupName).To(Equal("MC_fooCluster_fooName_fooLocation"))
 	g.Expect(amcp.Spec.VirtualNetwork.Name).To(Equal("fooName"))
-	g.Expect(amcp.Spec.VirtualNetwork.CIDRBlock).To(Equal(defaultAKSVnetCIDR))
 	g.Expect(amcp.Spec.VirtualNetwork.Subnet.Name).To(Equal("fooName"))
-	g.Expect(amcp.Spec.VirtualNetwork.Subnet.CIDRBlock).To(Equal(defaultAKSNodeSubnetCIDR))
-	g.Expect(amcp.Spec.SKU.Tier).To(Equal(FreeManagedControlPlaneTier))
-	g.Expect(amcp.Spec.Identity.Type).To(Equal(ManagedControlPlaneIdentityTypeSystemAssigned))
-	g.Expect(*amcp.Spec.OIDCIssuerProfile.Enabled).To(BeFalse())
 	g.Expect(amcp.Spec.DNSPrefix).NotTo(BeNil())
 	g.Expect(*amcp.Spec.DNSPrefix).To(Equal(amcp.Name))
 	g.Expect(amcp.Spec.Extensions[0].Plan.Name).To(Equal("fooName-test-product"))
-	g.Expect(amcp.Spec.EnablePreviewFeatures).NotTo(BeNil())
-	g.Expect(*amcp.Spec.EnablePreviewFeatures).To(BeFalse())
 
 	t.Logf("Testing amcp defaulting webhook with baseline")
 	netPlug := "kubenet"
@@ -163,6 +155,7 @@ func TestDefaultingWebhook(t *testing.T) {
 						Enabled: true,
 					},
 				},
+				SKU: &AKSSku{},
 			},
 			SSHPublicKey: ptr.To(""),
 		},
@@ -4068,6 +4061,7 @@ func TestValidateAMCPVirtualNetwork(t *testing.T) {
 								},
 							},
 						},
+						SKU: &AKSSku{},
 					},
 				},
 			},
@@ -4096,6 +4090,7 @@ func TestValidateAMCPVirtualNetwork(t *testing.T) {
 								},
 							},
 						},
+						SKU: &AKSSku{},
 					},
 				},
 			},
@@ -4124,60 +4119,7 @@ func TestValidateAMCPVirtualNetwork(t *testing.T) {
 								},
 							},
 						},
-					},
-				},
-			},
-			wantErr: "pre-existing virtual networks CIDR block should contain the subnet CIDR block",
-		},
-		{
-			name: "Testing invalid VirtualNetwork in different resource group: no subnet CIDR",
-			amcp: &AzureManagedControlPlane{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "fooName",
-					Labels: map[string]string{
-						clusterv1.ClusterNameLabel: "fooCluster",
-					},
-				},
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
-						ResourceGroupName: "rg1",
-						VirtualNetwork: ManagedControlPlaneVirtualNetwork{
-							ResourceGroup: "rg2",
-							Name:          "vnet1",
-							ManagedControlPlaneVirtualNetworkClassSpec: ManagedControlPlaneVirtualNetworkClassSpec{
-								CIDRBlock: "10.1.0.0/16",
-								Subnet: ManagedControlPlaneSubnet{
-									Name: "subnet1",
-								},
-							},
-						},
-					},
-				},
-			},
-			wantErr: "pre-existing virtual networks CIDR block should contain the subnet CIDR block",
-		},
-		{
-			name: "Testing invalid VirtualNetwork in different resource group: no VNet CIDR",
-			amcp: &AzureManagedControlPlane{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "fooName",
-					Labels: map[string]string{
-						clusterv1.ClusterNameLabel: "fooCluster",
-					},
-				},
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
-						ResourceGroupName: "rg1",
-						VirtualNetwork: ManagedControlPlaneVirtualNetwork{
-							ResourceGroup: "rg2",
-							Name:          "vnet1",
-							ManagedControlPlaneVirtualNetworkClassSpec: ManagedControlPlaneVirtualNetworkClassSpec{
-								Subnet: ManagedControlPlaneSubnet{
-									Name:      "subnet1",
-									CIDRBlock: "11.0.0.0/24",
-								},
-							},
-						},
+						SKU: &AKSSku{},
 					},
 				},
 			},
@@ -4206,37 +4148,11 @@ func TestValidateAMCPVirtualNetwork(t *testing.T) {
 								},
 							},
 						},
+						SKU: &AKSSku{},
 					},
 				},
 			},
 			wantErr: "pre-existing virtual networks CIDR block is invalid",
-		},
-		{
-			name: "Testing invalid VirtualNetwork in different resource group: invalid Subnet CIDR",
-			amcp: &AzureManagedControlPlane{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "fooName",
-					Labels: map[string]string{
-						clusterv1.ClusterNameLabel: "fooCluster",
-					},
-				},
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
-						ResourceGroupName: "rg1",
-						VirtualNetwork: ManagedControlPlaneVirtualNetwork{
-							ResourceGroup: "rg2",
-							Name:          "vnet1",
-							ManagedControlPlaneVirtualNetworkClassSpec: ManagedControlPlaneVirtualNetworkClassSpec{
-								Subnet: ManagedControlPlaneSubnet{
-									Name:      "subnet1",
-									CIDRBlock: "invalid_subnet_CIDR",
-								},
-							},
-						},
-					},
-				},
-			},
-			wantErr: "pre-existing subnets CIDR block is invalid",
 		},
 	}
 

--- a/api/v1beta1/azuremanagedcontrolplanetemplate_default.go
+++ b/api/v1beta1/azuremanagedcontrolplanetemplate_default.go
@@ -35,7 +35,6 @@ func (mcp *AzureManagedControlPlaneTemplate) setDefaults() {
 	mcp.setDefaultVirtualNetwork()
 	mcp.setDefaultSubnet()
 	mcp.Spec.Template.Spec.SKU = setDefaultSku(mcp.Spec.Template.Spec.SKU)
-	mcp.Spec.Template.Spec.AutoScalerProfile = setDefaultAutoScalerProfile(mcp.Spec.Template.Spec.AutoScalerProfile)
 }
 
 // setDefaultVirtualNetwork sets the default VirtualNetwork for an AzureManagedControlPlaneTemplate.

--- a/api/v1beta1/azuremanagedcontrolplanetemplate_webhook_test.go
+++ b/api/v1beta1/azuremanagedcontrolplanetemplate_webhook_test.go
@@ -39,7 +39,6 @@ func TestControlPlaneTemplateDefaultingWebhook(t *testing.T) {
 	g.Expect(amcpt.Spec.Template.Spec.VirtualNetwork.CIDRBlock).To(Equal(defaultAKSVnetCIDR))
 	g.Expect(amcpt.Spec.Template.Spec.VirtualNetwork.Subnet.Name).To(Equal("fooName"))
 	g.Expect(amcpt.Spec.Template.Spec.VirtualNetwork.Subnet.CIDRBlock).To(Equal(defaultAKSNodeSubnetCIDR))
-	g.Expect(amcpt.Spec.Template.Spec.SKU.Tier).To(Equal(FreeManagedControlPlaneTier))
 	g.Expect(*amcpt.Spec.Template.Spec.EnablePreviewFeatures).To(BeFalse())
 
 	t.Logf("Testing amcp defaulting webhook with baseline")
@@ -440,6 +439,7 @@ func getAzureManagedControlPlaneTemplate(changes ...func(*AzureManagedControlPla
 					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
 						Location: "fooLocation",
 						Version:  "v1.17.5",
+						SKU:      &AKSSku{},
 					},
 				},
 			},

--- a/api/v1beta1/azuremanagedmachinepool_webhook_test.go
+++ b/api/v1beta1/azuremanagedmachinepool_webhook_test.go
@@ -62,7 +62,6 @@ func TestAzureManagedMachinePoolDefaultingWebhook(t *testing.T) {
 	g.Expect(ok).To(BeTrue())
 	g.Expect(val).To(Equal("System"))
 	g.Expect(*ammp.Spec.Name).To(Equal("fooname"))
-	g.Expect(*ammp.Spec.OSType).To(Equal(LinuxOS))
 
 	t.Logf("Testing ammp defaulting webhook with empty string name specified in Spec")
 	emptyName := ""

--- a/api/v1beta1/types.go
+++ b/api/v1beta1/types.go
@@ -596,6 +596,7 @@ const (
 // conversion-gen where the warning message generated uses a relative directory import rather than the fully
 // qualified import when generating outside of the GOPATH.
 type OSDisk struct {
+	// +kubebuilder:default:=Linux
 	OSType string `json:"osType"`
 	// DiskSizeGB is the size in GB to assign to the OS disk.
 	// Will have a default of 30GB if not provided
@@ -609,6 +610,7 @@ type OSDisk struct {
 	// CachingType specifies the caching requirements.
 	// +optional
 	// +kubebuilder:validation:Enum=None;ReadOnly;ReadWrite
+	// +kubebuilder:default:=None
 	CachingType string `json:"cachingType,omitempty"`
 }
 

--- a/api/v1beta1/types_class.go
+++ b/api/v1beta1/types_class.go
@@ -114,6 +114,7 @@ type AzureManagedControlPlaneClassSpec struct {
 
 	// NetworkPlugin used for building Kubernetes network.
 	// +kubebuilder:validation:Enum=azure;kubenet;none
+	// +kubebuilder:default:=azure
 	// +optional
 	NetworkPlugin *string `json:"networkPlugin,omitempty"`
 
@@ -248,6 +249,7 @@ type AzureManagedControlPlaneClassSpec struct {
 	ASOManagedClusterPatches []string `json:"asoManagedClusterPatches,omitempty"`
 
 	// EnablePreviewFeatures enables preview features for the cluster.
+	// +kubebuilder:default:=false
 	// +optional
 	EnablePreviewFeatures *bool `json:"enablePreviewFeatures,omitempty"`
 }
@@ -340,6 +342,7 @@ type AzureManagedMachinePoolClassSpec struct {
 	//
 	// [AKS doc]: https://learn.microsoft.com/rest/api/aks/agent-pools/create-or-update?tabs=HTTP#ostype
 	// +kubebuilder:validation:Enum=Linux;Windows
+	// +kubebuilder:default:=Linux
 	// +optional
 	OSType *string `json:"osType,omitempty"`
 
@@ -419,6 +422,7 @@ type AzureManagedMachinePoolClassSpec struct {
 
 // ManagedControlPlaneVirtualNetworkClassSpec defines the ManagedControlPlaneVirtualNetwork properties that may be shared across several managed control plane vnets.
 type ManagedControlPlaneVirtualNetworkClassSpec struct {
+	// +kubebuilder:default:="10.0.0.0/8"
 	CIDRBlock string `json:"cidrBlock"`
 	// +optional
 	Subnet ManagedControlPlaneSubnet `json:"subnet,omitempty"`
@@ -503,6 +507,7 @@ type LoadBalancerClassSpec struct {
 // FleetsMemberClassSpec defines the FleetsMemberSpec properties that may be shared across several Azure clusters.
 type FleetsMemberClassSpec struct {
 	// Group is the group this member belongs to for multi-cluster update management.
+	// +kubebuilder:default:=default
 	// +optional
 	Group string `json:"group,omitempty"`
 

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremachinepools.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremachinepools.yaml
@@ -561,6 +561,7 @@ spec:
                       for a Virtual Machine
                     properties:
                       cachingType:
+                        default: None
                         description: CachingType specifies the caching requirements.
                         enum:
                         - None
@@ -642,6 +643,7 @@ spec:
                             type: string
                         type: object
                       osType:
+                        default: Linux
                         type: string
                     required:
                     - osType

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremachines.yaml
@@ -481,6 +481,7 @@ spec:
                   disk of the machine
                 properties:
                   cachingType:
+                    default: None
                     description: CachingType specifies the caching requirements.
                     enum:
                     - None
@@ -562,6 +563,7 @@ spec:
                         type: string
                     type: object
                   osType:
+                    default: Linux
                     type: string
                 required:
                 - osType

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremachinetemplates.yaml
@@ -496,6 +496,7 @@ spec:
                           system disk of the machine
                         properties:
                           cachingType:
+                            default: None
                             description: CachingType specifies the caching requirements.
                             enum:
                             - None
@@ -578,6 +579,7 @@ spec:
                                 type: string
                             type: object
                           osType:
+                            default: Linux
                             type: string
                         required:
                         - osType

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremanagedcontrolplanes.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremanagedcontrolplanes.yaml
@@ -164,6 +164,7 @@ spec:
                   the cluster-autoscaler when enabled
                 properties:
                   balanceSimilarNodeGroups:
+                    default: "false"
                     description: BalanceSimilarNodeGroups - Valid values are 'true'
                       and 'false'. The default is false.
                     enum:
@@ -171,6 +172,7 @@ spec:
                     - "false"
                     type: string
                   expander:
+                    default: random
                     description: Expander - If not specified, the default is 'random'.
                       See [expanders](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#what-are-expanders)
                       for more information.
@@ -181,19 +183,23 @@ spec:
                     - random
                     type: string
                   maxEmptyBulkDelete:
+                    default: "10"
                     description: MaxEmptyBulkDelete - The default is 10.
                     type: string
                   maxGracefulTerminationSec:
+                    default: "600"
                     description: MaxGracefulTerminationSec - The default is 600.
                     pattern: ^(\d+)$
                     type: string
                   maxNodeProvisionTime:
+                    default: 15m
                     description: MaxNodeProvisionTime - The default is '15m'. Values
                       must be an integer followed by an 'm'. No unit of time other
                       than minutes (m) is supported.
                     pattern: ^(\d+)m$
                     type: string
                   maxTotalUnreadyPercentage:
+                    default: "45"
                     description: MaxTotalUnreadyPercentage - The default is 45. The
                       maximum is 100 and the minimum is 0.
                     maxLength: 3
@@ -201,6 +207,7 @@ spec:
                     pattern: ^(\d+)$
                     type: string
                   newPodScaleUpDelay:
+                    default: 0s
                     description: NewPodScaleUpDelay - For scenarios like burst/batch
                       scale where you don't want CA to act before the kubernetes scheduler
                       could schedule all the pods, you can tell CA to ignore unscheduled
@@ -209,55 +216,65 @@ spec:
                       for minutes, 'h' for hours, etc).
                     type: string
                   okTotalUnreadyCount:
+                    default: "3"
                     description: OkTotalUnreadyCount - This must be an integer. The
                       default is 3.
                     pattern: ^(\d+)$
                     type: string
                   scaleDownDelayAfterAdd:
+                    default: 10m
                     description: ScaleDownDelayAfterAdd - The default is '10m'. Values
                       must be an integer followed by an 'm'. No unit of time other
                       than minutes (m) is supported.
                     pattern: ^(\d+)m$
                     type: string
                   scaleDownDelayAfterDelete:
+                    default: 10s
                     description: ScaleDownDelayAfterDelete - The default is the scan-interval.
                       Values must be an integer followed by an 's'. No unit of time
                       other than seconds (s) is supported.
                     pattern: ^(\d+)s$
                     type: string
                   scaleDownDelayAfterFailure:
+                    default: 3m
                     description: ScaleDownDelayAfterFailure - The default is '3m'.
                       Values must be an integer followed by an 'm'. No unit of time
                       other than minutes (m) is supported.
                     pattern: ^(\d+)m$
                     type: string
                   scaleDownUnneededTime:
+                    default: 10m
                     description: ScaleDownUnneededTime - The default is '10m'. Values
                       must be an integer followed by an 'm'. No unit of time other
                       than minutes (m) is supported.
                     pattern: ^(\d+)m$
                     type: string
                   scaleDownUnreadyTime:
+                    default: 20m
                     description: ScaleDownUnreadyTime - The default is '20m'. Values
                       must be an integer followed by an 'm'. No unit of time other
                       than minutes (m) is supported.
                     pattern: ^(\d+)m$
                     type: string
                   scaleDownUtilizationThreshold:
+                    default: "0.5"
                     description: ScaleDownUtilizationThreshold - The default is '0.5'.
                     type: string
                   scanInterval:
+                    default: 10s
                     description: ScanInterval - How often cluster is reevaluated for
                       scale up or down. The default is '10s'.
                     pattern: ^(\d+)s$
                     type: string
                   skipNodesWithLocalStorage:
+                    default: "false"
                     description: SkipNodesWithLocalStorage - The default is false.
                     enum:
                     - "true"
                     - "false"
                     type: string
                   skipNodesWithSystemPods:
+                    default: "true"
                     description: SkipNodesWithSystemPods - The default is true.
                     enum:
                     - "true"
@@ -319,6 +336,7 @@ spec:
                   Immutable.
                 type: string
               enablePreviewFeatures:
+                default: false
                 description: EnablePreviewFeatures enables preview features for the
                   cluster.
                 type: boolean
@@ -434,6 +452,7 @@ spec:
                   [AKS doc]: https://learn.microsoft.com/en-us/azure/templates/microsoft.containerservice/2023-03-15-preview/fleets/members
                 properties:
                   group:
+                    default: default
                     description: Group is the group this member belongs to for multi-cluster
                       update management.
                     type: string
@@ -478,6 +497,7 @@ spec:
                 description: Identity configuration used by the AKS control plane.
                 properties:
                   type:
+                    default: SystemAssigned
                     description: Type - The Identity type to use.
                     enum:
                     - SystemAssigned
@@ -598,6 +618,7 @@ spec:
                 - cilium
                 type: string
               networkPlugin:
+                default: azure
                 description: NetworkPlugin used for building Kubernetes network.
                 enum:
                 - azure
@@ -630,6 +651,7 @@ spec:
                   Cluster.
                 properties:
                   enabled:
+                    default: false
                     description: Enabled is whether the OIDC issuer is enabled.
                     type: boolean
                 type: object
@@ -733,6 +755,7 @@ spec:
                 description: SKU is the SKU of the AKS to be provisioned.
                 properties:
                   tier:
+                    default: Free
                     description: Tier - Tier of an AKS cluster.
                     enum:
                     - Free
@@ -761,6 +784,7 @@ spec:
                   AKS cluster. It will be created if it does not already exist.
                 properties:
                   cidrBlock:
+                    default: 10.0.0.0/8
                     type: string
                   name:
                     description: Name is the name of the virtual network.
@@ -774,6 +798,7 @@ spec:
                       an AKS cluster.
                     properties:
                       cidrBlock:
+                        default: 10.240.0.0/16
                         type: string
                       name:
                         type: string

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremanagedcontrolplanetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremanagedcontrolplanetemplates.yaml
@@ -155,6 +155,7 @@ spec:
                           to the cluster-autoscaler when enabled
                         properties:
                           balanceSimilarNodeGroups:
+                            default: "false"
                             description: BalanceSimilarNodeGroups - Valid values are
                               'true' and 'false'. The default is false.
                             enum:
@@ -162,6 +163,7 @@ spec:
                             - "false"
                             type: string
                           expander:
+                            default: random
                             description: Expander - If not specified, the default
                               is 'random'. See [expanders](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#what-are-expanders)
                               for more information.
@@ -172,20 +174,24 @@ spec:
                             - random
                             type: string
                           maxEmptyBulkDelete:
+                            default: "10"
                             description: MaxEmptyBulkDelete - The default is 10.
                             type: string
                           maxGracefulTerminationSec:
+                            default: "600"
                             description: MaxGracefulTerminationSec - The default is
                               600.
                             pattern: ^(\d+)$
                             type: string
                           maxNodeProvisionTime:
+                            default: 15m
                             description: MaxNodeProvisionTime - The default is '15m'.
                               Values must be an integer followed by an 'm'. No unit
                               of time other than minutes (m) is supported.
                             pattern: ^(\d+)m$
                             type: string
                           maxTotalUnreadyPercentage:
+                            default: "45"
                             description: MaxTotalUnreadyPercentage - The default is
                               45. The maximum is 100 and the minimum is 0.
                             maxLength: 3
@@ -193,6 +199,7 @@ spec:
                             pattern: ^(\d+)$
                             type: string
                           newPodScaleUpDelay:
+                            default: 0s
                             description: NewPodScaleUpDelay - For scenarios like burst/batch
                               scale where you don't want CA to act before the kubernetes
                               scheduler could schedule all the pods, you can tell
@@ -202,17 +209,20 @@ spec:
                               'h' for hours, etc).
                             type: string
                           okTotalUnreadyCount:
+                            default: "3"
                             description: OkTotalUnreadyCount - This must be an integer.
                               The default is 3.
                             pattern: ^(\d+)$
                             type: string
                           scaleDownDelayAfterAdd:
+                            default: 10m
                             description: ScaleDownDelayAfterAdd - The default is '10m'.
                               Values must be an integer followed by an 'm'. No unit
                               of time other than minutes (m) is supported.
                             pattern: ^(\d+)m$
                             type: string
                           scaleDownDelayAfterDelete:
+                            default: 10s
                             description: ScaleDownDelayAfterDelete - The default is
                               the scan-interval. Values must be an integer followed
                               by an 's'. No unit of time other than seconds (s) is
@@ -220,33 +230,39 @@ spec:
                             pattern: ^(\d+)s$
                             type: string
                           scaleDownDelayAfterFailure:
+                            default: 3m
                             description: ScaleDownDelayAfterFailure - The default
                               is '3m'. Values must be an integer followed by an 'm'.
                               No unit of time other than minutes (m) is supported.
                             pattern: ^(\d+)m$
                             type: string
                           scaleDownUnneededTime:
+                            default: 10m
                             description: ScaleDownUnneededTime - The default is '10m'.
                               Values must be an integer followed by an 'm'. No unit
                               of time other than minutes (m) is supported.
                             pattern: ^(\d+)m$
                             type: string
                           scaleDownUnreadyTime:
+                            default: 20m
                             description: ScaleDownUnreadyTime - The default is '20m'.
                               Values must be an integer followed by an 'm'. No unit
                               of time other than minutes (m) is supported.
                             pattern: ^(\d+)m$
                             type: string
                           scaleDownUtilizationThreshold:
+                            default: "0.5"
                             description: ScaleDownUtilizationThreshold - The default
                               is '0.5'.
                             type: string
                           scanInterval:
+                            default: 10s
                             description: ScanInterval - How often cluster is reevaluated
                               for scale up or down. The default is '10s'.
                             pattern: ^(\d+)s$
                             type: string
                           skipNodesWithLocalStorage:
+                            default: "false"
                             description: SkipNodesWithLocalStorage - The default is
                               false.
                             enum:
@@ -254,6 +270,7 @@ spec:
                             - "false"
                             type: string
                           skipNodesWithSystemPods:
+                            default: "true"
                             description: SkipNodesWithSystemPods - The default is
                               true.
                             enum:
@@ -296,6 +313,7 @@ spec:
                           Immutable.
                         type: string
                       enablePreviewFeatures:
+                        default: false
                         description: EnablePreviewFeatures enables preview features
                           for the cluster.
                         type: boolean
@@ -414,6 +432,7 @@ spec:
                           [AKS doc]: https://learn.microsoft.com/en-us/azure/templates/microsoft.containerservice/2023-03-15-preview/fleets/members
                         properties:
                           group:
+                            default: default
                             description: Group is the group this member belongs to
                               for multi-cluster update management.
                             type: string
@@ -457,6 +476,7 @@ spec:
                           plane.
                         properties:
                           type:
+                            default: SystemAssigned
                             description: Type - The Identity type to use.
                             enum:
                             - SystemAssigned
@@ -579,6 +599,7 @@ spec:
                         - cilium
                         type: string
                       networkPlugin:
+                        default: azure
                         description: NetworkPlugin used for building Kubernetes network.
                         enum:
                         - azure
@@ -604,6 +625,7 @@ spec:
                           of the Managed Cluster.
                         properties:
                           enabled:
+                            default: false
                             description: Enabled is whether the OIDC issuer is enabled.
                             type: boolean
                         type: object
@@ -711,6 +733,7 @@ spec:
                         description: SKU is the SKU of the AKS to be provisioned.
                         properties:
                           tier:
+                            default: Free
                             description: Tier - Tier of an AKS cluster.
                             enum:
                             - Free
@@ -734,6 +757,7 @@ spec:
                           exist.
                         properties:
                           cidrBlock:
+                            default: 10.0.0.0/8
                             type: string
                           name:
                             description: Name is the name of the virtual network.
@@ -747,6 +771,7 @@ spec:
                               for an AKS cluster.
                             properties:
                               cidrBlock:
+                                default: 10.240.0.0/16
                                 type: string
                               name:
                                 type: string

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremanagedmachinepools.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremanagedmachinepools.yaml
@@ -535,6 +535,7 @@ spec:
                 - Managed
                 type: string
               osType:
+                default: Linux
                 description: |-
                   OSType specifies the virtual machine operating system. Default to Linux. Possible values include: 'Linux', 'Windows'.
                   'Windows' requires the AzureManagedControlPlane's `spec.networkPlugin` to be `azure`.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremanagedmachinepooltemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremanagedmachinepooltemplates.yaml
@@ -521,6 +521,7 @@ spec:
                         - Managed
                         type: string
                       osType:
+                        default: Linux
                         description: |-
                           OSType specifies the virtual machine operating system. Default to Linux. Possible values include: 'Linux', 'Windows'.
                           'Windows' requires the AzureManagedControlPlane's `spec.networkPlugin` to be `azure`.


### PR DESCRIPTION
<!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
This commit removes default values previously set in webhooks and adds the default values directly in the API through the kubebuilder annotation, `kubebuilder:default`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4204

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Removes default values previously set in webhooks and adds the default values directly in the API through the kubebuilder annotation, `kubebuilder:default`.
```
