### PR TITLE
[release-1.17] bug: Fix APIServerLB nil pointer deref

### DIFF
--- a/azure/scope/cluster.go
+++ b/azure/scope/cluster.go
@@ -700,7 +700,11 @@ func (s *ClusterScope) ControlPlaneOutboundLB() *infrav1.LoadBalancerSpec {
 
 // APIServerLBName returns the API Server LB name.
 func (s *ClusterScope) APIServerLBName() string {
-	return s.APIServerLB().Name
+	apiServerLB := s.APIServerLB()
+	if apiServerLB != nil {
+		return apiServerLB.Name
+	}
+	return ""
 }
 
 // IsAPIServerPrivate returns true if the API Server LB is of type Internal.

--- a/azure/scope/cluster_test.go
+++ b/azure/scope/cluster_test.go
@@ -4256,3 +4256,46 @@ func TestGroupSpecs(t *testing.T) {
 		})
 	}
 }
+
+func TestAPIServerLBName(t *testing.T) {
+	tests := []struct {
+		name     string
+		cluster  *ClusterScope
+		expected string
+	}{
+		{
+			name: "APIServerLB is not nil",
+			cluster: &ClusterScope{
+				AzureCluster: &infrav1.AzureCluster{
+					Spec: infrav1.AzureClusterSpec{
+						NetworkSpec: infrav1.NetworkSpec{
+							APIServerLB: infrav1.LoadBalancerSpec{
+								Name: "test-lb",
+							},
+						},
+					},
+				},
+			},
+			expected: "test-lb",
+		},
+		{
+			name: "APIServerLB is nil",
+			cluster: &ClusterScope{
+				AzureCluster: &infrav1.AzureCluster{
+					Spec: infrav1.AzureClusterSpec{
+						NetworkSpec: infrav1.NetworkSpec{},
+					},
+				},
+			},
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			result := tt.cluster.APIServerLBName()
+			g.Expect(result).To(Equal(tt.expected))
+		})
+	}
+}


### PR DESCRIPTION
This is an ~automated~ manual cherry-pick of #5453. 
Automated cherry-pick wont let me push to it. Automated cherry-pick: https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/5456

/assign nawazkh

```release-note
Fixes a possible nil pointer deference when returning the name of the API Server LoadBalancer. In some cases like externally managed infrastructure, there might not be an API Server LoadBalancer in the AzureCluster CR
```