### PR TITLE
Fix aks-create when default az output isn't JSON

### DIFF
--- a/scripts/aks-as-mgmt.sh
+++ b/scripts/aks-as-mgmt.sh
@@ -137,13 +137,13 @@ create_aks_cluster() {
   echo "mgmt resource identity: ${AKS_MI_RESOURCE_ID}"
 
   # save resource identity name and resource group
-  MANAGED_IDENTITY_NAME=$(az identity show --ids "${AKS_MI_RESOURCE_ID}" | jq -r '.name')
+  MANAGED_IDENTITY_NAME=$(az identity show --ids "${AKS_MI_RESOURCE_ID}" --output json | jq -r '.name')
   # export MANAGED_IDENTITY_NAME
   echo "mgmt resource identity name: ${MANAGED_IDENTITY_NAME}"
   USER_IDENTITY=$MANAGED_IDENTITY_NAME
   export USER_IDENTITY
 
-  MANAGED_IDENTITY_RG=$(az identity show --ids "${AKS_MI_RESOURCE_ID}" | jq -r '.resourceGroup')
+  MANAGED_IDENTITY_RG=$(az identity show --ids "${AKS_MI_RESOURCE_ID}" --output json | jq -r '.resourceGroup')
   export MANAGED_IDENTITY_RG
   echo "mgmt resource identity resource group: ${MANAGED_IDENTITY_RG}"
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Adds `-o json` to two `az` commands in `aks-create` to ensure that the output is JSON and can be parsed. (Users can configure a different default output for `az`; mine is `--output table`, which was causing these `jq` commands to fail.)

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:

```release-note
NONE
```
