### PR TITLE
make Private IP of the internal LB of the API Server configurable

### DIFF
--- a/api/v1beta1/azurecluster_default_test.go
+++ b/api/v1beta1/azurecluster_default_test.go
@@ -106,8 +106,9 @@ func TestVnetDefaults(t *testing.T) {
 						Subnets: Subnets{
 							{
 								SubnetClassSpec: SubnetClassSpec{
-									Role: SubnetControlPlane,
-									Name: "control-plane-subnet",
+									Role:       SubnetControlPlane,
+									Name:       "control-plane-subnet",
+									CIDRBlocks: []string{DefaultControlPlaneSubnetCIDR},
 								},
 
 								SecurityGroup: SecurityGroup{},
@@ -130,6 +131,12 @@ func TestVnetDefaults(t *testing.T) {
 									PublicIP: &PublicIPSpec{
 										Name:    "public-ip",
 										DNSName: "myfqdn.azure.com",
+									},
+								},
+								{
+									Name: "ip-config-internal-ip",
+									FrontendIPClass: FrontendIPClass{
+										PrivateIPAddress: DefaultInternalLBIPAddress,
 									},
 								},
 							},
@@ -1237,6 +1244,12 @@ func TestAPIServerLBDefaults(t *testing.T) {
 										DNSName: "",
 									},
 								},
+								{
+									Name: "cluster-test-public-lb-frontEnd-internal-ip",
+									FrontendIPClass: FrontendIPClass{
+										PrivateIPAddress: DefaultInternalLBIPAddress,
+									},
+								},
 							},
 							BackendPool: BackendPool{
 								Name: "cluster-test-public-lb-backendPool",
@@ -1276,7 +1289,7 @@ func TestAPIServerLBDefaults(t *testing.T) {
 						APIServerLB: LoadBalancerSpec{
 							FrontendIPs: []FrontendIP{
 								{
-									Name: "cluster-test-internal-lb-frontEnd",
+									Name: "cluster-test-internal-lb-frontEnd-internal-ip",
 									FrontendIPClass: FrontendIPClass{
 										PrivateIPAddress: DefaultInternalLBIPAddress,
 									},
@@ -1324,7 +1337,7 @@ func TestAPIServerLBDefaults(t *testing.T) {
 						APIServerLB: LoadBalancerSpec{
 							FrontendIPs: []FrontendIP{
 								{
-									Name: "cluster-test-internal-lb-frontEnd",
+									Name: "cluster-test-internal-lb-frontEnd-internal-ip",
 									FrontendIPClass: FrontendIPClass{
 										PrivateIPAddress: DefaultInternalLBIPAddress,
 									},

--- a/azure/scope/cluster.go
+++ b/azure/scope/cluster.go
@@ -242,10 +242,52 @@ func (s *ClusterScope) PublicIPSpecs() []azure.ResourceSpecGetter {
 
 // LBSpecs returns the load balancer specs.
 func (s *ClusterScope) LBSpecs() []azure.ResourceSpecGetter {
+	// construct the frontend LB
+	frontendLB := &loadbalancers.LBSpec{
+		Name:                 s.APIServerLB().Name,
+		ResourceGroup:        s.ResourceGroup(),
+		SubscriptionID:       s.SubscriptionID(),
+		ClusterName:          s.ClusterName(),
+		Location:             s.Location(),
+		ExtendedLocation:     s.ExtendedLocation(),
+		VNetName:             s.Vnet().Name,
+		VNetResourceGroup:    s.Vnet().ResourceGroup,
+		SubnetName:           s.ControlPlaneSubnet().Name,
+		APIServerPort:        s.APIServerPort(),
+		Type:                 s.APIServerLB().Type,
+		SKU:                  s.APIServerLB().SKU,
+		Role:                 infrav1.APIServerRole,
+		BackendPoolName:      s.APIServerLB().BackendPool.Name,
+		IdleTimeoutInMinutes: s.APIServerLB().IdleTimeoutInMinutes,
+		AdditionalTags:       s.AdditionalTags(),
+	}
+
+	// get the internal LB IP and the public LB IPs
+	apiServerInternalLBIP := infrav1.FrontendIP{}
+	apiServerFrontendLBIP := make([]infrav1.FrontendIP, 0)
+	if s.APIServerLB().FrontendIPs != nil {
+		for _, frontendIP := range s.APIServerLB().FrontendIPs {
+			// save the public IPs for the frontend LB
+			// or if the LB is of the type internal, save the only IP allowed for the frontend LB
+			if frontendIP.PublicIP != nil || frontendLB.Type == infrav1.Internal {
+				apiServerFrontendLBIP = append(apiServerFrontendLBIP, frontendIP)
+			}
+
+			if frontendIP.PrivateIPAddress != "" {
+				apiServerInternalLBIP = frontendIP
+			}
+		}
+	}
+
+	// set the frontend IPs for the frontend LB
+	frontendLB.FrontendIPConfigs = apiServerFrontendLBIP
 	specs := []azure.ResourceSpecGetter{
-		&loadbalancers.LBSpec{
-			// API Server LB
-			Name:                 s.APIServerLB().Name,
+		frontendLB,
+	}
+
+	if s.APIServerLB().Type != infrav1.Internal {
+		internalLB := &loadbalancers.LBSpec{
+			Name:                 s.APIServerLB().Name + "-internal",
 			ResourceGroup:        s.ResourceGroup(),
 			SubscriptionID:       s.SubscriptionID(),
 			ClusterName:          s.ClusterName(),
@@ -254,36 +296,6 @@ func (s *ClusterScope) LBSpecs() []azure.ResourceSpecGetter {
 			VNetName:             s.Vnet().Name,
 			VNetResourceGroup:    s.Vnet().ResourceGroup,
 			SubnetName:           s.ControlPlaneSubnet().Name,
-			FrontendIPConfigs:    s.APIServerLB().FrontendIPs,
-			APIServerPort:        s.APIServerPort(),
-			Type:                 s.APIServerLB().Type,
-			SKU:                  s.APIServerLB().SKU,
-			Role:                 infrav1.APIServerRole,
-			BackendPoolName:      s.APIServerLB().BackendPool.Name,
-			IdleTimeoutInMinutes: s.APIServerLB().IdleTimeoutInMinutes,
-			AdditionalTags:       s.AdditionalTags(),
-		},
-	}
-
-	if s.APIServerLB().Type != infrav1.Internal {
-		specs = append(specs, &loadbalancers.LBSpec{
-			Name:              s.APIServerLB().Name + "-internal",
-			ResourceGroup:     s.ResourceGroup(),
-			SubscriptionID:    s.SubscriptionID(),
-			ClusterName:       s.ClusterName(),
-			Location:          s.Location(),
-			ExtendedLocation:  s.ExtendedLocation(),
-			VNetName:          s.Vnet().Name,
-			VNetResourceGroup: s.Vnet().ResourceGroup,
-			SubnetName:        s.ControlPlaneSubnet().Name,
-			FrontendIPConfigs: []infrav1.FrontendIP{
-				{
-					Name: s.APIServerLB().Name + "-internal-frontEnd", // TODO: improve this name.
-					FrontendIPClass: infrav1.FrontendIPClass{
-						PrivateIPAddress: infrav1.DefaultInternalLBIPAddress,
-					},
-				},
-			},
 			APIServerPort:        s.APIServerPort(),
 			Type:                 infrav1.Internal,
 			SKU:                  s.APIServerLB().SKU,
@@ -291,7 +303,11 @@ func (s *ClusterScope) LBSpecs() []azure.ResourceSpecGetter {
 			BackendPoolName:      s.APIServerLB().BackendPool.Name + "-internal",
 			IdleTimeoutInMinutes: s.APIServerLB().IdleTimeoutInMinutes,
 			AdditionalTags:       s.AdditionalTags(),
-		})
+		}
+
+		// set the internal IP for the internal LB
+		internalLB.FrontendIPConfigs = []infrav1.FrontendIP{apiServerInternalLBIP}
+		specs = append(specs, internalLB)
 	}
 
 	// Node outbound LB

--- a/azure/scope/cluster_test.go
+++ b/azure/scope/cluster_test.go
@@ -2577,12 +2577,6 @@ func TestClusterScope_LBSpecs(t *testing.T) {
 									Role: infrav1.SubnetControlPlane,
 								},
 							},
-							{
-								SubnetClassSpec: infrav1.SubnetClassSpec{
-									Name: "node-subnet",
-									Role: infrav1.SubnetNode,
-								},
-							},
 						},
 						APIServerLB: infrav1.LoadBalancerSpec{
 							Name: "api-server-lb",
@@ -2599,6 +2593,14 @@ func TestClusterScope_LBSpecs(t *testing.T) {
 									Name: "api-server-lb-frontend-ip",
 									PublicIP: &infrav1.PublicIPSpec{
 										Name: "api-server-lb-frontend-ip",
+									},
+								},
+								{
+									// The private IP for the internal LB is set by the Defaulting Webhook
+									// since no defaulters are called here, we have to update the test
+									Name: "api-server-internal-lb-private-ip",
+									FrontendIPClass: infrav1.FrontendIPClass{
+										PrivateIPAddress: "10.10.10.100",
 									},
 								},
 							},
@@ -2683,9 +2685,9 @@ func TestClusterScope_LBSpecs(t *testing.T) {
 					SubnetName:        "cp-subnet",
 					FrontendIPConfigs: []infrav1.FrontendIP{
 						{
-							Name: "api-server-lb-internal-frontEnd",
+							Name: "api-server-internal-lb-private-ip",
 							FrontendIPClass: infrav1.FrontendIPClass{
-								PrivateIPAddress: infrav1.DefaultInternalLBIPAddress,
+								PrivateIPAddress: "10.10.10.100",
 							},
 						},
 					},
@@ -2792,6 +2794,14 @@ func TestClusterScope_LBSpecs(t *testing.T) {
 								IdleTimeoutInMinutes: ptr.To[int32](30),
 								SKU:                  infrav1.SKUStandard,
 							},
+							FrontendIPs: []infrav1.FrontendIP{
+								{
+									Name: "api-server-lb-internal-ip",
+									FrontendIPClass: infrav1.FrontendIPClass{
+										PrivateIPAddress: infrav1.DefaultInternalLBIPAddress,
+									},
+								},
+							},
 						},
 					},
 				},
@@ -2813,6 +2823,14 @@ func TestClusterScope_LBSpecs(t *testing.T) {
 					BackendPoolName:      "api-server-lb-backend-pool",
 					IdleTimeoutInMinutes: ptr.To[int32](30),
 					AdditionalTags:       infrav1.Tags{},
+					FrontendIPConfigs: []infrav1.FrontendIP{
+						{
+							Name: "api-server-lb-internal-ip",
+							FrontendIPClass: infrav1.FrontendIPClass{
+								PrivateIPAddress: infrav1.DefaultInternalLBIPAddress,
+							},
+						},
+					},
 				},
 			},
 		},


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
- This PR makes the private IP of the internal LB of the API Server configurable.
- We need private IP of the workload's API server to be configurable when deploying multiple workload clusters. 
  - CAPZ defaults the Private IP to `10.0.0.100` (strongly coupled with `DefaultVnetCIDR` and `DefaultControlPlaneSubnetCIDR`)
  - While working with AKS as the management cluster; we peer mgmt VNet with Workload cluster's VNet so that mgmt cluster can reach to FQDN of the workload cluster's controlplane. 
  - Since we peer VNets, we need the VNet CIDRs to be non-overlapping.
  - Since the VNet CIDRs have to be non-overlapping, we cannot default to `10.0.0.100` as the VNet CIDR will be opinionated when peering mgmt and workload cluster VNets.
  - Therefore, we want to have a configurable Private IP of the Internal LB of the API Server.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #5264 

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->


- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Private IP of the Internal LB of the API Server will be configurable
```
