### PR TITLE
Update handling Capabilities that have a float value

### DIFF
--- a/azure/services/resourceskus/sku.go
+++ b/azure/services/resourceskus/sku.go
@@ -17,6 +17,7 @@ limitations under the License.
 package resourceskus
 
 import (
+	"math"
 	"strconv"
 	"strings"
 
@@ -112,10 +113,11 @@ func (s SKU) HasCapabilityWithCapacity(name string, value int64) (bool, error) {
 			continue
 		}
 
-		intVal, err := strconv.ParseInt(*capability.Value, 10, 64)
+		floatVal, err := strconv.ParseFloat(*capability.Value, 64)
 		if err != nil {
-			return false, errors.Wrapf(err, "failed to parse string '%s' as int64", *capability.Value)
+			return false, errors.Wrapf(err, "failed to parse string '%s' as float", *capability.Value)
 		}
+		intVal := int64(math.Round(floatVal))
 
 		if intVal >= value {
 			return true, nil

--- a/azure/services/scalesets/scalesets_test.go
+++ b/azure/services/scalesets/scalesets_test.go
@@ -101,6 +101,13 @@ func getResultVMSS() armcompute.VirtualMachineScaleSet {
 	return resultVMSS
 }
 
+func getMemFloatResultVMSS() armcompute.VirtualMachineScaleSet {
+	resultVMSS := newDefaultVMSS("VM_SIZE_MEM_FLOAT")
+	resultVMSS.ID = ptr.To(defaultVMSSID)
+
+	return resultVMSS
+}
+
 func TestReconcileVMSS(t *testing.T) {
 	defaultInstances := newDefaultInstances()
 	resultVMSS := newDefaultVMSS("VM_SIZE")
@@ -212,6 +219,29 @@ func TestReconcileVMSS(t *testing.T) {
 				spec.Capacity = 2
 				spec.SSHKeyData = sshKeyData
 				s.ScaleSetSpec(gomockinternal.AContext()).Return(&spec).AnyTimes()
+			},
+		},
+		{
+			name:          "validate spec success: Memory is float",
+			expectedError: "",
+			expect: func(g *WithT, s *mock_scalesets.MockScaleSetScopeMockRecorder, r *mock_async.MockReconcilerMockRecorder, m *mock_scalesets.MockClientMockRecorder) {
+				s.DefaultedAzureServiceReconcileTimeout().Return(reconciler.DefaultAzureServiceReconcileTimeout)
+				spec := newVMSSSpecWithSKU(resourceskus.MemoryGB, "217.13")
+				spec.Size = "VM_SIZE_MEM_FLOAT"
+				spec.Capacity = 2
+				spec.SSHKeyData = sshKeyData
+				memFloatVMSS := newDefaultVMSS("VM_SIZE_MEM_FLOAT")
+				memFloatVMSS.ID = ptr.To(defaultVMSSID)
+
+				s.ScaleSetSpec(gomockinternal.AContext()).Return(&spec).AnyTimes()
+				m.Get(gomockinternal.AContext(), &spec).Return(memFloatVMSS, nil)
+				m.ListInstances(gomockinternal.AContext(), spec.ResourceGroup, spec.Name).Return(defaultInstances, nil)
+				fetchedMemFloatVMSS := converters.SDKToVMSS(getMemFloatResultVMSS(), defaultInstances)
+				s.ReconcileReplicas(gomockinternal.AContext(), &fetchedMemFloatVMSS).Return(nil).Times(2)
+				s.SetProviderID(azureutil.ProviderIDPrefix + defaultVMSSID).Times(2)
+				s.SetVMSSState(&fetchedMemFloatVMSS).Times(2)
+				r.CreateOrUpdateResource(gomockinternal.AContext(), &spec, serviceName).Return(getMemFloatResultVMSS(), nil)
+				s.UpdatePutStatus(infrav1.BootstrapSucceededCondition, serviceName, nil)
 			},
 		},
 		{
@@ -633,6 +663,34 @@ func getFakeSkus() []armcompute.ResourceSKU {
 				},
 			},
 		},
+		{
+			Name:         ptr.To("VM_SIZE_MEM_FLOAT"),
+			ResourceType: ptr.To(string(resourceskus.VirtualMachines)),
+			Kind:         ptr.To(string(resourceskus.VirtualMachines)),
+			Locations: []*string{
+				ptr.To("test-location"),
+			},
+			LocationInfo: []*armcompute.ResourceSKULocationInfo{
+				{
+					Location: ptr.To("test-location"),
+					Zones:    []*string{ptr.To("1"), ptr.To("3")},
+				},
+			},
+			Capabilities: []*armcompute.ResourceSKUCapabilities{
+				{
+					Name:  ptr.To(resourceskus.AcceleratedNetworking),
+					Value: ptr.To(string(resourceskus.CapabilityUnsupported)),
+				},
+				{
+					Name:  ptr.To(resourceskus.VCPUs),
+					Value: ptr.To("4"),
+				},
+				{
+					Name:  ptr.To(resourceskus.MemoryGB),
+					Value: ptr.To("217.13"),
+				},
+			},
+		},
 	}
 }
 
@@ -727,6 +785,15 @@ func newWindowsVMSSSpec() ScaleSetSpec {
 	vmss := newDefaultVMSSSpec()
 	vmss.OSDisk.OSType = azure.WindowsOS
 	return vmss
+}
+func newVMSSSpecWithSKU(capName string, capValue string) ScaleSetSpec {
+	vmsSpec := newDefaultVMSSSpec()
+	inputCapability := armcompute.ResourceSKUCapabilities{
+		Name:  ptr.To(capName),
+		Value: ptr.To(capValue),
+	}
+	vmsSpec.SKU.Capabilities = append(vmsSpec.SKU.Capabilities, &inputCapability)
+	return vmsSpec
 }
 
 func newDefaultExistingVMSS() armcompute.VirtualMachineScaleSet {


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
In the case of "Standard_M8-4ms", their memory capability is specified as a float with value 218.75 GiB.

Added a fix to handle capabilitites that have a float value instead of erroring from reconcile because of inability to parse float values.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
https://github.com/kubernetes-sigs/cluster-api-provider-azure/issues/5480

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->


**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] cherry-pick candidate

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Update handling of AzureMachine's `VMSize` Capabilities that have a float value
```
