### PR TITLE
pin go toolchain to 1.22.11 and go directive to 1.22.7

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module sigs.k8s.io/cluster-api-provider-azure
 
-go 1.22.11
+go 1.22.7
+
+toolchain go1.22.11
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.17.0


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
- Without this fix, we are unable to build CAPZ images locally. 
- We run into below error
```sh
 => ERROR [builder 4/4] RUN --mount=type=cache,target=/root/.cache/go-build     --mount=type=cache,target=/go/pkg/mod     CGO_ENABLED=0 GOOS=linux GOARCH=amd64     go buil  0.1s
------
 > [builder 4/4] RUN --mount=type=cache,target=/root/.cache/go-build     --mount=type=cache,target=/go/pkg/mod     CGO_ENABLED=0 GOOS=linux GOARCH=amd64     go build -ldflags "-X 'sigs.k8s.io/cluster-api-provider-azure/version.buildDate=2025-02-04T00:41:56Z' -X 'sigs.k8s.io/cluster-api-provider-azure/version.gitCommit=817eb2889fd6dc58a46f2115629d77ef432b847d' -X 'sigs.k8s.io/cluster-api-provider-azure/version.gitTreeState=dirty' -X 'sigs.k8s.io/cluster-api-provider-azure/version.gitMajor=1' -X 'sigs.k8s.io/cluster-api-provider-azure/version.gitMinor=18' -X 'sigs.k8s.io/cluster-api-provider-azure/version.gitVersion=v1.18.0-18-817eb2889fd6dc-dirty' -extldflags '-static'"     -o manager .:
0.137 go: go.mod requires go >= 1.22.11 (running go 1.22.7; GOTOOLCHAIN=local)
------
```
- Adding the patch version in the Dockerfile of CAPZ is ensures that right go version is used to build the images. 
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
related to https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/5393 

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->
- ~I tried clean `modcache` and running `mod tidy`, and yet I would run into the above error.~
- ~I even tried to update the GO SDK in my IDE to 1.22.11 toolchain and even then I would run into the above error.~
- ~If anyone else has an idea on how to fix this issue without pinning the go version in the Dockerfile, please let me know.~


**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] cherry-pick candidate

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
