### PR TITLE
fix kustomize warnings for deprecated patchesStrategicMerge

### DIFF
--- a/templates/flavors/flatcar-sysext/kustomization.yaml
+++ b/templates/flavors/flatcar-sysext/kustomization.yaml
@@ -4,6 +4,6 @@ resources:
   - machine-deployment.yaml
   - ../../azure-cluster-identity
 
-patchesStrategicMerge:
-  - patches/kubeadm-controlplane.yaml
-  - ../../azure-cluster-identity/azurecluster-identity-ref.yaml
+patches:
+  - path: patches/kubeadm-controlplane.yaml
+  - path: ../../azure-cluster-identity/azurecluster-identity-ref.yaml

--- a/templates/test/ci/prow-flatcar-sysext/kustomization.yaml
+++ b/templates/test/ci/prow-flatcar-sysext/kustomization.yaml
@@ -6,8 +6,8 @@ resources:
   - ../../../addons/cluster-api-helm/calico.yaml
   - ../../../addons/cluster-api-helm/azuredisk-csi-driver.yaml
   - ../../../addons/cluster-api-helm/cloud-provider-azure-flatcar-sysext.yaml
-patchesStrategicMerge:
-  - ../patches/tags.yaml
-  - ../patches/controller-manager.yaml
-  - ../patches/cluster-label-calico.yaml
-  - ../patches/cluster-label-cloud-provider-azure-flatcar-sysext.yaml
+patches:
+  - path: ../patches/tags.yaml
+  - path: ../patches/controller-manager.yaml
+  - path: ../patches/cluster-label-calico.yaml
+  - path: ../patches/cluster-label-cloud-provider-azure-flatcar-sysext.yaml


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind cleanup

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

This fixes these warnings that get emitted by kustomize when building the flavor templates:
```
# Warning: 'patchesStrategicMerge' is deprecated. Please use 'patches' instead. Run 'kustomize edit fix' to update your Kustomization automatically.
# Warning: 'patchesStrategicMerge' is deprecated. Please use 'patches' instead. Run 'kustomize edit fix' to update your Kustomization automatically.
# Warning: 'patchesStrategicMerge' is deprecated. Please use 'patches' instead. Run 'kustomize edit fix' to update your Kustomization automatically.
```

This doesn't affect the rendered templates at all.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
