### PR TITLE
Fix documentation links hard-coded to capz.k8s.io

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -6,7 +6,7 @@ about: Tell us about a problem you are experiencing.
 
 /kind bug
 
-[Before submitting an issue, have you checked the [Troubleshooting Guide](https://capz.sigs.k8s.io/topics/troubleshooting.html)?]
+[Before submitting an issue, have you checked the Troubleshooting Guide [self-managed](https://capz.sigs.k8s.io/self-managed/troubleshooting.html) & [managed](https://capz.sigs.k8s.io/managed/troubleshooting.html)?]
 
 **What steps did you take and what happened:**
 [A clear and concise description of what the bug is.]

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 ## Quick start
 
-- [Getting started](https://capz.sigs.k8s.io/topics/getting-started.html)
+- [Getting started](https://capz.sigs.k8s.io/getting-started.html)
 - [Cluster API quick start](https://cluster-api.sigs.k8s.io/user/quick-start.html)
 
 ## Features
@@ -22,7 +22,8 @@
 
 ## Troubleshooting
 
-- [Troubleshooting guide](https://capz.sigs.k8s.io/topics/troubleshooting.html)
+- [Self-managed troubleshooting guide](https://capz.sigs.k8s.io/self-managed/troubleshooting.html)
+- [Managed troubleshooting guide](https://capz.sigs.k8s.io/managed/troubleshooting.html)
 
 ## Docs contributors
 

--- a/docs/book/src/roadmap.md
+++ b/docs/book/src/roadmap.md
@@ -16,7 +16,7 @@ Azure Service Operator (ASO) is automatically installed with CAPZ and can be uti
 CAPZ can provision three major types of clusters, each of which have a different investment priority.
 
 1. Self-Managed clusters - maintain the current functionality via bug fixes and security patches.  New features will be accepted via contributor pull requests.
-2. Managed clusters (AzureManaged* current API) - maintain the current functionality via bug fixes and security patches.  New features will be accepted via contributor pull requests. It is recommended that the existing [asoManaged*Patches functionality](https://capz.sigs.k8s.io/topics/managedcluster#warning-warning-this-is-meant-to-be-used-sparingly-to-enable-features-for-development-and-testing-that-are-not-otherwise-represented-in-the-capz-api-misconfiguration-that-conflicts-with-capzs-normal-mode-of-operation-is-possible) be considered as a stop-gap to missing features in the CAPZ definitions for AKS.
+2. Managed clusters (AzureManaged* current API) - maintain the current functionality via bug fixes and security patches.  New features will be accepted via contributor pull requests. It is recommended that the existing [asoManaged*Patches functionality](./managed/managedcluster.md#warning-warning-this-is-meant-to-be-used-sparingly-to-enable-features-for-development-and-testing-that-are-not-otherwise-represented-in-the-capz-api-misconfiguration-that-conflicts-with-capzs-normal-mode-of-operation-is-possible) be considered as a stop-gap to missing features in the CAPZ definitions for AKS.
 See deprecation timeline below.
 3. Managed clusters (AzureASOManaged* new API) - was moved out of experimentation in July for the 1.16 release and is where the investment lies moving forward for provisioning AKS clusters.
 

--- a/docs/book/src/self-managed/addons.md
+++ b/docs/book/src/self-managed/addons.md
@@ -1,6 +1,6 @@
 # Overview
 
-This section provides examples for addons for self-managed clusters. For managed cluster addons, please go to the [managed cluster specifications](https://capz.sigs.k8s.io/topics/managedcluster.html#specification).
+This section provides examples for addons for self-managed clusters. For managed cluster addons, please go to the [managed cluster specifications](../managed/managedcluster.md#specification).
 
 Self managed cluster addon options covered here:
 

--- a/docs/book/src/self-managed/custom-vnet.md
+++ b/docs/book/src/self-managed/custom-vnet.md
@@ -70,7 +70,7 @@ spec:
   resourceGroup: cluster-vnet-peering
   ```
 
-Currently, only virtual networks on the same subscription can be peered. Also, note that when creating workload clusters with internal load balancers, the management cluster must be in the same VNet or a peered VNet. See [here](https://capz.sigs.k8s.io/topics/api-server-endpoint.html#warning) for more details.
+Currently, only virtual networks on the same subscription can be peered. Also, note that when creating workload clusters with internal load balancers, the management cluster must be in the same VNet or a peered VNet. See [here](./api-server-endpoint.md#warning) for more details.
 
 ## Custom Network Spec
 

--- a/docs/book/src/self-managed/publicmec-clusters.md
+++ b/docs/book/src/self-managed/publicmec-clusters.md
@@ -68,14 +68,14 @@ Execute clusterctl to template the resources:
 clusterctl init --infrastructure azure
 clusterctl generate cluster ${CLUSTER_NAME} --kubernetes-version ${KUBERNETES_VERSION} --flavor edgezone > edgezone-cluster.yaml
 ```
-Public MEC doesn't have access to CAPI images in Azure Marketplace, therefore, users need to prepare CAPI image by themselves. You can follow doc [Custom Images](https://capz.sigs.k8s.io/topics/custom-images.html) to setup custom image.
+Public MEC doesn't have access to CAPI images in Azure Marketplace, therefore, users need to prepare CAPI image by themselves. You can follow doc [Custom Images](./custom-images.md) to setup custom image.
 
 Apply the modified template to your kind management cluster:
 ```bash
 kubectl apply -f edgezone-cluster.yaml
 ```
 
-Once target cluster's control plane is up, install [Azure cloud provider components](https://github.com/kubernetes-sigs/cloud-provider-azure/tree/master/helm/cloud-provider-azure) by helm. The minimum version for "out-of-tree" Azure cloud provider is v1.0.3,  "in-tree" Azure cloud provider is not supported. (Reference: https://capz.sigs.k8s.io/topics/addons.html#external-cloud-provider)
+Once target cluster's control plane is up, install [Azure cloud provider components](https://github.com/kubernetes-sigs/cloud-provider-azure/tree/master/helm/cloud-provider-azure) by helm. The minimum version for "out-of-tree" Azure cloud provider is v1.0.3,  "in-tree" Azure cloud provider is not supported. (Reference: ./addons.md#external-cloud-provider)
 
 ```bash
 # get the kubeconfig of the cluster


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind documentation

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
This PR fixes some broken link errors that are caused by links hard-coded to capz.k8s.io instead of the local file, which will cause issues if locations or names of files are changed between versions.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix documentation links hard-coded to capz.k8s.io
```
