### PR TITLE
fix ServicePrincipalCertificate not reading from Secret

### DIFF
--- a/azure/scope/identity.go
+++ b/azure/scope/identity.go
@@ -212,6 +212,8 @@ func (p *AzureCredentialsProvider) hasClientSecret() bool {
 	switch p.Identity.Spec.Type {
 	case infrav1.ServicePrincipal, infrav1.ManualServicePrincipal:
 		return true
+	case infrav1.ServicePrincipalCertificate:
+		return p.Identity.Spec.CertPath == ""
 	default:
 		return false
 	}

--- a/azure/scope/identity_test.go
+++ b/azure/scope/identity_test.go
@@ -166,6 +166,16 @@ func TestHasClientSecret(t *testing.T) {
 					Type: infrav1.ServicePrincipalCertificate,
 				},
 			},
+			want: true,
+		},
+		{
+			name: "service principal with certificate path",
+			identity: &infrav1.AzureClusterIdentity{
+				Spec: infrav1.AzureClusterIdentitySpec{
+					Type:     infrav1.ServicePrincipalCertificate,
+					CertPath: "something",
+				},
+			},
 			want: false,
 		},
 		{


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

This change broke CAPZ's ability to read Service Principal certificate content from a Secret: https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/5200/files#diff-b6ab207506064afcbd1d777c1c7296e2953d2653a8843bfb39107af5cf5b0a87R213

I caught this while iterating on some of the unit tests that intersect with this. I'll try to refactor the tests to better catch things like this later.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [ ] includes documentation
- [X] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
