### PR TITLE
split verify-gen into multiple targets in pre-push pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,66 +1,78 @@
 default_stages: [pre-commit, pre-push]
 default_install_hook_types: [pre-commit, pre-push]
 repos:
-- repo: https://github.com/gitleaks/gitleaks
-  rev: v8.21.1
-  hooks:
-  - id: gitleaks
-    stages: [pre-commit]
-- repo: https://github.com/koalaman/shellcheck-precommit
-  rev: v0.10.0
-  hooks:
-  - id: shellcheck
-    args: ["--external-sources"]
-    stages: [pre-commit]
-- repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v5.0.0
-  hooks:
-  - id: end-of-file-fixer
-    stages: [pre-commit]
-  - id: trailing-whitespace
-    stages: [pre-commit]
-  - id: detect-private-key
-    stages: [pre-commit]
-- repo: https://github.com/pylint-dev/pylint
-  rev: v3.3.1
-  hooks:
-  - id: pylint
-    exclude: ^hack/boilerplate/boilerplate.py$
-    stages: [pre-commit]
-- repo: https://github.com/jumanjihouse/pre-commit-hooks
-  rev: 3.0.0
-  hooks:
-  - id: forbid-binary
-    stages: [pre-commit]
-- repo: local
-  hooks:
-  - id: make-modules
-    name: Run make verify-modules
-    entry: make verify-modules
-    language: system
-    stages: [pre-push]
-  - id: make-gen
-    name: Run make verify-gen
-    entry: make verify-gen
-    language: system
-    stages: [pre-push]
-  - id: make-spellcheck
-    name: Run make verify-shellcheck
-    entry: make verify-shellcheck
-    language: system
-    stages: [pre-push]
-  - id: make-conversions
-    name: Run make verify-conversions
-    entry: make verify-conversions
-    language: system
-    stages: [pre-push]
-  - id: make-tiltfile
-    name: Run make verify-tiltfile
-    entry: make verify-tiltfile
-    language: system
-    stages: [pre-push]
-  - id: make-test
-    name: Run make go-test
-    entry: make go-test
-    language: system
-    stages: [pre-push]
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.21.1
+    hooks:
+      - id: gitleaks
+        stages: [pre-commit]
+  - repo: https://github.com/koalaman/shellcheck-precommit
+    rev: v0.10.0
+    hooks:
+      - id: shellcheck
+        args: ["--external-sources"]
+        stages: [pre-commit]
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: end-of-file-fixer
+        stages: [pre-commit]
+      - id: trailing-whitespace
+        stages: [pre-commit]
+      - id: detect-private-key
+        stages: [pre-commit]
+  - repo: https://github.com/pylint-dev/pylint
+    rev: v3.3.1
+    hooks:
+      - id: pylint
+        exclude: ^hack/boilerplate/boilerplate.py$
+        stages: [pre-commit]
+  - repo: https://github.com/jumanjihouse/pre-commit-hooks
+    rev: 3.0.0
+    hooks:
+      - id: forbid-binary
+        stages: [pre-commit]
+  - repo: local
+    hooks:
+      - id: make-modules
+        name: Run make verify-modules
+        entry: make verify-modules
+        stages: [pre-push]
+        language: system
+        require_serial: true
+      - id: make-gen
+        name: Run make generate
+        entry: make generate
+        stages: [pre-push]
+        language: system
+        require_serial: true
+      - id: make-verify-generate-local
+        name: Run make verify-generate-local
+        entry: make verify-generate-local
+        stages: [ pre-push ]
+        language: system
+        require_serial: true
+      - id: make-spellcheck
+        name: Run make verify-shellcheck
+        entry: make verify-shellcheck
+        stages: [pre-push]
+        language: system
+        require_serial: true
+      - id: make-conversions
+        name: Run make verify-conversions
+        entry: make verify-conversions
+        stages: [pre-push]
+        language: system
+        require_serial: true
+      - id: make-tiltfile
+        name: Run make verify-tiltfile
+        entry: make verify-tiltfile
+        stages: [pre-push]
+        language: system
+        require_serial: true
+      - id: make-test
+        name: Run make go-test
+        entry: make go-test
+        stages: [pre-push]
+        language: system
+        require_serial: true

--- a/Makefile
+++ b/Makefile
@@ -287,6 +287,13 @@ verify-gen: generate ## Verify generated files are the latest.
 		git diff; echo "generated files are out of date, run make generate"; exit 1; \
 	fi
 
+.PHONY: verify-generate-local
+verify-generate-local: ## Verify generated files are the latest. To be run locally
+	@if !(git diff --quiet HEAD); then \
+		git diff; echo "generated files are out of date, run make generate"; exit 1; \
+	fi
+
+
 .PHONY: verify-shellcheck
 verify-shellcheck: ## Verify shell files are shellcheck.
 	./hack/verify-shellcheck.sh
@@ -379,7 +386,7 @@ create-workload-cluster: $(ENVSUBST) $(KUBECTL) ## Create a workload cluster.
 	$(KUBECTL) get secret/$(CLUSTER_NAME)-kubeconfig -n default -o json | jq -r .data.value | base64 --decode > ./kubeconfig
 	# TODO: Standardize timeouts across the Makefile and make them configurable based on the job.
 	$(KUBECTL) -n default wait --for=condition=Ready --timeout=60m cluster "$(CLUSTER_NAME)"
-	
+
 	# Set the namespace to `default` b/c when the service account is auto mounted, the namespace is changed to `test-pods`.
 	$(KUBECTL) --kubeconfig=./kubeconfig config set-context --current --namespace="default"
 


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind cleanup 

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
- I found that splitting make verify-gen into two targets is helping with swap file accumulation that was slowing down pre-push stage.
- Without this change, upon running pre-push stage locally, the swap file was increasing to 56GB and the pre-push stage ran for 52 mins. 😢 


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #https://github.com/kubernetes-sigs/cluster-api-provider-azure/issues/5318

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->


**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] cherry-pick candidate

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
