### PR TITLE
Add a file watcher for Azure client cert auth

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -122,7 +122,7 @@ require (
 	github.com/evanphx/json-patch/v5 v5.9.0
 	github.com/fatih/camelcase v1.0.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
-	github.com/fsnotify/fsnotify v1.7.0 // indirect
+	github.com/fsnotify/fsnotify v1.7.0
 	github.com/go-errors/errors v1.4.2 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect

--- a/util/filewatcher/filewatcher.go
+++ b/util/filewatcher/filewatcher.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package filewatcher
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/fsnotify/fsnotify"
+	"k8s.io/klog/v2"
+)
+
+var watchCertificateFileOnce sync.Once
+
+// WatchFileForChanges watches the file, fileToWatch, for changes. If the file contents have changed, the pod this
+// function is running on will be restarted.
+func WatchFileForChanges(fileToWatch string) error {
+	var err error
+
+	// This starts only one occurrence of the file watcher, which watches the file, fileToWatch.
+	watchCertificateFileOnce.Do(func() {
+		klog.V(2).Infof("Starting the file change watcher on file, %s", fileToWatch)
+
+		// Update the file path to watch in case this is a symlink
+		fileToWatch, err = filepath.EvalSymlinks(fileToWatch)
+		if err != nil {
+			return
+		}
+		klog.V(2).Infof("Watching file, %s", fileToWatch)
+
+		// Start the file watcher to monitor file changes
+		go func() {
+			err := checkForFileChanges(fileToWatch)
+			klog.Errorf("Error checking for file changes: %v", err)
+		}()
+	})
+	return err
+}
+
+// checkForFileChanges starts a new file watcher. If the file is changed, the pod running this function will exit.
+func checkForFileChanges(path string) error {
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return err
+	}
+
+	go func() {
+		for {
+			select {
+			case event, ok := <-watcher.Events:
+				if ok && (event.Has(fsnotify.Write) || event.Has(fsnotify.Chmod) || event.Has(fsnotify.Remove)) {
+					klog.Infof("file, %s, was modified, exiting...", event.Name)
+					os.Exit(0)
+				}
+			case err, ok := <-watcher.Errors:
+				if ok {
+					klog.Errorf("file watcher error: %v", err)
+				}
+			}
+		}
+	}()
+
+	err = watcher.Add(path)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION


 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Add a file watcher, utilizing fsnotify, to monitor the Azure client certificate authentication. If the file changes, the pod will need to be restarted since Azure SDK doesn't support hotloading a new certificate yet.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
This is a follow up to https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/5200

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE

```
