### PR TITLE
Bump go to v1.22.12

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module sigs.k8s.io/cluster-api-provider-azure
 
 go 1.22.7
 
-toolchain go1.22.11
+toolchain go1.22.12
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.17.0


### PR DESCRIPTION
/area dependency

**What this PR does / why we need it**:

Updates the Go toolchain to the latest 1.22.x patch release.

> go1.22.12 (released 2025-02-04) includes security fixes to the crypto/elliptic package, as well as bug fixes to the compiler and the go command. See the [Go 1.22.12 milestone](https://github.com/golang/go/issues?q=milestone%3AGo1.22.12+label%3ACherryPickApproved) on our issue tracker for details.

**Which issue(s) this PR fixes**:

N/A

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [x] cherry-pick candidate

**Release note**:

```release-note
NONE
```
