### PR TITLE
use correct image for Tilt

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -251,7 +251,7 @@ def capz():
         print("Using REGISTRY: " + registry + " from tilt-settings.yaml")
         image = registry + "/cluster-api-azure-controller"
     else:
-        image = "gcr.io/cluster-api-provider-azure/cluster-api-azure-controller"
+        image = "gcr.io/k8s-staging-cluster-api-azure/cluster-api-azure-controller"
 
     # Set up an image build for the provider. The live update configuration syncs the output from the local_resource
     # build into the container.


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

This change fixes the following warning when loading Tilt, which causes the hot-reloading not to propagate local changes to the live CAPZ controller manager Pod:
```
Image not used in any Kubernetes config:
    ✕ gcr.io/cluster-api-provider-azure/cluster-api-azure-controller
Did you mean…
    - gcr.io/k8s-staging-cluster-api-azure/cluster-api-azure-controller
    - ghcr.io/jont828/cluster-api-visualizer
    - gcr.io/distroless/base
Skipping this image build
If this is deliberate, suppress this warning with: update_settings(suppress_unused_image_warnings=["gcr.io/cluster-api-provider-azure/cluster-api-azure-controller"])
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
