### PR TITLE
Revert "Update Tiltfile to use env variable to check aks cluster is being used"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -742,12 +742,10 @@ verify-container-images: ## Verify container images
 .PHONY: kind-create
 kind-create: $(KUBECTL) ## Create capz kind cluster if needed.
 	./scripts/kind-with-registry.sh
-	unset MGMT_CLUSTER_TYPE
 
 .PHONY: aks-create
 aks-create: $(KUBECTL) ## Create aks cluster as mgmt cluster.
 	./scripts/aks-as-mgmt.sh
-	export MGMT_CLUSTER_TYPE=aks
 
 .PHONY: tilt-up
 tilt-up: install-tools ## Start tilt and build kind cluster if needed.

--- a/Tiltfile
+++ b/Tiltfile
@@ -50,9 +50,8 @@ if "allowed_contexts" in settings:
 if "default_registry" in settings:
     default_registry(settings.get("default_registry"))
 
-mgmt_cluster_type = os.getenv("MGMT_CLUSTER_TYPE", "")
 os_arch = str(local("go env GOARCH")).rstrip("\n")
-if mgmt_cluster_type == "aks":
+if "aks" in settings.get("kustomize_substitutions", {}).get("MGMT_CLUSTER_NAME", ""):
     print("Using AKS as management cluster, setting os_arch to amd64")
     os_arch = "amd64"
 


### PR DESCRIPTION
Reverts kubernetes-sigs/cluster-api-provider-azure#5306

Reason to revert: https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/5306#issuecomment-2568682563