### PR TITLE
Support any bootstrap provider with MachinePools

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -46,15 +46,6 @@ rules:
   verbs:
   - create
 - apiGroups:
-  - bootstrap.cluster.x-k8s.io
-  resources:
-  - kubeadmconfigs
-  - kubeadmconfigs/status
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
   - cluster.x-k8s.io
   resources:
   - clusters

--- a/exp/controllers/azuremachinepool_controller_test.go
+++ b/exp/controllers/azuremachinepool_controller_test.go
@@ -46,7 +46,7 @@ var _ = Describe("AzureMachinePoolReconciler", func() {
 	Context("Reconcile an AzureMachinePool", func() {
 		It("should not error with minimal set up", func() {
 			reconciler := NewAzureMachinePoolReconciler(testEnv, testEnv.GetEventRecorderFor("azuremachinepool-reconciler"),
-				reconciler.Timeouts{}, "", "", testEnv.CredentialCache)
+				reconciler.Timeouts{}, "", testEnv.CredentialCache)
 			By("Calling reconcile")
 			instance := &infrav1exp.AzureMachinePool{ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "default"}}
 			result, err := reconciler.Reconcile(context.Background(), ctrl.Request{
@@ -81,7 +81,7 @@ func TestAzureMachinePoolReconcilePaused(t *testing.T) {
 
 	recorder := record.NewFakeRecorder(1)
 
-	reconciler := NewAzureMachinePoolReconciler(c, recorder, reconciler.Timeouts{}, "", "", azure.NewCredentialCache())
+	reconciler := NewAzureMachinePoolReconciler(c, recorder, reconciler.Timeouts{}, "", azure.NewCredentialCache())
 	name := test.RandomName("paused", 10)
 	namespace := "default"
 

--- a/exp/controllers/suite_test.go
+++ b/exp/controllers/suite_test.go
@@ -55,7 +55,7 @@ var _ = BeforeSuite(func() {
 	ctx = log.IntoContext(ctx, logr.New(testEnv.Log))
 
 	Expect(NewAzureMachinePoolReconciler(testEnv, testEnv.GetEventRecorderFor("azuremachinepool-reconciler"),
-		reconciler.Timeouts{}, "", "", testEnv.CredentialCache).SetupWithManager(ctx, testEnv.Manager, controllers.Options{Options: controller.Options{MaxConcurrentReconciles: 1}})).To(Succeed())
+		reconciler.Timeouts{}, "", testEnv.CredentialCache).SetupWithManager(ctx, testEnv.Manager, controllers.Options{Options: controller.Options{MaxConcurrentReconciles: 1}})).To(Succeed())
 
 	Expect(NewAzureMachinePoolMachineController(testEnv, testEnv.GetEventRecorderFor("azuremachinepoolmachine-reconciler"),
 		reconciler.Timeouts{}, "", testEnv.CredentialCache).SetupWithManager(ctx, testEnv.Manager, controllers.Options{Options: controller.Options{MaxConcurrentReconciles: 1}})).To(Succeed())

--- a/main.go
+++ b/main.go
@@ -109,7 +109,6 @@ var (
 	azureMachineConcurrency            int
 	azureMachinePoolConcurrency        int
 	azureMachinePoolMachineConcurrency int
-	azureBootrapConfigGVK              string
 	debouncingTimer                    time.Duration
 	syncPeriod                         time.Duration
 	healthAddr                         string
@@ -256,12 +255,6 @@ func InitFlags(fs *pflag.FlagSet) {
 		"enable-tracing",
 		false,
 		"Enable tracing to the opentelemetry-collector service in the same namespace.",
-	)
-
-	fs.StringVar(&azureBootrapConfigGVK,
-		"bootstrap-config-gvk",
-		"",
-		"Provide fully qualified GVK string to override default kubeadm config watch source, in the form of Kind.version.group (default: KubeadmConfig.v1beta1.bootstrap.cluster.x-k8s.io)",
 	)
 
 	flags.AddManagerOptions(fs, &managerOptions)
@@ -449,7 +442,6 @@ func registerControllers(ctx context.Context, mgr manager.Manager) {
 			mgr.GetEventRecorderFor("azuremachinepool-reconciler"),
 			timeouts,
 			watchFilterValue,
-			azureBootrapConfigGVK,
 			credCache,
 		).SetupWithManager(ctx, mgr, controllers.Options{Options: controller.Options{MaxConcurrentReconciles: azureMachinePoolConcurrency}, Cache: mpCache}); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "AzureMachinePool")


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

This patch makes the AzureMachinePool controller (Bootstrap)Config agnostic.

Instead watching `KubeadmConfigs` (or any other custom config added via `bootstrap-config-gvk` argument), the controller is now watching any bootstrap secret directly, bypassing the config layer. 
As per [bootstrap contract](https://cluster-api.sigs.k8s.io/developer/providers/contracts/bootstrap-config#bootstrapconfig-data-secret), the watch logic works in the following way:
1. Only watch `cluster.x-k8s.io/cluster-name` labeled Secrets
2. Retrieve the (Bootstrap)Config name and kind from the first controller owner reference on the bootstrap Secret
3. (This step was not changed by this PR) Assume the (Bootstrap)Config name has the same name of its related `MachinePool` to enqueue an also related `AzureMachinePool` reconcile.

Note that since we are not watching KubeadmConfigs directly, the related RBAC permission was also cleaned up.
Since we don't actually trying to fetch any (Bootstrap)Config, there is no need for further RBAC settings when using other Bootstrap providers.

This should now also work in case of users providing their bootstrap Secret manually, assigning a custom `DataSecretName` in their (Bootstrap)Config. Still assuming they respect the contract linked above when creating the custom Secret. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/rancher/highlander/issues/100

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->


**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests
- [ ] cherry-pick candidate

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
4. If no release note is required, just write "NONE".
-->
```release-note
action required
The `bootstrap-config-gvk` controller argument has been deprecated. The controller is now able to work with all [bootstrap providers](https://cluster-api.sigs.k8s.io/reference/providers#bootstrap).  
Users managing their own bootstrap Secrets, by configuring the `Machine.spec.bootstrap.dataSecretName` manually, are expected to respect the [bootstrap secret contract](https://cluster-api.sigs.k8s.io/developer/providers/contracts/bootstrap-config#bootstrapconfig-data-secret).
```
