### PR TITLE
fix: remove deprecated kube-apiserver cloud-provider arg

### DIFF
--- a/templates/cluster-template-aad.yaml
+++ b/templates/cluster-template-aad.yaml
@@ -49,7 +49,6 @@ spec:
     clusterConfiguration:
       apiServer:
         extraArgs:
-          cloud-provider: external
           oidc-client-id: ${AZURE_SERVER_APP_ID}
           oidc-groups-claim: groups
           oidc-issuer-url: https://sts.windows.net/${AZURE_TENANT_ID}/

--- a/templates/cluster-template-apiserver-ilb.yaml
+++ b/templates/cluster-template-apiserver-ilb.yaml
@@ -62,8 +62,7 @@ spec:
   kubeadmConfigSpec:
     clusterConfiguration:
       apiServer:
-        extraArgs:
-          cloud-provider: external
+        extraArgs: {}
         timeoutForControlPlane: 20m
       controllerManager:
         extraArgs:

--- a/templates/cluster-template-azure-bastion.yaml
+++ b/templates/cluster-template-azure-bastion.yaml
@@ -50,8 +50,7 @@ spec:
   kubeadmConfigSpec:
     clusterConfiguration:
       apiServer:
-        extraArgs:
-          cloud-provider: external
+        extraArgs: {}
         timeoutForControlPlane: 20m
       controllerManager:
         extraArgs:

--- a/templates/cluster-template-azure-cni-v1.yaml
+++ b/templates/cluster-template-azure-cni-v1.yaml
@@ -48,8 +48,7 @@ spec:
   kubeadmConfigSpec:
     clusterConfiguration:
       apiServer:
-        extraArgs:
-          cloud-provider: external
+        extraArgs: {}
         timeoutForControlPlane: 20m
       controllerManager:
         extraArgs:

--- a/templates/cluster-template-clusterclass.yaml
+++ b/templates/cluster-template-clusterclass.yaml
@@ -145,8 +145,7 @@ spec:
       kubeadmConfigSpec:
         clusterConfiguration:
           apiServer:
-            extraArgs:
-              cloud-provider: external
+            extraArgs: {}
             timeoutForControlPlane: 20m
           controllerManager:
             extraArgs:

--- a/templates/cluster-template-dual-stack.yaml
+++ b/templates/cluster-template-dual-stack.yaml
@@ -64,8 +64,7 @@ spec:
   kubeadmConfigSpec:
     clusterConfiguration:
       apiServer:
-        extraArgs:
-          cloud-provider: external
+        extraArgs: {}
         timeoutForControlPlane: 20m
       controllerManager:
         extraArgs:

--- a/templates/cluster-template-edgezone.yaml
+++ b/templates/cluster-template-edgezone.yaml
@@ -51,8 +51,7 @@ spec:
   kubeadmConfigSpec:
     clusterConfiguration:
       apiServer:
-        extraArgs:
-          cloud-provider: external
+        extraArgs: {}
         timeoutForControlPlane: 20m
       controllerManager:
         extraArgs:

--- a/templates/cluster-template-ephemeral.yaml
+++ b/templates/cluster-template-ephemeral.yaml
@@ -48,8 +48,7 @@ spec:
   kubeadmConfigSpec:
     clusterConfiguration:
       apiServer:
-        extraArgs:
-          cloud-provider: external
+        extraArgs: {}
         timeoutForControlPlane: 20m
       controllerManager:
         extraArgs:

--- a/templates/cluster-template-flatcar-sysext.yaml
+++ b/templates/cluster-template-flatcar-sysext.yaml
@@ -129,8 +129,7 @@ spec:
   kubeadmConfigSpec:
     clusterConfiguration:
       apiServer:
-        extraArgs:
-          cloud-provider: external
+        extraArgs: {}
         timeoutForControlPlane: 20m
       controllerManager:
         extraArgs:

--- a/templates/cluster-template-flatcar.yaml
+++ b/templates/cluster-template-flatcar.yaml
@@ -48,8 +48,7 @@ spec:
   kubeadmConfigSpec:
     clusterConfiguration:
       apiServer:
-        extraArgs:
-          cloud-provider: external
+        extraArgs: {}
         timeoutForControlPlane: 20m
       controllerManager:
         extraArgs:

--- a/templates/cluster-template-ipv6.yaml
+++ b/templates/cluster-template-ipv6.yaml
@@ -62,7 +62,6 @@ spec:
       apiServer:
         extraArgs:
           bind-address: '::'
-          cloud-provider: external
         timeoutForControlPlane: 20m
       controllerManager:
         extraArgs:

--- a/templates/cluster-template-machinepool-windows.yaml
+++ b/templates/cluster-template-machinepool-windows.yaml
@@ -52,8 +52,7 @@ spec:
   kubeadmConfigSpec:
     clusterConfiguration:
       apiServer:
-        extraArgs:
-          cloud-provider: external
+        extraArgs: {}
         timeoutForControlPlane: 20m
       controllerManager:
         extraArgs:

--- a/templates/cluster-template-machinepool.yaml
+++ b/templates/cluster-template-machinepool.yaml
@@ -48,8 +48,7 @@ spec:
   kubeadmConfigSpec:
     clusterConfiguration:
       apiServer:
-        extraArgs:
-          cloud-provider: external
+        extraArgs: {}
         timeoutForControlPlane: 20m
       controllerManager:
         extraArgs:

--- a/templates/cluster-template-nvidia-gpu.yaml
+++ b/templates/cluster-template-nvidia-gpu.yaml
@@ -48,8 +48,7 @@ spec:
   kubeadmConfigSpec:
     clusterConfiguration:
       apiServer:
-        extraArgs:
-          cloud-provider: external
+        extraArgs: {}
         timeoutForControlPlane: 20m
       controllerManager:
         extraArgs:

--- a/templates/cluster-template-private.yaml
+++ b/templates/cluster-template-private.yaml
@@ -57,8 +57,7 @@ spec:
   kubeadmConfigSpec:
     clusterConfiguration:
       apiServer:
-        extraArgs:
-          cloud-provider: external
+        extraArgs: {}
         timeoutForControlPlane: 20m
       controllerManager:
         extraArgs:

--- a/templates/cluster-template-windows-apiserver-ilb.yaml
+++ b/templates/cluster-template-windows-apiserver-ilb.yaml
@@ -66,8 +66,7 @@ spec:
   kubeadmConfigSpec:
     clusterConfiguration:
       apiServer:
-        extraArgs:
-          cloud-provider: external
+        extraArgs: {}
         timeoutForControlPlane: 20m
       controllerManager:
         extraArgs:

--- a/templates/cluster-template-windows.yaml
+++ b/templates/cluster-template-windows.yaml
@@ -52,8 +52,7 @@ spec:
   kubeadmConfigSpec:
     clusterConfiguration:
       apiServer:
-        extraArgs:
-          cloud-provider: external
+        extraArgs: {}
         timeoutForControlPlane: 20m
       controllerManager:
         extraArgs:

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -48,8 +48,7 @@ spec:
   kubeadmConfigSpec:
     clusterConfiguration:
       apiServer:
-        extraArgs:
-          cloud-provider: external
+        extraArgs: {}
         timeoutForControlPlane: 20m
       controllerManager:
         extraArgs:

--- a/templates/flavors/base/cluster-template.yaml
+++ b/templates/flavors/base/cluster-template.yaml
@@ -58,8 +58,7 @@ spec:
     clusterConfiguration:
       apiServer:
         timeoutForControlPlane: 20m
-        extraArgs:
-          cloud-provider: external
+        extraArgs: {}
       controllerManager:
         extraArgs:
           allocate-node-cidrs: "false"

--- a/templates/flavors/clusterclass/kubeadm-controlplane-template.yaml
+++ b/templates/flavors/clusterclass/kubeadm-controlplane-template.yaml
@@ -9,8 +9,7 @@ spec:
       kubeadmConfigSpec:
         clusterConfiguration:
           apiServer:
-            extraArgs:
-              cloud-provider: external
+            extraArgs: {}
             timeoutForControlPlane: 20m
           controllerManager:
             extraArgs:

--- a/templates/test/ci/cluster-template-prow-apiserver-ilb.yaml
+++ b/templates/test/ci/cluster-template-prow-apiserver-ilb.yaml
@@ -69,8 +69,7 @@ spec:
   kubeadmConfigSpec:
     clusterConfiguration:
       apiServer:
-        extraArgs:
-          cloud-provider: external
+        extraArgs: {}
         timeoutForControlPlane: 20m
       controllerManager:
         extraArgs:

--- a/templates/test/ci/cluster-template-prow-azure-cni-v1.yaml
+++ b/templates/test/ci/cluster-template-prow-azure-cni-v1.yaml
@@ -54,8 +54,7 @@ spec:
   kubeadmConfigSpec:
     clusterConfiguration:
       apiServer:
-        extraArgs:
-          cloud-provider: external
+        extraArgs: {}
         timeoutForControlPlane: 20m
       controllerManager:
         extraArgs:

--- a/templates/test/ci/cluster-template-prow-ci-version-dra.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version-dra.yaml
@@ -60,7 +60,6 @@ spec:
     clusterConfiguration:
       apiServer:
         extraArgs:
-          cloud-provider: external
           feature-gates: ${K8S_FEATURE_GATES:-"DynamicResourceAllocation=true"}
           runtime-config: resource.k8s.io/v1alpha3=true
         timeoutForControlPlane: 20m

--- a/templates/test/ci/cluster-template-prow-ci-version-dual-stack.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version-dual-stack.yaml
@@ -74,7 +74,6 @@ spec:
     clusterConfiguration:
       apiServer:
         extraArgs:
-          cloud-provider: external
           feature-gates: ${K8S_FEATURE_GATES:-""}
         timeoutForControlPlane: 20m
       controllerManager:

--- a/templates/test/ci/cluster-template-prow-ci-version-ipv6.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version-ipv6.yaml
@@ -73,7 +73,6 @@ spec:
       apiServer:
         extraArgs:
           bind-address: '::'
-          cloud-provider: external
           feature-gates: ${K8S_FEATURE_GATES:-""}
         timeoutForControlPlane: 20m
       controllerManager:

--- a/templates/test/ci/cluster-template-prow-ci-version.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version.yaml
@@ -60,7 +60,6 @@ spec:
     clusterConfiguration:
       apiServer:
         extraArgs:
-          cloud-provider: external
           feature-gates: ${K8S_FEATURE_GATES:-""}
         timeoutForControlPlane: 20m
       controllerManager:

--- a/templates/test/ci/cluster-template-prow-clusterclass-ci-default.yaml
+++ b/templates/test/ci/cluster-template-prow-clusterclass-ci-default.yaml
@@ -379,8 +379,7 @@ spec:
       kubeadmConfigSpec:
         clusterConfiguration:
           apiServer:
-            extraArgs:
-              cloud-provider: external
+            extraArgs: {}
             timeoutForControlPlane: 20m
           controllerManager:
             extraArgs:

--- a/templates/test/ci/cluster-template-prow-custom-vnet.yaml
+++ b/templates/test/ci/cluster-template-prow-custom-vnet.yaml
@@ -62,8 +62,7 @@ spec:
   kubeadmConfigSpec:
     clusterConfiguration:
       apiServer:
-        extraArgs:
-          cloud-provider: external
+        extraArgs: {}
         timeoutForControlPlane: 20m
       controllerManager:
         extraArgs:

--- a/templates/test/ci/cluster-template-prow-dual-stack.yaml
+++ b/templates/test/ci/cluster-template-prow-dual-stack.yaml
@@ -69,8 +69,7 @@ spec:
   kubeadmConfigSpec:
     clusterConfiguration:
       apiServer:
-        extraArgs:
-          cloud-provider: external
+        extraArgs: {}
         timeoutForControlPlane: 20m
       controllerManager:
         extraArgs:

--- a/templates/test/ci/cluster-template-prow-edgezone.yaml
+++ b/templates/test/ci/cluster-template-prow-edgezone.yaml
@@ -58,8 +58,7 @@ spec:
   kubeadmConfigSpec:
     clusterConfiguration:
       apiServer:
-        extraArgs:
-          cloud-provider: external
+        extraArgs: {}
         timeoutForControlPlane: 20m
       controllerManager:
         extraArgs:

--- a/templates/test/ci/cluster-template-prow-flatcar-sysext.yaml
+++ b/templates/test/ci/cluster-template-prow-flatcar-sysext.yaml
@@ -205,8 +205,7 @@ spec:
   kubeadmConfigSpec:
     clusterConfiguration:
       apiServer:
-        extraArgs:
-          cloud-provider: external
+        extraArgs: {}
         timeoutForControlPlane: 20m
       controllerManager:
         extraArgs:

--- a/templates/test/ci/cluster-template-prow-flatcar.yaml
+++ b/templates/test/ci/cluster-template-prow-flatcar.yaml
@@ -55,8 +55,7 @@ spec:
   kubeadmConfigSpec:
     clusterConfiguration:
       apiServer:
-        extraArgs:
-          cloud-provider: external
+        extraArgs: {}
         timeoutForControlPlane: 20m
       controllerManager:
         extraArgs:

--- a/templates/test/ci/cluster-template-prow-ipv6.yaml
+++ b/templates/test/ci/cluster-template-prow-ipv6.yaml
@@ -69,7 +69,6 @@ spec:
       apiServer:
         extraArgs:
           bind-address: '::'
-          cloud-provider: external
         timeoutForControlPlane: 20m
       controllerManager:
         extraArgs:

--- a/templates/test/ci/cluster-template-prow-machine-pool-ci-version.yaml
+++ b/templates/test/ci/cluster-template-prow-machine-pool-ci-version.yaml
@@ -59,8 +59,7 @@ spec:
   kubeadmConfigSpec:
     clusterConfiguration:
       apiServer:
-        extraArgs:
-          cloud-provider: external
+        extraArgs: {}
         timeoutForControlPlane: 20m
       controllerManager:
         extraArgs:

--- a/templates/test/ci/cluster-template-prow-machine-pool-flex.yaml
+++ b/templates/test/ci/cluster-template-prow-machine-pool-flex.yaml
@@ -59,8 +59,7 @@ spec:
   kubeadmConfigSpec:
     clusterConfiguration:
       apiServer:
-        extraArgs:
-          cloud-provider: external
+        extraArgs: {}
         timeoutForControlPlane: 20m
       controllerManager:
         extraArgs:

--- a/templates/test/ci/cluster-template-prow-machine-pool.yaml
+++ b/templates/test/ci/cluster-template-prow-machine-pool.yaml
@@ -59,8 +59,7 @@ spec:
   kubeadmConfigSpec:
     clusterConfiguration:
       apiServer:
-        extraArgs:
-          cloud-provider: external
+        extraArgs: {}
         timeoutForControlPlane: 20m
       controllerManager:
         extraArgs:

--- a/templates/test/ci/cluster-template-prow-nvidia-gpu.yaml
+++ b/templates/test/ci/cluster-template-prow-nvidia-gpu.yaml
@@ -55,8 +55,7 @@ spec:
   kubeadmConfigSpec:
     clusterConfiguration:
       apiServer:
-        extraArgs:
-          cloud-provider: external
+        extraArgs: {}
         timeoutForControlPlane: 20m
       controllerManager:
         extraArgs:

--- a/templates/test/ci/cluster-template-prow-private.yaml
+++ b/templates/test/ci/cluster-template-prow-private.yaml
@@ -86,8 +86,7 @@ spec:
   kubeadmConfigSpec:
     clusterConfiguration:
       apiServer:
-        extraArgs:
-          cloud-provider: external
+        extraArgs: {}
         timeoutForControlPlane: 20m
       controllerManager:
         extraArgs:

--- a/templates/test/ci/cluster-template-prow-spot.yaml
+++ b/templates/test/ci/cluster-template-prow-spot.yaml
@@ -55,8 +55,7 @@ spec:
   kubeadmConfigSpec:
     clusterConfiguration:
       apiServer:
-        extraArgs:
-          cloud-provider: external
+        extraArgs: {}
         timeoutForControlPlane: 20m
       controllerManager:
         extraArgs:

--- a/templates/test/ci/cluster-template-prow.yaml
+++ b/templates/test/ci/cluster-template-prow.yaml
@@ -59,7 +59,6 @@ spec:
     clusterConfiguration:
       apiServer:
         extraArgs:
-          cloud-provider: external
           feature-gates: ${K8S_FEATURE_GATES:-""}
         timeoutForControlPlane: 20m
       controllerManager:

--- a/templates/test/dev/cluster-template-custom-builds-dra.yaml
+++ b/templates/test/dev/cluster-template-custom-builds-dra.yaml
@@ -62,7 +62,6 @@ spec:
     clusterConfiguration:
       apiServer:
         extraArgs:
-          cloud-provider: external
           feature-gates: ${K8S_FEATURE_GATES:-"DynamicResourceAllocation=true"}
           runtime-config: resource.k8s.io/v1alpha3=true
         timeoutForControlPlane: 20m

--- a/templates/test/dev/cluster-template-custom-builds-load.yaml
+++ b/templates/test/dev/cluster-template-custom-builds-load.yaml
@@ -64,7 +64,6 @@ spec:
     clusterConfiguration:
       apiServer:
         extraArgs:
-          cloud-provider: external
           feature-gates: ${K8S_FEATURE_GATES:-""}
         timeoutForControlPlane: 20m
       controllerManager:

--- a/templates/test/dev/cluster-template-custom-builds-machine-pool.yaml
+++ b/templates/test/dev/cluster-template-custom-builds-machine-pool.yaml
@@ -61,8 +61,7 @@ spec:
   kubeadmConfigSpec:
     clusterConfiguration:
       apiServer:
-        extraArgs:
-          cloud-provider: external
+        extraArgs: {}
         timeoutForControlPlane: 20m
       controllerManager:
         extraArgs:

--- a/templates/test/dev/cluster-template-custom-builds.yaml
+++ b/templates/test/dev/cluster-template-custom-builds.yaml
@@ -62,7 +62,6 @@ spec:
     clusterConfiguration:
       apiServer:
         extraArgs:
-          cloud-provider: external
           feature-gates: ${K8S_FEATURE_GATES:-""}
         timeoutForControlPlane: 20m
       controllerManager:

--- a/test/e2e/data/infrastructure-azure/v1.17.3/cluster-template-prow-machine-and-machine-pool.yaml
+++ b/test/e2e/data/infrastructure-azure/v1.17.3/cluster-template-prow-machine-and-machine-pool.yaml
@@ -81,7 +81,6 @@ spec:
     clusterConfiguration:
       apiServer:
         extraArgs:
-          cloud-provider: external
           feature-gates: ${K8S_FEATURE_GATES:-""}
         timeoutForControlPlane: 20m
       controllerManager:

--- a/test/e2e/data/infrastructure-azure/v1.17.3/cluster-template-prow.yaml
+++ b/test/e2e/data/infrastructure-azure/v1.17.3/cluster-template-prow.yaml
@@ -59,7 +59,6 @@ spec:
     clusterConfiguration:
       apiServer:
         extraArgs:
-          cloud-provider: external
           feature-gates: ${K8S_FEATURE_GATES:-""}
         timeoutForControlPlane: 20m
       controllerManager:

--- a/test/e2e/data/infrastructure-azure/v1.18.0/cluster-template-prow-machine-and-machine-pool.yaml
+++ b/test/e2e/data/infrastructure-azure/v1.18.0/cluster-template-prow-machine-and-machine-pool.yaml
@@ -81,7 +81,6 @@ spec:
     clusterConfiguration:
       apiServer:
         extraArgs:
-          cloud-provider: external
           feature-gates: ${K8S_FEATURE_GATES:-""}
         timeoutForControlPlane: 20m
       controllerManager:

--- a/test/e2e/data/infrastructure-azure/v1.18.0/cluster-template-prow.yaml
+++ b/test/e2e/data/infrastructure-azure/v1.18.0/cluster-template-prow.yaml
@@ -59,7 +59,6 @@ spec:
     clusterConfiguration:
       apiServer:
         extraArgs:
-          cloud-provider: external
           feature-gates: ${K8S_FEATURE_GATES:-""}
         timeoutForControlPlane: 20m
       controllerManager:

--- a/test/e2e/data/infrastructure-azure/v1beta1/bases/cluster-with-kcp.yaml
+++ b/test/e2e/data/infrastructure-azure/v1beta1/bases/cluster-with-kcp.yaml
@@ -72,8 +72,7 @@ spec:
   kubeadmConfigSpec:
     clusterConfiguration:
       apiServer:
-        extraArgs:
-          cloud-provider: external
+        extraArgs: {}
         extraVolumes:
           - hostPath: /etc/kubernetes/azure.json
             mountPath: /etc/kubernetes/azure.json

--- a/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-kcp-remediation.yaml
+++ b/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-kcp-remediation.yaml
@@ -188,8 +188,7 @@ spec:
   kubeadmConfigSpec:
     clusterConfiguration:
       apiServer:
-        extraArgs:
-          cloud-provider: external
+        extraArgs: {}
         extraVolumes:
         - hostPath: /etc/kubernetes/azure.json
           mountPath: /etc/kubernetes/azure.json

--- a/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-kcp-scale-in.yaml
+++ b/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-kcp-scale-in.yaml
@@ -174,8 +174,7 @@ spec:
   kubeadmConfigSpec:
     clusterConfiguration:
       apiServer:
-        extraArgs:
-          cloud-provider: external
+        extraArgs: {}
         extraVolumes:
         - hostPath: /etc/kubernetes/azure.json
           mountPath: /etc/kubernetes/azure.json

--- a/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-machine-and-machine-pool.yaml
+++ b/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-machine-and-machine-pool.yaml
@@ -216,8 +216,7 @@ spec:
   kubeadmConfigSpec:
     clusterConfiguration:
       apiServer:
-        extraArgs:
-          cloud-provider: external
+        extraArgs: {}
         extraVolumes:
         - hostPath: /etc/kubernetes/azure.json
           mountPath: /etc/kubernetes/azure.json

--- a/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-machine-pool.yaml
+++ b/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-machine-pool.yaml
@@ -170,8 +170,7 @@ spec:
   kubeadmConfigSpec:
     clusterConfiguration:
       apiServer:
-        extraArgs:
-          cloud-provider: external
+        extraArgs: {}
         extraVolumes:
         - hostPath: /etc/kubernetes/azure.json
           mountPath: /etc/kubernetes/azure.json

--- a/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-md-remediation.yaml
+++ b/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-md-remediation.yaml
@@ -192,8 +192,7 @@ spec:
   kubeadmConfigSpec:
     clusterConfiguration:
       apiServer:
-        extraArgs:
-          cloud-provider: external
+        extraArgs: {}
         extraVolumes:
         - hostPath: /etc/kubernetes/azure.json
           mountPath: /etc/kubernetes/azure.json

--- a/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-node-drain.yaml
+++ b/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-node-drain.yaml
@@ -175,8 +175,7 @@ spec:
   kubeadmConfigSpec:
     clusterConfiguration:
       apiServer:
-        extraArgs:
-          cloud-provider: external
+        extraArgs: {}
         extraVolumes:
         - hostPath: /etc/kubernetes/azure.json
           mountPath: /etc/kubernetes/azure.json

--- a/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-upgrades.yaml
+++ b/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-upgrades.yaml
@@ -115,8 +115,7 @@ spec:
   kubeadmConfigSpec:
     clusterConfiguration:
       apiServer:
-        extraArgs:
-          cloud-provider: external
+        extraArgs: {}
         extraVolumes:
         - hostPath: /etc/kubernetes/azure.json
           mountPath: /etc/kubernetes/azure.json

--- a/test/e2e/data/infrastructure-azure/v1beta1/cluster-template.yaml
+++ b/test/e2e/data/infrastructure-azure/v1beta1/cluster-template.yaml
@@ -174,8 +174,7 @@ spec:
   kubeadmConfigSpec:
     clusterConfiguration:
       apiServer:
-        extraArgs:
-          cloud-provider: external
+        extraArgs: {}
         extraVolumes:
         - hostPath: /etc/kubernetes/azure.json
           mountPath: /etc/kubernetes/azure.json


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind cleanup

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
This is a test PR with no changes to test conformance tests

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->


**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] cherry-pick candidate

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
