### PR TITLE
check for google project silently

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,10 +147,11 @@ SETUP_ENVTEST_PKG := sigs.k8s.io/controller-runtime/tools/setup-envtest
 KUBEBUILDER_ASSETS ?= $(shell $(SETUP_ENVTEST) use --use-env -p path $(KUBEBUILDER_ENVTEST_KUBERNETES_VERSION))
 
 # Define Docker related variables. Releases should modify and double check these vars.
-ifneq (,$(shell command -v gcloud))
-	ifneq (,$(shell gcloud config get-value project))
-		REGISTRY ?= gcr.io/$(shell gcloud config get-value project)
-	endif
+ifneq ($(shell command -v gcloud),)
+    GCLOUD_PROJECT := $(shell gcloud config get-value project 2>/dev/null)
+    ifneq ($(GCLOUD_PROJECT),)
+        REGISTRY ?= gcr.io/$(GCLOUD_PROJECT)
+    endif
 endif
 
 # If REGISTRY is not set, default to localhost:5000 to use the kind registry.


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind cleanup

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

I see `(unset)` being added before the execution of every make target. 
For example:
```bash
❯ make clean
(unset)              <------
/Library/Developer/CommandLineTools/usr/bin/make clean-bin
(unset)              <------
rm -rf bin
rm -rf hack/tools/bin
/Library/Developer/CommandLineTools/usr/bin/make clean-temporary
(unset)              <------
rm -f minikube.kubeconfig
rm -f kubeconfig
rm -f *.kubeconfig
```

Unless it is intended, adding `2>/dev/null` to the `shell gcloud config get-value project` suppresses the error if `gcloud` cannot find the project.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Related to https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/5218#issuecomment-2445948675

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
