### PR TITLE
consolidate CreateOrUpdateAsync params, solve for revive lint violations

### DIFF
--- a/azure/services/async/interfaces.go
+++ b/azure/services/async/interfaces.go
@@ -43,7 +43,7 @@ type TagsGetter interface {
 // Creator creates or updates a resource asynchronously.
 type Creator[T any] interface {
 	Getter
-	CreateOrUpdateAsync(ctx context.Context, spec azure.ResourceSpecGetter, resumeToken string, parameters interface{}) (result interface{}, poller *runtime.Poller[T], err error)
+	CreateOrUpdateAsync(ctx context.Context, spec azure.ResourceSpecGetter, opts azure.CreateOrUpdateAsyncOpts) (result interface{}, poller *runtime.Poller[T], err error)
 }
 
 // Deleter deletes a resource asynchronously.

--- a/azure/services/async/mock_async/async_mock.go
+++ b/azure/services/async/mock_async/async_mock.go
@@ -277,9 +277,9 @@ func (m *MockCreator[T]) EXPECT() *MockCreatorMockRecorder[T] {
 }
 
 // CreateOrUpdateAsync mocks base method.
-func (m *MockCreator[T]) CreateOrUpdateAsync(ctx context.Context, spec azure.ResourceSpecGetter, resumeToken string, parameters any) (any, *runtime.Poller[T], error) {
+func (m *MockCreator[T]) CreateOrUpdateAsync(ctx context.Context, spec azure.ResourceSpecGetter, opts azure.CreateOrUpdateAsyncOpts) (any, *runtime.Poller[T], error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateOrUpdateAsync", ctx, spec, resumeToken, parameters)
+	ret := m.ctrl.Call(m, "CreateOrUpdateAsync", ctx, spec, opts)
 	ret0, _ := ret[0].(any)
 	ret1, _ := ret[1].(*runtime.Poller[T])
 	ret2, _ := ret[2].(error)
@@ -287,9 +287,9 @@ func (m *MockCreator[T]) CreateOrUpdateAsync(ctx context.Context, spec azure.Res
 }
 
 // CreateOrUpdateAsync indicates an expected call of CreateOrUpdateAsync.
-func (mr *MockCreatorMockRecorder[T]) CreateOrUpdateAsync(ctx, spec, resumeToken, parameters any) *gomock.Call {
+func (mr *MockCreatorMockRecorder[T]) CreateOrUpdateAsync(ctx, spec, opts any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateOrUpdateAsync", reflect.TypeOf((*MockCreator[T])(nil).CreateOrUpdateAsync), ctx, spec, resumeToken, parameters)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateOrUpdateAsync", reflect.TypeOf((*MockCreator[T])(nil).CreateOrUpdateAsync), ctx, spec, opts)
 }
 
 // Get mocks base method.

--- a/azure/services/availabilitysets/client.go
+++ b/azure/services/availabilitysets/client.go
@@ -60,13 +60,13 @@ func (ac *AzureClient) Get(ctx context.Context, spec azure.ResourceSpecGetter) (
 // CreateOrUpdateAsync creates or updates an availability set asynchronously.
 // It sends a PUT request to Azure and if accepted without error, the func will return a Poller which can be used to track the ongoing
 // progress of the operation.
-func (ac *AzureClient) CreateOrUpdateAsync(ctx context.Context, spec azure.ResourceSpecGetter, _resumeToken string, parameters interface{}) (result interface{}, poller *runtime.Poller[armcompute.AvailabilitySetsClientCreateOrUpdateResponse], err error) { //nolint:revive // keeping _resumeToken for understanding purposes
+func (ac *AzureClient) CreateOrUpdateAsync(ctx context.Context, spec azure.ResourceSpecGetter, opts azure.CreateOrUpdateAsyncOpts) (result interface{}, poller *runtime.Poller[armcompute.AvailabilitySetsClientCreateOrUpdateResponse], err error) {
 	ctx, _, done := tele.StartSpanWithLogger(ctx, "availabilitySets.AzureClient.CreateOrUpdateAsync")
 	defer done()
 
-	availabilitySet, ok := parameters.(armcompute.AvailabilitySet)
-	if !ok && parameters != nil {
-		return nil, nil, errors.Errorf("%T is not an armcompute.AvailabilitySet", parameters)
+	availabilitySet, ok := opts.Parameters.(armcompute.AvailabilitySet)
+	if !ok && opts.Parameters != nil {
+		return nil, nil, errors.Errorf("%T is not an armcompute.AvailabilitySet", opts.Parameters)
 	}
 
 	// Note: there is no async `BeginCreateOrUpdate` implementation for availability sets, so this func will never return a poller.
@@ -82,7 +82,7 @@ func (ac *AzureClient) CreateOrUpdateAsync(ctx context.Context, spec azure.Resou
 // DeleteAsync deletes a availability set asynchronously. DeleteAsync sends a DELETE
 // request to Azure and if accepted without error, the func will return a Poller which can be used to track the ongoing
 // progress of the operation.
-func (ac *AzureClient) DeleteAsync(ctx context.Context, spec azure.ResourceSpecGetter, _resumeToken string) (poller *runtime.Poller[armcompute.AvailabilitySetsClientDeleteResponse], err error) { //nolint:revive // keeping _resumeToken for understanding purposes
+func (ac *AzureClient) DeleteAsync(ctx context.Context, spec azure.ResourceSpecGetter, _ string) (poller *runtime.Poller[armcompute.AvailabilitySetsClientDeleteResponse], err error) {
 	ctx, _, done := tele.StartSpanWithLogger(ctx, "availabilitysets.AzureClient.DeleteAsync")
 	defer done()
 

--- a/azure/services/inboundnatrules/client.go
+++ b/azure/services/inboundnatrules/client.go
@@ -90,18 +90,18 @@ func (ac *azureClient) List(ctx context.Context, resourceGroupName, lbName strin
 // CreateOrUpdateAsync creates or updates an inbound NAT rule asynchronously.
 // It sends a PUT request to Azure and if accepted without error, the func will return a Poller which can be used to track the ongoing
 // progress of the operation.
-func (ac *azureClient) CreateOrUpdateAsync(ctx context.Context, spec azure.ResourceSpecGetter, resumeToken string, parameters interface{}) (result interface{}, poller *runtime.Poller[armnetwork.InboundNatRulesClientCreateOrUpdateResponse], err error) {
+func (ac *azureClient) CreateOrUpdateAsync(ctx context.Context, spec azure.ResourceSpecGetter, opts azure.CreateOrUpdateAsyncOpts) (result interface{}, poller *runtime.Poller[armnetwork.InboundNatRulesClientCreateOrUpdateResponse], err error) {
 	ctx, log, done := tele.StartSpanWithLogger(ctx, "inboundnatrules.azureClient.CreateOrUpdateAsync")
 	defer done()
 
-	natRule, ok := parameters.(armnetwork.InboundNatRule)
-	if !ok && parameters != nil {
-		return nil, nil, errors.Errorf("%T is not an armnetwork.InboundNatRule", parameters)
+	natRule, ok := opts.Parameters.(armnetwork.InboundNatRule)
+	if !ok && opts.Parameters != nil {
+		return nil, nil, errors.Errorf("%T is not an armnetwork.InboundNatRule", opts.Parameters)
 	}
 
-	opts := &armnetwork.InboundNatRulesClientBeginCreateOrUpdateOptions{ResumeToken: resumeToken}
-	log.V(4).Info("sending request", "resumeToken", resumeToken)
-	poller, err = ac.inboundnatrules.BeginCreateOrUpdate(ctx, spec.ResourceGroupName(), spec.OwnerResourceName(), spec.ResourceName(), natRule, opts)
+	beginOpts := &armnetwork.InboundNatRulesClientBeginCreateOrUpdateOptions{ResumeToken: opts.ResumeToken}
+	log.V(4).Info("sending request", "resumeToken", opts.ResumeToken)
+	poller, err = ac.inboundnatrules.BeginCreateOrUpdate(ctx, spec.ResourceGroupName(), spec.OwnerResourceName(), spec.ResourceName(), natRule, beginOpts)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/azure/services/loadbalancers/client.go
+++ b/azure/services/loadbalancers/client.go
@@ -67,13 +67,13 @@ func (ac *azureClient) Get(ctx context.Context, spec azure.ResourceSpecGetter) (
 // CreateOrUpdateAsync creates or updates a load balancer asynchronously.
 // It sends a PUT request to Azure and if accepted without error, the func will return a Poller which can be used to track the ongoing
 // progress of the operation.
-func (ac *azureClient) CreateOrUpdateAsync(ctx context.Context, spec azure.ResourceSpecGetter, resumeToken string, parameters interface{}) (result interface{}, poller *runtime.Poller[armnetwork.LoadBalancersClientCreateOrUpdateResponse], err error) {
+func (ac *azureClient) CreateOrUpdateAsync(ctx context.Context, spec azure.ResourceSpecGetter, opts azure.CreateOrUpdateAsyncOpts) (result interface{}, poller *runtime.Poller[armnetwork.LoadBalancersClientCreateOrUpdateResponse], err error) {
 	ctx, _, done := tele.StartSpanWithLogger(ctx, "loadbalancers.azureClient.CreateOrUpdate")
 	defer done()
 
-	loadBalancer, ok := parameters.(armnetwork.LoadBalancer)
-	if !ok && parameters != nil {
-		return nil, nil, errors.Errorf("%T is not an armnetwork.LoadBalancer", parameters)
+	loadBalancer, ok := opts.Parameters.(armnetwork.LoadBalancer)
+	if !ok && opts.Parameters != nil {
+		return nil, nil, errors.Errorf("%T is not an armnetwork.LoadBalancer", opts.Parameters)
 	}
 
 	var extraPolicies []policy.Policy
@@ -97,8 +97,8 @@ func (ac *azureClient) CreateOrUpdateAsync(ctx context.Context, spec azure.Resou
 	}
 
 	client := factory.NewLoadBalancersClient()
-	opts := &armnetwork.LoadBalancersClientBeginCreateOrUpdateOptions{ResumeToken: resumeToken}
-	poller, err = client.BeginCreateOrUpdate(ctx, spec.ResourceGroupName(), spec.ResourceName(), loadBalancer, opts)
+	beginOpts := &armnetwork.LoadBalancersClientBeginCreateOrUpdateOptions{ResumeToken: opts.ResumeToken}
+	poller, err = client.BeginCreateOrUpdate(ctx, spec.ResourceGroupName(), spec.ResourceName(), loadBalancer, beginOpts)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/azure/services/networkinterfaces/client.go
+++ b/azure/services/networkinterfaces/client.go
@@ -36,7 +36,7 @@ type azureClient struct {
 }
 
 // NewClient creates a new network interfaces client from an authorizer.
-func NewClient(auth azure.Authorizer, apiCallTimeout time.Duration) (*azureClient, error) { //nolint:revive // leave it as is
+func NewClient(auth azure.Authorizer, apiCallTimeout time.Duration) (*azureClient, error) {
 	opts, err := azure.ARMClientOptions(auth.CloudEnvironment())
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create networkinterfaces client options")
@@ -63,17 +63,17 @@ func (ac *azureClient) Get(ctx context.Context, spec azure.ResourceSpecGetter) (
 // CreateOrUpdateAsync creates or updates a network interface asynchronously.
 // It sends a PUT request to Azure and if accepted without error, the func will return a poller which can be used to track the ongoing
 // progress of the operation.
-func (ac *azureClient) CreateOrUpdateAsync(ctx context.Context, spec azure.ResourceSpecGetter, resumeToken string, parameters interface{}) (result interface{}, poller *runtime.Poller[armnetwork.InterfacesClientCreateOrUpdateResponse], err error) {
+func (ac *azureClient) CreateOrUpdateAsync(ctx context.Context, spec azure.ResourceSpecGetter, opts azure.CreateOrUpdateAsyncOpts) (result interface{}, poller *runtime.Poller[armnetwork.InterfacesClientCreateOrUpdateResponse], err error) {
 	ctx, _, done := tele.StartSpanWithLogger(ctx, "networkinterfaces.AzureClient.CreateOrUpdateAsync")
 	defer done()
 
-	networkInterface, ok := parameters.(armnetwork.Interface)
-	if !ok && parameters != nil {
-		return nil, nil, errors.Errorf("%T is not an armnetwork.Interface", parameters)
+	networkInterface, ok := opts.Parameters.(armnetwork.Interface)
+	if !ok && opts.Parameters != nil {
+		return nil, nil, errors.Errorf("%T is not an armnetwork.Interface", opts.Parameters)
 	}
 
-	opts := &armnetwork.InterfacesClientBeginCreateOrUpdateOptions{ResumeToken: resumeToken}
-	poller, err = ac.interfaces.BeginCreateOrUpdate(ctx, spec.ResourceGroupName(), spec.ResourceName(), networkInterface, opts)
+	beginOpts := &armnetwork.InterfacesClientBeginCreateOrUpdateOptions{ResumeToken: opts.ResumeToken}
+	poller, err = ac.interfaces.BeginCreateOrUpdate(ctx, spec.ResourceGroupName(), spec.ResourceName(), networkInterface, beginOpts)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/azure/services/networkinterfaces/client.go
+++ b/azure/services/networkinterfaces/client.go
@@ -29,14 +29,14 @@ import (
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
 )
 
-// azureClient contains the Azure go-sdk Client.
-type azureClient struct {
+// AzureClient contains the Azure go-sdk Client.
+type AzureClient struct {
 	interfaces     *armnetwork.InterfacesClient
 	apiCallTimeout time.Duration
 }
 
 // NewClient creates a new network interfaces client from an authorizer.
-func NewClient(auth azure.Authorizer, apiCallTimeout time.Duration) (*azureClient, error) {
+func NewClient(auth azure.Authorizer, apiCallTimeout time.Duration) (*AzureClient, error) {
 	opts, err := azure.ARMClientOptions(auth.CloudEnvironment())
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create networkinterfaces client options")
@@ -45,11 +45,11 @@ func NewClient(auth azure.Authorizer, apiCallTimeout time.Duration) (*azureClien
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create armnetwork client factory")
 	}
-	return &azureClient{factory.NewInterfacesClient(), apiCallTimeout}, nil
+	return &AzureClient{factory.NewInterfacesClient(), apiCallTimeout}, nil
 }
 
 // Get gets the specified network interface.
-func (ac *azureClient) Get(ctx context.Context, spec azure.ResourceSpecGetter) (result interface{}, err error) {
+func (ac *AzureClient) Get(ctx context.Context, spec azure.ResourceSpecGetter) (result interface{}, err error) {
 	ctx, _, done := tele.StartSpanWithLogger(ctx, "networkinterfaces.AzureClient.Get")
 	defer done()
 
@@ -63,7 +63,7 @@ func (ac *azureClient) Get(ctx context.Context, spec azure.ResourceSpecGetter) (
 // CreateOrUpdateAsync creates or updates a network interface asynchronously.
 // It sends a PUT request to Azure and if accepted without error, the func will return a poller which can be used to track the ongoing
 // progress of the operation.
-func (ac *azureClient) CreateOrUpdateAsync(ctx context.Context, spec azure.ResourceSpecGetter, opts azure.CreateOrUpdateAsyncOpts) (result interface{}, poller *runtime.Poller[armnetwork.InterfacesClientCreateOrUpdateResponse], err error) {
+func (ac *AzureClient) CreateOrUpdateAsync(ctx context.Context, spec azure.ResourceSpecGetter, opts azure.CreateOrUpdateAsyncOpts) (result interface{}, poller *runtime.Poller[armnetwork.InterfacesClientCreateOrUpdateResponse], err error) {
 	ctx, _, done := tele.StartSpanWithLogger(ctx, "networkinterfaces.AzureClient.CreateOrUpdateAsync")
 	defer done()
 
@@ -96,7 +96,7 @@ func (ac *azureClient) CreateOrUpdateAsync(ctx context.Context, spec azure.Resou
 // DeleteAsync deletes a network interface asynchronously. DeleteAsync sends a DELETE
 // request to Azure and if accepted without error, the func will return a poller which can be used to track the ongoing
 // progress of the operation.
-func (ac *azureClient) DeleteAsync(ctx context.Context, spec azure.ResourceSpecGetter, resumeToken string) (poller *runtime.Poller[armnetwork.InterfacesClientDeleteResponse], err error) {
+func (ac *AzureClient) DeleteAsync(ctx context.Context, spec azure.ResourceSpecGetter, resumeToken string) (poller *runtime.Poller[armnetwork.InterfacesClientDeleteResponse], err error) {
 	ctx, _, done := tele.StartSpanWithLogger(ctx, "networkinterfaces.AzureClient.DeleteAsync")
 	defer done()
 

--- a/azure/services/privatedns/link_client.go
+++ b/azure/services/privatedns/link_client.go
@@ -63,17 +63,17 @@ func (avc *azureVirtualNetworkLinksClient) Get(ctx context.Context, spec azure.R
 // CreateOrUpdateAsync creates or updates a virtual network link asynchronously.
 // It sends a PUT request to Azure and if accepted without error, the func will return a poller which can be used to track the ongoing
 // progress of the operation.
-func (avc *azureVirtualNetworkLinksClient) CreateOrUpdateAsync(ctx context.Context, spec azure.ResourceSpecGetter, resumeToken string, parameters interface{}) (result interface{}, poller *runtime.Poller[armprivatedns.VirtualNetworkLinksClientCreateOrUpdateResponse], err error) {
+func (avc *azureVirtualNetworkLinksClient) CreateOrUpdateAsync(ctx context.Context, spec azure.ResourceSpecGetter, opts azure.CreateOrUpdateAsyncOpts) (result interface{}, poller *runtime.Poller[armprivatedns.VirtualNetworkLinksClientCreateOrUpdateResponse], err error) {
 	ctx, _, done := tele.StartSpanWithLogger(ctx, "privatedns.azureVirtualNetworkLinksClient.CreateOrUpdateAsync")
 	defer done()
 
-	link, ok := parameters.(armprivatedns.VirtualNetworkLink)
-	if !ok && parameters != nil {
-		return nil, nil, errors.Errorf("%T is not an armprivatedns.VirtualNetworkLink", parameters)
+	link, ok := opts.Parameters.(armprivatedns.VirtualNetworkLink)
+	if !ok && opts.Parameters != nil {
+		return nil, nil, errors.Errorf("%T is not an armprivatedns.VirtualNetworkLink", opts.Parameters)
 	}
 
-	opts := &armprivatedns.VirtualNetworkLinksClientBeginCreateOrUpdateOptions{ResumeToken: resumeToken}
-	poller, err = avc.vnetlinks.BeginCreateOrUpdate(ctx, spec.ResourceGroupName(), spec.OwnerResourceName(), spec.ResourceName(), link, opts)
+	beginOpts := &armprivatedns.VirtualNetworkLinksClientBeginCreateOrUpdateOptions{ResumeToken: opts.ResumeToken}
+	poller, err = avc.vnetlinks.BeginCreateOrUpdate(ctx, spec.ResourceGroupName(), spec.OwnerResourceName(), spec.ResourceName(), link, beginOpts)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/azure/services/privatedns/record_client.go
+++ b/azure/services/privatedns/record_client.go
@@ -52,13 +52,13 @@ func (arc *azureRecordsClient) Get(_ context.Context, _ azure.ResourceSpecGetter
 
 // CreateOrUpdateAsync creates or updates a record asynchronously.
 // Creating a record set is not a long-running operation, so we don't ever return a future.
-func (arc *azureRecordsClient) CreateOrUpdateAsync(ctx context.Context, spec azure.ResourceSpecGetter, _ string, parameters interface{}) (result interface{}, poller *runtime.Poller[armprivatedns.RecordSetsClientCreateOrUpdateResponse], err error) {
+func (arc *azureRecordsClient) CreateOrUpdateAsync(ctx context.Context, spec azure.ResourceSpecGetter, opts azure.CreateOrUpdateAsyncOpts) (result interface{}, poller *runtime.Poller[armprivatedns.RecordSetsClientCreateOrUpdateResponse], err error) {
 	ctx, _, done := tele.StartSpanWithLogger(ctx, "privatedns.azureRecordsClient.CreateOrUpdateAsync")
 	defer done()
 
-	set, ok := parameters.(armprivatedns.RecordSet)
-	if !ok && parameters != nil {
-		return nil, nil, errors.Errorf("%T is not an armprivatedns.RecordSet", parameters)
+	set, ok := opts.Parameters.(armprivatedns.RecordSet)
+	if !ok && opts.Parameters != nil {
+		return nil, nil, errors.Errorf("%T is not an armprivatedns.RecordSet", opts.Parameters)
 	}
 
 	// Determine record type.

--- a/azure/services/privatedns/zone_client.go
+++ b/azure/services/privatedns/zone_client.go
@@ -63,17 +63,17 @@ func (azc *azureZonesClient) Get(ctx context.Context, spec azure.ResourceSpecGet
 // CreateOrUpdateAsync creates or updates a private dns zone asynchronously.
 // It sends a PUT request to Azure and if accepted without error, the func will return a poller which can be used to track the ongoing
 // progress of the operation.
-func (azc *azureZonesClient) CreateOrUpdateAsync(ctx context.Context, spec azure.ResourceSpecGetter, resumeToken string, parameters interface{}) (result interface{}, poller *runtime.Poller[armprivatedns.PrivateZonesClientCreateOrUpdateResponse], err error) {
+func (azc *azureZonesClient) CreateOrUpdateAsync(ctx context.Context, spec azure.ResourceSpecGetter, opts azure.CreateOrUpdateAsyncOpts) (result interface{}, poller *runtime.Poller[armprivatedns.PrivateZonesClientCreateOrUpdateResponse], err error) {
 	ctx, _, done := tele.StartSpanWithLogger(ctx, "privatedns.azureZonesClient.CreateOrUpdateAsync")
 	defer done()
 
-	zone, ok := parameters.(armprivatedns.PrivateZone)
-	if !ok && parameters != nil {
-		return nil, nil, errors.Errorf("%T is not an armprivatedns.PrivateZone", parameters)
+	zone, ok := opts.Parameters.(armprivatedns.PrivateZone)
+	if !ok && opts.Parameters != nil {
+		return nil, nil, errors.Errorf("%T is not an armprivatedns.PrivateZone", opts.Parameters)
 	}
 
-	opts := &armprivatedns.PrivateZonesClientBeginCreateOrUpdateOptions{ResumeToken: resumeToken}
-	poller, err = azc.privatezones.BeginCreateOrUpdate(ctx, spec.ResourceGroupName(), spec.ResourceName(), zone, opts)
+	beginOpts := &armprivatedns.PrivateZonesClientBeginCreateOrUpdateOptions{ResumeToken: opts.ResumeToken}
+	poller, err = azc.privatezones.BeginCreateOrUpdate(ctx, spec.ResourceGroupName(), spec.ResourceName(), zone, beginOpts)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/azure/services/publicips/client.go
+++ b/azure/services/publicips/client.go
@@ -64,17 +64,17 @@ func (ac *AzureClient) Get(ctx context.Context, spec azure.ResourceSpecGetter) (
 // CreateOrUpdateAsync creates or updates a static or dynamic public IP address.
 // It sends a PUT request to Azure and if accepted without error, the func will return a Poller which can be used to track the ongoing
 // progress of the operation.
-func (ac *AzureClient) CreateOrUpdateAsync(ctx context.Context, spec azure.ResourceSpecGetter, resumeToken string, parameters interface{}) (result interface{}, poller *runtime.Poller[armnetwork.PublicIPAddressesClientCreateOrUpdateResponse], err error) {
+func (ac *AzureClient) CreateOrUpdateAsync(ctx context.Context, spec azure.ResourceSpecGetter, opts azure.CreateOrUpdateAsyncOpts) (result interface{}, poller *runtime.Poller[armnetwork.PublicIPAddressesClientCreateOrUpdateResponse], err error) {
 	ctx, _, done := tele.StartSpanWithLogger(ctx, "publicips.AzureClient.CreateOrUpdate")
 	defer done()
 
-	publicip, ok := parameters.(armnetwork.PublicIPAddress)
-	if !ok && parameters != nil {
-		return nil, nil, errors.Errorf("%T is not an armnetwork.PublicIPAddress", parameters)
+	publicip, ok := opts.Parameters.(armnetwork.PublicIPAddress)
+	if !ok && opts.Parameters != nil {
+		return nil, nil, errors.Errorf("%T is not an armnetwork.PublicIPAddress", opts.Parameters)
 	}
 
-	opts := &armnetwork.PublicIPAddressesClientBeginCreateOrUpdateOptions{ResumeToken: resumeToken}
-	poller, err = ac.publicips.BeginCreateOrUpdate(ctx, spec.ResourceGroupName(), spec.ResourceName(), publicip, opts)
+	beginOpts := &armnetwork.PublicIPAddressesClientBeginCreateOrUpdateOptions{ResumeToken: opts.ResumeToken}
+	poller, err = ac.publicips.BeginCreateOrUpdate(ctx, spec.ResourceGroupName(), spec.ResourceName(), publicip, beginOpts)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/azure/services/roleassignments/client.go
+++ b/azure/services/roleassignments/client.go
@@ -59,13 +59,13 @@ func (ac *azureClient) Get(ctx context.Context, spec azure.ResourceSpecGetter) (
 
 // CreateOrUpdateAsync creates a roleassignment.
 // Creating a roleassignment is not a long running operation, so we don't ever return a poller.
-func (ac *azureClient) CreateOrUpdateAsync(ctx context.Context, spec azure.ResourceSpecGetter, resumeToken string, parameters interface{}) (result interface{}, poller *runtime.Poller[armauthorization.RoleAssignmentsClientCreateResponse], err error) { //nolint:revive // keeping resumeToken for readability
+func (ac *azureClient) CreateOrUpdateAsync(ctx context.Context, spec azure.ResourceSpecGetter, opts azure.CreateOrUpdateAsyncOpts) (result interface{}, poller *runtime.Poller[armauthorization.RoleAssignmentsClientCreateResponse], err error) {
 	ctx, _, done := tele.StartSpanWithLogger(ctx, "roleassignments.azureClient.CreateOrUpdateAsync")
 	defer done()
 
-	createParams, ok := parameters.(armauthorization.RoleAssignmentCreateParameters)
+	createParams, ok := opts.Parameters.(armauthorization.RoleAssignmentCreateParameters)
 	if !ok {
-		return nil, nil, errors.Errorf("%T is not an armauthorization.RoleAssignmentCreateParameters", parameters)
+		return nil, nil, errors.Errorf("%T is not an armauthorization.RoleAssignmentCreateParameters", opts.Parameters)
 	}
 	resp, err := ac.roleassignments.Create(ctx, spec.OwnerResourceName(), spec.ResourceName(), createParams, nil)
 	return resp.RoleAssignment, nil, err

--- a/azure/services/routetables/client.go
+++ b/azure/services/routetables/client.go
@@ -63,17 +63,17 @@ func (ac *azureClient) Get(ctx context.Context, spec azure.ResourceSpecGetter) (
 // CreateOrUpdateAsync creates or updates a route table asynchronously.
 // It sends a PUT request to Azure and if accepted without error, the func will return a Poller which can be used to track the ongoing
 // progress of the operation.
-func (ac *azureClient) CreateOrUpdateAsync(ctx context.Context, spec azure.ResourceSpecGetter, resumeToken string, parameters interface{}) (result interface{}, poller *runtime.Poller[armnetwork.RouteTablesClientCreateOrUpdateResponse], err error) {
+func (ac *azureClient) CreateOrUpdateAsync(ctx context.Context, spec azure.ResourceSpecGetter, opts azure.CreateOrUpdateAsyncOpts) (result interface{}, poller *runtime.Poller[armnetwork.RouteTablesClientCreateOrUpdateResponse], err error) {
 	ctx, _, done := tele.StartSpanWithLogger(ctx, "routetables.azureClient.CreateOrUpdateAsync")
 	defer done()
 
-	rt, ok := parameters.(armnetwork.RouteTable)
-	if !ok && parameters != nil {
-		return nil, nil, errors.Errorf("%T is not an armnetwork.RouteTable", parameters)
+	rt, ok := opts.Parameters.(armnetwork.RouteTable)
+	if !ok && opts.Parameters != nil {
+		return nil, nil, errors.Errorf("%T is not an armnetwork.RouteTable", opts.Parameters)
 	}
 
-	opts := &armnetwork.RouteTablesClientBeginCreateOrUpdateOptions{ResumeToken: resumeToken}
-	poller, err = ac.routetables.BeginCreateOrUpdate(ctx, spec.ResourceGroupName(), spec.ResourceName(), rt, opts)
+	beginOpts := &armnetwork.RouteTablesClientBeginCreateOrUpdateOptions{ResumeToken: opts.ResumeToken}
+	poller, err = ac.routetables.BeginCreateOrUpdate(ctx, spec.ResourceGroupName(), spec.ResourceName(), rt, beginOpts)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/azure/services/scalesets/mock_scalesets/client_mock.go
+++ b/azure/services/scalesets/mock_scalesets/client_mock.go
@@ -59,9 +59,9 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 }
 
 // CreateOrUpdateAsync mocks base method.
-func (m *MockClient) CreateOrUpdateAsync(ctx context.Context, spec azure.ResourceSpecGetter, resumeToken string, parameters any) (any, *runtime.Poller[armcompute.VirtualMachineScaleSetsClientCreateOrUpdateResponse], error) {
+func (m *MockClient) CreateOrUpdateAsync(ctx context.Context, spec azure.ResourceSpecGetter, opts azure.CreateOrUpdateAsyncOpts) (any, *runtime.Poller[armcompute.VirtualMachineScaleSetsClientCreateOrUpdateResponse], error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateOrUpdateAsync", ctx, spec, resumeToken, parameters)
+	ret := m.ctrl.Call(m, "CreateOrUpdateAsync", ctx, spec, opts)
 	ret0, _ := ret[0].(any)
 	ret1, _ := ret[1].(*runtime.Poller[armcompute.VirtualMachineScaleSetsClientCreateOrUpdateResponse])
 	ret2, _ := ret[2].(error)
@@ -69,9 +69,9 @@ func (m *MockClient) CreateOrUpdateAsync(ctx context.Context, spec azure.Resourc
 }
 
 // CreateOrUpdateAsync indicates an expected call of CreateOrUpdateAsync.
-func (mr *MockClientMockRecorder) CreateOrUpdateAsync(ctx, spec, resumeToken, parameters any) *gomock.Call {
+func (mr *MockClientMockRecorder) CreateOrUpdateAsync(ctx, spec, opts any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateOrUpdateAsync", reflect.TypeOf((*MockClient)(nil).CreateOrUpdateAsync), ctx, spec, resumeToken, parameters)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateOrUpdateAsync", reflect.TypeOf((*MockClient)(nil).CreateOrUpdateAsync), ctx, spec, opts)
 }
 
 // DeleteAsync mocks base method.

--- a/azure/services/scalesetvms/client.go
+++ b/azure/services/scalesetvms/client.go
@@ -32,7 +32,7 @@ import (
 // client wraps go-sdk.
 type client interface {
 	Get(context.Context, azure.ResourceSpecGetter) (interface{}, error)
-	CreateOrUpdateAsync(context.Context, azure.ResourceSpecGetter, string, interface{}) (interface{}, *runtime.Poller[armcompute.VirtualMachineScaleSetVMsClientUpdateResponse], error)
+	CreateOrUpdateAsync(context.Context, azure.ResourceSpecGetter, azure.CreateOrUpdateAsyncOpts) (interface{}, *runtime.Poller[armcompute.VirtualMachineScaleSetVMsClientUpdateResponse], error)
 	DeleteAsync(context.Context, azure.ResourceSpecGetter, string) (*runtime.Poller[armcompute.VirtualMachineScaleSetVMsClientDeleteResponse], error)
 }
 
@@ -70,7 +70,7 @@ func (ac *azureClient) Get(ctx context.Context, spec azure.ResourceSpecGetter) (
 }
 
 // CreateOrUpdateAsync is a dummy implementation to fulfill the async.Reconciler interface.
-func (ac *azureClient) CreateOrUpdateAsync(ctx context.Context, _ azure.ResourceSpecGetter, _ string, _ interface{}) (result interface{}, poller *runtime.Poller[armcompute.VirtualMachineScaleSetVMsClientUpdateResponse], err error) {
+func (ac *azureClient) CreateOrUpdateAsync(ctx context.Context, _ azure.ResourceSpecGetter, _ azure.CreateOrUpdateAsyncOpts) (result interface{}, poller *runtime.Poller[armcompute.VirtualMachineScaleSetVMsClientUpdateResponse], err error) {
 	_, _, done := tele.StartSpanWithLogger(ctx, "scalesets.AzureClient.CreateOrUpdateAsync")
 	defer done()
 

--- a/azure/services/scalesetvms/mock_scalesetvms/client_mock.go
+++ b/azure/services/scalesetvms/mock_scalesetvms/client_mock.go
@@ -59,9 +59,9 @@ func (m *Mockclient) EXPECT() *MockclientMockRecorder {
 }
 
 // CreateOrUpdateAsync mocks base method.
-func (m *Mockclient) CreateOrUpdateAsync(arg0 context.Context, arg1 azure.ResourceSpecGetter, arg2 string, arg3 any) (any, *runtime.Poller[armcompute.VirtualMachineScaleSetVMsClientUpdateResponse], error) {
+func (m *Mockclient) CreateOrUpdateAsync(arg0 context.Context, arg1 azure.ResourceSpecGetter, arg2 azure.CreateOrUpdateAsyncOpts) (any, *runtime.Poller[armcompute.VirtualMachineScaleSetVMsClientUpdateResponse], error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateOrUpdateAsync", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "CreateOrUpdateAsync", arg0, arg1, arg2)
 	ret0, _ := ret[0].(any)
 	ret1, _ := ret[1].(*runtime.Poller[armcompute.VirtualMachineScaleSetVMsClientUpdateResponse])
 	ret2, _ := ret[2].(error)
@@ -69,9 +69,9 @@ func (m *Mockclient) CreateOrUpdateAsync(arg0 context.Context, arg1 azure.Resour
 }
 
 // CreateOrUpdateAsync indicates an expected call of CreateOrUpdateAsync.
-func (mr *MockclientMockRecorder) CreateOrUpdateAsync(arg0, arg1, arg2, arg3 any) *gomock.Call {
+func (mr *MockclientMockRecorder) CreateOrUpdateAsync(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateOrUpdateAsync", reflect.TypeOf((*Mockclient)(nil).CreateOrUpdateAsync), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateOrUpdateAsync", reflect.TypeOf((*Mockclient)(nil).CreateOrUpdateAsync), arg0, arg1, arg2)
 }
 
 // DeleteAsync mocks base method.

--- a/azure/services/securitygroups/client.go
+++ b/azure/services/securitygroups/client.go
@@ -65,13 +65,13 @@ func (ac *azureClient) Get(ctx context.Context, spec azure.ResourceSpecGetter) (
 // CreateOrUpdateAsync creates or updates a network security group in the specified resource group.
 // It sends a PUT request to Azure and if accepted without error, the func will return a Poller which can be used to track the ongoing
 // progress of the operation.
-func (ac *azureClient) CreateOrUpdateAsync(ctx context.Context, spec azure.ResourceSpecGetter, resumeToken string, parameters interface{}) (result interface{}, poller *runtime.Poller[armnetwork.SecurityGroupsClientCreateOrUpdateResponse], err error) {
+func (ac *azureClient) CreateOrUpdateAsync(ctx context.Context, spec azure.ResourceSpecGetter, opts azure.CreateOrUpdateAsyncOpts) (result interface{}, poller *runtime.Poller[armnetwork.SecurityGroupsClientCreateOrUpdateResponse], err error) {
 	ctx, _, done := tele.StartSpanWithLogger(ctx, "securitygroups.azureClient.CreateOrUpdate")
 	defer done()
 
-	sg, ok := parameters.(armnetwork.SecurityGroup)
-	if !ok && parameters != nil {
-		return nil, nil, errors.Errorf("%T is not an armnetwork.SecurityGroup", parameters)
+	sg, ok := opts.Parameters.(armnetwork.SecurityGroup)
+	if !ok && opts.Parameters != nil {
+		return nil, nil, errors.Errorf("%T is not an armnetwork.SecurityGroup", opts.Parameters)
 	}
 
 	var extraPolicies []policy.Policy
@@ -94,8 +94,8 @@ func (ac *azureClient) CreateOrUpdateAsync(ctx context.Context, spec azure.Resou
 	}
 	client := factory.NewSecurityGroupsClient()
 
-	opts := &armnetwork.SecurityGroupsClientBeginCreateOrUpdateOptions{ResumeToken: resumeToken}
-	poller, err = client.BeginCreateOrUpdate(ctx, spec.ResourceGroupName(), spec.ResourceName(), sg, opts)
+	beginOpts := &armnetwork.SecurityGroupsClientBeginCreateOrUpdateOptions{ResumeToken: opts.ResumeToken}
+	poller, err = client.BeginCreateOrUpdate(ctx, spec.ResourceGroupName(), spec.ResourceName(), sg, beginOpts)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/azure/services/virtualmachines/mock_virtualmachines/client_mock.go
+++ b/azure/services/virtualmachines/mock_virtualmachines/client_mock.go
@@ -59,9 +59,9 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 }
 
 // CreateOrUpdateAsync mocks base method.
-func (m *MockClient) CreateOrUpdateAsync(ctx context.Context, spec azure.ResourceSpecGetter, resumeToken string, parameters any) (any, *runtime.Poller[armcompute.VirtualMachinesClientCreateOrUpdateResponse], error) {
+func (m *MockClient) CreateOrUpdateAsync(ctx context.Context, spec azure.ResourceSpecGetter, opts azure.CreateOrUpdateAsyncOpts) (any, *runtime.Poller[armcompute.VirtualMachinesClientCreateOrUpdateResponse], error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateOrUpdateAsync", ctx, spec, resumeToken, parameters)
+	ret := m.ctrl.Call(m, "CreateOrUpdateAsync", ctx, spec, opts)
 	ret0, _ := ret[0].(any)
 	ret1, _ := ret[1].(*runtime.Poller[armcompute.VirtualMachinesClientCreateOrUpdateResponse])
 	ret2, _ := ret[2].(error)
@@ -69,9 +69,9 @@ func (m *MockClient) CreateOrUpdateAsync(ctx context.Context, spec azure.Resourc
 }
 
 // CreateOrUpdateAsync indicates an expected call of CreateOrUpdateAsync.
-func (mr *MockClientMockRecorder) CreateOrUpdateAsync(ctx, spec, resumeToken, parameters any) *gomock.Call {
+func (mr *MockClientMockRecorder) CreateOrUpdateAsync(ctx, spec, opts any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateOrUpdateAsync", reflect.TypeOf((*MockClient)(nil).CreateOrUpdateAsync), ctx, spec, resumeToken, parameters)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateOrUpdateAsync", reflect.TypeOf((*MockClient)(nil).CreateOrUpdateAsync), ctx, spec, opts)
 }
 
 // DeleteAsync mocks base method.

--- a/azure/services/vmextensions/client.go
+++ b/azure/services/vmextensions/client.go
@@ -63,17 +63,17 @@ func (ac *azureClient) Get(ctx context.Context, spec azure.ResourceSpecGetter) (
 // CreateOrUpdateAsync creates or updates a VM extension asynchronously.
 // It sends a PUT request to Azure and if accepted without error, the func will return a Poller which can be used to track the ongoing
 // progress of the operation.
-func (ac *azureClient) CreateOrUpdateAsync(ctx context.Context, spec azure.ResourceSpecGetter, resumeToken string, parameters interface{}) (result interface{}, poller *runtime.Poller[armcompute.VirtualMachineExtensionsClientCreateOrUpdateResponse], err error) {
+func (ac *azureClient) CreateOrUpdateAsync(ctx context.Context, spec azure.ResourceSpecGetter, opts azure.CreateOrUpdateAsyncOpts) (result interface{}, poller *runtime.Poller[armcompute.VirtualMachineExtensionsClientCreateOrUpdateResponse], err error) {
 	ctx, _, done := tele.StartSpanWithLogger(ctx, "vmextensions.azureClient.CreateOrUpdateAsync")
 	defer done()
 
-	vmextension, ok := parameters.(armcompute.VirtualMachineExtension)
-	if !ok && parameters != nil {
-		return nil, nil, errors.Errorf("%T is not an armcompute.VirtualMachineExtension", parameters)
+	vmextension, ok := opts.Parameters.(armcompute.VirtualMachineExtension)
+	if !ok && opts.Parameters != nil {
+		return nil, nil, errors.Errorf("%T is not an armcompute.VirtualMachineExtension", opts.Parameters)
 	}
 
-	opts := &armcompute.VirtualMachineExtensionsClientBeginCreateOrUpdateOptions{ResumeToken: resumeToken}
-	poller, err = ac.vmextensions.BeginCreateOrUpdate(ctx, spec.ResourceGroupName(), spec.OwnerResourceName(), spec.ResourceName(), vmextension, opts)
+	beginOpts := &armcompute.VirtualMachineExtensionsClientBeginCreateOrUpdateOptions{ResumeToken: opts.ResumeToken}
+	poller, err = ac.vmextensions.BeginCreateOrUpdate(ctx, spec.ResourceGroupName(), spec.OwnerResourceName(), spec.ResourceName(), vmextension, beginOpts)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/azure/services/vnetpeerings/client.go
+++ b/azure/services/vnetpeerings/client.go
@@ -63,17 +63,17 @@ func (ac *AzureClient) Get(ctx context.Context, spec azure.ResourceSpecGetter) (
 // CreateOrUpdateAsync creates or updates a virtual network peering asynchronously.
 // It sends a PUT request to Azure and if accepted without error, the func will return a Poller which can be used to track the ongoing
 // progress of the operation.
-func (ac *AzureClient) CreateOrUpdateAsync(ctx context.Context, spec azure.ResourceSpecGetter, resumeToken string, parameters interface{}) (result interface{}, poller *runtime.Poller[armnetwork.VirtualNetworkPeeringsClientCreateOrUpdateResponse], err error) {
+func (ac *AzureClient) CreateOrUpdateAsync(ctx context.Context, spec azure.ResourceSpecGetter, opts azure.CreateOrUpdateAsyncOpts) (result interface{}, poller *runtime.Poller[armnetwork.VirtualNetworkPeeringsClientCreateOrUpdateResponse], err error) {
 	ctx, _, done := tele.StartSpanWithLogger(ctx, "vnetpeerings.AzureClient.CreateOrUpdateAsync")
 	defer done()
 
-	peering, ok := parameters.(armnetwork.VirtualNetworkPeering)
-	if !ok && parameters != nil {
-		return nil, nil, errors.Errorf("%T is not an armnetwork.VirtualNetworkPeering", parameters)
+	peering, ok := opts.Parameters.(armnetwork.VirtualNetworkPeering)
+	if !ok && opts.Parameters != nil {
+		return nil, nil, errors.Errorf("%T is not an armnetwork.VirtualNetworkPeering", opts.Parameters)
 	}
 
-	opts := &armnetwork.VirtualNetworkPeeringsClientBeginCreateOrUpdateOptions{ResumeToken: resumeToken}
-	poller, err = ac.peerings.BeginCreateOrUpdate(ctx, spec.ResourceGroupName(), spec.OwnerResourceName(), spec.ResourceName(), peering, opts)
+	beginOpts := &armnetwork.VirtualNetworkPeeringsClientBeginCreateOrUpdateOptions{ResumeToken: opts.ResumeToken}
+	poller, err = ac.peerings.BeginCreateOrUpdate(ctx, spec.ResourceGroupName(), spec.OwnerResourceName(), spec.ResourceName(), peering, beginOpts)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/azure/types.go
+++ b/azure/types.go
@@ -26,6 +26,12 @@ import (
 	azureutil "sigs.k8s.io/cluster-api-provider-azure/util/azure"
 )
 
+// CreateOrUpdateAsyncOpts defines the options for CreateOrUpdateAsync async method.
+type CreateOrUpdateAsyncOpts struct {
+	ResumeToken string
+	Parameters  interface{}
+}
+
 // RoleAssignmentSpec defines the specification for a Role Assignment.
 type RoleAssignmentSpec struct {
 	MachineName  string

--- a/test/e2e/cni.go
+++ b/test/e2e/cni.go
@@ -45,7 +45,7 @@ const (
 // EnsureCNI installs the CNI plugin depending on the input.CNIManifestPath
 func EnsureCNI(ctx context.Context, input clusterctl.ApplyCustomClusterTemplateAndWaitInput, installHelmChart bool, cidrBlocks []string, hasWindows bool) {
 	if input.CNIManifestPath != "" {
-		InstallCNIManifest(ctx, input, hasWindows)
+		InstallCNIManifest(ctx, input)
 	} else {
 		EnsureCalicoIsReady(ctx, input, installHelmChart, cidrBlocks, hasWindows)
 	}

--- a/test/e2e/cni.go
+++ b/test/e2e/cni.go
@@ -45,14 +45,14 @@ const (
 // EnsureCNI installs the CNI plugin depending on the input.CNIManifestPath
 func EnsureCNI(ctx context.Context, input clusterctl.ApplyCustomClusterTemplateAndWaitInput, installHelmChart bool, cidrBlocks []string, hasWindows bool) {
 	if input.CNIManifestPath != "" {
-		InstallCNIManifest(ctx, input, cidrBlocks, hasWindows)
+		InstallCNIManifest(ctx, input, hasWindows)
 	} else {
 		EnsureCalicoIsReady(ctx, input, installHelmChart, cidrBlocks, hasWindows)
 	}
 }
 
 // InstallCNIManifest installs the CNI manifest provided by the user
-func InstallCNIManifest(ctx context.Context, input clusterctl.ApplyCustomClusterTemplateAndWaitInput, cidrBlocks []string, hasWindows bool) { //nolint:revive // leaving unused cidrBlocks and hasWindows for understanding
+func InstallCNIManifest(ctx context.Context, input clusterctl.ApplyCustomClusterTemplateAndWaitInput) {
 	By("Installing a CNI plugin to the workload cluster")
 	workloadCluster := input.ClusterProxy.GetWorkloadCluster(ctx, input.Namespace, input.ClusterName)
 


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

/kind cleanup

**What this PR does / why we need it**:

This PR updates the `async.CreateOrUpdateAsync` method signature so that it takes a single strongly typed structure to express various configurations, to accommodate for the fact that across the various implementations of this interface we use a combination of those configurations. This makes it easier to implement the interface method in a variety of ways without having to ignore the parameter input variable (`_`), or declaring a function parameter variable + not using it, and then declaring `//nolint:revive` to avoid a source code lint violation.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->


**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] cherry-pick candidate

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
