### PR TITLE
[WIP] Make private IP of the internal LB configurable

### DIFF
--- a/azure/scope/cluster_test.go
+++ b/azure/scope/cluster_test.go
@@ -2956,7 +2956,7 @@ func TestClusterScope_LBSpecs(t *testing.T) {
 					SubnetName:        "cp-subnet",
 					FrontendIPConfigs: []infrav1.FrontendIP{
 						{
-							Name: "api-server-lb-internal-frontEnd",
+							Name: "api-server-lb-internal-ip",
 							FrontendIPClass: infrav1.FrontendIPClass{
 								PrivateIPAddress: infrav1.DefaultInternalLBIPAddress,
 							},

--- a/templates/cluster-template-windows-apiserver-ilb.yaml
+++ b/templates/cluster-template-windows-apiserver-ilb.yaml
@@ -39,12 +39,20 @@ spec:
         publicIP:
           dnsName: ${CLUSTER_NAME}-${APISERVER_LB_DNS_SUFFIX}.${AZURE_LOCATION}.cloudapp.azure.com
           name: ${CLUSTER_NAME}-api-lb
+      - name: ${CLUSTER_NAME}-internal-lb-private-ip
+        privateIP: 40.0.11.100
     subnets:
-    - name: control-plane-subnet
+    - cidrBlocks:
+      - 40.0.0.0/16
+      name: control-plane-subnet
       role: control-plane
-    - name: node-subnet
+    - cidrBlocks:
+      - 40.1.0.0/16
+      name: node-subnet
       role: node
     vnet:
+      cidrBlocks:
+      - 40.0.0.0/8
       name: ${AZURE_VNET_NAME:=${CLUSTER_NAME}-vnet}
   resourceGroup: ${AZURE_RESOURCE_GROUP:=${CLUSTER_NAME}}
   subscriptionID: ${AZURE_SUBSCRIPTION_ID}
@@ -200,7 +208,7 @@ spec:
             cloud-provider: external
           name: '{{ ds.meta_data["local_hostname"] }}'
       preKubeadmCommands:
-      - echo '10.0.0.100   ${CLUSTER_NAME}-${APISERVER_LB_DNS_SUFFIX}.${AZURE_LOCATION}.cloudapp.azure.com'
+      - echo '40.0.0.100   ${CLUSTER_NAME}-${APISERVER_LB_DNS_SUFFIX}.${AZURE_LOCATION}.cloudapp.azure.com'
         >> /etc/hosts
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
@@ -298,7 +306,7 @@ spec:
       - powershell C:/defender-exclude-calico.ps1
       preKubeadmCommands:
       - powershell -Command "Add-Content -Path 'C:\\Windows\\System32\\drivers\\etc\\hosts'
-        -Value '10.0.0.100   ${CLUSTER_NAME}-${APISERVER_LB_DNS_SUFFIX}.${AZURE_LOCATION}.cloudapp.azure.com'"
+        -Value '40.0.0.100 ${CLUSTER_NAME}-${APISERVER_LB_DNS_SUFFIX}.${AZURE_LOCATION}.cloudapp.azure.com'"
       users:
       - groups: Administrators
         name: capi

--- a/templates/flavors/apiserver-ilb/patches/control-plane.yaml
+++ b/templates/flavors/apiserver-ilb/patches/control-plane.yaml
@@ -12,3 +12,17 @@ spec:
           publicIP:
             name: ${CLUSTER_NAME}-api-lb
             dnsName: ${CLUSTER_NAME}-${APISERVER_LB_DNS_SUFFIX}.${AZURE_LOCATION}.cloudapp.azure.com
+        - name: ${CLUSTER_NAME}-internal-lb-private-ip
+          privateIP: 30.0.0.100
+    vnet:
+      cidrBlocks:
+        - 30.0.0.0/8
+    subnets:
+      - name: control-plane-subnet
+        role: control-plane
+        cidrBlocks:
+          - 30.0.0.0/16
+      - name: node-subnet
+        role: node
+        cidrBlocks:
+          - 30.1.0.0/16

--- a/templates/flavors/apiserver-ilb/patches/kubeadm-config-template.yaml
+++ b/templates/flavors/apiserver-ilb/patches/kubeadm-config-template.yaml
@@ -8,6 +8,5 @@ spec:
       # /etc/hosts file is updated with a pre-created DNS name of the API server and internal load-balancer's IP.
       # This custom DNS Resolution of the API server ensures that the worker nodes can reach the API server when
       # the public IP of the API server is not accessible.
-      # 10.0.0.100 is the default IP that gets assigned to an internal load balancer.
       preKubeadmCommands:
-        - echo '10.0.0.100   ${CLUSTER_NAME}-${APISERVER_LB_DNS_SUFFIX}.${AZURE_LOCATION}.cloudapp.azure.com' >> /etc/hosts
+        - echo '30.0.0.100   ${CLUSTER_NAME}-${APISERVER_LB_DNS_SUFFIX}.${AZURE_LOCATION}.cloudapp.azure.com' >> /etc/hosts

--- a/templates/flavors/windows-apiserver-ilb/kustomization.yaml
+++ b/templates/flavors/windows-apiserver-ilb/kustomization.yaml
@@ -2,12 +2,51 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: default
 resources:
-- ../apiserver-ilb
-- machine-deployment-windows.yaml
+  - ../apiserver-ilb
+  - machine-deployment-windows.yaml
 
 patches:
-- path: ../base-windows-containerd/cluster.yaml
-- path: patches/kubeadm-config-template.yaml
+  - path: ../base-windows-containerd/cluster.yaml
+  - path: patches/kubeadm-config-template.yaml
+  - target:
+      kind: KubeadmConfigTemplate
+      name: .*-md-0
+    patch: |-
+      - op: replace
+        path: /spec/template/spec/preKubeadmCommands/0
+        value: echo '40.0.0.100   ${CLUSTER_NAME}-${APISERVER_LB_DNS_SUFFIX}.${AZURE_LOCATION}.cloudapp.azure.com' >> /etc/hosts
+  - target:
+      kind: AzureCluster
+    patch: |-
+      - op: replace
+        path: /spec/networkSpec/apiServerLB/frontendIPs/1/privateIP
+        value: 40.0.11.100
+  - target:
+      kind: AzureCluster
+    patch: |-
+      - op: replace
+        path: /spec/networkSpec/vnet/cidrBlocks/0
+        value: 40.0.0.0/8
+  - target:
+      kind: AzureCluster
+    patch: |-
+      - op: replace
+        path: /spec/networkSpec/subnets/0/cidrBlocks/0
+        value: 40.0.0.0/16
+  - target:
+      kind: AzureCluster
+    patch: |-
+      - op: replace
+        path: /spec/networkSpec/subnets/1/cidrBlocks/0
+        value: 40.1.0.0/16
+  - target:
+      kind: KubeadmConfigTemplate
+      name: .*-md-win
+    patch: |-
+      - op: replace
+        path: /spec/template/spec/preKubeadmCommands/0
+        value:
+          powershell -Command "Add-Content -Path 'C:\\Windows\\System32\\drivers\\etc\\hosts' -Value '40.0.0.100 ${CLUSTER_NAME}-${APISERVER_LB_DNS_SUFFIX}.${AZURE_LOCATION}.cloudapp.azure.com'"
 
 sortOptions:
   order: fifo

--- a/templates/test/ci/cluster-template-prow-apiserver-ilb.yaml
+++ b/templates/test/ci/cluster-template-prow-apiserver-ilb.yaml
@@ -1,6 +1,9 @@
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster
 metadata:
+  labels:
+    cloud-provider: ${CLOUD_PROVIDER_AZURE_LABEL:=azure}
+    cni: calico
   name: ${CLUSTER_NAME}
   namespace: default
 spec:
@@ -23,6 +26,10 @@ metadata:
   name: ${CLUSTER_NAME}
   namespace: default
 spec:
+  additionalTags:
+    buildProvenance: ${BUILD_PROVENANCE}
+    creationTimestamp: ${TIMESTAMP}
+    jobName: ${JOB_NAME}
   identityRef:
     apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: AzureClusterIdentity
@@ -36,19 +43,19 @@ spec:
           dnsName: ${CLUSTER_NAME}-${APISERVER_LB_DNS_SUFFIX}.${AZURE_LOCATION}.cloudapp.azure.com
           name: ${CLUSTER_NAME}-api-lb
       - name: ${CLUSTER_NAME}-internal-lb-private-ip
-        privateIP: 30.0.0.100
+        privateIP: ${AZURE_INTERNAL_LB_PRIVATE_IP}
     subnets:
     - cidrBlocks:
-      - 30.0.0.0/16
+      - ${AZURE_CP_SUBNET_CIDR}
       name: control-plane-subnet
       role: control-plane
     - cidrBlocks:
-      - 30.1.0.0/16
+      - ${AZURE_NODE_SUBNET_CIDR}
       name: node-subnet
       role: node
     vnet:
       cidrBlocks:
-      - 30.0.0.0/8
+      - ${AZURE_VNET_CIDR}
       name: ${AZURE_VNET_NAME:=${CLUSTER_NAME}-vnet}
   resourceGroup: ${AZURE_RESOURCE_GROUP:=${CLUSTER_NAME}}
   subscriptionID: ${AZURE_SUBSCRIPTION_ID}
@@ -70,6 +77,7 @@ spec:
           allocate-node-cidrs: "false"
           cloud-provider: external
           cluster-name: ${CLUSTER_NAME}
+          v: "4"
       etcd:
         local:
           dataDir: /var/lib/etcddisk/etcd
@@ -176,10 +184,13 @@ metadata:
 spec:
   template:
     spec:
+      identity: UserAssigned
       osDisk:
         diskSizeGB: 128
         osType: Linux
       sshPublicKey: ${AZURE_SSH_PUBLIC_KEY_B64:=""}
+      userAssignedIdentities:
+      - providerID: /subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${CI_RG:=capz-ci}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER_IDENTITY:=cloud-provider-user-identity}
       vmSize: ${AZURE_NODE_MACHINE_TYPE}
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
@@ -204,7 +215,7 @@ spec:
             cloud-provider: external
           name: '{{ ds.meta_data["local_hostname"] }}'
       preKubeadmCommands:
-      - echo '30.0.0.100   ${CLUSTER_NAME}-${APISERVER_LB_DNS_SUFFIX}.${AZURE_LOCATION}.cloudapp.azure.com'
+      - echo '${AZURE_INTERNAL_LB_PRIVATE_IP}   ${CLUSTER_NAME}-${APISERVER_LB_DNS_SUFFIX}.${AZURE_LOCATION}.cloudapp.azure.com'
         >> /etc/hosts
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
@@ -219,3 +230,105 @@ spec:
   clientID: ${AZURE_CLIENT_ID_USER_ASSIGNED_IDENTITY}
   tenantID: ${AZURE_TENANT_ID}
   type: ${CLUSTER_IDENTITY_TYPE:=WorkloadIdentity}
+---
+apiVersion: addons.cluster.x-k8s.io/v1alpha1
+kind: HelmChartProxy
+metadata:
+  name: calico
+  namespace: default
+spec:
+  chartName: tigera-operator
+  clusterSelector:
+    matchLabels:
+      cni: calico
+  namespace: tigera-operator
+  releaseName: projectcalico
+  repoURL: https://docs.tigera.io/calico/charts
+  valuesTemplate: |-
+    installation:
+      cni:
+        type: Calico
+      calicoNetwork:
+        bgp: Disabled
+        mtu: 1350
+        ipPools:
+        ipPools:{{range $i, $cidr := .Cluster.spec.clusterNetwork.pods.cidrBlocks }}
+        - cidr: {{ $cidr }}
+          encapsulation: VXLAN{{end}}
+      registry: mcr.microsoft.com/oss
+    # Image and registry configuration for the tigera/operator pod.
+    tigeraOperator:
+      image: tigera/operator
+      registry: mcr.microsoft.com/oss
+    calicoctl:
+      image: mcr.microsoft.com/oss/calico/ctl
+  version: ${CALICO_VERSION}
+---
+apiVersion: addons.cluster.x-k8s.io/v1alpha1
+kind: HelmChartProxy
+metadata:
+  name: azuredisk-csi-driver-chart
+  namespace: default
+spec:
+  chartName: azuredisk-csi-driver
+  clusterSelector:
+    matchLabels:
+      azuredisk-csi: "true"
+  namespace: kube-system
+  releaseName: azuredisk-csi-driver-oot
+  repoURL: https://raw.githubusercontent.com/kubernetes-sigs/azuredisk-csi-driver/master/charts
+  valuesTemplate: |-
+    controller:
+      replicas: 1
+      runOnControlPlane: true
+    windows:
+      useHostProcessContainers: {{ hasKey .Cluster.metadata.labels "cni-windows" }}
+---
+apiVersion: addons.cluster.x-k8s.io/v1alpha1
+kind: HelmChartProxy
+metadata:
+  name: cloud-provider-azure-chart
+  namespace: default
+spec:
+  chartName: cloud-provider-azure
+  clusterSelector:
+    matchLabels:
+      cloud-provider: azure
+  releaseName: cloud-provider-azure-oot
+  repoURL: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/helm/repo
+  valuesTemplate: |
+    infra:
+      clusterName: {{ .Cluster.metadata.name }}
+    cloudControllerManager:
+      clusterCIDR: {{ .Cluster.spec.clusterNetwork.pods.cidrBlocks | join "," }}
+      logVerbosity: 4
+---
+apiVersion: addons.cluster.x-k8s.io/v1alpha1
+kind: HelmChartProxy
+metadata:
+  name: cloud-provider-azure-chart-ci
+  namespace: default
+spec:
+  chartName: cloud-provider-azure
+  clusterSelector:
+    matchLabels:
+      cloud-provider: azure-ci
+  releaseName: cloud-provider-azure-oot
+  repoURL: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/helm/repo
+  valuesTemplate: |
+    infra:
+      clusterName: {{ .Cluster.metadata.name }}
+    cloudControllerManager:
+      cloudConfig: ${CLOUD_CONFIG:-"/etc/kubernetes/azure.json"}
+      cloudConfigSecretName: ${CONFIG_SECRET_NAME:-""}
+      clusterCIDR: {{ .Cluster.spec.clusterNetwork.pods.cidrBlocks | join "," }}
+      imageName: "${CCM_IMAGE_NAME:-""}"
+      imageRepository: "${IMAGE_REGISTRY:-""}"
+      imageTag: "${IMAGE_TAG_CCM:-""}"
+      logVerbosity: ${CCM_LOG_VERBOSITY:-4}
+      replicas: ${CCM_COUNT:-1}
+      enableDynamicReloading: ${ENABLE_DYNAMIC_RELOADING:-false}
+    cloudNodeManager:
+      imageName: "${CNM_IMAGE_NAME:-""}"
+      imageRepository: "${IMAGE_REGISTRY:-""}"
+      imageTag: "${IMAGE_TAG_CNM:-""}"

--- a/templates/test/ci/prow-apiserver-ilb/kustomization.yaml
+++ b/templates/test/ci/prow-apiserver-ilb/kustomization.yaml
@@ -1,0 +1,51 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: default
+resources:
+  - ../../../flavors/apiserver-ilb
+  - ../../../addons/cluster-api-helm/calico.yaml
+  - ../../../addons/cluster-api-helm/azuredisk-csi-driver.yaml
+  - ../../../addons/cluster-api-helm/cloud-provider-azure.yaml
+  - ../../../addons/cluster-api-helm/cloud-provider-azure-ci.yaml
+
+patches:
+  - path: ../patches/tags.yaml
+  - path: ../patches/controller-manager.yaml
+  - path: ../patches/uami-md-0.yaml
+  - path: ../patches/uami-control-plane.yaml
+  - path: ../patches/cluster-label-calico.yaml
+  - path: ../patches/cluster-label-cloud-provider-azure.yaml
+  - target:
+      kind: KubeadmConfigTemplate
+      name: .*-md-0
+    patch: |-
+      - op: replace
+        path: /spec/template/spec/preKubeadmCommands/0
+        value: echo '${AZURE_INTERNAL_LB_PRIVATE_IP}   ${CLUSTER_NAME}-${APISERVER_LB_DNS_SUFFIX}.${AZURE_LOCATION}.cloudapp.azure.com' >> /etc/hosts
+  - target:
+      kind: AzureCluster
+    patch: |-
+      - op: replace
+        path: /spec/networkSpec/apiServerLB/frontendIPs/1/privateIP
+        value: ${AZURE_INTERNAL_LB_PRIVATE_IP}
+  - target:
+      kind: AzureCluster
+    patch: |-
+      - op: replace
+        path: /spec/networkSpec/vnet/cidrBlocks/0
+        value: ${AZURE_VNET_CIDR}
+  - target:
+      kind: AzureCluster
+    patch: |-
+      - op: replace
+        path: /spec/networkSpec/subnets/0/cidrBlocks/0
+        value: ${AZURE_CP_SUBNET_CIDR}
+  - target:
+      kind: AzureCluster
+    patch: |-
+      - op: replace
+        path: /spec/networkSpec/subnets/1/cidrBlocks/0
+        value: ${AZURE_NODE_SUBNET_CIDR}
+
+sortOptions:
+  order: fifo

--- a/test/e2e/azure_apiserver_ilb.go
+++ b/test/e2e/azure_apiserver_ilb.go
@@ -1,0 +1,447 @@
+//go:build e2e
+// +build e2e
+
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+/*
+                                  +--------------------------------+
+                                  |           Start Test           |
+                                  +--------------------------------+
+                                             |
+                                             v
++-------------------------------------------+--------------------------------------------+
+| Fetch Azure Credentials                   | Get Azure Load Balancer Client             |
++-------------------------------------------+--------------------------------------------+
+                                             |
+                                             v
++-------------------------------------------+--------------------------------------------+
+| Verify Azure Internal Load Balancer       | - Check Load Balancer Name                 |
+| - Verify Provisioning State               | - Confirm Succeeded State                  |
++-------------------------------------------+--------------------------------------------+
+                                             |
+                                             v
++-------------------------------------------+--------------------------------------------+
+| Create Dynamic Client for Management      | Get Azure Cluster Resource                 |
+| Cluster                                   | - Extract Control Plane Endpoint           |
+|                                           | - Extract API Server ILB Private IP         |
++-------------------------------------------+--------------------------------------------+
+                                             |
+                                             v
++-------------------------------------------+--------------------------------------------+
+| Create Kubernetes Client Set for          | Create Workload Cluster Proxy              |
+| Workload Cluster                          |                                            |
++-------------------------------------------+--------------------------------------------+
+                                             |
+                                             v
++-------------------------------------------+--------------------------------------------+
+| Deploy Node-Debug DaemonSet               | - Add to Default Namespace                 |
+| - Mount Host /etc/hosts                   | - Configure Privileged Container           |
++-------------------------------------------+--------------------------------------------+
+                                             |
+                                             v
++-------------------------------------------+--------------------------------------------+
+| List and Verify Worker Nodes              | - Ensure Expected Number of Nodes          |
+| - Identify Worker Nodes                   | - Confirm Node Names Match Cluster         |
++-------------------------------------------+--------------------------------------------+
+                                             |
+                                             v
++-------------------------------------------+--------------------------------------------+
+| List Node-Debug Pods                      | - Verify Pods on Worker Nodes              |
+| - Check Pod Status                        | - Ensure Running Phase                     |
++-------------------------------------------+--------------------------------------------+
+                                             |
+                                             v
++-------------------------------------------+--------------------------------------------+
+| Execute Test Commands on Each Pod         | 1. Verify "Hello from node-debug pod"      |
+| - Use Remote Exec                         | 2. Check /host/etc contents                |
+| - Stream stdout/stderr                    | 3. Validate Against Expected Outputs       |
++-------------------------------------------+--------------------------------------------+
+                                             |
+                                             v
++-------------------------------------------+--------------------------------------------+
+| Validate Test Results                     | - Check All Pods Pass Tests                |
+| - Retry if Any Pod Fails                  | - Ensure Consistent Results                |
++-------------------------------------------+--------------------------------------------+
+                                             |
+                                             v
+                                  +--------------------------------+
+                                  |        Test Complete           |
+                                  +--------------------------------+
+*/
+
+package e2e
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v4"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/tools/remotecommand"
+	"k8s.io/kubectl/pkg/scheme"
+	"k8s.io/utils/ptr"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/test/framework"
+
+	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
+)
+
+// AzureAPIServerILBSpecInput is the input for AzureAPIServerILBSpec.
+type AzureAPIServerILBSpecInput struct {
+	BootstrapClusterProxy framework.ClusterProxy
+	Cluster               *clusterv1.Cluster
+	Namespace             *corev1.Namespace
+	ClusterName           string
+	ExpectedWorkerNodes   int32
+	WaitIntervals         []interface{}
+}
+
+// AzureAPIServerILBSpec implements a test that verifies the Azure API server ILB is created.
+func AzureAPIServerILBSpec(ctx context.Context, inputGetter func() AzureAPIServerILBSpecInput) {
+	var (
+		specName = "azure-apiserver-ilb"
+		input    AzureAPIServerILBSpecInput
+	)
+
+	input = inputGetter()
+	Expect(input.Namespace).NotTo(BeNil(), "Invalid argument. input.Namespace can't be nil when calling %s spec", specName)
+	Expect(input.ClusterName).NotTo(BeEmpty(), "Invalid argument. input.ClusterName can't be empty when calling %s spec", specName)
+
+	By("Fetching new Azure Credentials")
+	cred, err := azidentity.NewDefaultAzureCredential(nil)
+	Expect(err).NotTo(HaveOccurred())
+
+	By("Getting azureLoadBalancerClient")
+	azureLoadBalancerClient, err := armnetwork.NewLoadBalancersClient(getSubscriptionID(Default), cred, nil)
+	Expect(err).NotTo(HaveOccurred())
+
+	By("Verifying the Azure API Server Internal Load Balancer is created")
+	groupName := os.Getenv(AzureResourceGroup)
+	fmt.Fprintf(GinkgoWriter, "Azure Resource Group: %s\n", groupName)
+	internalLoadbalancerName := fmt.Sprintf("%s-%s", input.ClusterName, "public-lb-internal")
+
+	backoff := wait.Backoff{
+		Duration: 300 * time.Second,
+		Factor:   0.5,
+		Jitter:   0.5,
+		Steps:    7,
+	}
+	retryFn := func(ctx context.Context) (bool, error) {
+		defer GinkgoRecover()
+		resp, err := azureLoadBalancerClient.Get(ctx, groupName, internalLoadbalancerName, nil)
+		if err != nil {
+			return false, err
+		}
+
+		By("Verifying the Azure API Server Internal Load Balancer is the right one created")
+		internalLoadbalancer := resp.LoadBalancer
+		Expect(ptr.Deref(internalLoadbalancer.Name, "")).To(Equal(internalLoadbalancerName))
+
+		By("Verifying the Azure API Server Internal Load Balancer is in a succeeded state")
+		switch ptr.Deref(internalLoadbalancer.Properties.ProvisioningState, "") {
+		case armnetwork.ProvisioningStateSucceeded:
+			return true, nil
+		case armnetwork.ProvisioningStateUpdating:
+			// Wait for operation to complete.
+			return false, nil
+		default:
+			return false, fmt.Errorf("azure internal loadbalancer provisioning failed with state: %q", ptr.Deref(internalLoadbalancer.Properties.ProvisioningState, "(nil)"))
+		}
+	}
+	err = wait.ExponentialBackoffWithContext(ctx, backoff, retryFn)
+	Expect(err).NotTo(HaveOccurred())
+
+	// ------------------------ //
+	By("Creating a dynamic client for accessing custom resources in the management cluster")
+	mgmtRestConfig := input.BootstrapClusterProxy.GetRESTConfig()
+	mgmtDynamicClientSet, err := dynamic.NewForConfig(mgmtRestConfig)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(mgmtDynamicClientSet).NotTo(BeNil())
+
+	By("Getting the AzureCluster using the dynamic client set")
+	azureClusterGVR := schema.GroupVersionResource{
+		Group:    "infrastructure.cluster.x-k8s.io",
+		Version:  "v1beta1",
+		Resource: "azureclusters",
+	}
+
+	azureCluster, err := mgmtDynamicClientSet.Resource(azureClusterGVR).
+		Namespace(input.Namespace.Name).
+		Get(ctx, input.ClusterName, metav1.GetOptions{})
+	Expect(err).NotTo(HaveOccurred())
+
+	deployedAzureCluster := &infrav1.AzureCluster{}
+	err = runtime.DefaultUnstructuredConverter.FromUnstructured(
+		azureCluster.UnstructuredContent(),
+		deployedAzureCluster,
+	)
+	Expect(err).NotTo(HaveOccurred())
+
+	By("Getting the controlplane endpoint name")
+	controlPlaneEndpointName, apiServerILBPrivateIP := "", ""
+	for _, frontendIP := range deployedAzureCluster.Spec.NetworkSpec.APIServerLB.FrontendIPs {
+		if frontendIP.PublicIP != nil && frontendIP.PublicIP.DNSName != "" {
+			controlPlaneEndpointName = frontendIP.PublicIP.DNSName
+		} else if frontendIP.PrivateIPAddress != "" {
+			apiServerILBPrivateIP = frontendIP.PrivateIPAddress
+		}
+	}
+	Expect(controlPlaneEndpointName).NotTo(BeEmpty(), "controlPlaneEndpointName should be found at AzureCluster.Spec.NetworkSpec.APIServerLB.FrontendIPs with a valid DNS name")
+	Expect(controlPlaneEndpointName).To(Equal(fmt.Sprintf("%s-%s.%s.cloudapp.azure.com", input.ClusterName, os.Getenv("APISERVER_LB_DNS_SUFFIX"), os.Getenv("AZURE_LOCATION"))))
+	Expect(apiServerILBPrivateIP).NotTo(BeEmpty(), "apiServerILBPrivateIP should be found at AzureCluster.Spec.NetworkSpec.APIServerLB.FrontendIPs when apiserver ilb feature flag is enabled")
+	// ------------------------ //
+
+	By("Creating a Kubernetes client set to the workload cluster")
+	workloadClusterProxy := input.BootstrapClusterProxy.GetWorkloadCluster(ctx, input.Namespace.Name, input.ClusterName)
+	Expect(workloadClusterProxy).NotTo(BeNil())
+	workloadClusterClient := workloadClusterProxy.GetClient()
+	Expect(workloadClusterClient).NotTo(BeNil())
+	workloadClusterClientSet := workloadClusterProxy.GetClientSet()
+	Expect(workloadClusterClientSet).NotTo(BeNil())
+
+	// Deploy node-debug daemonset to workload cluster
+	By("Deploying node-debug daemonset to the workload cluster")
+	nodeDebugDS := &v1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "node-debug",
+			Namespace: "default",
+		},
+		Spec: v1.DaemonSetSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app": "node-debug",
+				},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"app": "node-debug",
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "node-debug",
+							Image: "docker.io/library/busybox:latest",
+							SecurityContext: &corev1.SecurityContext{
+								Privileged: ptr.To(true),
+							},
+							Command: []string{
+								"sh",
+								"-c",
+								"tail -f /dev/null",
+							},
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      "etc-hosts",
+									MountPath: "/host/etc",
+									ReadOnly:  true,
+								},
+							},
+							ReadinessProbe: &corev1.Probe{
+								ProbeHandler: corev1.ProbeHandler{
+									Exec: &corev1.ExecAction{
+										Command: []string{"ls"},
+									},
+								},
+								InitialDelaySeconds: 0,
+								PeriodSeconds:       1,
+								TimeoutSeconds:      60,
+							},
+						},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: "etc-hosts",
+							VolumeSource: corev1.VolumeSource{
+								HostPath: &corev1.HostPathVolumeSource{
+									Path: "/etc/hosts",
+									Type: ptr.To(corev1.HostPathFile),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	err = workloadClusterClient.Create(ctx, nodeDebugDS)
+	Expect(err).NotTo(HaveOccurred())
+
+	backoff = wait.Backoff{
+		Duration: 100 * time.Second,
+		Factor:   0.5,
+		Jitter:   0.5,
+		Steps:    5,
+	}
+	retryDSFn := func(ctx context.Context) (bool, error) {
+		defer GinkgoRecover()
+
+		By("Saving all the nodes")
+		allNodes := &corev1.NodeList{}
+		err = workloadClusterClient.List(ctx, allNodes)
+		if err != nil {
+			return false, fmt.Errorf("failed to list nodes in the workload cluster: %v", err)
+		}
+
+		if len(allNodes.Items) == 0 {
+			return false, fmt.Errorf("no nodes found in the workload cluster")
+		}
+
+		By("Saving all the worker nodes")
+		workerNodes := make(map[string]corev1.Node, 0)
+		for i, node := range allNodes.Items {
+			if strings.Contains(node.Name, input.ClusterName+"-md-0") {
+				workerNodes[node.Name] = allNodes.Items[i]
+			}
+		}
+		if len(workerNodes) != int(input.ExpectedWorkerNodes) {
+			return false, fmt.Errorf("expected number of worker nodes: %d, got: %d", input.ExpectedWorkerNodes, len(workerNodes))
+		}
+
+		By("Saving all the node-debug pods running on the worker nodes")
+		allNodeDebugPods, err := workloadClusterClientSet.CoreV1().Pods("default").List(ctx, metav1.ListOptions{
+			LabelSelector: "app=node-debug",
+		})
+		if err != nil {
+			return false, fmt.Errorf("failed to list node-debug pods in the workload cluster: %v", err)
+		}
+
+		workerDSPods := make(map[string]corev1.Pod, 0)
+		workerDSPodsTestResult := make(map[string]bool, 0)
+		for _, daemonsetPod := range allNodeDebugPods.Items {
+			if _, ok := workerNodes[daemonsetPod.Spec.NodeName]; ok {
+				workerDSPods[daemonsetPod.Name] = daemonsetPod
+				workerDSPodsTestResult[daemonsetPod.Name] = false
+			}
+		}
+		if len(workerDSPods) != int(input.ExpectedWorkerNodes) {
+			return false, fmt.Errorf("expected number of worker node-debug daemonset pods: %d, got: %d", input.ExpectedWorkerNodes, len(workerDSPods))
+		}
+
+		By("Getting the kubeconfig path for the workload cluster")
+		workloadClusterKubeConfigPath := workloadClusterProxy.GetKubeconfigPath()
+		workloadClusterKubeConfig, err := clientcmd.BuildConfigFromFlags("", workloadClusterKubeConfigPath)
+
+		if err != nil {
+			return false, fmt.Errorf("failed to build workload cluster kubeconfig from flags: %v", err)
+		}
+
+		fmt.Fprintf(GinkgoWriter, "Number of node debug pods deployed on worker nodes: %v\n", len(workerDSPods))
+		for _, nodeDebugPod := range workerDSPods {
+			fmt.Fprintf(GinkgoWriter, "node-debug pod %v is deployed on node %v\n", nodeDebugPod.Name, nodeDebugPod.Spec.NodeName)
+
+			By("Checking the status of the node-debug pod")
+			switch nodeDebugPod.Status.Phase {
+			case corev1.PodPending:
+				fmt.Fprintf(GinkgoWriter, "Pod %s is in Pending phase. Retrying\n", nodeDebugPod.Name)
+				return false /* retry */, nil
+			case corev1.PodRunning:
+				fmt.Fprintf(GinkgoWriter, "Pod %s is in Running phase. Proceeding\n", nodeDebugPod.Name)
+			default:
+				return false, fmt.Errorf("node-debug pod %s is in an unexpected phase: %v", nodeDebugPod.Name, nodeDebugPod.Status.Phase)
+			}
+
+			listOfCommands := map[string][]string{
+				"Hello from node-debug pod": {"sh", "-c", "echo \"Hello from node-debug pod\""},
+				apiServerILBPrivateIP:       {"sh", "-c", "test -f /host/etc && cat /host/etc || echo 'File not found'"}, // /etc/host is mounted as /host/etc/hosts in the node-debug pod
+			}
+			testResult := map[string]bool{
+				"Hello from node-debug pod": false,
+				apiServerILBPrivateIP:       false,
+			}
+			for expectedCmdOutput, execCommand := range listOfCommands {
+				fmt.Fprintf(GinkgoWriter, "Trying to exec into the pod %s at namespace %s and running the command %s\n", nodeDebugPod.Name, nodeDebugPod.Namespace, strings.Join(execCommand, " "))
+				execRequest := workloadClusterClientSet.CoreV1().RESTClient().Post().Resource("pods").Name(nodeDebugPod.Name).
+					Namespace(nodeDebugPod.Namespace).
+					SubResource("exec")
+
+				option := &corev1.PodExecOptions{
+					Command: execCommand,
+					Stdin:   false,
+					Stdout:  true,
+					Stderr:  true,
+					TTY:     false,
+				}
+
+				execRequest.VersionedParams(
+					option,
+					scheme.ParameterCodec,
+				)
+
+				fmt.Fprintf(GinkgoWriter, "Creating executor for the pod %s using the URL %v\n", nodeDebugPod.Name, execRequest.URL())
+				exec, err := remotecommand.NewSPDYExecutor(workloadClusterKubeConfig, "POST", execRequest.URL())
+				if err != nil {
+					return false, fmt.Errorf("failed to create executor: %v", err)
+				}
+
+				By("Streaming stdout/err from the daemonset")
+				var stdout, stderr bytes.Buffer
+				err = exec.StreamWithContext(context.Background(), remotecommand.StreamOptions{
+					Stdin:  nil,
+					Stdout: &stdout,
+					Stderr: &stderr,
+					Tty:    false,
+				})
+				if err != nil {
+					return false, fmt.Errorf("failed to stream stdout/err from the daemonset: %v", err)
+				}
+				output := stdout.String()
+				fmt.Fprintf(GinkgoWriter, "Captured output:\n%s\n", output)
+
+				if strings.Contains(output, expectedCmdOutput) {
+					testResult[expectedCmdOutput] = true
+				}
+			}
+
+			if testResult[apiServerILBPrivateIP] && testResult["Hello from node-debug pod"] {
+				fmt.Fprintf(GinkgoWriter, "Tests passed for the pod %s\n", nodeDebugPod.Name)
+				workerDSPodsTestResult[nodeDebugPod.Name] = true
+			} else {
+				fmt.Fprintf(GinkgoWriter, "Tests did not pass for the pod %s\n", nodeDebugPod.Name)
+				fmt.Fprintf(GinkgoWriter, "Tests update: %v, %v\n", testResult["Hello from node-debug pod"], testResult[apiServerILBPrivateIP])
+				return false /* retry */, nil
+			}
+		}
+
+		checkTestOutputForAllWorkerPods := true
+		for podName, testResult := range workerDSPodsTestResult {
+			fmt.Fprintf(GinkgoWriter, "Test result for pod %s: %v\n", podName, testResult)
+			checkTestOutputForAllWorkerPods = checkTestOutputForAllWorkerPods && testResult
+		}
+
+		if checkTestOutputForAllWorkerPods {
+			return true, nil
+		}
+		return false /* retry */, nil
+	}
+	err = wait.ExponentialBackoffWithContext(ctx, backoff, retryDSFn)
+	Expect(err).NotTo(HaveOccurred())
+}

--- a/test/e2e/azure_test.go
+++ b/test/e2e/azure_test.go
@@ -1153,4 +1153,56 @@ var _ = Describe("Workload cluster creation", func() {
 			By("PASSED!")
 		})
 	})
+
+	Context("Creating a self-managed VM based cluster using API Server ILB feature gate [OPTIONAL][API-Server-ILB]", func() {
+		It("with three controlplane node and three worker nodes", func() {
+			clusterName = getClusterName(clusterNamePrefix, "apiserver-ilb")
+
+			// Set the environment variables required for the API Server ILB feature gate
+			Expect(os.Setenv("EXP_APISERVER_ILB", "true")).To(Succeed())
+			Expect(os.Setenv("AZURE_INTERNAL_LB_PRIVATE_IP", "40.0.0.100")).To(Succeed())
+			Expect(os.Setenv("AZURE_VNET_CIDR", "40.0.0.0/8")).To(Succeed())
+			Expect(os.Setenv("AZURE_CP_SUBNET_CIDR", "40.0.0.0/16")).To(Succeed())
+			Expect(os.Setenv("AZURE_NODE_SUBNET_CIDR", "40.1.0.0/16")).To(Succeed())
+
+			clusterctl.ApplyClusterTemplateAndWait(ctx, createApplyClusterTemplateInput(
+				specName,
+				withFlavor("apiserver-ilb"),
+				withNamespace(namespace.Name),
+				withClusterName(clusterName),
+				withControlPlaneMachineCount(3),
+				withWorkerMachineCount(2),
+				withControlPlaneInterval(specName, "wait-control-plane-ha"),
+				withControlPlaneWaiters(clusterctl.ControlPlaneWaiters{
+					WaitForControlPlaneInitialized: EnsureControlPlaneInitializedNoAddons,
+				}),
+				withPostMachinesProvisioned(func() {
+					EnsureDaemonsets(ctx, func() DaemonsetsSpecInput {
+						return DaemonsetsSpecInput{
+							BootstrapClusterProxy: bootstrapClusterProxy,
+							Namespace:             namespace,
+							ClusterName:           clusterName,
+						}
+					})
+				}),
+			), result)
+
+			By("Probing workload cluster with APIServerILB feature gate", func() {
+				AzureAPIServerILBSpec(ctx, func() AzureAPIServerILBSpecInput {
+					return AzureAPIServerILBSpecInput{
+						BootstrapClusterProxy: bootstrapClusterProxy,
+						Cluster:               result.Cluster,
+						Namespace:             namespace,
+						ClusterName:           clusterName,
+						ExpectedWorkerNodes:   result.ExpectedWorkerNodes(),
+						WaitIntervals:         e2eConfig.GetIntervals(specName, "wait-worker-nodes"),
+					}
+				})
+			})
+
+			By("PASSED!")
+		})
+	})
+
+	// TODO: add a same test as above for a windows cluster
 })

--- a/test/e2e/config/azure-dev.yaml
+++ b/test/e2e/config/azure-dev.yaml
@@ -172,6 +172,8 @@ providers:
         targetName: "cluster-template-azure-cni-v1.yaml"
       - sourcePath: "${PWD}/templates/test/ci/cluster-template-prow-spot.yaml"
         targetName: "cluster-template-spot.yaml"
+      - sourcePath: "${PWD}/templates/test/ci/cluster-template-prow-apiserver-ilb.yaml"
+        targetName: "cluster-template-apiserver-ilb.yaml"
       replacements:
       - old: "--v=0"
         new: "--v=2"
@@ -240,6 +242,7 @@ variables:
   LATEST_CAAPH_UPGRADE_VERSION: "v0.2.5"
   CI_RG: capz-ci
   USER_IDENTITY: cloud-provider-user-identity
+  EXP_APISERVER_ILB: "true"
 
 intervals:
   default/wait-controllers: ["3m", "10s"]


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind feature

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
- This PR is needed for updating Tilt workflow to spin up VM based templates with custom, non-overlapping Private IPs. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #5264 

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->
- Lets merge this PR once https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/5311 is merged.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests
- [ ] cherry-pick candidate

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
feat APIServerILB: private IP of the internal LB can be customized
```
