### PR TITLE
Remove deprecated field NumberOfProbes

### DIFF
--- a/azure/services/loadbalancers/spec.go
+++ b/azure/services/loadbalancers/spec.go
@@ -289,7 +289,7 @@ func getProbes(lbSpec LBSpec) []*armnetwork.Probe {
 					Port:              ptr.To[int32](lbSpec.APIServerPort),
 					RequestPath:       ptr.To(httpsProbeRequestPath),
 					IntervalInSeconds: ptr.To[int32](15),
-					NumberOfProbes:    ptr.To[int32](4),
+					ProbeThreshold:    ptr.To[int32](1),
 				},
 			},
 		}

--- a/azure/services/loadbalancers/spec_test.go
+++ b/azure/services/loadbalancers/spec_test.go
@@ -240,11 +240,11 @@ func newDefaultNodeOutboundLB() armnetwork.LoadBalancer {
 	}
 }
 
-func newSamplePublicAPIServerLB(verifyFrontendIP bool, verifyBackendAddressPools bool, verifyLBRules bool, verifyProbes bool, verifyOutboundRules bool, modifications ...func(*armnetwork.LoadBalancer)) armnetwork.LoadBalancer {
+func newSamplePublicAPIServerLB(verifyFrontendIP bool, verifyBackendAddressPools bool, verifyLBRules bool, verifyThreshold bool, verifyOutboundRules bool, modifications ...func(*armnetwork.LoadBalancer)) armnetwork.LoadBalancer {
 	var subnet *armnetwork.Subnet
 	var backendAddressPoolProps *armnetwork.BackendAddressPoolPropertiesFormat
 	enableFloatingIP := ptr.To(false)
-	numProbes := ptr.To[int32](4)
+	probeThreshold := ptr.To[int32](1)
 	idleTimeout := ptr.To[int32](4)
 
 	if verifyFrontendIP {
@@ -260,8 +260,8 @@ func newSamplePublicAPIServerLB(verifyFrontendIP bool, verifyBackendAddressPools
 	if verifyLBRules {
 		enableFloatingIP = ptr.To(true)
 	}
-	if verifyProbes {
-		numProbes = ptr.To[int32](999)
+	if verifyThreshold {
+		probeThreshold = ptr.To[int32](999)
 	}
 	if verifyOutboundRules {
 		idleTimeout = ptr.To[int32](1000)
@@ -321,7 +321,7 @@ func newSamplePublicAPIServerLB(verifyFrontendIP bool, verifyBackendAddressPools
 						Port:              ptr.To[int32](6443),
 						RequestPath:       ptr.To(httpsProbeRequestPath),
 						IntervalInSeconds: ptr.To[int32](15),
-						NumberOfProbes:    numProbes, // Add to verify that Probes aren't overwritten on update
+						ProbeThreshold:    probeThreshold, // Add to verify that Probes aren't overwritten on update
 					},
 				},
 			},
@@ -408,7 +408,7 @@ func newDefaultInternalAPIServerLB() armnetwork.LoadBalancer {
 						Port:              ptr.To[int32](6443),
 						RequestPath:       ptr.To(httpsProbeRequestPath),
 						IntervalInSeconds: ptr.To[int32](15),
-						NumberOfProbes:    ptr.To[int32](4),
+						ProbeThreshold:    ptr.To[int32](1),
 					},
 				},
 			},


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup

/kind design
/kind documentation
/kind failing-test
/kind flake
-->

/kind deprecation

**What this PR does / why we need it**:

Microsoft is retiring the numberOfProbes property in 2027. It is being replaced by probeThreshold.

https://learn.microsoft.com/en-us/answers/questions/2104921/action-required-end-of-support-for-microsoft-azure

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->


**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [x] cherry-pick candidate

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Deprecated field NumberOfProbes has been replaced with ProbeThreshold
```
