### PR TITLE
rebase DRA templates onto machinepool templates

### DIFF
--- a/templates/test/ci/cluster-template-prow-ci-version-dra.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version-dra.yaml
@@ -7,7 +7,7 @@ metadata:
     cni-windows: ${CLUSTER_NAME}-calico
     containerd-logger: enabled
     csi-proxy: enabled
-    metrics-server: enabled
+    windows: enabled
   name: ${CLUSTER_NAME}
   namespace: default
 spec:
@@ -263,213 +263,188 @@ spec:
         osType: Linux
       sshPublicKey: ${AZURE_SSH_PUBLIC_KEY_B64:=""}
       userAssignedIdentities:
-      - providerID: /subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${CI_RG}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER_IDENTITY}
+      - providerID: /subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${CI_RG:=capz-ci}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER_IDENTITY:=cloud-provider-user-identity}
       vmSize: ${AZURE_CONTROL_PLANE_MACHINE_TYPE}
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
-kind: MachineDeployment
+kind: MachinePool
 metadata:
-  name: ${CLUSTER_NAME}-md-0
+  name: ${CLUSTER_NAME}-mp-0
   namespace: default
 spec:
   clusterName: ${CLUSTER_NAME}
   replicas: ${WORKER_MACHINE_COUNT:=2}
-  selector: {}
   template:
-    metadata:
-      labels:
-        nodepool: pool1
     spec:
       bootstrap:
         configRef:
           apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
-          kind: KubeadmConfigTemplate
-          name: ${CLUSTER_NAME}-md-0
+          kind: KubeadmConfig
+          name: ${CLUSTER_NAME}-mp-0
       clusterName: ${CLUSTER_NAME}
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-        kind: AzureMachineTemplate
-        name: ${CLUSTER_NAME}-md-0
+        kind: AzureMachinePool
+        name: ${CLUSTER_NAME}-mp-0
       version: ${KUBERNETES_VERSION}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-kind: AzureMachineTemplate
+kind: AzureMachinePool
 metadata:
-  name: ${CLUSTER_NAME}-md-0
+  name: ${CLUSTER_NAME}-mp-0
   namespace: default
 spec:
+  identity: UserAssigned
+  location: ${AZURE_LOCATION}
+  strategy:
+    rollingUpdate:
+      deletePolicy: Oldest
+      maxSurge: 25%
+      maxUnavailable: 1
+    type: RollingUpdate
   template:
-    spec:
-      identity: UserAssigned
-      image:
-        marketplace:
-          offer: capi
-          publisher: cncf-upstream
-          sku: ubuntu-2204-gen1
-          version: latest
-      osDisk:
-        diskSizeGB: 128
-        osType: Linux
-      sshPublicKey: ${AZURE_SSH_PUBLIC_KEY_B64:=""}
-      userAssignedIdentities:
-      - providerID: /subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${CI_RG:=capz-ci}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER_IDENTITY:=cloud-provider-user-identity}
-      vmExtensions:
-      - name: CustomScript
-        protectedSettings:
-          commandToExecute: |
-            #!/bin/sh
-            echo "This script is a no-op used for extension testing purposes ..."
-            touch test_file
-        publisher: Microsoft.Azure.Extensions
-        version: "2.1"
-      vmSize: ${AZURE_NODE_MACHINE_TYPE}
+    image:
+      marketplace:
+        offer: capi
+        publisher: cncf-upstream
+        sku: ubuntu-2204-gen1
+        version: latest
+    osDisk:
+      diskSizeGB: 30
+      managedDisk:
+        storageAccountType: Premium_LRS
+      osType: Linux
+    sshPublicKey: ${AZURE_SSH_PUBLIC_KEY_B64:=""}
+    vmExtensions:
+    - name: CustomScript
+      protectedSettings:
+        commandToExecute: |
+          #!/bin/sh
+          echo "This script is a no-op used for extension testing purposes ..."
+          touch test_file
+      publisher: Microsoft.Azure.Extensions
+      version: "2.1"
+    vmSize: ${AZURE_NODE_MACHINE_TYPE}
+  userAssignedIdentities:
+  - providerID: /subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${CI_RG:=capz-ci}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER_IDENTITY:=cloud-provider-user-identity}
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
-kind: KubeadmConfigTemplate
+kind: KubeadmConfig
 metadata:
-  name: ${CLUSTER_NAME}-md-0
+  name: ${CLUSTER_NAME}-mp-0
   namespace: default
 spec:
-  template:
-    spec:
-      files:
-      - contentFrom:
-          secret:
-            key: worker-node-azure.json
-            name: ${CLUSTER_NAME}-md-0-azure-json
-        owner: root:root
-        path: /etc/kubernetes/azure.json
-        permissions: "0644"
-      - content: |
-          #!/bin/bash
+  files:
+  - content: |
+      #!/bin/bash
 
-          set -o nounset
-          set -o pipefail
-          set -o errexit
-          [[ $(id -u) != 0 ]] && SUDO="sudo" || SUDO=""
+      set -o nounset
+      set -o pipefail
+      set -o errexit
+      [[ $(id -u) != 0 ]] && SUDO="sudo" || SUDO=""
 
-          # Run the az login command with managed identity
-          if az login --identity > /dev/null 2>&1; then
-            echo "Logged in Azure with managed identity"
-            echo "Use OOT credential provider"
-            mkdir -p /var/lib/kubelet/credential-provider
-            az storage blob download --blob-url "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${IMAGE_TAG_ACR_CREDENTIAL_PROVIDER}/azure-acr-credential-provider" -f /var/lib/kubelet/credential-provider/acr-credential-provider --auth-mode login
-            chmod 755 /var/lib/kubelet/credential-provider/acr-credential-provider
-            az storage blob download --blob-url "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${IMAGE_TAG_ACR_CREDENTIAL_PROVIDER}/credential-provider-config.yaml" -f /var/lib/kubelet/credential-provider-config.yaml --auth-mode login
-            chmod 644 /var/lib/kubelet/credential-provider-config.yaml
-          else
-            echo "Use OOT credential provider"
-            mkdir -p /var/lib/kubelet/credential-provider
-            curl --retry 10 --retry-delay 5 -w "response status code is %{http_code}" -Lo /var/lib/kubelet/credential-provider/acr-credential-provider "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${IMAGE_TAG_ACR_CREDENTIAL_PROVIDER}/azure-acr-credential-provider"
-            chmod 755 /var/lib/kubelet/credential-provider/acr-credential-provider
-            curl --retry 10 --retry-delay 5 -w "response status code is %{http_code}" -Lo /var/lib/kubelet/credential-provider-config.yaml "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${IMAGE_TAG_ACR_CREDENTIAL_PROVIDER}/credential-provider-config.yaml"
-            chmod 644 /var/lib/kubelet/credential-provider-config.yaml
+      # Run the az login command with managed identity
+      if az login --identity > /dev/null 2>&1; then
+        echo "Logged in Azure with managed identity"
+        echo "Use OOT credential provider"
+        mkdir -p /var/lib/kubelet/credential-provider
+        az storage blob download --blob-url "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${IMAGE_TAG_ACR_CREDENTIAL_PROVIDER}/azure-acr-credential-provider" -f /var/lib/kubelet/credential-provider/acr-credential-provider --auth-mode login
+        chmod 755 /var/lib/kubelet/credential-provider/acr-credential-provider
+        az storage blob download --blob-url "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${IMAGE_TAG_ACR_CREDENTIAL_PROVIDER}/credential-provider-config.yaml" -f /var/lib/kubelet/credential-provider-config.yaml --auth-mode login
+        chmod 644 /var/lib/kubelet/credential-provider-config.yaml
+      else
+        echo "Using curl to download the OOT credential provider"
+        mkdir -p /var/lib/kubelet/credential-provider
+        curl --retry 10 --retry-delay 5 -w "response status code is %{http_code}" -Lo /var/lib/kubelet/credential-provider/acr-credential-provider "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${IMAGE_TAG_ACR_CREDENTIAL_PROVIDER}/azure-acr-credential-provider"
+        chmod 755 /var/lib/kubelet/credential-provider/acr-credential-provider
+        curl --retry 10 --retry-delay 5 -w "response status code is %{http_code}" -Lo /var/lib/kubelet/credential-provider-config.yaml "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${IMAGE_TAG_ACR_CREDENTIAL_PROVIDER}/credential-provider-config.yaml"
+        chmod 644 /var/lib/kubelet/credential-provider-config.yaml
+      fi
+    owner: root:root
+    path: /tmp/oot-cred-provider.sh
+    permissions: "0744"
+  - content: |
+      #!/bin/bash
+
+      set -o nounset
+      set -o pipefail
+      set -o errexit
+      [[ $(id -u) != 0 ]] && SUDO="sudo" || SUDO=""
+
+      # This test installs release packages or binaries that are a result of the CI and release builds.
+      # It runs '... --version' commands to verify that the binaries are correctly installed
+      # and finally uninstalls the packages.
+      # For the release packages it tests all versions in the support skew.
+      LINE_SEPARATOR="*************************************************"
+      echo "$$LINE_SEPARATOR"
+      CI_VERSION=${CI_VERSION}
+      if [[ "$${CI_VERSION}" != "" ]]; then
+        CI_DIR=/tmp/k8s-ci
+        mkdir -p $$CI_DIR
+        declare -a PACKAGES_TO_TEST=("kubectl" "kubelet" "kubeadm")
+        declare -a CONTAINERS_TO_TEST=("kube-apiserver" "kube-controller-manager" "kube-proxy" "kube-scheduler")
+        CONTAINER_EXT="tar"
+        echo "* testing CI version $$CI_VERSION"
+        # Check for semver
+        if [[ "$${CI_VERSION}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          VERSION_WITHOUT_PREFIX="${CI_VERSION#v}"
+          DEBIAN_FRONTEND=noninteractive apt-get install -y apt-transport-https curl
+          curl -fsSL https://pkgs.k8s.io/core:/stable:/${KUBERNETES_VERSION}/deb/Release.key | gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+          echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/${KUBERNETES_VERSION}/deb/ /" | tee /etc/apt/sources.list.d/kubernetes.list
+          apt-get update
+          # replace . with \.
+          VERSION_REGEX="${VERSION_WITHOUT_PREFIX//./\\.}"
+          PACKAGE_VERSION="$(apt-cache madison kubelet|grep $${VERSION_REGEX}- | head -n1 | cut -d '|' -f 2 | tr -d '[:space:]')"
+          for CI_PACKAGE in "$${PACKAGES_TO_TEST[@]}"; do
+            echo "* installing package: $$CI_PACKAGE $${PACKAGE_VERSION}"
+            DEBIAN_FRONTEND=noninteractive apt-get install -y $$CI_PACKAGE=$$PACKAGE_VERSION
+          done
+        else
+          CI_URL="https://storage.googleapis.com/k8s-release-dev/ci/$${CI_VERSION}/bin/linux/amd64"
           fi
-        owner: root:root
-        path: /tmp/oot-cred-provider.sh
-        permissions: "0744"
-      - content: |
-          #!/bin/bash
-
-          set -o nounset
-          set -o pipefail
-          set -o errexit
-          [[ $(id -u) != 0 ]] && SUDO="sudo" || SUDO=""
-
-          # This test installs release packages or binaries that are a result of the CI and release builds.
-          # It runs '... --version' commands to verify that the binaries are correctly installed
-          # and finally uninstalls the packages.
-          # For the release packages it tests all versions in the support skew.
-          LINE_SEPARATOR="*************************************************"
-          echo "$$LINE_SEPARATOR"
-          CI_VERSION=${CI_VERSION}
-          if [[ "$${CI_VERSION}" != "" ]]; then
-            CI_DIR=/tmp/k8s-ci
-            mkdir -p $$CI_DIR
-            declare -a PACKAGES_TO_TEST=("kubectl" "kubelet" "kubeadm")
-            declare -a CONTAINERS_TO_TEST=("kube-apiserver" "kube-controller-manager" "kube-proxy" "kube-scheduler")
-            CONTAINER_EXT="tar"
-            echo "* testing CI version $$CI_VERSION"
-            # Check for semver
-            if [[ "$${CI_VERSION}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-              VERSION_WITHOUT_PREFIX="${CI_VERSION#v}"
-              DEBIAN_FRONTEND=noninteractive apt-get install -y apt-transport-https curl
-              curl -fsSL https://pkgs.k8s.io/core:/stable:/${KUBERNETES_VERSION}/deb/Release.key | gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
-              echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/${KUBERNETES_VERSION}/deb/ /" | tee /etc/apt/sources.list.d/kubernetes.list
-              apt-get update
-              # replace . with \.
-              VERSION_REGEX="${VERSION_WITHOUT_PREFIX//./\\.}"
-              PACKAGE_VERSION="$(apt-cache madison kubelet|grep $${VERSION_REGEX}- | head -n1 | cut -d '|' -f 2 | tr -d '[:space:]')"
-              for CI_PACKAGE in "$${PACKAGES_TO_TEST[@]}"; do
-                echo "* installing package: $$CI_PACKAGE $${PACKAGE_VERSION}"
-                DEBIAN_FRONTEND=noninteractive apt-get install -y $$CI_PACKAGE=$$PACKAGE_VERSION
-              done
-            else
-              CI_URL="https://storage.googleapis.com/k8s-release-dev/ci/$${CI_VERSION}/bin/linux/amd64"
-              for CI_PACKAGE in "$${PACKAGES_TO_TEST[@]}"; do
-                echo "* downloading binary: $$CI_URL/$$CI_PACKAGE"
-                wget --inet4-only "$$CI_URL/$$CI_PACKAGE" -nv -O "$$CI_DIR/$$CI_PACKAGE"
-                chmod +x "$$CI_DIR/$$CI_PACKAGE"
-                mv "$$CI_DIR/$$CI_PACKAGE" "/usr/bin/$$CI_PACKAGE"
-              done
-              IMAGE_REGISTRY_PREFIX=registry.k8s.io
-              for CI_CONTAINER in "$${CONTAINERS_TO_TEST[@]}"; do
-                echo "* downloading package: $$CI_URL/$$CI_CONTAINER.$$CONTAINER_EXT"
-                wget --inet4-only "$$CI_URL/$$CI_CONTAINER.$$CONTAINER_EXT" -nv -O "$$CI_DIR/$$CI_CONTAINER.$$CONTAINER_EXT"
-                $${SUDO} ctr -n k8s.io images import "$$CI_DIR/$$CI_CONTAINER.$$CONTAINER_EXT" || echo "* ignoring expected 'ctr images import' result"
-                $${SUDO} ctr -n k8s.io images tag $$IMAGE_REGISTRY_PREFIX/$$CI_CONTAINER-amd64:"$${CI_VERSION//+/_}" $$IMAGE_REGISTRY_PREFIX/$$CI_CONTAINER:"$${CI_VERSION//+/_}"
-                $${SUDO} ctr -n k8s.io images tag $$IMAGE_REGISTRY_PREFIX/$$CI_CONTAINER-amd64:"$${CI_VERSION//+/_}" gcr.io/k8s-staging-ci-images/$$CI_CONTAINER:"$${CI_VERSION//+/_}"
-              done
-            fi
-            systemctl restart kubelet
-          fi
-          echo "* checking binary versions"
-          echo "ctr version: " $(ctr version)
-          echo "kubeadm version: " $(kubeadm version -o=short)
-          echo "kubectl version: " $(kubectl version --client=true)
-          echo "kubelet version: " $(kubelet --version)
-          echo "$$LINE_SEPARATOR"
-        owner: root:root
-        path: /tmp/kubeadm-bootstrap.sh
-        permissions: "0744"
-      - content: |
-          #!/bin/bash
-
-          echo "enabling containerd CDI plugin"
-          sed -i '/\[plugins."io.containerd.grpc.v1.cri"\]/a\    enable_cdi = true' /etc/containerd/config.toml
-          systemctl restart containerd
-        owner: root:root
-        path: /tmp/containerd-config.sh
-        permissions: "0744"
-      joinConfiguration:
-        nodeRegistration:
-          kubeletExtraArgs:
-            cloud-provider: external
-            feature-gates: ${NODE_FEATURE_GATES:-"DynamicResourceAllocation=true"}
-            image-credential-provider-bin-dir: /var/lib/kubelet/credential-provider
-            image-credential-provider-config: /var/lib/kubelet/credential-provider-config.yaml
-          name: '{{ ds.meta_data["local_hostname"] }}'
-      preKubeadmCommands:
-      - bash -c /tmp/containerd-config.sh
-      - bash -c /tmp/oot-cred-provider.sh
-      - bash -c /tmp/kubeadm-bootstrap.sh
-      verbosity: 5
----
-apiVersion: cluster.x-k8s.io/v1beta1
-kind: MachineHealthCheck
-metadata:
-  name: ${CLUSTER_NAME}-mhc-0
-  namespace: default
-spec:
-  clusterName: ${CLUSTER_NAME}
-  maxUnhealthy: 100%
-  selector:
-    matchLabels:
-      nodepool: pool1
-  unhealthyConditions:
-  - status: "True"
-    timeout: 30s
-    type: E2ENodeUnhealthy
+          for CI_PACKAGE in "$${PACKAGES_TO_TEST[@]}"; do
+            echo "* downloading binary: $$CI_URL/$$CI_PACKAGE"
+            wget --inet4-only "$$CI_URL/$$CI_PACKAGE" -nv -O "$$CI_DIR/$$CI_PACKAGE"
+            chmod +x "$$CI_DIR/$$CI_PACKAGE"
+            mv "$$CI_DIR/$$CI_PACKAGE" "/usr/bin/$$CI_PACKAGE"
+          done
+          IMAGE_REGISTRY_PREFIX=registry.k8s.io
+          for CI_CONTAINER in "$${CONTAINERS_TO_TEST[@]}"; do
+            echo "* downloading package: $$CI_URL/$$CI_CONTAINER.$$CONTAINER_EXT"
+            wget --inet4-only "$$CI_URL/$$CI_CONTAINER.$$CONTAINER_EXT" -nv -O "$$CI_DIR/$$CI_CONTAINER.$$CONTAINER_EXT"
+            $${SUDO} ctr -n k8s.io images import "$$CI_DIR/$$CI_CONTAINER.$$CONTAINER_EXT" || echo "* ignoring expected 'ctr images import' result"
+            $${SUDO} ctr -n k8s.io images tag $$IMAGE_REGISTRY_PREFIX/$$CI_CONTAINER-amd64:"$${CI_VERSION//+/_}" $$IMAGE_REGISTRY_PREFIX/$$CI_CONTAINER:"$${CI_VERSION//+/_}"
+            $${SUDO} ctr -n k8s.io images tag $$IMAGE_REGISTRY_PREFIX/$$CI_CONTAINER-amd64:"$${CI_VERSION//+/_}" gcr.io/k8s-staging-ci-images/$$CI_CONTAINER:"$${CI_VERSION//+/_}"
+          done
+        fi
+        systemctl restart kubelet
+      fi
+      echo "* checking binary versions"
+      echo "ctr version: " $(ctr version)
+      echo "kubeadm version: " $(kubeadm version -o=short)
+      echo "kubectl version: " $(kubectl version --client=true)
+      echo "kubelet version: " $(kubelet --version)
+      echo "$$LINE_SEPARATOR"
+    owner: root:root
+    path: /tmp/kubeadm-bootstrap.sh
+    permissions: "0744"
+  - contentFrom:
+      secret:
+        key: worker-node-azure.json
+        name: ${CLUSTER_NAME}-mp-0-azure-json
+    owner: root:root
+    path: /etc/kubernetes/azure.json
+    permissions: "0644"
+  joinConfiguration:
+    nodeRegistration:
+      kubeletExtraArgs:
+        cloud-provider: external
+        image-credential-provider-bin-dir: /var/lib/kubelet/credential-provider
+        image-credential-provider-config: /var/lib/kubelet/credential-provider-config.yaml
+      name: '{{ ds.meta_data["local_hostname"] }}'
+  preKubeadmCommands:
+  - bash -c /tmp/oot-cred-provider.sh
+  - bash -c /tmp/kubeadm-bootstrap.sh
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: AzureClusterIdentity
@@ -770,234 +745,4 @@ metadata:
   labels:
     type: generated
   name: containerd-logger-${CLUSTER_NAME}
-  namespace: default
----
-apiVersion: addons.cluster.x-k8s.io/v1beta1
-kind: ClusterResourceSet
-metadata:
-  name: metrics-server-${CLUSTER_NAME}
-  namespace: default
-spec:
-  clusterSelector:
-    matchLabels:
-      metrics-server: enabled
-  resources:
-  - kind: ConfigMap
-    name: metrics-server-${CLUSTER_NAME}
-  strategy: ApplyOnce
----
-apiVersion: v1
-data:
-  metrics-server: |
-    apiVersion: v1
-    kind: ServiceAccount
-    metadata:
-      labels:
-        k8s-app: metrics-server
-      name: metrics-server
-      namespace: kube-system
-    ---
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: ClusterRole
-    metadata:
-      labels:
-        k8s-app: metrics-server
-        rbac.authorization.k8s.io/aggregate-to-admin: "true"
-        rbac.authorization.k8s.io/aggregate-to-edit: "true"
-        rbac.authorization.k8s.io/aggregate-to-view: "true"
-      name: system:aggregated-metrics-reader
-    rules:
-    - apiGroups:
-      - metrics.k8s.io
-      resources:
-      - pods
-      - nodes
-      verbs:
-      - get
-      - list
-      - watch
-    ---
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: ClusterRole
-    metadata:
-      labels:
-        k8s-app: metrics-server
-      name: system:metrics-server
-    rules:
-    - apiGroups:
-      - ""
-      resources:
-      - nodes/metrics
-      verbs:
-      - get
-    - apiGroups:
-      - ""
-      resources:
-      - pods
-      - nodes
-      verbs:
-      - get
-      - list
-      - watch
-    ---
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: RoleBinding
-    metadata:
-      labels:
-        k8s-app: metrics-server
-      name: metrics-server-auth-reader
-      namespace: kube-system
-    roleRef:
-      apiGroup: rbac.authorization.k8s.io
-      kind: Role
-      name: extension-apiserver-authentication-reader
-    subjects:
-    - kind: ServiceAccount
-      name: metrics-server
-      namespace: kube-system
-    ---
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: ClusterRoleBinding
-    metadata:
-      labels:
-        k8s-app: metrics-server
-      name: metrics-server:system:auth-delegator
-    roleRef:
-      apiGroup: rbac.authorization.k8s.io
-      kind: ClusterRole
-      name: system:auth-delegator
-    subjects:
-    - kind: ServiceAccount
-      name: metrics-server
-      namespace: kube-system
-    ---
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: ClusterRoleBinding
-    metadata:
-      labels:
-        k8s-app: metrics-server
-      name: system:metrics-server
-    roleRef:
-      apiGroup: rbac.authorization.k8s.io
-      kind: ClusterRole
-      name: system:metrics-server
-    subjects:
-    - kind: ServiceAccount
-      name: metrics-server
-      namespace: kube-system
-    ---
-    apiVersion: v1
-    kind: Service
-    metadata:
-      labels:
-        k8s-app: metrics-server
-      name: metrics-server
-      namespace: kube-system
-    spec:
-      ports:
-      - name: https
-        port: 443
-        protocol: TCP
-        targetPort: https
-      selector:
-        k8s-app: metrics-server
-    ---
-    apiVersion: apps/v1
-    kind: Deployment
-    metadata:
-      labels:
-        k8s-app: metrics-server
-      name: metrics-server
-      namespace: kube-system
-    spec:
-      selector:
-        matchLabels:
-          k8s-app: metrics-server
-      strategy:
-        rollingUpdate:
-          maxUnavailable: 0
-      template:
-        metadata:
-          labels:
-            k8s-app: metrics-server
-        spec:
-          containers:
-          - args:
-            - --cert-dir=/tmp
-            - --secure-port=4443
-            - --kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname
-            - --kubelet-use-node-status-port
-            - --metric-resolution=15s
-            - --kubelet-insecure-tls
-            image: registry.k8s.io/metrics-server/metrics-server:v0.6.3
-            imagePullPolicy: IfNotPresent
-            livenessProbe:
-              failureThreshold: 3
-              httpGet:
-                path: /livez
-                port: https
-                scheme: HTTPS
-              periodSeconds: 10
-            name: metrics-server
-            ports:
-            - containerPort: 4443
-              name: https
-              protocol: TCP
-            readinessProbe:
-              failureThreshold: 3
-              httpGet:
-                path: /readyz
-                port: https
-                scheme: HTTPS
-              initialDelaySeconds: 20
-              periodSeconds: 10
-            resources:
-              requests:
-                cpu: 100m
-                memory: 200Mi
-            securityContext:
-              allowPrivilegeEscalation: false
-              readOnlyRootFilesystem: true
-              runAsNonRoot: true
-              runAsUser: 1000
-            volumeMounts:
-            - mountPath: /tmp
-              name: tmp-dir
-          nodeSelector:
-            kubernetes.io/os: linux
-          priorityClassName: system-cluster-critical
-          serviceAccountName: metrics-server
-          tolerations:
-          - effect: NoSchedule
-            key: node-role.kubernetes.io/master
-            operator: Exists
-          - effect: NoSchedule
-            key: node-role.kubernetes.io/control-plane
-            operator: Exists
-          volumes:
-          - emptyDir: {}
-            name: tmp-dir
-    ---
-    apiVersion: apiregistration.k8s.io/v1
-    kind: APIService
-    metadata:
-      labels:
-        k8s-app: metrics-server
-      name: v1beta1.metrics.k8s.io
-    spec:
-      group: metrics.k8s.io
-      groupPriorityMinimum: 100
-      insecureSkipTLSVerify: true
-      service:
-        name: metrics-server
-        namespace: kube-system
-      version: v1beta1
-      versionPriority: 100
-kind: ConfigMap
-metadata:
-  annotations:
-    note: generated
-  labels:
-    type: generated
-  name: metrics-server-${CLUSTER_NAME}
   namespace: default

--- a/templates/test/ci/prow-ci-version-dra/kustomization.yaml
+++ b/templates/test/ci/prow-ci-version-dra/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: default
 resources:
-- ../prow-ci-version
+- ../prow-machine-pool-ci-version
 patches:
 - path: ../patches/no-windows.yaml
   target:

--- a/templates/test/dev/cluster-template-custom-builds-dra.yaml
+++ b/templates/test/dev/cluster-template-custom-builds-dra.yaml
@@ -7,7 +7,7 @@ metadata:
     cni-windows: ${CLUSTER_NAME}-calico
     containerd-logger: enabled
     csi-proxy: enabled
-    metrics-server: enabled
+    windows: enabled
   name: ${CLUSTER_NAME}
   namespace: default
 spec:
@@ -100,41 +100,6 @@ spec:
         overwrite: false
         tableType: gpt
     files:
-    - contentFrom:
-        secret:
-          key: control-plane-azure.json
-          name: ${CLUSTER_NAME}-control-plane-azure-json
-      owner: root:root
-      path: /etc/kubernetes/azure.json
-      permissions: "0644"
-    - content: |
-        #!/bin/bash
-
-        set -o nounset
-        set -o pipefail
-        set -o errexit
-        [[ $(id -u) != 0 ]] && SUDO="sudo" || SUDO=""
-
-        # Run the az login command with managed identity
-        if az login --identity > /dev/null 2>&1; then
-          echo "Logged in Azure with managed identity"
-          echo "Use OOT credential provider"
-          mkdir -p /var/lib/kubelet/credential-provider
-          az storage blob download --blob-url "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${IMAGE_TAG_ACR_CREDENTIAL_PROVIDER}/azure-acr-credential-provider" -f /var/lib/kubelet/credential-provider/acr-credential-provider --auth-mode login
-          chmod 755 /var/lib/kubelet/credential-provider/acr-credential-provider
-          az storage blob download --blob-url "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${IMAGE_TAG_ACR_CREDENTIAL_PROVIDER}/credential-provider-config.yaml" -f /var/lib/kubelet/credential-provider-config.yaml --auth-mode login
-          chmod 644 /var/lib/kubelet/credential-provider-config.yaml
-        else
-          echo "Using curl to download the OOT credential provider"
-          mkdir -p /var/lib/kubelet/credential-provider
-          curl --retry 10 --retry-delay 5 -w "response status code is %{http_code}" -Lo /var/lib/kubelet/credential-provider/acr-credential-provider "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${IMAGE_TAG_ACR_CREDENTIAL_PROVIDER}/azure-acr-credential-provider"
-          chmod 755 /var/lib/kubelet/credential-provider/acr-credential-provider
-          curl --retry 10 --retry-delay 5 -w "response status code is %{http_code}" -Lo /var/lib/kubelet/credential-provider-config.yaml "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${IMAGE_TAG_ACR_CREDENTIAL_PROVIDER}/credential-provider-config.yaml"
-          chmod 644 /var/lib/kubelet/credential-provider-config.yaml
-        fi
-      owner: root:root
-      path: /tmp/oot-cred-provider.sh
-      permissions: "0744"
     - content: |
         #!/bin/bash
 
@@ -143,12 +108,23 @@ spec:
         set -o errexit
 
         systemctl stop kubelet
+
         declare -a BINARIES=("kubeadm" "kubectl" "kubelet")
-        az login --identity
-        for BINARY in "$${BINARIES[@]}"; do
-          echo "* installing package: $${BINARY} ${KUBE_GIT_VERSION}"
-          az storage blob download --blob-url "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${BINARY}" -f "/usr/bin/$${BINARY}" --auth-mode login
-        done
+
+        # Run the az login command with managed identity
+        if az login --identity > /dev/null 2>&1; then
+          echo "Logged in Azure with managed identity"
+          for BINARY in "$${BINARIES[@]}"; do
+            echo "* installing package: $${BINARY} ${KUBE_GIT_VERSION}"
+            az storage blob download --blob-url "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${BINARY}" -f "/usr/bin/$${BINARY}" --auth-mode login
+          done
+        else
+          echo "Using curl to download the binaries"
+          for BINARY in "$${BINARIES[@]}"; do
+            echo "* installing package: $${BINARY} ${KUBE_GIT_VERSION}"
+            curl --retry 10 --retry-delay 5 -w "response status code is %{http_code}" "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${BINARY}" --output "/usr/bin/$${BINARY}"
+          done
+        fi
         systemctl restart kubelet
 
         # prepull images from gcr.io/k8s-staging-ci-images and retag it to
@@ -188,6 +164,41 @@ spec:
       owner: root:root
       path: /tmp/replace-k8s-components.sh
       permissions: "0744"
+    - contentFrom:
+        secret:
+          key: control-plane-azure.json
+          name: ${CLUSTER_NAME}-control-plane-azure-json
+      owner: root:root
+      path: /etc/kubernetes/azure.json
+      permissions: "0644"
+    - content: |
+        #!/bin/bash
+
+        set -o nounset
+        set -o pipefail
+        set -o errexit
+        [[ $(id -u) != 0 ]] && SUDO="sudo" || SUDO=""
+
+        # Run the az login command with managed identity
+        if az login --identity > /dev/null 2>&1; then
+          echo "Logged in Azure with managed identity"
+          echo "Use OOT credential provider"
+          mkdir -p /var/lib/kubelet/credential-provider
+          az storage blob download --blob-url "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${IMAGE_TAG_ACR_CREDENTIAL_PROVIDER}/azure-acr-credential-provider" -f /var/lib/kubelet/credential-provider/acr-credential-provider --auth-mode login
+          chmod 755 /var/lib/kubelet/credential-provider/acr-credential-provider
+          az storage blob download --blob-url "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${IMAGE_TAG_ACR_CREDENTIAL_PROVIDER}/credential-provider-config.yaml" -f /var/lib/kubelet/credential-provider-config.yaml --auth-mode login
+          chmod 644 /var/lib/kubelet/credential-provider-config.yaml
+        else
+          echo "Using curl to download the OOT credential provider"
+          mkdir -p /var/lib/kubelet/credential-provider
+          curl --retry 10 --retry-delay 5 -w "response status code is %{http_code}" -Lo /var/lib/kubelet/credential-provider/acr-credential-provider "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${IMAGE_TAG_ACR_CREDENTIAL_PROVIDER}/azure-acr-credential-provider"
+          chmod 755 /var/lib/kubelet/credential-provider/acr-credential-provider
+          curl --retry 10 --retry-delay 5 -w "response status code is %{http_code}" -Lo /var/lib/kubelet/credential-provider-config.yaml "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${IMAGE_TAG_ACR_CREDENTIAL_PROVIDER}/credential-provider-config.yaml"
+          chmod 644 /var/lib/kubelet/credential-provider-config.yaml
+        fi
+      owner: root:root
+      path: /tmp/oot-cred-provider.sh
+      permissions: "0744"
     - content: |
         #!/bin/bash
 
@@ -220,8 +231,8 @@ spec:
     - bash -c /tmp/replace-k8s-components.sh
     preKubeadmCommands:
     - bash -c /tmp/containerd-config.sh
-    - bash -c /tmp/oot-cred-provider.sh
     - bash -c /tmp/replace-k8s-binaries.sh
+    - bash -c /tmp/oot-cred-provider.sh
     verbosity: 5
   machineTemplate:
     infrastructureRef:
@@ -255,170 +266,141 @@ spec:
         osType: Linux
       sshPublicKey: ${AZURE_SSH_PUBLIC_KEY_B64:=""}
       userAssignedIdentities:
-      - providerID: /subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${CI_RG}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER_IDENTITY}
+      - providerID: /subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${CI_RG:=capz-ci}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER_IDENTITY:=cloud-provider-user-identity}
       vmSize: ${AZURE_CONTROL_PLANE_MACHINE_TYPE}
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
-kind: MachineDeployment
+kind: MachinePool
 metadata:
-  name: ${CLUSTER_NAME}-md-0
+  name: ${CLUSTER_NAME}-mp-0
   namespace: default
 spec:
   clusterName: ${CLUSTER_NAME}
   replicas: ${WORKER_MACHINE_COUNT:=2}
-  selector: {}
   template:
-    metadata:
-      labels:
-        nodepool: pool1
     spec:
       bootstrap:
         configRef:
           apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
-          kind: KubeadmConfigTemplate
-          name: ${CLUSTER_NAME}-md-0
+          kind: KubeadmConfig
+          name: ${CLUSTER_NAME}-mp-0
       clusterName: ${CLUSTER_NAME}
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-        kind: AzureMachineTemplate
-        name: ${CLUSTER_NAME}-md-0
+        kind: AzureMachinePool
+        name: ${CLUSTER_NAME}-mp-0
       version: ${KUBERNETES_VERSION}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-kind: AzureMachineTemplate
+kind: AzureMachinePool
 metadata:
-  name: ${CLUSTER_NAME}-md-0
+  name: ${CLUSTER_NAME}-mp-0
   namespace: default
 spec:
+  location: ${AZURE_LOCATION}
+  strategy:
+    rollingUpdate:
+      deletePolicy: Oldest
+      maxSurge: 25%
+      maxUnavailable: 1
+    type: RollingUpdate
   template:
-    spec:
-      identity: UserAssigned
-      image:
-        marketplace:
-          offer: capi
-          publisher: cncf-upstream
-          sku: ubuntu-2204-gen1
-          version: latest
-      osDisk:
-        diskSizeGB: 128
-        osType: Linux
-      sshPublicKey: ${AZURE_SSH_PUBLIC_KEY_B64:=""}
-      userAssignedIdentities:
-      - providerID: /subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${CI_RG}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER_IDENTITY}
-      vmExtensions:
-      - name: CustomScript
-        protectedSettings:
-          commandToExecute: |
-            #!/bin/sh
-            echo "This script is a no-op used for extension testing purposes ..."
-            touch test_file
-        publisher: Microsoft.Azure.Extensions
-        version: "2.1"
-      vmSize: ${AZURE_NODE_MACHINE_TYPE}
+    image:
+      marketplace:
+        offer: capi
+        publisher: cncf-upstream
+        sku: ubuntu-2204-gen1
+        version: latest
+    osDisk:
+      diskSizeGB: 30
+      managedDisk:
+        storageAccountType: Premium_LRS
+      osType: Linux
+    sshPublicKey: ${AZURE_SSH_PUBLIC_KEY_B64:=""}
+    vmExtensions:
+    - name: CustomScript
+      protectedSettings:
+        commandToExecute: |
+          #!/bin/sh
+          echo "This script is a no-op used for extension testing purposes ..."
+          touch test_file
+      publisher: Microsoft.Azure.Extensions
+      version: "2.1"
+    vmSize: ${AZURE_NODE_MACHINE_TYPE}
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
-kind: KubeadmConfigTemplate
+kind: KubeadmConfig
 metadata:
-  name: ${CLUSTER_NAME}-md-0
+  name: ${CLUSTER_NAME}-mp-0
   namespace: default
 spec:
-  template:
-    spec:
-      files:
-      - contentFrom:
-          secret:
-            key: worker-node-azure.json
-            name: ${CLUSTER_NAME}-md-0-azure-json
-        owner: root:root
-        path: /etc/kubernetes/azure.json
-        permissions: "0644"
-      - content: |
-          #!/bin/bash
+  files:
+  - content: |
+      #!/bin/bash
 
-          set -o nounset
-          set -o pipefail
-          set -o errexit
-          [[ $(id -u) != 0 ]] && SUDO="sudo" || SUDO=""
+      set -o nounset
+      set -o pipefail
+      set -o errexit
+      [[ $(id -u) != 0 ]] && SUDO="sudo" || SUDO=""
 
-          # Run the az login command with managed identity
-          if az login --identity > /dev/null 2>&1; then
-            echo "Logged in Azure with managed identity"
-            echo "Use OOT credential provider"
-            mkdir -p /var/lib/kubelet/credential-provider
-            az storage blob download --blob-url "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${IMAGE_TAG_ACR_CREDENTIAL_PROVIDER}/azure-acr-credential-provider" -f /var/lib/kubelet/credential-provider/acr-credential-provider --auth-mode login
-            chmod 755 /var/lib/kubelet/credential-provider/acr-credential-provider
-            az storage blob download --blob-url "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${IMAGE_TAG_ACR_CREDENTIAL_PROVIDER}/credential-provider-config.yaml" -f /var/lib/kubelet/credential-provider-config.yaml --auth-mode login
-            chmod 644 /var/lib/kubelet/credential-provider-config.yaml
-          else
-            echo "Use OOT credential provider"
-            mkdir -p /var/lib/kubelet/credential-provider
-            curl --retry 10 --retry-delay 5 -w "response status code is %{http_code}" -Lo /var/lib/kubelet/credential-provider/acr-credential-provider "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${IMAGE_TAG_ACR_CREDENTIAL_PROVIDER}/azure-acr-credential-provider"
-            chmod 755 /var/lib/kubelet/credential-provider/acr-credential-provider
-            curl --retry 10 --retry-delay 5 -w "response status code is %{http_code}" -Lo /var/lib/kubelet/credential-provider-config.yaml "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${IMAGE_TAG_ACR_CREDENTIAL_PROVIDER}/credential-provider-config.yaml"
-            chmod 644 /var/lib/kubelet/credential-provider-config.yaml
-          fi
-        owner: root:root
-        path: /tmp/oot-cred-provider.sh
-        permissions: "0744"
-      - content: |
-          #!/bin/bash
+      # Run the az login command with managed identity
+      if az login --identity > /dev/null 2>&1; then
+        echo "Logged in Azure with managed identity"
+        echo "Use OOT credential provider"
+        mkdir -p /var/lib/kubelet/credential-provider
+        az storage blob download --blob-url "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${IMAGE_TAG_ACR_CREDENTIAL_PROVIDER}/azure-acr-credential-provider" -f /var/lib/kubelet/credential-provider/acr-credential-provider --auth-mode login
+        chmod 755 /var/lib/kubelet/credential-provider/acr-credential-provider
+        az storage blob download --blob-url "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${IMAGE_TAG_ACR_CREDENTIAL_PROVIDER}/credential-provider-config.yaml" -f /var/lib/kubelet/credential-provider-config.yaml --auth-mode login
+        chmod 644 /var/lib/kubelet/credential-provider-config.yaml
+      else
+        echo "Using curl to download the OOT credential provider"
+        mkdir -p /var/lib/kubelet/credential-provider
+        curl --retry 10 --retry-delay 5 -w "response status code is %{http_code}" -Lo /var/lib/kubelet/credential-provider/acr-credential-provider "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${IMAGE_TAG_ACR_CREDENTIAL_PROVIDER}/azure-acr-credential-provider"
+        chmod 755 /var/lib/kubelet/credential-provider/acr-credential-provider
+        curl --retry 10 --retry-delay 5 -w "response status code is %{http_code}" -Lo /var/lib/kubelet/credential-provider-config.yaml "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${IMAGE_TAG_ACR_CREDENTIAL_PROVIDER}/credential-provider-config.yaml"
+        chmod 644 /var/lib/kubelet/credential-provider-config.yaml
+      fi
+    owner: root:root
+    path: /tmp/oot-cred-provider.sh
+    permissions: "0744"
+  - content: |
+      #!/bin/bash
 
-          set -o nounset
-          set -o pipefail
-          set -o errexit
+      set -o nounset
+      set -o pipefail
+      set -o errexit
 
-          systemctl stop kubelet
-          declare -a BINARIES=("kubeadm" "kubectl" "kubelet")
-          az login --identity
-          for BINARY in "$${BINARIES[@]}"; do
-            echo "* installing package: $${BINARY} ${KUBE_GIT_VERSION}"
-            az storage blob download --blob-url "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${BINARY}" -f "/usr/bin/$${BINARY}" --auth-mode login
-          done
-          systemctl restart kubelet
+      systemctl stop kubelet
+      declare -a BINARIES=("kubeadm" "kubectl" "kubelet")
+      for BINARY in "$${BINARIES[@]}"; do
+        echo "* installing package: $${BINARY} ${KUBE_GIT_VERSION}"
+        curl --retry 10 --retry-delay 5 -w "response status code is %{http_code}" "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${BINARY}" --output "/usr/bin/$${BINARY}"
+      done
+      systemctl restart kubelet
 
-          echo "kubeadm version: $(kubeadm version -o=short)"
-          echo "kubectl version: $(kubectl version --client=true)"
-          echo "kubelet version: $(kubelet --version)"
-        owner: root:root
-        path: /tmp/replace-k8s-binaries.sh
-        permissions: "0744"
-      - content: |
-          #!/bin/bash
-
-          echo "enabling containerd CDI plugin"
-          sed -i '/\[plugins."io.containerd.grpc.v1.cri"\]/a\    enable_cdi = true' /etc/containerd/config.toml
-          systemctl restart containerd
-        owner: root:root
-        path: /tmp/containerd-config.sh
-        permissions: "0744"
-      joinConfiguration:
-        nodeRegistration:
-          kubeletExtraArgs:
-            cloud-provider: external
-            feature-gates: ${NODE_FEATURE_GATES:-"DynamicResourceAllocation=true"}
-            image-credential-provider-bin-dir: /var/lib/kubelet/credential-provider
-            image-credential-provider-config: /var/lib/kubelet/credential-provider-config.yaml
-          name: '{{ ds.meta_data["local_hostname"] }}'
-      preKubeadmCommands:
-      - bash -c /tmp/containerd-config.sh
-      - bash -c /tmp/oot-cred-provider.sh
-      - bash -c /tmp/replace-k8s-binaries.sh
----
-apiVersion: cluster.x-k8s.io/v1beta1
-kind: MachineHealthCheck
-metadata:
-  name: ${CLUSTER_NAME}-mhc-0
-  namespace: default
-spec:
-  clusterName: ${CLUSTER_NAME}
-  maxUnhealthy: 100%
-  selector:
-    matchLabels:
-      nodepool: pool1
-  unhealthyConditions:
-  - status: "True"
-    timeout: 30s
-    type: E2ENodeUnhealthy
+      echo "kubeadm version: $(kubeadm version -o=short)"
+      echo "kubectl version: $(kubectl version --client=true)"
+      echo "kubelet version: $(kubelet --version)"
+    owner: root:root
+    path: /tmp/replace-k8s-binaries.sh
+    permissions: "0744"
+  - contentFrom:
+      secret:
+        key: control-plane-azure.json
+        name: ${CLUSTER_NAME}-control-plane-azure-json
+    owner: root:root
+    path: /etc/kubernetes/azure.json
+    permissions: "0644"
+  joinConfiguration:
+    nodeRegistration:
+      kubeletExtraArgs:
+        cloud-provider: external
+        image-credential-provider-bin-dir: /var/lib/kubelet/credential-provider
+        image-credential-provider-config: /var/lib/kubelet/credential-provider-config.yaml
+      name: '{{ ds.meta_data["local_hostname"] }}'
+  preKubeadmCommands:
+  - bash -c /tmp/oot-cred-provider.sh
+  - bash -c /tmp/replace-k8s-binaries.sh
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: AzureClusterIdentity
@@ -719,234 +701,4 @@ metadata:
   labels:
     type: generated
   name: containerd-logger-${CLUSTER_NAME}
-  namespace: default
----
-apiVersion: addons.cluster.x-k8s.io/v1beta1
-kind: ClusterResourceSet
-metadata:
-  name: metrics-server-${CLUSTER_NAME}
-  namespace: default
-spec:
-  clusterSelector:
-    matchLabels:
-      metrics-server: enabled
-  resources:
-  - kind: ConfigMap
-    name: metrics-server-${CLUSTER_NAME}
-  strategy: ApplyOnce
----
-apiVersion: v1
-data:
-  metrics-server: |
-    apiVersion: v1
-    kind: ServiceAccount
-    metadata:
-      labels:
-        k8s-app: metrics-server
-      name: metrics-server
-      namespace: kube-system
-    ---
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: ClusterRole
-    metadata:
-      labels:
-        k8s-app: metrics-server
-        rbac.authorization.k8s.io/aggregate-to-admin: "true"
-        rbac.authorization.k8s.io/aggregate-to-edit: "true"
-        rbac.authorization.k8s.io/aggregate-to-view: "true"
-      name: system:aggregated-metrics-reader
-    rules:
-    - apiGroups:
-      - metrics.k8s.io
-      resources:
-      - pods
-      - nodes
-      verbs:
-      - get
-      - list
-      - watch
-    ---
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: ClusterRole
-    metadata:
-      labels:
-        k8s-app: metrics-server
-      name: system:metrics-server
-    rules:
-    - apiGroups:
-      - ""
-      resources:
-      - nodes/metrics
-      verbs:
-      - get
-    - apiGroups:
-      - ""
-      resources:
-      - pods
-      - nodes
-      verbs:
-      - get
-      - list
-      - watch
-    ---
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: RoleBinding
-    metadata:
-      labels:
-        k8s-app: metrics-server
-      name: metrics-server-auth-reader
-      namespace: kube-system
-    roleRef:
-      apiGroup: rbac.authorization.k8s.io
-      kind: Role
-      name: extension-apiserver-authentication-reader
-    subjects:
-    - kind: ServiceAccount
-      name: metrics-server
-      namespace: kube-system
-    ---
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: ClusterRoleBinding
-    metadata:
-      labels:
-        k8s-app: metrics-server
-      name: metrics-server:system:auth-delegator
-    roleRef:
-      apiGroup: rbac.authorization.k8s.io
-      kind: ClusterRole
-      name: system:auth-delegator
-    subjects:
-    - kind: ServiceAccount
-      name: metrics-server
-      namespace: kube-system
-    ---
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: ClusterRoleBinding
-    metadata:
-      labels:
-        k8s-app: metrics-server
-      name: system:metrics-server
-    roleRef:
-      apiGroup: rbac.authorization.k8s.io
-      kind: ClusterRole
-      name: system:metrics-server
-    subjects:
-    - kind: ServiceAccount
-      name: metrics-server
-      namespace: kube-system
-    ---
-    apiVersion: v1
-    kind: Service
-    metadata:
-      labels:
-        k8s-app: metrics-server
-      name: metrics-server
-      namespace: kube-system
-    spec:
-      ports:
-      - name: https
-        port: 443
-        protocol: TCP
-        targetPort: https
-      selector:
-        k8s-app: metrics-server
-    ---
-    apiVersion: apps/v1
-    kind: Deployment
-    metadata:
-      labels:
-        k8s-app: metrics-server
-      name: metrics-server
-      namespace: kube-system
-    spec:
-      selector:
-        matchLabels:
-          k8s-app: metrics-server
-      strategy:
-        rollingUpdate:
-          maxUnavailable: 0
-      template:
-        metadata:
-          labels:
-            k8s-app: metrics-server
-        spec:
-          containers:
-          - args:
-            - --cert-dir=/tmp
-            - --secure-port=4443
-            - --kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname
-            - --kubelet-use-node-status-port
-            - --metric-resolution=15s
-            - --kubelet-insecure-tls
-            image: registry.k8s.io/metrics-server/metrics-server:v0.6.3
-            imagePullPolicy: IfNotPresent
-            livenessProbe:
-              failureThreshold: 3
-              httpGet:
-                path: /livez
-                port: https
-                scheme: HTTPS
-              periodSeconds: 10
-            name: metrics-server
-            ports:
-            - containerPort: 4443
-              name: https
-              protocol: TCP
-            readinessProbe:
-              failureThreshold: 3
-              httpGet:
-                path: /readyz
-                port: https
-                scheme: HTTPS
-              initialDelaySeconds: 20
-              periodSeconds: 10
-            resources:
-              requests:
-                cpu: 100m
-                memory: 200Mi
-            securityContext:
-              allowPrivilegeEscalation: false
-              readOnlyRootFilesystem: true
-              runAsNonRoot: true
-              runAsUser: 1000
-            volumeMounts:
-            - mountPath: /tmp
-              name: tmp-dir
-          nodeSelector:
-            kubernetes.io/os: linux
-          priorityClassName: system-cluster-critical
-          serviceAccountName: metrics-server
-          tolerations:
-          - effect: NoSchedule
-            key: node-role.kubernetes.io/master
-            operator: Exists
-          - effect: NoSchedule
-            key: node-role.kubernetes.io/control-plane
-            operator: Exists
-          volumes:
-          - emptyDir: {}
-            name: tmp-dir
-    ---
-    apiVersion: apiregistration.k8s.io/v1
-    kind: APIService
-    metadata:
-      labels:
-        k8s-app: metrics-server
-      name: v1beta1.metrics.k8s.io
-    spec:
-      group: metrics.k8s.io
-      groupPriorityMinimum: 100
-      insecureSkipTLSVerify: true
-      service:
-        name: metrics-server
-        namespace: kube-system
-      version: v1beta1
-      versionPriority: 100
-kind: ConfigMap
-metadata:
-  annotations:
-    note: generated
-  labels:
-    type: generated
-  name: metrics-server-${CLUSTER_NAME}
   namespace: default

--- a/templates/test/dev/custom-builds-dra/kustomization.yaml
+++ b/templates/test/dev/custom-builds-dra/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: default
 resources:
-- ../custom-builds
+- ../custom-builds-machine-pool
 patches:
 - path: ../../ci/patches/no-windows.yaml
   target:


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind cleanup

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

This change updates the templates used to run DRA tests to use MachinePools instead of MachineDeployments since we're more interested in exercising VMSS with DRA.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
