### PR TITLE
[release-1.19] Bump CAPI to v1.9.6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -328,7 +328,7 @@ create-management-cluster: $(KUSTOMIZE) $(ENVSUBST) $(KUBECTL) $(KIND) ## Create
 	./hack/create-custom-cloud-provider-config.sh
 
 	# Deploy CAPI
-	timeout --foreground 300 bash -c "until curl --retry $(CURL_RETRIES) -sSL https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.9.5/cluster-api-components.yaml | $(ENVSUBST) | $(KUBECTL) apply -f -; do sleep 5; done"
+	timeout --foreground 300 bash -c "until curl --retry $(CURL_RETRIES) -sSL https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.9.6/cluster-api-components.yaml | $(ENVSUBST) | $(KUBECTL) apply -f -; do sleep 5; done"
 
 	# Deploy CAAPH
 	timeout --foreground 300 bash -c "until curl --retry $(CURL_RETRIES) -sSL https://github.com/kubernetes-sigs/cluster-api-addon-provider-helm/releases/download/v0.2.5/addon-components.yaml | $(ENVSUBST) | $(KUBECTL) apply -f -; do sleep 5; done"

--- a/Tiltfile
+++ b/Tiltfile
@@ -24,7 +24,7 @@ settings = {
     "kind_cluster_name": "capz",
     "capi_version": "v1.9.5",
     "caaph_version": "v0.2.5",
-    "cert_manager_version": "v1.16.2",
+    "cert_manager_version": "v1.16.4",
     "kubernetes_version": "v1.30.2",
     "aks_kubernetes_version": "v1.30.2",
     "flatcar_version": "3374.2.1",

--- a/Tiltfile
+++ b/Tiltfile
@@ -22,7 +22,7 @@ settings = {
     "deploy_cert_manager": True,
     "preload_images_for_kind": True,
     "kind_cluster_name": "capz",
-    "capi_version": "v1.9.5",
+    "capi_version": "v1.9.6",
     "caaph_version": "v0.2.5",
     "cert_manager_version": "v1.16.4",
     "kubernetes_version": "v1.30.2",

--- a/docs/book/src/getting-started.md
+++ b/docs/book/src/getting-started.md
@@ -120,7 +120,7 @@ helm install cert-manager jetstack/cert-manager --namespace cert-manager --creat
 Create a `values.yaml` file for the CAPI Operator Helm chart like so:
 
 ```yaml
-core: "cluster-api:v1.9.5"
+core: "cluster-api:v1.9.6"
 infrastructure: "azure:v1.17.2"
 addon: "helm:v0.2.5"
 manager:

--- a/go.mod
+++ b/go.mod
@@ -56,8 +56,8 @@ require (
 	k8s.io/kubectl v0.30.3
 	k8s.io/utils v0.0.0-20240821151609-f90d01438635
 	sigs.k8s.io/cloud-provider-azure v1.30.4
-	sigs.k8s.io/cluster-api v1.9.5
-	sigs.k8s.io/cluster-api/test v1.9.5
+	sigs.k8s.io/cluster-api v1.9.6
+	sigs.k8s.io/cluster-api/test v1.9.6
 	sigs.k8s.io/controller-runtime v0.19.6
 	sigs.k8s.io/kind v0.27.0
 )

--- a/go.sum
+++ b/go.sum
@@ -743,10 +743,10 @@ sigs.k8s.io/cloud-provider-azure/pkg/azclient v0.0.29 h1:qiifAaaBqV3d/EcN9dKJaJI
 sigs.k8s.io/cloud-provider-azure/pkg/azclient v0.0.29/go.mod h1:ZFAt0qF1kR+w8nBVJK56s6CFvLrlosN1i2c+Sxb7LBk=
 sigs.k8s.io/cloud-provider-azure/pkg/azclient/configloader v0.0.16 h1:Fm/Yjv4nXjUtJ90uXKSKwPwaTWYuDFMhDNNOd77PlOg=
 sigs.k8s.io/cloud-provider-azure/pkg/azclient/configloader v0.0.16/go.mod h1:+kl90flu4+WCP6HBGVYbKVQR+5ztDzUNrWJz8rsnvRU=
-sigs.k8s.io/cluster-api v1.9.5 h1:68164Q201Y5ANVkhyrOZenoMbfL2SEBjVYZs/ihhSro=
-sigs.k8s.io/cluster-api v1.9.5/go.mod h1:DyqyZ4jRvKGKewDRn1Q4OCHaVjsdTogymbO6mrgHEDI=
-sigs.k8s.io/cluster-api/test v1.9.5 h1:DtiiDWCIGaWhp4cA7xzGPWeM796XIRQwOptLATe0yFg=
-sigs.k8s.io/cluster-api/test v1.9.5/go.mod h1:YL2wANe8TFWFBka9CDkxjPj7KALqUtK+PtKa4ChNIok=
+sigs.k8s.io/cluster-api v1.9.6 h1:2jZ434qC0bzrPQzmRDm4/b0PZWVMnOocoCjsAonQN5Q=
+sigs.k8s.io/cluster-api v1.9.6/go.mod h1:DyqyZ4jRvKGKewDRn1Q4OCHaVjsdTogymbO6mrgHEDI=
+sigs.k8s.io/cluster-api/test v1.9.6 h1:bnplAOqKRBFWP2q2L8kbY2DZTLBY8JTpucnGSLgS/Kw=
+sigs.k8s.io/cluster-api/test v1.9.6/go.mod h1:YL2wANe8TFWFBka9CDkxjPj7KALqUtK+PtKa4ChNIok=
 sigs.k8s.io/controller-runtime v0.19.6 h1:fuq53qTLQ7aJTA7aNsklNnu7eQtSFqJUomOyM+phPLk=
 sigs.k8s.io/controller-runtime v0.19.6/go.mod h1:iRmWllt8IlaLjvTTDLhRBXIEtkCK6hwVBJJsYS9Ajf4=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd h1:EDPBXCAspyGV4jQlpZSudPeMmr1bNJefnuqLsRAsHZo=

--- a/hack/install-cert-manager.sh
+++ b/hack/install-cert-manager.sh
@@ -54,7 +54,7 @@ source "${REPO_ROOT}/hack/common-vars.sh"
 make --directory="${REPO_ROOT}" "${KUBECTL##*/}"
 
 ## Install cert manager and wait for availability
-"${KUBECTL}" apply -f https://github.com/jetstack/cert-manager/releases/download/v1.16.2/cert-manager.yaml
+"${KUBECTL}" apply -f https://github.com/jetstack/cert-manager/releases/download/v1.16.4/cert-manager.yaml
 "${KUBECTL}" wait --for=condition=Available --timeout=5m -n cert-manager deployment/cert-manager
 "${KUBECTL}" wait --for=condition=Available --timeout=5m -n cert-manager deployment/cert-manager-cainjector
 "${KUBECTL}" wait --for=condition=Available --timeout=5m -n cert-manager deployment/cert-manager-webhook

--- a/test/e2e/config/azure-dev.yaml
+++ b/test/e2e/config/azure-dev.yaml
@@ -3,11 +3,11 @@ managementClusterName: capz-e2e
 images:
   - name: ${MANAGER_IMAGE}
     loadBehavior: mustLoad
-  - name: registry.k8s.io/cluster-api/cluster-api-controller:v1.9.5
+  - name: registry.k8s.io/cluster-api/cluster-api-controller:v1.9.6
     loadBehavior: tryLoad
-  - name: registry.k8s.io/cluster-api/kubeadm-bootstrap-controller:v1.9.5
+  - name: registry.k8s.io/cluster-api/kubeadm-bootstrap-controller:v1.9.6
     loadBehavior: tryLoad
-  - name: registry.k8s.io/cluster-api/kubeadm-control-plane-controller:v1.9.5
+  - name: registry.k8s.io/cluster-api/kubeadm-control-plane-controller:v1.9.6
     loadBehavior: tryLoad
   - name: registry.k8s.io/cluster-api-helm/cluster-api-helm-controller:v0.2.5
     loadBehavior: tryLoad
@@ -16,8 +16,8 @@ providers:
   - name: cluster-api
     type: CoreProvider
     versions:
-    - name: v1.8.10 # latest patch of earliest minor in supported v1beta1 releases; this is used for v1beta1 old --> v1beta1 latest clusterctl upgrades test only.
-      value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.8.10/core-components.yaml"
+    - name: v1.8.11 # latest patch of earliest minor in supported v1beta1 releases; this is used for v1beta1 old --> v1beta1 latest clusterctl upgrades test only.
+      value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.8.11/core-components.yaml"
       type: "url"
       contract: v1beta1
       replacements:
@@ -25,8 +25,8 @@ providers:
           new: --metrics-addr=:8080
       files:
         - sourcePath: "../data/shared/v1beta1/metadata.yaml"
-    - name: v1.9.5
-      value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.9.5/core-components.yaml
+    - name: v1.9.6
+      value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.9.6/core-components.yaml
       type: url
       contract: v1beta1
       files:
@@ -39,8 +39,8 @@ providers:
   - name: kubeadm
     type: BootstrapProvider
     versions:
-    - name: v1.8.10 # latest patch of earliest minor in supported v1beta1 releases; this is used for v1beta1 old --> v1beta1 latest clusterctl upgrades test only.
-      value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.8.10/bootstrap-components.yaml"
+    - name: v1.8.11 # latest patch of earliest minor in supported v1beta1 releases; this is used for v1beta1 old --> v1beta1 latest clusterctl upgrades test only.
+      value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.8.11/bootstrap-components.yaml"
       type: "url"
       contract: v1beta1
       replacements:
@@ -48,8 +48,8 @@ providers:
           new: --metrics-addr=:8080
       files:
         - sourcePath: "../data/shared/v1beta1/metadata.yaml"
-    - name: v1.9.5
-      value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.9.5/bootstrap-components.yaml
+    - name: v1.9.6
+      value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.9.6/bootstrap-components.yaml
       type: url
       contract: v1beta1
       files:
@@ -61,8 +61,8 @@ providers:
   - name: kubeadm
     type: ControlPlaneProvider
     versions:
-    - name: v1.8.10 # latest patch of earliest minor in supported v1beta1 releases; this is used for v1beta1 old --> v1beta1 latest clusterctl upgrades test only.
-      value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.8.10/control-plane-components.yaml"
+    - name: v1.8.11 # latest patch of earliest minor in supported v1beta1 releases; this is used for v1beta1 old --> v1beta1 latest clusterctl upgrades test only.
+      value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.8.11/control-plane-components.yaml"
       type: "url"
       contract: v1beta1
       replacements:
@@ -70,8 +70,8 @@ providers:
           new: --metrics-addr=:8080
       files:
         - sourcePath: "../data/shared/v1beta1/metadata.yaml"
-    - name: v1.9.5
-      value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.9.5/control-plane-components.yaml
+    - name: v1.9.6
+      value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.9.6/control-plane-components.yaml
       type: url
       contract: v1beta1
       files:
@@ -234,8 +234,8 @@ variables:
   KUBETEST_CONFIGURATION: "./data/kubetest/conformance.yaml"
   WINDOWS_CONTAINERD_URL: "${WINDOWS_CONTAINERD_URL:-}"
   AZURE_CNI_V1_MANIFEST_PATH: "${PWD}/templates/addons/azure-cni-v1.yaml"
-  OLD_CAPI_UPGRADE_VERSION: "v1.8.10"
-  LATEST_CAPI_UPGRADE_VERSION: "v1.9.5"
+  OLD_CAPI_UPGRADE_VERSION: "v1.8.11"
+  LATEST_CAPI_UPGRADE_VERSION: "v1.9.6"
   OLD_PROVIDER_UPGRADE_VERSION: "v1.17.3"
   LATEST_PROVIDER_UPGRADE_VERSION: "v1.18.0"
   OLD_CAAPH_UPGRADE_VERSION: "v0.1.0-alpha.10"

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -32,6 +32,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog/v2"
 	capi_e2e "sigs.k8s.io/cluster-api/test/e2e"
 	"sigs.k8s.io/cluster-api/test/framework"
@@ -171,6 +172,7 @@ func setupBootstrapCluster(config *clusterctl.E2EConfig, useExistingCluster bool
 		kubeconfigPath = clusterProvider.GetKubeconfigPath()
 		Expect(kubeconfigPath).To(BeAnExistingFile(), "Failed to get the kubeconfig file for the bootstrap cluster")
 	} else {
+		kubeconfigPath = clientcmd.NewDefaultClientConfigLoadingRules().GetDefaultFilename()
 		// @sonasingh46: Workaround for testing workload identity.
 		// Loading image for already created cluster
 		imagesInput := bootstrap.LoadImagesToKindClusterInput{


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Manual cherry-pick of #5530.

Updates CAPI to [v1.9.6](https://github.com/kubernetes-sigs/cluster-api/releases/tag/v1.9.6). 

**Which issue(s) this PR fixes**:

N/A.

**Special notes for your reviewer**:

- [x] cherry-pick candidate

**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:

```release-note
Bump CAPI to v1.9.6
```
