### PR TITLE
Bump golangci-lint to v1.64.8

### DIFF
--- a/.github/workflows/pr-golangci-lint.yaml
+++ b/.github/workflows/pr-golangci-lint.yaml
@@ -33,6 +33,6 @@ jobs:
         uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84 # tag=v6.5.2
         with:
           # update the version when updating golangci-lint
-          version: v1.60.2
+          version: v1.64.8
           args: --out-format=colored-line-number
           working-directory: ${{matrix.working-directory}}

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -46,12 +46,12 @@ linters:
     - revive # better version of golint
     - staticcheck # some of staticcheck's rules
     - stylecheck # another replacement for golint
-    - tenv # using os.Setenv instead of t.Setenv in tests
     - thelper # test helpers not starting with t.Helper()
     - unconvert # unnecessary type conversions
     - unparam # unused function parameters
     - unused # unused constants, variables,functions, types
     - usestdlibvars # using variables/constants from the standard library
+    - usetesting # reports uses of functions with replacement inside the testing package
     - whitespace # unnecessary newlines
 
 linters-settings:

--- a/api/v1beta1/azurecluster_validation_test.go
+++ b/api/v1beta1/azurecluster_validation_test.go
@@ -483,7 +483,7 @@ func TestResourceGroupInvalid(t *testing.T) {
 		g := NewWithT(t)
 		err := validateResourceGroup(testCase.resourceGroup,
 			field.NewPath("spec").Child("networkSpec").Child("vnet").Child("resourceGroup"))
-		g.Expect(err).NotTo(BeNil())
+		g.Expect(err).To(HaveOccurred())
 		g.Expect(err.Type).To(Equal(field.ErrorTypeInvalid))
 		g.Expect(err.Field).To(Equal("spec.networkSpec.vnet.resourceGroup"))
 		g.Expect(err.BadValue).To(BeEquivalentTo(testCase.resourceGroup))
@@ -743,7 +743,7 @@ func TestSubnetNameInvalid(t *testing.T) {
 		g := NewWithT(t)
 		err := validateSubnetName(testCase.subnetName,
 			field.NewPath("spec").Child("networkSpec").Child("subnets").Index(0).Child("name"))
-		g.Expect(err).NotTo(BeNil())
+		g.Expect(err).To(HaveOccurred())
 		g.Expect(err.Type).To(Equal(field.ErrorTypeInvalid))
 		g.Expect(err.Field).To(Equal("spec.networkSpec.subnets[0].name"))
 		g.Expect(err.BadValue).To(BeEquivalentTo(testCase.subnetName))

--- a/azure/scope/machinepool_test.go
+++ b/azure/scope/machinepool_test.go
@@ -1700,7 +1700,7 @@ func TestBootstrapDataChanges(t *testing.T) {
 
 	spec := s.ScaleSetSpec(ctx)
 	sSpec := spec.(*scalesets.ScaleSetSpec)
-	g.Expect(sSpec.ShouldPatchCustomData).To(Equal(false))
+	g.Expect(sSpec.ShouldPatchCustomData).To(BeFalse())
 
 	amp.Annotations[azure.CustomDataHashAnnotation] = "old"
 
@@ -1710,7 +1710,7 @@ func TestBootstrapDataChanges(t *testing.T) {
 
 	spec = s.ScaleSetSpec(ctx)
 	sSpec = spec.(*scalesets.ScaleSetSpec)
-	g.Expect(sSpec.ShouldPatchCustomData).To(Equal(true))
+	g.Expect(sSpec.ShouldPatchCustomData).To(BeTrue())
 }
 
 func sha256Hash(text string) []byte {

--- a/controllers/asosecret_controller_test.go
+++ b/controllers/asosecret_controller_test.go
@@ -39,10 +39,10 @@ import (
 )
 
 func TestASOSecretReconcile(t *testing.T) {
-	os.Setenv("AZURE_CLIENT_ID", "fooClient")             //nolint:tenv // we want to use os.Setenv here instead of t.Setenv
-	os.Setenv("AZURE_CLIENT_SECRET", "fooSecret")         //nolint:tenv // we want to use os.Setenv here instead of t.Setenv
-	os.Setenv("AZURE_TENANT_ID", "fooTenant")             //nolint:tenv // we want to use os.Setenv here instead of t.Setenv
-	os.Setenv("AZURE_SUBSCRIPTION_ID", "fooSubscription") //nolint:tenv // we want to use os.Setenv here instead of t.Setenv
+	os.Setenv("AZURE_CLIENT_ID", "fooClient")             //nolint:gosec,usetesting // we want to use os.Setenv here instead of t.Setenv
+	os.Setenv("AZURE_CLIENT_SECRET", "fooSecret")         //nolint:gosec,usetesting // we want to use os.Setenv here instead of t.Setenv
+	os.Setenv("AZURE_TENANT_ID", "fooTenant")             //nolint:gosec,usetesting // we want to use os.Setenv here instead of t.Setenv
+	os.Setenv("AZURE_SUBSCRIPTION_ID", "fooSubscription") //nolint:gosec,usetesting // we want to use os.Setenv here instead of t.Setenv
 
 	scheme := runtime.NewScheme()
 	_ = clusterv1.AddToScheme(scheme)

--- a/controllers/helpers_test.go
+++ b/controllers/helpers_test.go
@@ -165,9 +165,9 @@ func TestGetCloudProviderConfig(t *testing.T) {
 		},
 	}
 
-	os.Setenv("AZURE_CLIENT_ID", "fooClient")     //nolint:tenv // we want to use os.Setenv here instead of t.Setenv
-	os.Setenv("AZURE_CLIENT_SECRET", "fooSecret") //nolint:tenv // we want to use os.Setenv here instead of t.Setenv
-	os.Setenv("AZURE_TENANT_ID", "fooTenant")     //nolint:tenv // we want to use os.Setenv here instead of t.Setenv
+	os.Setenv("AZURE_CLIENT_ID", "fooClient")     //nolint:gosec,usetesting // we want to use os.Setenv here instead of t.Setenv
+	os.Setenv("AZURE_CLIENT_SECRET", "fooSecret") //nolint:gosec,usetesting // we want to use os.Setenv here instead of t.Setenv
+	os.Setenv("AZURE_TENANT_ID", "fooTenant")     //nolint:gosec,usetesting // we want to use os.Setenv here instead of t.Setenv
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {

--- a/test/e2e/azure_privatecluster.go
+++ b/test/e2e/azure_privatecluster.go
@@ -99,7 +99,7 @@ func AzurePrivateClusterSpec(ctx context.Context, inputGetter func() AzurePrivat
 	Consistently(func() error {
 		ns := &corev1.Namespace{}
 		return publicClusterProxy.GetClient().Get(ctx, client.ObjectKey{Name: kubesystem}, ns)
-	}, "5s", "100ms").Should(BeNil(), "Failed to assert public API server stability")
+	}, "5s", "100ms").Should(Succeed(), "Failed to assert public API server stability")
 
 	// **************
 	// Get the Client ID for the user assigned identity
@@ -113,10 +113,10 @@ func AzurePrivateClusterSpec(ctx context.Context, inputGetter func() AzurePrivat
 		userID = "cloud-provider-user-identity"
 	}
 	resourceID := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.ManagedIdentity/userAssignedIdentities/%s", subscriptionID, identityRG, userID)
-	os.Setenv("UAMI_CLIENT_ID", getClientIDforMSI(resourceID))
+	Expect(os.Setenv("UAMI_CLIENT_ID", getClientIDforMSI(resourceID))).To(Succeed())
 
-	os.Setenv("CLUSTER_IDENTITY_NAME", "cluster-identity-user-assigned")
-	os.Setenv("CLUSTER_IDENTITY_NAMESPACE", input.Namespace.Name)
+	Expect(os.Setenv("CLUSTER_IDENTITY_NAME", "cluster-identity-user-assigned")).To(Succeed())
+	Expect(os.Setenv("CLUSTER_IDENTITY_NAMESPACE", input.Namespace.Name)).To(Succeed())
 	// *************
 
 	By("Creating a private workload cluster")

--- a/test/e2e/azure_selfhosted.go
+++ b/test/e2e/azure_selfhosted.go
@@ -132,11 +132,11 @@ func SelfHostedSpec(ctx context.Context, inputGetter func() SelfHostedSpecInput)
 		Consistently(func() error {
 			ns := &corev1.Namespace{}
 			return input.BootstrapClusterProxy.GetClient().Get(ctx, client.ObjectKey{Name: kubesystem}, ns)
-		}, "5s", "100ms").Should(BeNil(), "Failed to assert bootstrap API server stability")
+		}, "5s", "100ms").Should(Succeed(), "Failed to assert bootstrap API server stability")
 		Consistently(func() error {
 			ns := &corev1.Namespace{}
 			return selfHostedClusterProxy.GetClient().Get(ctx, client.ObjectKey{Name: kubesystem}, ns)
-		}, "5s", "100ms").Should(BeNil(), "Failed to assert self-hosted API server stability")
+		}, "5s", "100ms").Should(Succeed(), "Failed to assert self-hosted API server stability")
 
 		By("Moving the cluster to self hosted")
 		clusterctl.Move(ctx, clusterctl.MoveInput{
@@ -218,11 +218,11 @@ func SelfHostedSpec(ctx context.Context, inputGetter func() SelfHostedSpecInput)
 			Consistently(func() error {
 				ns := &corev1.Namespace{}
 				return input.BootstrapClusterProxy.GetClient().Get(ctx, client.ObjectKey{Name: kubesystem}, ns)
-			}, "5s", "100ms").Should(BeNil(), "Failed to assert bootstrap API server stability")
+			}, "5s", "100ms").Should(Succeed(), "Failed to assert bootstrap API server stability")
 			Consistently(func() error {
 				ns := &corev1.Namespace{}
 				return selfHostedClusterProxy.GetClient().Get(ctx, client.ObjectKey{Name: kubesystem}, ns)
-			}, "5s", "100ms").Should(BeNil(), "Failed to assert self-hosted API server stability")
+			}, "5s", "100ms").Should(Succeed(), "Failed to assert self-hosted API server stability")
 
 			By("Moving the cluster back to bootstrap")
 			clusterctl.Move(ctx, clusterctl.MoveInput{

--- a/test/e2e/azure_test.go
+++ b/test/e2e/azure_test.go
@@ -916,7 +916,7 @@ var _ = Describe("Workload cluster creation", func() {
 	Context("Creating an AKS cluster using ClusterClass [Managed Kubernetes]", func() {
 		It("with a single control plane node and 1 node", func() {
 			// Use default as the clusterclass name so test infra can find the clusterclass template
-			os.Setenv("CLUSTER_CLASS_NAME", "default")
+			Expect(os.Setenv("CLUSTER_CLASS_NAME", "default")).To(Succeed())
 
 			// Use "cc" as spec name because NAT gateway pip name exceeds limit.
 			clusterName = getClusterName(clusterNamePrefix, "cc")

--- a/test/e2e/capi_test.go
+++ b/test/e2e/capi_test.go
@@ -198,7 +198,7 @@ var _ = Describe("Running the Cluster API E2E tests", func() {
 				identityName := e2eConfig.GetVariable(AzureUserIdentity)
 				identity, err := identityClient.Get(ctx, identityRG, identityName, nil)
 				Expect(err).NotTo(HaveOccurred())
-				os.Setenv("AZURE_CLIENT_ID_CLOUD_PROVIDER", *identity.Properties.ClientID)
+				Expect(os.Setenv("AZURE_CLIENT_ID_CLOUD_PROVIDER", *identity.Properties.ClientID)).To(Succeed())
 			})
 
 			Context("upgrade from an old version of v1beta1 to current, and scale workload clusters created in the old version", func() {

--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -372,7 +372,9 @@ func describeEvents(ctx context.Context, clientset *kubernetes.Clientset, namesp
 				fmt.Fprintf(w, "%s\t%s\t%s\t%s/%s\t%s\n", e.LastTimestamp, e.Type, e.Reason,
 					strings.ToLower(e.InvolvedObject.Kind), e.InvolvedObject.Name, e.Message)
 			}
-			w.Flush()
+			if err = w.Flush(); err != nil {
+				b.WriteString(err.Error())
+			}
 		}
 	}
 	return b.String()

--- a/util/system/namespace_test.go
+++ b/util/system/namespace_test.go
@@ -44,7 +44,7 @@ func TestGetNamespace(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.Name, func(t *testing.T) {
 			g := gomega.NewWithT(t)
-			os.Setenv(NamespaceEnvVarName, c.PodNamespace) //nolint:tenv // leave it as is
+			os.Setenv(NamespaceEnvVarName, c.PodNamespace) //nolint:gosec,usetesting // leave it as is
 			defer os.Unsetenv(NamespaceEnvVarName)
 			g.Expect(GetManagerNamespace()).To(gomega.Equal(c.Expected))
 		})


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Bumps golangci-lint to v1.64.8. I didn't go for v2.0.2 because it seemed potentially more disruptive; we can follow on with those changes later.

**Which issue(s) this PR fixes**:

N/A, but I've been having trouble getting the current linter ever to pass locally: it just times out. This version seems to work, and quickly. Maybe something got fixed. :shrug:

**Special notes for your reviewer**:


**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] cherry-pick candidate

**Release note**:

```release-note
NONE
```
