### PR TITLE
fix ever-accumulating memory in logger

### DIFF
--- a/util/tele/span_logger.go
+++ b/util/tele/span_logger.go
@@ -88,14 +88,18 @@ func (s *spanLogSink) Error(err error, msg string, keysAndValues ...interface{})
 	)
 }
 
-func (s *spanLogSink) WithValues(keysAndValues ...interface{}) logr.LogSink {
-	s.vals = append(s.vals, keysAndValues...)
-	return s
+func (s spanLogSink) WithValues(keysAndValues ...interface{}) logr.LogSink {
+	// always create a new slice to avoid multiple loggers writing to the same backing array
+	vals := make([]interface{}, len(s.vals)+len(keysAndValues))
+	copy(vals, s.vals)
+	copy(vals[len(s.vals):], keysAndValues)
+	s.vals = vals
+	return &s
 }
 
-func (s *spanLogSink) WithName(name string) logr.LogSink {
+func (s spanLogSink) WithName(name string) logr.LogSink {
 	s.name = name
-	return s
+	return &s
 }
 
 // NewSpanLogSink is the main entry-point to this implementation.

--- a/util/tele/span_logger_test.go
+++ b/util/tele/span_logger_test.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tele
+
+import (
+	"testing"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/gomega"
+)
+
+func TestSpanLogSinkWithValues(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	var log0 logr.LogSink = &spanLogSink{
+		// simulating a slice with cap() > len() where an append() will not create a new array
+		vals: make([]interface{}, 0, 4),
+	}
+
+	log0 = log0.WithValues("k0", "v0")
+
+	g.Expect(log0.(*spanLogSink).vals).To(HaveExactElements("k0", "v0"))
+
+	log1 := log0.WithValues("k1", "v1")
+
+	g.Expect(log0.(*spanLogSink).vals).To(HaveExactElements("k0", "v0"))
+	g.Expect(log1.(*spanLogSink).vals).To(HaveExactElements("k0", "v0", "k1", "v1"))
+
+	log2 := log0.WithValues("k2", "v2")
+
+	g.Expect(log0.(*spanLogSink).vals).To(HaveExactElements("k0", "v0"))
+	g.Expect(log1.(*spanLogSink).vals).To(HaveExactElements("k0", "v0", "k1", "v1"))
+	g.Expect(log2.(*spanLogSink).vals).To(HaveExactElements("k0", "v0", "k2", "v2"))
+}


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

This PR fixes an issue where the long-lived loggers created in the `SetupWithManager` methods for each controller were accumulating a constantly-growing set of key/value pairs that could never be garbage collected.

Here is a Prometheus graph showing the fix enabled halfway through:
![memleak](https://github.com/user-attachments/assets/4a310fc1-ec92-474a-bc41-1e54811749aa)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #5245

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

Reproducing this is actually fairly straightforward. I was testing this by creating about 10 `spec.paused: true` Clusters from the `machinepool` flavor in Tilt, then running this command in 3 or 4 terminal windows to spam updates to the CAPZ resources to generate logs:
```
while true; do kubectl annotate azurecluster,amp,azuremachine --all --overwrite jon=$(head -c 32 /dev/urandom | base64); done
```

Pretty much immediately in Prometheus you'll see memory start to climb.

- [X] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [ ] includes documentation
- [X] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixed an issue where CAPZ was accumulating memory over time that could never be garbage collected.
```
