### PR TITLE
remove unnecassary caching of of golangci-lint

### DIFF
--- a/.github/workflows/pr-golangci-lint.yaml
+++ b/.github/workflows/pr-golangci-lint.yaml
@@ -29,17 +29,6 @@ jobs:
         with:
           go-version: ${{ steps.vars.outputs.go_version }}
 
-      - name: Cache golangci-lint binary
-        id: golangci-cache
-        uses: actions/cache@v4
-        with:
-          # Cache location used by golangci-lint-action
-          path: ~/.cache/golangci-lint
-          # Change this when updating golangci-lint version
-          key: golangci-lint-v1.60.2
-          restore-keys: |
-            golangci-lint-
-
       - name: golangci-lint
         uses: golangci/golangci-lint-action@971e284b6050e8a5849b72094c50ab08da042db8 # tag=v6.1.1
         with:


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind cleanup

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
- golangci-lint step auto caches the binary. Explicit caching step is not needed anymore. Refer to https://github.com/golangci/golangci-lint-action?tab=readme-ov-file#internals

- Of course, we could cache a specific version of golangci-lint instead of go.mod hash. But effort to create that logic
 outweighs its impact. However, golangci-lint.cache-{runner_os}-{working_directory}-{interval_number}-{go.mod_hash} has its advantages; it updates itself with go.mod changes.
- We delete older caches using auto delete cache workflow. https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/5165

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
