### PR TITLE
keep stable order of agent pool profiles when reconciling managed cluster

### DIFF
--- a/azure/services/managedclusters/spec.go
+++ b/azure/services/managedclusters/spec.go
@@ -21,6 +21,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"net"
+	"sort"
 
 	asocontainerservicev1 "github.com/Azure/azure-service-operator/v2/api/containerservice/v1api20231001"
 	asocontainerservicev1hub "github.com/Azure/azure-service-operator/v2/api/containerservice/v1api20231001/storage"
@@ -714,6 +715,11 @@ func (s *ManagedClusterSpec) Parameters(ctx context.Context, existingObj genrunt
 			prevAgentPoolProfiles = append(prevAgentPoolProfiles, profile)
 		}
 	}
+
+	// keep a consistent order to prevent unnecessary updates
+	sort.Slice(prevAgentPoolProfiles, func(i, j int) bool {
+		return ptr.Deref(prevAgentPoolProfiles[i].Name, "") < ptr.Deref(prevAgentPoolProfiles[j].Name, "")
+	})
 
 	managedCluster.Spec.AgentPoolProfiles = prevAgentPoolProfiles
 

--- a/azure/services/managedclusters/spec_test.go
+++ b/azure/services/managedclusters/spec_test.go
@@ -57,8 +57,13 @@ func TestParameters(t *testing.T) {
 					&agentpools.AgentPoolSpec{
 						Replicas:  5,
 						Mode:      "mode",
-						AzureName: "agentpool",
+						AzureName: "agentpool-b",
 						Patches:   []string{`{"spec": {"tags": {"from": "patches"}}}`},
+					},
+					&agentpools.AgentPoolSpec{
+						Replicas:  10,
+						Mode:      "mode",
+						AzureName: "agentpool-a",
 					},
 				}, nil
 			},
@@ -141,10 +146,18 @@ func TestParameters(t *testing.T) {
 				},
 				AgentPoolProfiles: []asocontainerservicev1.ManagedClusterAgentPoolProfile{
 					{
+						Count:             ptr.To(10),
+						EnableAutoScaling: ptr.To(false),
+						Mode:              ptr.To(asocontainerservicev1.AgentPoolMode("mode")),
+						Name:              ptr.To("agentpool-a"),
+						OsDiskSizeGB:      ptr.To(asocontainerservicev1.ContainerServiceOSDisk(0)),
+						Type:              ptr.To(asocontainerservicev1.AgentPoolType_VirtualMachineScaleSets),
+					},
+					{
 						Count:             ptr.To(5),
 						EnableAutoScaling: ptr.To(false),
 						Mode:              ptr.To(asocontainerservicev1.AgentPoolMode("mode")),
-						Name:              ptr.To("agentpool"),
+						Name:              ptr.To("agentpool-b"),
 						OsDiskSizeGB:      ptr.To(asocontainerservicev1.ContainerServiceOSDisk(0)),
 						Type:              ptr.To(asocontainerservicev1.AgentPoolType_VirtualMachineScaleSets),
 						Tags:              map[string]string{"from": "patches"},


### PR DESCRIPTION
<!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind cleanup

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

When we first list the agent pools associated with a managed cluster to include them for the initial create, the nondeterministic order of the list causes some unnecessary updates to the ManagedCluster ASO resource. This change sorts the agent pools by name in the final ASO spec to ensure no unnecessary updates are made.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
