### PR TITLE
bug: Fix APIServerLB nil pointer deref

### DIFF
--- a/azure/scope/cluster.go
+++ b/azure/scope/cluster.go
@@ -769,7 +769,11 @@ func (s *ClusterScope) ControlPlaneOutboundLB() *infrav1.LoadBalancerSpec {
 
 // APIServerLBName returns the API Server LB name.
 func (s *ClusterScope) APIServerLBName() string {
-	return s.APIServerLB().Name
+	apiServerLB := s.APIServerLB()
+	if apiServerLB != nil {
+		return apiServerLB.Name
+	}
+	return ""
 }
 
 // IsAPIServerPrivate returns true if the API Server LB is of type Internal.

--- a/azure/scope/cluster_test.go
+++ b/azure/scope/cluster_test.go
@@ -3973,3 +3973,46 @@ func TestGroupSpecs(t *testing.T) {
 		})
 	}
 }
+
+func TestAPIServerLBName(t *testing.T) {
+	tests := []struct {
+		name     string
+		cluster  *ClusterScope
+		expected string
+	}{
+		{
+			name: "APIServerLB is not nil",
+			cluster: &ClusterScope{
+				AzureCluster: &infrav1.AzureCluster{
+					Spec: infrav1.AzureClusterSpec{
+						NetworkSpec: infrav1.NetworkSpec{
+							APIServerLB: &infrav1.LoadBalancerSpec{
+								Name: "test-lb",
+							},
+						},
+					},
+				},
+			},
+			expected: "test-lb",
+		},
+		{
+			name: "APIServerLB is nil",
+			cluster: &ClusterScope{
+				AzureCluster: &infrav1.AzureCluster{
+					Spec: infrav1.AzureClusterSpec{
+						NetworkSpec: infrav1.NetworkSpec{},
+					},
+				},
+			},
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			result := tt.cluster.APIServerLBName()
+			g.Expect(result).To(Equal(tt.expected))
+		})
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR fixes a possible nil pointer deference when returning the name of the API Server LoadBalancer. In some cases like externally managed infrastructure, there might not be an API Server LoadBalancer in the AzureCluster CR.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->


**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [x] cherry-pick candidate

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixes a possible nil pointer deference when returning the name of the API Server LoadBalancer. In some cases like externally managed infrastructure, there might not be an API Server LoadBalancer in the AzureCluster CR
```
