### PR TITLE
add FAQ for apparent ASO API version mismatches

### DIFF
--- a/docs/book/src/topics/FAQ.md
+++ b/docs/book/src/topics/FAQ.md
@@ -34,3 +34,16 @@ feature and its benefits.
 4. **Collaborate with the Community:** Engage with and receive updates from other contributors and maintainers through our [Slack channel](https://kubernetes.slack.com/messages/CEX9HENG7) or 
 [mailing lists](https://groups.google.com/forum/#!forum/kubernetes-sig-cluster-lifecycle) to gather support and feedback for Feature X.
 By actively participating, you can enhance CAPZ's functionalilty and ensure it meets the needs of the Kubernetes community on Azure. 
+
+## CAPZ creates a newer API version of an ASO resource, but kubectl shows me an older API version. Did the API version change?
+No, because the API version is not an integral property of Kubernetes resources. The same resource can be
+represented by several different API versions:
+https://kubernetes.io/docs/concepts/overview/kubernetes-api/#api-groups-and-versioning
+
+ASO's versioning scheme isn't compatible with Kubernetes's assumptions about API versions w.r.t. `kubectl`'s
+default version selection, so you'll usually end up seeing an older version than you might have used to create
+the resource if you do a plain `kubectl get managedcluster` vs. specifying the version explicitly like
+`kubectl get managedclusters.v1api20240402preview.containerservice.azure.com`.
+
+There is an open issue with ASO to smooth this out so the newest Azure API version is selected by default:
+https://github.com/Azure/azure-service-operator/issues/4147 for more context.


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind documentation

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

This PR adds a new FAQ explaining why `kubectl get` doesn't always show the same API version that a resource was created with. I adapted this from a [comment](https://github.com/kubernetes-sigs/cluster-api-provider-azure/issues/5168#issuecomment-2405423889) so that we don't have to [link to it from everywhere](https://github.com/kubernetes-sigs/cluster-api-provider-azure/issues/5520#issuecomment-2761797708).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->


**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [X] includes documentation
- [ ] adds unit tests
- [ ] cherry-pick candidate

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Added FAQ to documentation describing why `kubectl get` for an ASO resource shows a different API version than what CAPZ used to create it.
```
