### PR TITLE
remove special condition for workload id for conformance tests

### DIFF
--- a/scripts/kind-with-registry.sh
+++ b/scripts/kind-with-registry.sh
@@ -203,34 +203,22 @@ function upload_to_blob() {
 # to be mounted on the kind cluster and hence extra mount flags are required.
 function createKindForAZWI() {
   echo "creating workload-identity-enabled kind configuration"
-  if [ -n "${CONFORMANCE_FLAVOR}" ] && [ -n "${SERVICE_ACCOUNT_SIGNING_PUB}" ] && [ -n "${SERVICE_ACCOUNT_SIGNING_KEY}" ]; then
-    echo "using pre-existing service-account-issuer for kind cluster"
-    KIND_SERVICE_ACCOUNT_SIGNING_PUB_FILEPATH="${REPO_ROOT}/kind-wi-sa.pub"
-    KIND_SERVICE_ACCOUNT_SIGNING_KEY_FILEPATH="${REPO_ROOT}/kind-wi-sa.key"
-    echo "${SERVICE_ACCOUNT_SIGNING_PUB}" > "${KIND_SERVICE_ACCOUNT_SIGNING_PUB_FILEPATH}"
-    echo "${SERVICE_ACCOUNT_SIGNING_KEY}" > "${KIND_SERVICE_ACCOUNT_SIGNING_KEY_FILEPATH}"
-    KIND_SERVICE_ACCOUNT_ISSUER="https://oidcissuercapzci.blob.core.windows.net/oidc-capzci/"
-  else
-    KIND_SERVICE_ACCOUNT_SIGNING_PUB_FILEPATH="${SERVICE_ACCOUNT_SIGNING_PUB_FILEPATH}"
-    KIND_SERVICE_ACCOUNT_SIGNING_KEY_FILEPATH="${SERVICE_ACCOUNT_SIGNING_KEY_FILEPATH}"
-    KIND_SERVICE_ACCOUNT_ISSUER="${SERVICE_ACCOUNT_ISSUER}"
-  fi
   cat <<EOF | "${KIND}" create cluster --name "${KIND_CLUSTER_NAME}" --config=-
   kind: Cluster
   apiVersion: kind.x-k8s.io/v1alpha4
   nodes:
   - role: control-plane
     extraMounts:
-      - hostPath: "${KIND_SERVICE_ACCOUNT_SIGNING_PUB_FILEPATH}"
+      - hostPath: "${SERVICE_ACCOUNT_SIGNING_PUB_FILEPATH}"
         containerPath: /etc/kubernetes/pki/sa.pub
-      - hostPath: "${KIND_SERVICE_ACCOUNT_SIGNING_KEY_FILEPATH}"
+      - hostPath: "${SERVICE_ACCOUNT_SIGNING_KEY_FILEPATH}"
         containerPath: /etc/kubernetes/pki/sa.key
     kubeadmConfigPatches:
     - |
       kind: ClusterConfiguration
       apiServer:
         extraArgs:
-          service-account-issuer: ${KIND_SERVICE_ACCOUNT_ISSUER}
+          service-account-issuer: ${SERVICE_ACCOUNT_ISSUER}
           service-account-key-file: /etc/kubernetes/pki/sa.pub
           service-account-signing-key-file: /etc/kubernetes/pki/sa.key
       controllerManager:


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind cleanup

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

The [new DRA periodic job](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/periodic-cluster-api-provider-azure-conformance-with-ci-artifacts-dra-main/1833647506127327232) sets `CONFORMANCE_FLAVOR` in order to use a DRA-enabled template and hits this error in the kind setup script:
```
./scripts/kind-with-registry.sh: line 206: SERVICE_ACCOUNT_SIGNING_PUB: unbound variable
```

The other conformance jobs do not hit the same error because they leave `CONFORMACE_FLAVOR` undefined and let the e2e framework select a default flavor.

IIRC this condition in the kind script to use a different workload ID setup is a vestige of the pre-community infra and/or pre-workload ID default days and no longer is needed now.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

I don't see any other references to `CONFORMANCE_FLAVOR` in test-infra or any other repo, so I don't think this change should include any collateral damage.
https://github.com/search?q=CONFORMANCE_FLAVOR+%28org%3Akubernetes+OR+org%3Akubernetes-sigs%29&type=code

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
