### PR TITLE
simplify DRA config for containerd

### DIFF
--- a/templates/test/ci/cluster-template-prow-ci-version-dra.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version-dra.yaml
@@ -198,14 +198,13 @@ spec:
       path: /tmp/kubeadm-bootstrap.sh
       permissions: "0744"
     - content: |
-        #!/bin/bash
-
-        echo "enabling containerd CDI plugin"
-        sed -i '/\[plugins."io.containerd.grpc.v1.cri"\]/a\    enable_cdi = true' /etc/containerd/config.toml
-        systemctl restart containerd
+        version = 2
+        [plugins]
+          [plugins."io.containerd.grpc.v1.cri"]
+            enable_cdi = true
       owner: root:root
-      path: /tmp/containerd-config.sh
-      permissions: "0744"
+      path: /etc/containerd/conf.d/device-plugin.toml
+      permissions: "0644"
     initConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
@@ -227,7 +226,6 @@ spec:
       - /var/lib/etcddisk
     postKubeadmCommands: []
     preKubeadmCommands:
-    - bash -c /tmp/containerd-config.sh
     - bash -c /tmp/oot-cred-provider.sh
     - bash -c /tmp/kubeadm-bootstrap.sh
     verbosity: 5
@@ -436,14 +434,13 @@ spec:
     path: /etc/kubernetes/azure.json
     permissions: "0644"
   - content: |
-      #!/bin/bash
-
-      echo "enabling containerd CDI plugin"
-      sed -i '/\[plugins."io.containerd.grpc.v1.cri"\]/a\    enable_cdi = true' /etc/containerd/config.toml
-      systemctl restart containerd
+      version = 2
+      [plugins]
+        [plugins."io.containerd.grpc.v1.cri"]
+          enable_cdi = true
     owner: root:root
-    path: /tmp/containerd-config.sh
-    permissions: "0744"
+    path: /etc/containerd/conf.d/device-plugin.toml
+    permissions: "0644"
   joinConfiguration:
     nodeRegistration:
       kubeletExtraArgs:

--- a/templates/test/ci/patches/dra-kubeadmconfig.yaml
+++ b/templates/test/ci/patches/dra-kubeadmconfig.yaml
@@ -2,14 +2,13 @@
   path: /spec/files/-
   value:
     content: |
-      #!/bin/bash
-
-      echo "enabling containerd CDI plugin"
-      sed -i '/\[plugins."io.containerd.grpc.v1.cri"\]/a\    enable_cdi = true' /etc/containerd/config.toml
-      systemctl restart containerd
+      version = 2
+      [plugins]
+        [plugins."io.containerd.grpc.v1.cri"]
+          enable_cdi = true
     owner: root:root
-    path: /tmp/containerd-config.sh
-    permissions: "0744"
+    path: /etc/containerd/conf.d/device-plugin.toml
+    permissions: "0644"
 - op: add
   path: /spec/preKubeadmCommands/0
   value: bash -c /tmp/containerd-config.sh

--- a/templates/test/ci/patches/dra-kubeadmcontrolplane.yaml
+++ b/templates/test/ci/patches/dra-kubeadmcontrolplane.yaml
@@ -2,17 +2,13 @@
   path: /spec/kubeadmConfigSpec/files/-
   value:
     content: |
-      #!/bin/bash
-
-      echo "enabling containerd CDI plugin"
-      sed -i '/\[plugins."io.containerd.grpc.v1.cri"\]/a\    enable_cdi = true' /etc/containerd/config.toml
-      systemctl restart containerd
+      version = 2
+      [plugins]
+        [plugins."io.containerd.grpc.v1.cri"]
+          enable_cdi = true
     owner: root:root
-    path: /tmp/containerd-config.sh
-    permissions: "0744"
-- op: add
-  path: /spec/kubeadmConfigSpec/preKubeadmCommands/0
-  value: bash -c /tmp/containerd-config.sh
+    path: /etc/containerd/conf.d/device-plugin.toml
+    permissions: "0644"
 - op: add
   path: /spec/kubeadmConfigSpec/clusterConfiguration/apiServer/extraArgs/feature-gates
   value: ${K8S_FEATURE_GATES:-"DynamicResourceAllocation=true"}

--- a/templates/test/dev/cluster-template-custom-builds-dra.yaml
+++ b/templates/test/dev/cluster-template-custom-builds-dra.yaml
@@ -200,14 +200,13 @@ spec:
       path: /tmp/oot-cred-provider.sh
       permissions: "0744"
     - content: |
-        #!/bin/bash
-
-        echo "enabling containerd CDI plugin"
-        sed -i '/\[plugins."io.containerd.grpc.v1.cri"\]/a\    enable_cdi = true' /etc/containerd/config.toml
-        systemctl restart containerd
+        version = 2
+        [plugins]
+          [plugins."io.containerd.grpc.v1.cri"]
+            enable_cdi = true
       owner: root:root
-      path: /tmp/containerd-config.sh
-      permissions: "0744"
+      path: /etc/containerd/conf.d/device-plugin.toml
+      permissions: "0644"
     initConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
@@ -230,7 +229,6 @@ spec:
     postKubeadmCommands:
     - bash -c /tmp/replace-k8s-components.sh
     preKubeadmCommands:
-    - bash -c /tmp/containerd-config.sh
     - bash -c /tmp/replace-k8s-binaries.sh
     - bash -c /tmp/oot-cred-provider.sh
     verbosity: 5
@@ -392,14 +390,13 @@ spec:
     path: /etc/kubernetes/azure.json
     permissions: "0644"
   - content: |
-      #!/bin/bash
-
-      echo "enabling containerd CDI plugin"
-      sed -i '/\[plugins."io.containerd.grpc.v1.cri"\]/a\    enable_cdi = true' /etc/containerd/config.toml
-      systemctl restart containerd
+      version = 2
+      [plugins]
+        [plugins."io.containerd.grpc.v1.cri"]
+          enable_cdi = true
     owner: root:root
-    path: /tmp/containerd-config.sh
-    permissions: "0744"
+    path: /etc/containerd/conf.d/device-plugin.toml
+    permissions: "0644"
   joinConfiguration:
     nodeRegistration:
       kubeletExtraArgs:


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind cleanup

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

This change takes advantage of the pre-configured `/etc/containerd/conf.d` directory to configure DRA in a drop-in file there rather than tweaking the root config and restarting containerd.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
