### PR TITLE
Bump go to v1.22.11

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module sigs.k8s.io/cluster-api-provider-azure
 
-go 1.22.7
-
-toolchain go1.22.10
+go 1.22.11
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.17.0


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Bumps the go compiler to the recent patch v1.22.11. See the [release notes](https://github.com/golang/go/issues?q=milestone%3AGo1.22.11+label%3ACherryPickApproved) for more detail. 

**Which issue(s) this PR fixes**:

N/A, but see also kubernetes-sigs/cluster-api#11739. CAPI aggressively bumps the go version to keep on top of CVE and bug fixes; CAPZ should too.

**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [x] cherry-pick candidate

**Release note**:

```release-note
NONE
```
