### PR TITLE
add docs on migrating to new ASO API

### DIFF
--- a/.markdownlinkcheck.json
+++ b/.markdownlinkcheck.json
@@ -1,7 +1,7 @@
 {
     "ignorePatterns": [
         { "pattern": "^https://calendar.google.com/calendar" },
-        { "pattern": "^../reference/" }
+        { "pattern": "^\.\.?/" }
     ],
     "httpHeaders": [{
         "comment": "Workaround as suggested here: https://github.com/tcort/markdown-link-check/issues/201",

--- a/docs/book/src/managed/adopting-clusters.md
+++ b/docs/book/src/managed/adopting-clusters.md
@@ -2,7 +2,6 @@
 
 ### Option 1: Using the new AzureASOManaged API
 
-<!-- markdown-link-check-disable-next-line -->
 The [AzureASOManagedControlPlane and related APIs](./asomanagedcluster.md) support
 adoption as a first-class use case. Going forward, this method is likely to be easier, more reliable, include
 more features, and better supported for adopting AKS clusters than Option 2 below.
@@ -15,10 +14,10 @@ and AzureASOManagedMachinePools. The [`asoctl import
 azure-resource`](https://azure.github.io/azure-service-operator/tools/asoctl/#import-azure-resource) command
 can help generate the required YAML.
 
-Caveats:
-- The `asoctl import azure-resource` command has at least [one known
-  bug](https://github.com/Azure/azure-service-operator/issues/3805) requiring the YAML it generates to be
-  edited before it can be applied to a cluster.
+This method can also be used to [migrate](./asomanagedcluster#migrating-existing-clusters-to-azureasomanagedcontrolplane) from AzureManagedControlPlane and its associated APIs.
+
+#### Caveats
+
 - CAPZ currently only records the ASO resources in the CAPZ resources' `spec.resources` that it needs to
   function, which include the ManagedCluster, its ResourceGroup, and associated ManagedClustersAgentPools.
   Other resources owned by the ManagedCluster like Kubernetes extensions or Fleet memberships are not
@@ -29,6 +28,8 @@ Caveats:
 - Adopting existing clusters created with the GA AzureManagedControlPlane API to the experimental API with
   this method is theoretically possible, but untested. Care should be taken to prevent CAPZ from reconciling
   two different representations of the same underlying Azure resources.
+- This method cannot be used to import existing clusters as a ClusterClass or a topology, only as a standalone
+  Cluster.
 
 ### Option 2: Using the current AzureManagedControlPlane API
 


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind documentation

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
This PR adds docs describing how to migrate from AzureManagedControlPlane to AzureASOManagedControlPlane.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #5032

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [X] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Added docs describing how to migrate existing AKS clusters managed by CAPZ to the new ASO-based API
```
