### PR TITLE
fix: support ClusterCacheTracker

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -65,6 +65,10 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+          - name: POD_UID
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.uid
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
ClusterCacheTracker is only enabled if POD_NAME, POD_NAMESPACE, and POD_UID are set. 

https://github.com/kubernetes-sigs/cluster-api/blob/5815de795489c3edfca22a2c35cd87d7143d9545/controllers/clustercache/cluster_cache.go#L283-L296

**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [x] cherry-pick candidate

**Release note**:
```release-note
fixes manager deployment to enable cluster cache tracker
```
