### PR TITLE
Skip AKS BYO nodepool test

### DIFF
--- a/test/e2e/azure_test.go
+++ b/test/e2e/azure_test.go
@@ -853,16 +853,17 @@ var _ = Describe("Workload cluster creation", func() {
 				})
 			})
 
-			By("creating a byo nodepool", func() {
-				AKSBYONodeSpec(ctx, func() AKSBYONodeSpecInput {
-					return AKSBYONodeSpecInput{
-						Cluster:             result.Cluster,
-						KubernetesVersion:   kubernetesVersion,
-						WaitIntervals:       e2eConfig.GetIntervals(specName, "wait-worker-nodes"),
-						ExpectedWorkerNodes: result.ExpectedWorkerNodes(),
-					}
-				})
-			})
+			// TODO: restore when new CAPZ reference images are published
+			// By("creating a byo nodepool", func() {
+			// 	AKSBYONodeSpec(ctx, func() AKSBYONodeSpecInput {
+			// 		return AKSBYONodeSpecInput{
+			// 			Cluster:             result.Cluster,
+			// 			KubernetesVersion:   kubernetesVersion,
+			// 			WaitIntervals:       e2eConfig.GetIntervals(specName, "wait-worker-nodes"),
+			// 			ExpectedWorkerNodes: result.ExpectedWorkerNodes(),
+			// 		}
+			// 	})
+			// })
 
 			By("modifying custom patches", func() {
 				AKSPatchSpec(ctx, func() AKSPatchSpecInput {


### PR DESCRIPTION
**What type of PR is this?**

/kind failing-test

**What this PR does / why we need it**:

The AKS BYO nodepool testing has begun failing because CAPZ reference images are not published to match the latest Kubernetes version available in AKS (v1.30.4). For now, let's skip this test to get CI green, and re-enable when publishing is flowing again (soon).

**Which issue(s) this PR fixes**:
Fixes #5145

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [x] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
