### PR TITLE
AzureMachinePoolMachine: avoid setting FailureReason/FailureMessage

### DIFF
--- a/exp/controllers/azuremachinepoolmachine_controller.go
+++ b/exp/controllers/azuremachinepoolmachine_controller.go
@@ -294,8 +294,6 @@ func (ampmr *AzureMachinePoolMachineController) reconcileNormal(ctx context.Cont
 	switch state {
 	case infrav1.Failed:
 		ampmr.Recorder.Eventf(machineScope.AzureMachinePoolMachine, corev1.EventTypeWarning, "FailedVMState", "Azure scale set VM is in failed state")
-		machineScope.SetFailureReason(azure.UpdateError)
-		machineScope.SetFailureMessage(errors.Errorf("Azure VM state is %s", state))
 	case infrav1.Deleting:
 		log.V(4).Info("deleting machine because state is Deleting", "machine", machineScope.Name())
 		if err := ampmr.Client.Delete(ctx, machineScope.Machine); err != nil {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Field will get deprecated in v1beta2, setting this currently avoids the Machine from being reconciled at all which does not make sense in this case because a Failed provisioningState is not necessarily terminal

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #5303


**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [x] cherry-pick candidate

**Release note**:
```release-note
avoids marking an AzureMachinePoolMachine as terminal failure on provisioning failure. This ensures potential recovery from provisioning failure is handled correctly.
```
