### PR TITLE
fix KubeadmConfig patches for DRA templates

### DIFF
--- a/templates/test/ci/cluster-template-prow-ci-version-dra.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version-dra.yaml
@@ -435,14 +435,25 @@ spec:
     owner: root:root
     path: /etc/kubernetes/azure.json
     permissions: "0644"
+  - content: |
+      #!/bin/bash
+
+      echo "enabling containerd CDI plugin"
+      sed -i '/\[plugins."io.containerd.grpc.v1.cri"\]/a\    enable_cdi = true' /etc/containerd/config.toml
+      systemctl restart containerd
+    owner: root:root
+    path: /tmp/containerd-config.sh
+    permissions: "0744"
   joinConfiguration:
     nodeRegistration:
       kubeletExtraArgs:
         cloud-provider: external
+        feature-gates: ${NODE_FEATURE_GATES:-"DynamicResourceAllocation=true"}
         image-credential-provider-bin-dir: /var/lib/kubelet/credential-provider
         image-credential-provider-config: /var/lib/kubelet/credential-provider-config.yaml
       name: '{{ ds.meta_data["local_hostname"] }}'
   preKubeadmCommands:
+  - bash -c /tmp/containerd-config.sh
   - bash -c /tmp/oot-cred-provider.sh
   - bash -c /tmp/kubeadm-bootstrap.sh
 ---

--- a/templates/test/ci/patches/dra-kubeadmconfig.yaml
+++ b/templates/test/ci/patches/dra-kubeadmconfig.yaml
@@ -1,5 +1,5 @@
 - op: add
-  path: /spec/template/spec/files/-
+  path: /spec/files/-
   value:
     content: |
       #!/bin/bash
@@ -11,8 +11,8 @@
     path: /tmp/containerd-config.sh
     permissions: "0744"
 - op: add
-  path: /spec/template/spec/preKubeadmCommands/0
+  path: /spec/preKubeadmCommands/0
   value: bash -c /tmp/containerd-config.sh
 - op: add
-  path: /spec/template/spec/joinConfiguration/nodeRegistration/kubeletExtraArgs/feature-gates
+  path: /spec/joinConfiguration/nodeRegistration/kubeletExtraArgs/feature-gates
   value: ${NODE_FEATURE_GATES:-"DynamicResourceAllocation=true"}

--- a/templates/test/ci/prow-ci-version-dra/kustomization.yaml
+++ b/templates/test/ci/prow-ci-version-dra/kustomization.yaml
@@ -10,9 +10,9 @@ patches:
 - path: ../patches/dra-kubeadmcontrolplane.yaml
   target:
     kind: KubeadmControlPlane
-- path: ../patches/dra-kubeadmconfigtemplate.yaml
+- path: ../patches/dra-kubeadmconfig.yaml
   target:
-    kind: KubeadmConfigTemplate
+    kind: KubeadmConfig
 
 sortOptions:
   order: fifo

--- a/templates/test/dev/cluster-template-custom-builds-dra.yaml
+++ b/templates/test/dev/cluster-template-custom-builds-dra.yaml
@@ -391,14 +391,25 @@ spec:
     owner: root:root
     path: /etc/kubernetes/azure.json
     permissions: "0644"
+  - content: |
+      #!/bin/bash
+
+      echo "enabling containerd CDI plugin"
+      sed -i '/\[plugins."io.containerd.grpc.v1.cri"\]/a\    enable_cdi = true' /etc/containerd/config.toml
+      systemctl restart containerd
+    owner: root:root
+    path: /tmp/containerd-config.sh
+    permissions: "0744"
   joinConfiguration:
     nodeRegistration:
       kubeletExtraArgs:
         cloud-provider: external
+        feature-gates: ${NODE_FEATURE_GATES:-"DynamicResourceAllocation=true"}
         image-credential-provider-bin-dir: /var/lib/kubelet/credential-provider
         image-credential-provider-config: /var/lib/kubelet/credential-provider-config.yaml
       name: '{{ ds.meta_data["local_hostname"] }}'
   preKubeadmCommands:
+  - bash -c /tmp/containerd-config.sh
   - bash -c /tmp/oot-cred-provider.sh
   - bash -c /tmp/replace-k8s-binaries.sh
 ---

--- a/templates/test/dev/custom-builds-dra/kustomization.yaml
+++ b/templates/test/dev/custom-builds-dra/kustomization.yaml
@@ -10,9 +10,9 @@ patches:
 - path: ../../ci/patches/dra-kubeadmcontrolplane.yaml
   target:
     kind: KubeadmControlPlane
-- path: ../../ci/patches/dra-kubeadmconfigtemplate.yaml
+- path: ../../ci/patches/dra-kubeadmconfig.yaml
   target:
-    kind: KubeadmConfigTemplate
+    kind: KubeadmConfig
 
 sortOptions:
   order: fifo


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind failing-test


<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

Follow-up to #5220 to fix DRA templates by transforming the KubeadmConfigTemplate used for MachineDeployments to a KubeadmConfig for the MachinePool.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
