### PR TITLE
[release-1.17] re-enable AKS BYO node test

### DIFF
--- a/test/e2e/aks_byo_node.go
+++ b/test/e2e/aks_byo_node.go
@@ -22,6 +22,7 @@ package e2e
 import (
 	"context"
 	"os"
+	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -64,6 +65,15 @@ func AKSBYONodeSpec(ctx context.Context, inputGetter func() AKSBYONodeSpecInput)
 			Location: infraControlPlane.Spec.Location,
 			Template: infrav1exp.AzureMachinePoolMachineTemplate{
 				VMSize: os.Getenv("AZURE_NODE_MACHINE_TYPE"),
+				Image: &infrav1.Image{
+					// The old Marketplace images don't have newer Kubernetes versions that this test
+					// requires. Use the new Community Gallery instead.
+					ComputeGallery: &infrav1.AzureComputeGalleryImage{
+						Gallery: "ClusterAPI-f72ceb4f-5159-4c26-a0fe-2ea738f0d019",
+						Name:    "capi-ubun2-2404",
+						Version: strings.TrimPrefix(input.KubernetesVersion, "v"),
+					},
+				},
 			},
 		},
 	}

--- a/test/e2e/azure_test.go
+++ b/test/e2e/azure_test.go
@@ -853,17 +853,16 @@ var _ = Describe("Workload cluster creation", func() {
 				})
 			})
 
-			// TODO: restore when new CAPZ reference images are published
-			// By("creating a byo nodepool", func() {
-			// 	AKSBYONodeSpec(ctx, func() AKSBYONodeSpecInput {
-			// 		return AKSBYONodeSpecInput{
-			// 			Cluster:             result.Cluster,
-			// 			KubernetesVersion:   kubernetesVersion,
-			// 			WaitIntervals:       e2eConfig.GetIntervals(specName, "wait-worker-nodes"),
-			// 			ExpectedWorkerNodes: result.ExpectedWorkerNodes(),
-			// 		}
-			// 	})
-			// })
+			By("creating a byo nodepool", func() {
+				AKSBYONodeSpec(ctx, func() AKSBYONodeSpecInput {
+					return AKSBYONodeSpecInput{
+						Cluster:             result.Cluster,
+						KubernetesVersion:   kubernetesVersion,
+						WaitIntervals:       e2eConfig.GetIntervals(specName, "wait-worker-nodes"),
+						ExpectedWorkerNodes: result.ExpectedWorkerNodes(),
+					}
+				})
+			})
 
 			By("modifying custom patches", func() {
 				AKSPatchSpec(ctx, func() AKSPatchSpecInput {


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind failing-test

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

This PR updates the AKS BYO node test to use images from the new Community Gallery (#5167) which are back on track with versions of Kubernetes in use by AKS. This allows us to re-enable the test.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [X] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
