### PR TITLE
fix: reuse global TracerProvider to avoid memory leak

### DIFF
--- a/azure/defaults.go
+++ b/azure/defaults.go
@@ -17,7 +17,6 @@ limitations under the License.
 package azure
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"regexp"
@@ -28,8 +27,8 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
 	"github.com/Azure/azure-sdk-for-go/sdk/tracing/azotel"
+	"go.opentelemetry.io/otel"
 
-	"sigs.k8s.io/cluster-api-provider-azure/pkg/ot"
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
 	"sigs.k8s.io/cluster-api-provider-azure/version"
 )
@@ -380,11 +379,7 @@ func ARMClientOptions(azureEnvironment string, extraPolicies ...policy.Policy) (
 	opts.PerCallPolicies = append(opts.PerCallPolicies, extraPolicies...)
 	opts.Retry.MaxRetries = -1 // Less than zero means one try and no retries.
 
-	otelTP, err := ot.OTLPTracerProvider(context.TODO())
-	if err != nil {
-		return nil, err
-	}
-	opts.TracingProvider = azotel.NewTracingProvider(otelTP, nil)
+	opts.TracingProvider = azotel.NewTracingProvider(otel.GetTracerProvider(), nil)
 
 	return opts, nil
 }

--- a/controllers/aso_credential_cache.go
+++ b/controllers/aso_credential_cache.go
@@ -26,12 +26,12 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/tracing/azotel"
 	asoannotations "github.com/Azure/azure-service-operator/v2/pkg/common/annotations"
 	"github.com/Azure/azure-service-operator/v2/pkg/common/config"
+	"go.opentelemetry.io/otel"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/scope"
-	"sigs.k8s.io/cluster-api-provider-azure/pkg/ot"
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
 )
 
@@ -98,13 +98,8 @@ func (c *asoCredentialCache) clientOptsForASOResource(ctx context.Context, obj c
 		return azcore.ClientOptions{}, err
 	}
 
-	otelTP, err := ot.OTLPTracerProvider(ctx)
-	if err != nil {
-		return azcore.ClientOptions{}, err
-	}
-
 	opts := azcore.ClientOptions{
-		TracingProvider: azotel.NewTracingProvider(otelTP, nil),
+		TracingProvider: azotel.NewTracingProvider(otel.GetTracerProvider(), nil),
 		Cloud: cloud.Configuration{
 			ActiveDirectoryAuthorityHost: string(secret.Data[config.AzureAuthorityHost]),
 		},

--- a/pkg/ot/traces.go
+++ b/pkg/ot/traces.go
@@ -35,7 +35,7 @@ import (
 
 // RegisterTracing enables code tracing via OpenTelemetry.
 func RegisterTracing(ctx context.Context, log logr.Logger) error {
-	tp, err := OTLPTracerProvider(ctx)
+	tp, err := otlpTracerProvider(ctx)
 	if err != nil {
 		return err
 	}
@@ -54,8 +54,8 @@ func RegisterTracing(ctx context.Context, log logr.Logger) error {
 	return nil
 }
 
-// OTLPTracerProvider initializes an OTLP exporter and configures the corresponding tracer provider.
-func OTLPTracerProvider(ctx context.Context) (*sdktrace.TracerProvider, error) {
+// otlpTracerProvider initializes an OTLP exporter and configures the corresponding tracer provider.
+func otlpTracerProvider(ctx context.Context) (*sdktrace.TracerProvider, error) {
 	res, err := resource.New(ctx,
 		resource.WithAttributes(
 			semconv.ServiceNameKey.String("capz"),


### PR DESCRIPTION
/kind bug
**What this PR does / why we need it**:
Fixes a memory leak occurring since v1.18.0 by reusing the global tracer provider instead of re-instantiating it many times (for each request basicly). This also ensures tracing provider is set to a valid value only when `enableTracing` is set. 


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #5410

**Special notes for your reviewer**:
Global TraceProvider is set in:
https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/b32f0c6ba4c71007dc7892eac605d74c7eb47695/pkg/ot/traces.go#L37-L42

Which is called in main:
https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/b32f0c6ba4c71007dc7892eac605d74c7eb47695/main.go#L354-L359

It would be great if somebody could ensure tracing still works as intended - I did enable tracing to verify it works and it looks okay to me but I haven't verified it in great detail.

**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [x] cherry-pick candidate

**Release note**:
```release-note
fixes potential OOM due to tracing (even if tracing not enabled)
```
