### PR TITLE
Perform nil check on old lb in azurecluster_validation.go

### DIFF
--- a/api/v1beta1/azurecluster_validation.go
+++ b/api/v1beta1/azurecluster_validation.go
@@ -458,7 +458,7 @@ func validateAPIServerLB(lb *LoadBalancerSpec, old *LoadBalancerSpec, cidrs []st
 				allErrs = append(allErrs, err)
 			}
 
-			if len(old.FrontendIPs) != 0 && old.FrontendIPs[0].PrivateIPAddress != lb.FrontendIPs[0].PrivateIPAddress {
+			if old != nil && len(old.FrontendIPs) != 0 && old.FrontendIPs[0].PrivateIPAddress != lb.FrontendIPs[0].PrivateIPAddress {
 				allErrs = append(allErrs, field.Forbidden(fldPath.Child("name"), "API Server load balancer private IP should not be modified after AzureCluster creation."))
 			}
 		}

--- a/api/v1beta1/azurecluster_validation_test.go
+++ b/api/v1beta1/azurecluster_validation_test.go
@@ -893,15 +893,15 @@ func TestValidateAPIServerLB(t *testing.T) {
 	testcases := []struct {
 		name        string
 		featureGate featuregate.Feature
-		lb          LoadBalancerSpec
-		old         LoadBalancerSpec
+		lb          *LoadBalancerSpec
+		old         *LoadBalancerSpec
 		cpCIDRS     []string
 		wantErr     bool
 		expectedErr field.Error
 	}{
 		{
 			name: "invalid SKU",
-			lb: LoadBalancerSpec{
+			lb: &LoadBalancerSpec{
 				Name: "my-awesome-lb",
 				FrontendIPs: []FrontendIP{
 					{
@@ -923,7 +923,7 @@ func TestValidateAPIServerLB(t *testing.T) {
 		},
 		{
 			name: "invalid Type",
-			lb: LoadBalancerSpec{
+			lb: &LoadBalancerSpec{
 				LoadBalancerClassSpec: LoadBalancerClassSpec{
 					Type: "Foo",
 				},
@@ -938,7 +938,7 @@ func TestValidateAPIServerLB(t *testing.T) {
 		},
 		{
 			name: "invalid Name",
-			lb: LoadBalancerSpec{
+			lb: &LoadBalancerSpec{
 				Name: "***",
 			},
 			wantErr: true,
@@ -951,7 +951,7 @@ func TestValidateAPIServerLB(t *testing.T) {
 		},
 		{
 			name: "too many IP configs",
-			lb: LoadBalancerSpec{
+			lb: &LoadBalancerSpec{
 				LoadBalancerClassSpec: LoadBalancerClassSpec{
 					Type: Public,
 				},
@@ -982,7 +982,7 @@ func TestValidateAPIServerLB(t *testing.T) {
 		{
 			name:        "too many IP configs with feature flag APIServerILB enabled",
 			featureGate: feature.APIServerILB,
-			lb: LoadBalancerSpec{
+			lb: &LoadBalancerSpec{
 				LoadBalancerClassSpec: LoadBalancerClassSpec{
 					Type: Public,
 				},
@@ -1012,7 +1012,7 @@ func TestValidateAPIServerLB(t *testing.T) {
 		},
 		{
 			name: "public LB with private IP",
-			lb: LoadBalancerSpec{
+			lb: &LoadBalancerSpec{
 				FrontendIPs: []FrontendIP{
 					{
 						Name: "ip-1",
@@ -1035,7 +1035,7 @@ func TestValidateAPIServerLB(t *testing.T) {
 		{
 			name:        "public LB with private IP with feature flag APIServerILB enabled",
 			featureGate: feature.APIServerILB,
-			lb: LoadBalancerSpec{
+			lb: &LoadBalancerSpec{
 				Name: "my-awesome-lb",
 				FrontendIPs: []FrontendIP{
 					{
@@ -1062,7 +1062,7 @@ func TestValidateAPIServerLB(t *testing.T) {
 		},
 		{
 			name: "internal LB with public IP",
-			lb: LoadBalancerSpec{
+			lb: &LoadBalancerSpec{
 				FrontendIPs: []FrontendIP{
 					{
 						Name: "ip-1",
@@ -1085,7 +1085,7 @@ func TestValidateAPIServerLB(t *testing.T) {
 		{
 			name:        "internal LB with public IP with feature flag APIServerILB enabled",
 			featureGate: feature.APIServerILB,
-			lb: LoadBalancerSpec{
+			lb: &LoadBalancerSpec{
 				FrontendIPs: []FrontendIP{
 					{
 						Name: "ip-1",
@@ -1107,7 +1107,7 @@ func TestValidateAPIServerLB(t *testing.T) {
 		},
 		{
 			name: "internal LB with invalid private IP",
-			lb: LoadBalancerSpec{
+			lb: &LoadBalancerSpec{
 				FrontendIPs: []FrontendIP{
 					{
 						Name: "ip-1",
@@ -1131,7 +1131,7 @@ func TestValidateAPIServerLB(t *testing.T) {
 		{
 			name:        "internal LB with invalid private IP with feature flag APIServerILB enabled",
 			featureGate: feature.APIServerILB,
-			lb: LoadBalancerSpec{
+			lb: &LoadBalancerSpec{
 				FrontendIPs: []FrontendIP{
 					{
 						Name: "ip-1",
@@ -1154,7 +1154,7 @@ func TestValidateAPIServerLB(t *testing.T) {
 		},
 		{
 			name: "internal LB with out of range private IP",
-			lb: LoadBalancerSpec{
+			lb: &LoadBalancerSpec{
 				FrontendIPs: []FrontendIP{
 					{
 						Name: "ip-1",
@@ -1179,7 +1179,7 @@ func TestValidateAPIServerLB(t *testing.T) {
 		{
 			name:        "internal LB with out of range private IP with feature flag APIServerILB enabled",
 			featureGate: feature.APIServerILB,
-			lb: LoadBalancerSpec{
+			lb: &LoadBalancerSpec{
 				FrontendIPs: []FrontendIP{
 					{
 						Name: "ip-1",
@@ -1203,7 +1203,7 @@ func TestValidateAPIServerLB(t *testing.T) {
 		},
 		{
 			name: "internal LB with in range private IP",
-			lb: LoadBalancerSpec{
+			lb: &LoadBalancerSpec{
 				FrontendIPs: []FrontendIP{
 					{
 						Name: "ip-1",
@@ -1224,7 +1224,7 @@ func TestValidateAPIServerLB(t *testing.T) {
 		{
 			name:        "public LB with in-range private IP with feature flag APIServerILB enabled",
 			featureGate: feature.APIServerILB,
-			lb: LoadBalancerSpec{
+			lb: &LoadBalancerSpec{
 				FrontendIPs: []FrontendIP{
 					{
 						Name: "ip-1",
@@ -1252,7 +1252,7 @@ func TestValidateAPIServerLB(t *testing.T) {
 		{
 			name:        "public LB with out of range private IP with feature flag APIServerILB enabled",
 			featureGate: feature.APIServerILB,
-			lb: LoadBalancerSpec{
+			lb: &LoadBalancerSpec{
 				FrontendIPs: []FrontendIP{
 					{
 						Name: "ip-1",
@@ -1282,7 +1282,7 @@ func TestValidateAPIServerLB(t *testing.T) {
 			if test.featureGate == feature.APIServerILB {
 				defer featuregatetesting.SetFeatureGateDuringTest(t, feature.Gates, test.featureGate, true)()
 			}
-			err := validateAPIServerLB(&test.lb, &test.old, test.cpCIDRS, field.NewPath("apiServerLB"))
+			err := validateAPIServerLB(test.lb, test.old, test.cpCIDRS, field.NewPath("apiServerLB"))
 			if test.wantErr {
 				g.Expect(err).To(ContainElement(MatchError(test.expectedErr.Error())))
 			} else {


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
- Thanks @willie-yao for finding the bug!
- This PR adds a nil check on the `old` lb in the `validateAPIServerLB()` function to avoid any nil pointer errors. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # private cluster tests

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->


**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] cherry-pick candidate

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
perform nil check on private lb
```
