### PR TITLE
Add "cluster" type to subnet role validation

### DIFF
--- a/api/v1beta1/types_class.go
+++ b/api/v1beta1/types_class.go
@@ -473,7 +473,7 @@ type SubnetClassSpec struct {
 	Name string `json:"name"`
 
 	// Role defines the subnet role (eg. Node, ControlPlane)
-	// +kubebuilder:validation:Enum=node;control-plane;bastion;all
+	// +kubebuilder:validation:Enum=node;control-plane;bastion;cluster
 	Role SubnetRole `json:"role"`
 
 	// CIDRBlocks defines the subnet's address space, specified as one or more address prefixes in CIDR notation.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azureclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azureclusters.yaml
@@ -307,7 +307,7 @@ spec:
                             - node
                             - control-plane
                             - bastion
-                            - all
+                            - cluster
                             type: string
                           routeTable:
                             description: RouteTable defines the route table that should
@@ -1057,7 +1057,7 @@ spec:
                           - node
                           - control-plane
                           - bastion
-                          - all
+                          - cluster
                           type: string
                         routeTable:
                           description: RouteTable defines the route table that should

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azureclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azureclustertemplates.yaml
@@ -204,7 +204,7 @@ spec:
                                     - node
                                     - control-plane
                                     - bastion
-                                    - all
+                                    - cluster
                                     type: string
                                   securityGroup:
                                     description: SecurityGroup defines the NSG (network
@@ -698,7 +698,7 @@ spec:
                                   - node
                                   - control-plane
                                   - bastion
-                                  - all
+                                  - cluster
                                   type: string
                                 securityGroup:
                                   description: SecurityGroup defines the NSG (network


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Adds "cluster" to the valid kubebuilder types for a subnet role, as [documented](https://capz.sigs.k8s.io/reference/v1beta1-api.html#infrastructure.cluster.x-k8s.io/v1beta1.SubnetRole). Apparently we had added "all" instead.
https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/3770549429a7cbf0b70d1d1593991670115a37eb/api/v1beta1/types.go#L744-L745

**Which issue(s) this PR fixes**:
Fixes #5130

**Special notes for your reviewer**:

- [x] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:

```release-note
Add "cluster" type to subnet role validation
```
