### PR TITLE
delete AKS extensions when they are removed from spec

### DIFF
--- a/azure/services/aksextensions/aksextensions.go
+++ b/azure/services/aksextensions/aksextensions.go
@@ -17,10 +17,14 @@ limitations under the License.
 package aksextensions
 
 import (
+	"context"
+
 	asokubernetesconfigurationv1 "github.com/Azure/azure-service-operator/v2/api/kubernetesconfiguration/v1api20230501"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/services/aso"
+	"sigs.k8s.io/cluster-api-provider-azure/util/slice"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const serviceName = "extension"
@@ -41,10 +45,17 @@ type Service struct {
 // New creates a new service.
 func New(scope AKSExtensionScope) *Service {
 	svc := aso.NewService[*asokubernetesconfigurationv1.Extension, AKSExtensionScope](serviceName, scope)
+	svc.ListFunc = list
 	svc.Specs = scope.AKSExtensionSpecs()
 	svc.ConditionType = infrav1.AKSExtensionsReadyCondition
 	return &Service{
 		Scope:   scope,
 		Service: svc,
 	}
+}
+
+func list(ctx context.Context, client client.Client, opts ...client.ListOption) ([]*asokubernetesconfigurationv1.Extension, error) {
+	list := &asokubernetesconfigurationv1.ExtensionList{}
+	err := client.List(ctx, list, opts...)
+	return slice.ToPtrs(list.Items), err
 }


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

Lately our AKS e2e test has been flakily timing out when deleting the cluster. The cause according to #5120 is that the traefik extension is failing to delete, which seems to only happen when the extension's Pod is running on a Windows Node. Even though the e2e test creates a taint on the Windows nodepool to prevent this, the taint is removed before the k8s version upgrades take place which recycles all the nodes and causes pods to be rescheduled.

This change makes it possible to remove elements from an AzureManagedControlPlane's `spec.extensions` and the removed extensions will be deleted from the AKS cluster. This enables the e2e test to remove the extensions it adds before dropping the taint on the Windows nodepool to ensure traefik is never running on a Windows Node.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
AKS extensions removed from an AzureManagedControlPlane's `spec.extensions` will now be deleted.
```
