### PR TITLE
Add test for managedclusteradopt controller

### DIFF
--- a/controllers/managedclusteradopt_controller_test.go
+++ b/controllers/managedclusteradopt_controller_test.go
@@ -1,0 +1,89 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"testing"
+
+	asocontainerservicev1 "github.com/Azure/azure-service-operator/v2/api/containerservice/v1api20231001"
+	asoresourcesv1 "github.com/Azure/azure-service-operator/v2/api/resources/v1api20200601"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"sigs.k8s.io/cluster-api-provider-azure/api/v1alpha1"
+)
+
+func TestManagedClusterAdoptReconcile(t *testing.T) {
+	ctx := context.Background()
+	g := NewWithT(t)
+	req := ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      "fake-mc",
+			Namespace: "fake-ns",
+		},
+	}
+	managedCluster := &asocontainerservicev1.ManagedCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "fake-mc",
+			Namespace: "fake-ns",
+			Annotations: map[string]string{
+				adoptAnnotation: adoptAnnotationValue,
+			},
+		},
+		Spec: asocontainerservicev1.ManagedCluster_Spec{
+			Owner: &genruntime.KnownResourceReference{
+				Name: "fake-mc",
+			},
+		},
+	}
+
+	rg := &asoresourcesv1.ResourceGroup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "fake-mc",
+			Namespace: "fake-ns",
+		},
+	}
+
+	s := runtime.NewScheme()
+	err := asocontainerservicev1.AddToScheme(s)
+	g.Expect(err).ToNot(HaveOccurred())
+	err = clusterv1.AddToScheme(s)
+	g.Expect(err).ToNot(HaveOccurred())
+	err = asoresourcesv1.AddToScheme(s)
+	g.Expect(err).ToNot(HaveOccurred())
+	err = v1alpha1.AddToScheme(s)
+	g.Expect(err).ToNot(HaveOccurred())
+	client := fake.NewClientBuilder().WithScheme(s).WithObjects(managedCluster, rg).Build()
+	rec := ManagedClusterAdoptReconciler{
+		Client: client,
+	}
+	_, err = rec.Reconcile(ctx, req)
+	g.Expect(err).ToNot(HaveOccurred())
+	mcp := &v1alpha1.AzureASOManagedControlPlane{}
+	err = rec.Get(ctx, types.NamespacedName{Name: managedCluster.Name, Namespace: managedCluster.Namespace}, mcp)
+	g.Expect(err).ToNot(HaveOccurred())
+	asomc := &v1alpha1.AzureASOManagedCluster{}
+	err = rec.Get(ctx, types.NamespacedName{Name: managedCluster.Name, Namespace: managedCluster.Namespace}, asomc)
+	g.Expect(err).ToNot(HaveOccurred())
+}


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind cleanup

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
Adds testing to the controllers package

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # 
Part of https://github.com/kubernetes-sigs/cluster-api-provider-azure/issues/3649
**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->


**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] cherry-pick candidate

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
