### PR TITLE
chore: support registry overrides in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -158,8 +158,8 @@ endif
 ifndef REGISTRY
 	REGISTRY ?= localhost:5000
 endif
-STAGING_REGISTRY := gcr.io/k8s-staging-cluster-api-azure
-PROD_REGISTRY := registry.k8s.io/cluster-api-azure
+STAGING_REGISTRY ?= gcr.io/k8s-staging-cluster-api-azure
+PROD_REGISTRY ?= registry.k8s.io/cluster-api-azure
 IMAGE_NAME ?= cluster-api-azure-controller
 CONTROLLER_IMG ?= $(REGISTRY)/$(IMAGE_NAME)
 TAG ?= dev


### PR DESCRIPTION

/kind cleanup

**What this PR does / why we need it**:

This change adds support for `STAGING_REGISTRY`/`PROD_REGISTRY` overrides in the `Makefile`. The current configuration does not allow setting a different value for these parameters via environment variables. This is a limitation in, for example, an air-gapped environment where a user may want to create their own release of the provider and reference an image stored in a custom registry.

It should not affect any existing use cases as the default value is unchanged.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

- [ ] cherry-pick candidate

**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
