### PR TITLE
Default to Marketplace images for old Kubernetes versions

### DIFF
--- a/azure/services/virtualmachineimages/images.go
+++ b/azure/services/virtualmachineimages/images.go
@@ -60,6 +60,22 @@ func (s *Service) GetDefaultLinuxImage(ctx context.Context, _, k8sVersion string
 		return nil, errors.Wrapf(err, "unable to parse Kubernetes version \"%s\"", k8sVersion)
 	}
 
+	// Use the Azure Marketplace for specific older versions, to keep "clusterctl upgrade" from rolling new machines.
+	marketplaceVersionRange := semver.MustParseRange("<=1.28.12 || >=1.29.1 <=1.29.7 || >=1.30.0 <=1.30.3")
+	if marketplaceVersionRange(v) {
+		if version, ok := oldUbuntu2204Versions[v.String()]; ok {
+			return &infrav1.Image{
+				Marketplace: &infrav1.AzureMarketplaceImage{
+					ImagePlan: infrav1.ImagePlan{
+						Publisher: "cncf-upstream",
+						Offer:     "capi",
+						SKU:       "ubuntu-2204-gen1",
+					},
+					Version: version,
+				},
+			}, nil
+		}
+	}
 	return &infrav1.Image{
 		ComputeGallery: &infrav1.AzureComputeGalleryImage{
 			Gallery: azure.DefaultPublicGalleryName,
@@ -93,6 +109,22 @@ func (s *Service) GetDefaultWindowsImage(ctx context.Context, _, k8sVersion, run
 		imageName = strings.Replace(imageName, "2019", match[1], 1)
 	}
 
+	// Use the Azure Marketplace for specific older versions, to keep "clusterctl upgrade" from rolling new machines.
+	marketplaceVersionRange := semver.MustParseRange("<=1.28.12 || >=1.29.1 <=1.29.7 || >=1.30.0 <=1.30.3")
+	if marketplaceVersionRange(v) {
+		if version, ok := oldWindows2019Versions[v.String()]; ok {
+			return &infrav1.Image{
+				Marketplace: &infrav1.AzureMarketplaceImage{
+					ImagePlan: infrav1.ImagePlan{
+						Publisher: "cncf-upstream",
+						Offer:     "capi-windows",
+						SKU:       "windows-2019-containerd-gen1",
+					},
+					Version: version,
+				},
+			}, nil
+		}
+	}
 	return &infrav1.Image{
 		ComputeGallery: &infrav1.AzureComputeGalleryImage{
 			Gallery: azure.DefaultPublicGalleryName,
@@ -100,4 +132,66 @@ func (s *Service) GetDefaultWindowsImage(ctx context.Context, _, k8sVersion, run
 			Version: v.String(),
 		},
 	}, nil
+}
+
+// oldUbuntu2204Versions maps Kubernetes versions to Azure Marketplace image versions.
+// The Marketplace offer is deprecated and won't be updated, so these values are
+// hard-coded here to simplify lookup.
+var oldUbuntu2204Versions = map[string]string{
+	"1.27.14": "127.14.20240517",
+	"1.27.15": "127.15.20240612",
+	"1.27.16": "127.16.20240717",
+	"1.28.1":  "128.1.20230829",
+	"1.28.2":  "128.2.20230918",
+	"1.28.3":  "128.3.20231023",
+	"1.28.4":  "128.4.20231130",
+	"1.28.5":  "128.5.20240102",
+	"1.28.6":  "128.6.20240201",
+	"1.28.7":  "128.7.20240223",
+	"1.28.8":  "128.8.20240327",
+	"1.28.9":  "128.9.20240418",
+	"1.28.10": "128.10.20240517",
+	"1.28.11": "128.11.20240612",
+	"1.28.12": "128.12.20240717",
+	"1.29.1":  "129.1.20240206",
+	"1.29.2":  "129.2.20240223",
+	"1.29.3":  "129.3.20240327",
+	"1.29.4":  "129.4.20240418",
+	"1.29.5":  "129.5.20240517",
+	"1.29.6":  "129.6.20240612",
+	"1.29.7":  "129.7.20240717",
+	"1.30.0":  "130.0.20240506",
+	"1.30.1":  "130.1.20240517",
+	"1.30.2":  "130.2.20240612",
+	"1.30.3":  "130.3.20240717",
+}
+
+// oldWindows2019Versions maps Kubernetes versions to Azure Marketplace image versions.
+// The Marketplace offer is deprecated and won't be updated, so these values are
+// hard-coded here to simplify lookup.
+var oldWindows2019Versions = map[string]string{
+	"1.27.14": "127.14.20240515",
+	"1.28.1":  "128.1.20230830",
+	"1.28.2":  "128.2.20230918",
+	"1.28.3":  "128.3.20231023",
+	"1.28.4":  "128.4.20231122",
+	"1.28.5":  "128.5.20240102",
+	"1.28.6":  "128.6.20240201",
+	"1.28.7":  "128.7.20240223",
+	"1.28.8":  "128.8.20240327",
+	"1.28.9":  "128.9.20240418",
+	"1.28.10": "128.10.20240515",
+	"1.28.11": "128.11.20240612",
+	"1.28.12": "128.12.20240717",
+	"1.29.1":  "129.1.20240201",
+	"1.29.2":  "129.2.20240223",
+	"1.29.3":  "129.3.20240327",
+	"1.29.4":  "129.4.20240418",
+	"1.29.5":  "129.5.20240515",
+	"1.29.6":  "129.6.20240612",
+	"1.29.7":  "129.7.20240717",
+	"1.30.0":  "130.0.20240418",
+	"1.30.1":  "130.1.20240515",
+	"1.30.2":  "130.2.20240612",
+	"1.30.3":  "130.3.20240717",
 }

--- a/azure/services/virtualmachineimages/images_test.go
+++ b/azure/services/virtualmachineimages/images_test.go
@@ -69,6 +69,19 @@ func TestGetDefaultLinuxImage(t *testing.T) {
 			},
 			expectErr: false,
 		},
+		{
+			k8sVersion: "1.28.12",
+			expected: &infrav1.Image{
+				Marketplace: &infrav1.AzureMarketplaceImage{
+					ImagePlan: infrav1.ImagePlan{
+						Publisher: "cncf-upstream",
+						Offer:     "capi",
+						SKU:       "ubuntu-2204-gen1",
+					},
+					Version: "128.12.20240717",
+				},
+			},
+		},
 	}
 
 	location := "unused"
@@ -173,6 +186,19 @@ func TestGetDefaultWindowsImage(t *testing.T) {
 				},
 			},
 			expectErr: false,
+		},
+		{
+			k8sVersion: "1.28.12",
+			expected: &infrav1.Image{
+				Marketplace: &infrav1.AzureMarketplaceImage{
+					ImagePlan: infrav1.ImagePlan{
+						Publisher: "cncf-upstream",
+						Offer:     "capi-windows",
+						SKU:       "windows-2019-containerd-gen1",
+					},
+					Version: "128.12.20240717",
+				},
+			},
 		},
 	}
 


### PR DESCRIPTION
**What type of PR is this?**

/kind failing-test

**What this PR does / why we need it**:

Restores a truncated version of the Marketplace image lookup logic so that upgrading clusters don't see the change to community gallery images as a reason to recreate every Machine. 

**Which issue(s) this PR fixes**:
Fixes #5229

**Special notes for your reviewer**:

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:

```release-note
Default to Marketplace images for old Kubernetes versions
```
