### PR TITLE
Bump Go toolchain to v1.23.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@
 ARG ARCH
 
 # Build the manager binary
-FROM golang:1.22 AS builder
+FROM golang:1.23 AS builder
 WORKDIR /workspace
 
 # Run this with docker build --build_arg $(go env GOPROXY) to override the goproxy

--- a/Tiltfile
+++ b/Tiltfile
@@ -173,7 +173,7 @@ def validate_auth():
 
 tilt_helper_dockerfile_header = """
 # Tilt image
-FROM golang:1.22 AS tilt-helper
+FROM golang:1.23 AS tilt-helper
 # Support live reloading with Tilt
 RUN wget --output-document /restart.sh --quiet https://raw.githubusercontent.com/windmilleng/rerun-process-wrapper/master/restart.sh  && \
     wget --output-document /start.sh --quiet https://raw.githubusercontent.com/windmilleng/rerun-process-wrapper/master/start.sh && \

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module sigs.k8s.io/cluster-api-provider-azure
 
-go 1.22.7
+go 1.23.0
 
-toolchain go1.22.12
+toolchain go1.23.8
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.17.0

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -1,6 +1,8 @@
 module sigs.k8s.io/cluster-api-provider-azure/hack/tools
 
-go 1.21
+go 1.23.0
+
+toolchain go1.23.8
 
 require sigs.k8s.io/cluster-api/hack/tools v0.0.0-20240116152609-a150f715f5a6
 


### PR DESCRIPTION
/kind cleanup

**What this PR does / why we need it**:

Updates the Go toolchain to [v1.23.8](https://go.dev/doc/devel/release#go1.23.minor).

In the past, CAPZ bumped the Go version along with the CAPI minor version. But I extracted this change from #5533 because several other PRs seem to need the updated compiler, and it doesn't seem problematic to bump the Go version ahead of the CAPI version. Go v1.22 is also no longer receiving updates.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:


**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] cherry-pick candidate

**Release note**:

```release-note
NONE
```
