### PR TITLE
[release-1.16] Fix documentation links hard-coded to capz.k8s.io

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -6,7 +6,7 @@ about: Tell us about a problem you are experiencing.
 
 /kind bug
 
-[Before submitting an issue, have you checked the [Troubleshooting Guide](https://capz.sigs.k8s.io/topics/troubleshooting.html)?]
+[Before submitting an issue, have you checked the Troubleshooting Guide [self-managed](https://capz.sigs.k8s.io/self-managed/troubleshooting.html) & [managed](https://capz.sigs.k8s.io/managed/troubleshooting.html)?]
 
 **What steps did you take and what happened:**
 [A clear and concise description of what the bug is.]

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 ## Quick start
 
-- [Getting started](https://capz.sigs.k8s.io/topics/getting-started.html)
+- [Getting started](https://capz.sigs.k8s.io/getting-started.html)
 - [Cluster API quick start](https://cluster-api.sigs.k8s.io/user/quick-start.html)
 
 ## Features
@@ -22,7 +22,8 @@
 
 ## Troubleshooting
 
-- [Troubleshooting guide](https://capz.sigs.k8s.io/topics/troubleshooting.html)
+- [Self-managed troubleshooting guide](https://capz.sigs.k8s.io/self-managed/troubleshooting.html)
+- [Managed troubleshooting guide](https://capz.sigs.k8s.io/managed/troubleshooting.html)
 
 ## Docs contributors
 

--- a/docs/book/src/roadmap.md
+++ b/docs/book/src/roadmap.md
@@ -9,6 +9,24 @@ The "next" milestone is a very rough collection of issues for the milestone afte
 
 CAPZ is the official production-ready Cluster API implementation to administer the entire lifecycle of self-managed or managed Kubernetes clusters (AKS) on Azure. Cluster API extends the Kubernetes API to provide tooling consistent across on-premises and cloud providers to build and maintain Kubernetes clusters at scale while working with GitOps and the surrounding tooling ecosystem. [See related blog post.](https://cloudblogs.microsoft.com/opensource/2023/04/20/kubernetes-at-scale-with-gitops-and-cluster-api/)
 
-## Epics
+## Long-Term Priorities
 
-There are a number of large priority "Epics" which may span across milestones which we believe are important to providing CAPZ users an even better experience and improving the vision.  The [CAPZ project board roadmap view](https://github.com/orgs/kubernetes-sigs/projects/26/views/11) tracks the larger "epic issues" and their progress.
+CAPZ can provision three major types of clusters, each of which have a different investment priority.
+
+1. Self-Managed clusters - maintain the current functionality via bug fixes and security patches.  New features will be accepted via contributor pull requests.
+2. Managed clusters (AzureManaged* current API) - maintain the current functionality via bug fixes and security patches.  New features will be accepted via contributor pull requests. It is recommended that the existing [asoManaged*Patches functionality](./managed/managedcluster.md#warning-warning-this-is-meant-to-be-used-sparingly-to-enable-features-for-development-and-testing-that-are-not-otherwise-represented-in-the-capz-api-misconfiguration-that-conflicts-with-capzs-normal-mode-of-operation-is-possible) be considered as a stop-gap to missing features in the CAPZ definitions for AKS.
+See deprecation timeline below.
+3. Managed clusters (AzureASOManaged* new API) - was moved out of experimentation in July for the 1.16 release and is where the investment lies moving forward for provisioning AKS clusters.
+
+See the [managed clusters](./managed/managed.md) for further background and comparison of the two managed cluster APIs.
+
+Approximate timeline for deprecation of AzureManaged API:
+- Sept 2024 - 1.17 - Announcement of deprecation of AzureManaged API.
+- Nov 2024 - 1.18
+- Jan 2025 - 1.19 - move AzureASOManaged API to beta
+- Mar 2025 - 1.20 - no new features accepted for AzureManaged API. Warning message in code for deprecation.
+- May 2025 - 1.21 - GA AzureASOManaged API
+- July 2025 - 1.22
+- Sept 2025 - 1.23 - AzureManaged API is removed from code base, AzureASOManaged API is default.
+
+There may be investment creating a new API definition for AKS from the [Managed Kubernetes CAPI proposal](https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/proposals/20220725-managed-kubernetes.md) at some point in the future.  If interested in this functionality, please file an issue on the CAPZ repository and come to the community group meeting to discuss.

--- a/docs/book/src/self-managed/addons.md
+++ b/docs/book/src/self-managed/addons.md
@@ -1,6 +1,6 @@
 # Overview
 
-This section provides examples for addons for self-managed clusters. For managed cluster addons, please go to the [managed cluster specifications](https://capz.sigs.k8s.io/topics/managedcluster.html#specification).
+This section provides examples for addons for self-managed clusters. For managed cluster addons, please go to the [managed cluster specifications](../managed/managedcluster.md#specification).
 
 Self managed cluster addon options covered here:
 

--- a/docs/book/src/self-managed/custom-vnet.md
+++ b/docs/book/src/self-managed/custom-vnet.md
@@ -70,7 +70,7 @@ spec:
   resourceGroup: cluster-vnet-peering
   ```
 
-Currently, only virtual networks on the same subscription can be peered. Also, note that when creating workload clusters with internal load balancers, the management cluster must be in the same VNet or a peered VNet. See [here](https://capz.sigs.k8s.io/topics/api-server-endpoint.html#warning) for more details.
+Currently, only virtual networks on the same subscription can be peered. Also, note that when creating workload clusters with internal load balancers, the management cluster must be in the same VNet or a peered VNet. See [here](./api-server-endpoint.md#warning) for more details.
 
 ## Custom Network Spec
 

--- a/docs/book/src/self-managed/publicmec-clusters.md
+++ b/docs/book/src/self-managed/publicmec-clusters.md
@@ -68,14 +68,14 @@ Execute clusterctl to template the resources:
 clusterctl init --infrastructure azure
 clusterctl generate cluster ${CLUSTER_NAME} --kubernetes-version ${KUBERNETES_VERSION} --flavor edgezone > edgezone-cluster.yaml
 ```
-Public MEC doesn't have access to CAPI images in Azure Marketplace, therefore, users need to prepare CAPI image by themselves. You can follow doc [Custom Images](https://capz.sigs.k8s.io/topics/custom-images.html) to setup custom image.
+Public MEC doesn't have access to CAPI images in Azure Marketplace, therefore, users need to prepare CAPI image by themselves. You can follow doc [Custom Images](./custom-images.md) to setup custom image.
 
 Apply the modified template to your kind management cluster:
 ```bash
 kubectl apply -f edgezone-cluster.yaml
 ```
 
-Once target cluster's control plane is up, install [Azure cloud provider components](https://github.com/kubernetes-sigs/cloud-provider-azure/tree/master/helm/cloud-provider-azure) by helm. The minimum version for "out-of-tree" Azure cloud provider is v1.0.3,  "in-tree" Azure cloud provider is not supported. (Reference: https://capz.sigs.k8s.io/topics/addons.html#external-cloud-provider)
+Once target cluster's control plane is up, install [Azure cloud provider components](https://github.com/kubernetes-sigs/cloud-provider-azure/tree/master/helm/cloud-provider-azure) by helm. The minimum version for "out-of-tree" Azure cloud provider is v1.0.3,  "in-tree" Azure cloud provider is not supported. (Reference: ./addons.md#external-cloud-provider)
 
 ```bash
 # get the kubeconfig of the cluster


### PR DESCRIPTION
Manual cherry-pick of #5123 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix documentation links hard-coded to capz.k8s.io
```
