### PR TITLE
template/flatcar-sysext: use marketplace images

### DIFF
--- a/docs/book/src/self-managed/flatcar.md
+++ b/docs/book/src/self-managed/flatcar.md
@@ -6,7 +6,7 @@ CAPZ enables you to create Kubernetes clusters using Flatcar Container Linux on 
 
 ### The `flatcar-sysext` flavor (**recommended**)
 
-This variant relies on a vanilla Flatcar Community Gallery image which leverages the [systemd-sysext](https://www.flatcar.org/docs/latest/provisioning/sysext/) feature to install and update Kubernetes components. The Kubernetes version is not bound to the Flatcar version (i.e. Flatcar can be upgraded independently from Kubernetes and vice versa).
+This variant relies on a vanilla Flatcar marketplace image which leverages the [systemd-sysext](https://www.flatcar.org/docs/latest/provisioning/sysext/) feature to install and update Kubernetes components. The Kubernetes version is not bound to the Flatcar version (i.e. Flatcar can be upgraded independently from Kubernetes and vice versa).
 
 The template comes with a [systemd-sysupdate](https://www.freedesktop.org/software/systemd/man/latest/sysupdate.d.html) configuration file that will download each new patch version of Kubernetes (i.e. if you start with Kubernetes 1.x.y, systemd-sysupdate will automatically pull 1.x.y+1 but not 1.x+1.y). Please note that this behavior is disabled by default. To enable the Kubernetes auto-update you can:
   * Update the template to enable the `systemd-sysupdate.timer`
@@ -18,13 +18,13 @@ To coordinate the node reboot, we recommend using [Kured](https://github.com/kub
 
 Find the latest published images:
 ```console
-az sig image-version list --gallery-image-definition flatcar-stable-amd64 --gallery-name flatcar --resource-group flatcar-image-gallery-publishing -o table
-Location    Name      ProvisioningState    ResourceGroup
-----------  --------  -------------------  --------------------------------
-westeurope  3374.2.0  Succeeded            flatcar-image-gallery-publishing
-westeurope  3374.2.1  Succeeded            flatcar-image-gallery-publishing
-westeurope  3374.2.3  Succeeded            flatcar-image-gallery-publishing
-....
+az vm image list --offer flatcar-container-linux-corevm-amd64 --publisher kinvolk --sku stable-gen2 -o table --all
+Architecture    Offer                                 Publisher    Sku          Urn                                                                Version
+--------------  ------------------------------------  -----------  -----------  -----------------------------------------------------------------  ---------
+...
+x64             flatcar-container-linux-corevm-amd64  kinvolk      stable-gen2  kinvolk:flatcar-container-linux-corevm-amd64:stable-gen2:3975.2.0  3975.2.0
+x64             flatcar-container-linux-corevm-amd64  kinvolk      stable-gen2  kinvolk:flatcar-container-linux-corevm-amd64:stable-gen2:3975.2.1  3975.2.1
+x64             flatcar-container-linux-corevm-amd64  kinvolk      stable-gen2  kinvolk:flatcar-container-linux-corevm-amd64:stable-gen2:3975.2.2  3975.2.2
 ```
 
 ### The `flatcar` flavor

--- a/templates/cluster-template-flatcar-sysext.yaml
+++ b/templates/cluster-template-flatcar-sysext.yaml
@@ -292,9 +292,10 @@ spec:
         nameSuffix: etcddisk
       identity: UserAssigned
       image:
-        computeGallery:
-          gallery: flatcar-23485951-527a-48d6-9d11-6931ff0afc2e
-          name: flatcar-stable-amd64
+        marketplace:
+          offer: flatcar-container-linux-corevm-amd64
+          publisher: kinvolk
+          sku: stable-gen2
           version: ${FLATCAR_VERSION}
       osDisk:
         diskSizeGB: 128
@@ -313,9 +314,10 @@ spec:
   template:
     spec:
       image:
-        computeGallery:
-          gallery: flatcar-23485951-527a-48d6-9d11-6931ff0afc2e
-          name: flatcar-stable-amd64
+        marketplace:
+          offer: flatcar-container-linux-corevm-amd64
+          publisher: kinvolk
+          sku: stable-gen2
           version: ${FLATCAR_VERSION}
       osDisk:
         diskSizeGB: 128

--- a/templates/flavors/flatcar-sysext/machine-deployment.yaml
+++ b/templates/flavors/flatcar-sysext/machine-deployment.yaml
@@ -30,10 +30,11 @@ spec:
   template:
     spec:
       image:
-        computeGallery:
-          gallery: flatcar-23485951-527a-48d6-9d11-6931ff0afc2e
-          name: flatcar-stable-amd64
+        marketplace:
           version: ${FLATCAR_VERSION}
+          publisher: kinvolk
+          offer: flatcar-container-linux-corevm-amd64
+          sku: stable-gen2
       osDisk:
         diskSizeGB: 128
         osType: Linux

--- a/templates/flavors/flatcar-sysext/patches/kubeadm-controlplane.yaml
+++ b/templates/flavors/flatcar-sysext/patches/kubeadm-controlplane.yaml
@@ -95,7 +95,8 @@ spec:
   template:
     spec:
       image:
-        computeGallery:
-          gallery: flatcar-23485951-527a-48d6-9d11-6931ff0afc2e
-          name: flatcar-stable-amd64
+        marketplace:
           version: ${FLATCAR_VERSION}
+          publisher: kinvolk
+          offer: flatcar-container-linux-corevm-amd64
+          sku: stable-gen2

--- a/templates/test/ci/cluster-template-prow-flatcar-sysext.yaml
+++ b/templates/test/ci/cluster-template-prow-flatcar-sysext.yaml
@@ -373,9 +373,10 @@ spec:
         nameSuffix: etcddisk
       identity: UserAssigned
       image:
-        computeGallery:
-          gallery: flatcar-23485951-527a-48d6-9d11-6931ff0afc2e
-          name: flatcar-stable-amd64
+        marketplace:
+          offer: flatcar-container-linux-corevm-amd64
+          publisher: kinvolk
+          sku: stable-gen2
           version: ${FLATCAR_VERSION}
       osDisk:
         diskSizeGB: 128
@@ -394,9 +395,10 @@ spec:
   template:
     spec:
       image:
-        computeGallery:
-          gallery: flatcar-23485951-527a-48d6-9d11-6931ff0afc2e
-          name: flatcar-stable-amd64
+        marketplace:
+          offer: flatcar-container-linux-corevm-amd64
+          publisher: kinvolk
+          sku: stable-gen2
           version: ${FLATCAR_VERSION}
       osDisk:
         diskSizeGB: 128


### PR DESCRIPTION
Gallery images was the solution used for publishing Flatcar CAPZ images. We can now directly use marketplace images as Flatcar sysext template does not need images from the image-builder but can use a regular Flatcar images (which is automatically published at each release)

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**: Change the source of Flatcar images from gallery to marketplace (which is more up to date)


**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [x] includes documentation
- [x] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Use regular Flatcar images from Azure marketplace for flatcar-sysext template  
```
