### PR TITLE
skip prealloc linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -39,7 +39,8 @@ linters:
     - noctx # http requests without context.Context
     - nolintlint # badly formatted nolint directives
     - nosprintfhostport # using sprintf to construct host:port in a URL
-    - prealloc # suggest preallocating slices
+    # We don't want to use this one: https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/4703
+    # - prealloc # suggest preallocating slices
     - predeclared # shadowing predeclared identifiers
     - revive # better version of golint
     - staticcheck # some of staticcheck's rules

--- a/azure/services/subnets/spec.go
+++ b/azure/services/subnets/spec.go
@@ -98,8 +98,7 @@ func (s *SubnetSpec) Parameters(_ context.Context, existing *asonetworkv1.Virtua
 		}
 	}
 
-	// TODO (nojnhuh) : do we want to initialize serviceEndpoints with an empty slice instead?
-	var serviceEndpoints []asonetworkv1.ServiceEndpointPropertiesFormat //nolint:prealloc // leaving it as is for now
+	var serviceEndpoints []asonetworkv1.ServiceEndpointPropertiesFormat
 	for _, se := range s.ServiceEndpoints {
 		serviceEndpoints = append(serviceEndpoints, asonetworkv1.ServiceEndpointPropertiesFormat{Service: ptr.To(se.Service), Locations: se.Locations})
 	}

--- a/controllers/resource_reconciler.go
+++ b/controllers/resource_reconciler.go
@@ -63,10 +63,7 @@ func (r *ResourceReconciler) Reconcile(ctx context.Context) error {
 	defer done()
 	log.V(4).Info("reconciling resources")
 
-	// TODO (nojnhuh) : is there a functional diff between
-	// var newResourceStatuses []infrav1alpha.ResourceStatus and newResourceStatuses := make([]infrav1alpha.ResourceStatus,0)
-	// in the scenario below?
-	var newResourceStatuses []infrav1alpha.ResourceStatus //nolint:prealloc // leaving it as is for now
+	var newResourceStatuses []infrav1alpha.ResourceStatus
 
 	for _, spec := range r.resources {
 		gvk := spec.GroupVersionKind()


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

Skip the prealloc linter again for the same reasons as the first time we did this in #4703 after it got reenabled by #5158.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
