### PR TITLE
NIC should be try to fix itself when it is in ProvisioningFailed State

### DIFF
--- a/azure/services/async/async.go
+++ b/azure/services/async/async.go
@@ -61,6 +61,7 @@ func (s *Service[C, D]) CreateOrUpdateResource(ctx context.Context, spec azure.R
 	resourceName := spec.ResourceName()
 	rgName := spec.ResourceGroupName()
 	futureType := infrav1.PutFuture
+	log.V(4).Info("CreateOrUpdateResource", "resourceName", resourceName, "rgName", rgName, "futureType", futureType)
 
 	// Check if there is an ongoing long-running operation.
 	resumeToken := ""
@@ -71,6 +72,7 @@ func (s *Service[C, D]) CreateOrUpdateResource(ctx context.Context, spec azure.R
 			return "", errors.Wrap(err, "could not decode future data, resetting long-running operation state")
 		}
 		resumeToken = t
+		log.V(4).Info("Found a resume token for this long running operation", "resumeToken", resumeToken)
 	}
 
 	// Only when no long running operation is currently in progress do we need to get the parameters.

--- a/azure/services/networkinterfaces/spec.go
+++ b/azure/services/networkinterfaces/spec.go
@@ -28,6 +28,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/converters"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/services/resourceskus"
+	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
 )
 
 // NICSpec defines the specification for a Network Interface.
@@ -80,13 +81,26 @@ func (s *NICSpec) OwnerResourceName() string {
 }
 
 // Parameters returns the parameters for the network interface.
-func (s *NICSpec) Parameters(_ context.Context, existing interface{}) (parameters interface{}, err error) {
+func (s *NICSpec) Parameters(ctx context.Context, existing interface{}) (parameters interface{}, err error) {
+	_, log, done := tele.StartSpanWithLogger(ctx, "networkinterfaces.NICSpec.Parameters")
+	defer done()
+
 	if existing != nil {
-		if _, ok := existing.(armnetwork.Interface); !ok {
+		existingNIC, ok := existing.(armnetwork.Interface)
+		if !ok {
 			return nil, errors.Errorf("%T is not an armnetwork.Interface", existing)
 		}
-		// network interface already exists
-		return nil, nil
+
+		// If the NIC already exists, return a nil parameters and nil errors to skip the create or update of the already existing NIC.
+		// If the NIC is in ProvisioningFailed state, we will try to build the parameters of the existing NIC as the provisioning failed does not necessarily mean the NIC is in a bad state.
+		// Reference: https://learn.microsoft.com/en-us/azure/networking/troubleshoot-failed-state#provisioning-states and
+		// https://github.com/kubernetes-sigs/cluster-api-provider-azure/issues/5515
+		if existingNIC.Properties != nil && existingNIC.Properties.ProvisioningState != nil && *existingNIC.Properties.ProvisioningState != armnetwork.ProvisioningStateFailed {
+			// Return nil for both parameters and error as no changes are needed for the existing resource
+			// otherwise rebuild the parameters of the existing NIC so that we can patch the ProvisioningState
+			log.V(4).Info("existing NIC is not in ProvisioningFailed state, returning nil parameters and nil error", "ProvisioningState", *existingNIC.Properties.ProvisioningState)
+			return nil, nil
+		}
 	}
 
 	primaryIPConfig := &armnetwork.InterfaceIPConfigurationPropertiesFormat{

--- a/azure/services/networkinterfaces/spec_test.go
+++ b/azure/services/networkinterfaces/spec_test.go
@@ -671,7 +671,10 @@ func TestParameters(t *testing.T) {
 		},
 		{
 			name: "recreate parameters for network interface when Azure provisioning state is Failed",
-			spec: &fakeStaticPrivateIPNICSpec,
+			spec: func() *NICSpec {
+				s := fakeStaticPrivateIPNICSpec // value‑copy
+				return &s                       // pointer to the copy, not the global
+			}(),
 			existing: armnetwork.Interface{
 				ID:       ptr.To(""),
 				Name:     ptr.To("my-net-interface"),
@@ -713,7 +716,10 @@ func TestParameters(t *testing.T) {
 		},
 		{
 			name: "do not recreate parameters for network interface when Azure provisioning state is Deleting",
-			spec: &fakeStaticPrivateIPNICSpec,
+			spec: func() *NICSpec {
+				s := fakeStaticPrivateIPNICSpec // value‑copy
+				return &s                       // pointer to the copy, not the global
+			}(),
 			existing: armnetwork.Interface{
 				ID:       ptr.To(""),
 				Name:     ptr.To("my-net-interface"),
@@ -730,7 +736,10 @@ func TestParameters(t *testing.T) {
 		},
 		{
 			name: "do not recreate parameters for network interface when Azure provisioning state is Succeeded",
-			spec: &fakeStaticPrivateIPNICSpec,
+			spec: func() *NICSpec {
+				s := fakeStaticPrivateIPNICSpec // value‑copy
+				return &s                       // pointer to the copy, not the global
+			}(),
 			existing: armnetwork.Interface{
 				ID:       ptr.To(""),
 				Name:     ptr.To("my-net-interface"),
@@ -747,7 +756,10 @@ func TestParameters(t *testing.T) {
 		},
 		{
 			name: "do not recreate parameters for network interface when Azure provisioning state is Updating",
-			spec: &fakeStaticPrivateIPNICSpec,
+			spec: func() *NICSpec {
+				s := fakeStaticPrivateIPNICSpec // value‑copy
+				return &s                       // pointer to the copy, not the global
+			}(),
 			existing: armnetwork.Interface{
 				ID:       ptr.To(""),
 				Name:     ptr.To("my-net-interface"),
@@ -764,7 +776,10 @@ func TestParameters(t *testing.T) {
 		},
 		{
 			name: "recreate parameters for network interface when Azure provisioning state nil",
-			spec: &fakeStaticPrivateIPNICSpec,
+			spec: func() *NICSpec {
+				s := fakeStaticPrivateIPNICSpec // value‑copy
+				return &s                       // pointer to the copy, not the global
+			}(),
 			existing: armnetwork.Interface{
 				ID:       ptr.To(""),
 				Name:     ptr.To("my-net-interface"),

--- a/azure/services/networkinterfaces/spec_test.go
+++ b/azure/services/networkinterfaces/spec_test.go
@@ -669,6 +669,138 @@ func TestParameters(t *testing.T) {
 			},
 			expectedError: "",
 		},
+		{
+			name: "recreate parameters for network interface when Azure provisioning state is Failed",
+			spec: &fakeStaticPrivateIPNICSpec,
+			existing: armnetwork.Interface{
+				ID:       ptr.To(""),
+				Name:     ptr.To("my-net-interface"),
+				Location: ptr.To("fake-location"),
+				Type:     ptr.To("Microsoft.Network/networkInterfaces"),
+				Properties: &armnetwork.InterfacePropertiesFormat{
+					ProvisioningState: ptr.To(armnetwork.ProvisioningStateFailed),
+				},
+			},
+			expect: func(g *WithT, result interface{}) {
+				g.Expect(result).To(BeAssignableToTypeOf(armnetwork.Interface{}))
+				g.Expect(result.(armnetwork.Interface)).To(Equal(armnetwork.Interface{
+					Tags: map[string]*string{
+						"Name": ptr.To("my-net-interface"),
+						"sigs.k8s.io_cluster-api-provider-azure_cluster_my-cluster": ptr.To("owned"),
+					},
+					Location: ptr.To("fake-location"),
+					Properties: &armnetwork.InterfacePropertiesFormat{
+						Primary:                     nil,
+						EnableAcceleratedNetworking: ptr.To(true),
+						EnableIPForwarding:          ptr.To(false),
+						DNSSettings:                 &armnetwork.InterfaceDNSSettings{},
+						IPConfigurations: []*armnetwork.InterfaceIPConfiguration{
+							{
+								Name: ptr.To("pipConfig"),
+								Properties: &armnetwork.InterfaceIPConfigurationPropertiesFormat{
+									Primary:                         ptr.To(true),
+									LoadBalancerBackendAddressPools: []*armnetwork.BackendAddressPool{{ID: ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/loadBalancers/my-public-lb/backendAddressPools/cluster-name-outboundBackendPool")}},
+									PrivateIPAllocationMethod:       ptr.To(armnetwork.IPAllocationMethodStatic),
+									PrivateIPAddress:                ptr.To("fake.static.ip"),
+									Subnet:                          &armnetwork.Subnet{ID: ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/virtualNetworks/my-vnet/subnets/my-subnet")},
+								},
+							},
+						},
+					},
+				}))
+			},
+			expectedError: "",
+		},
+		{
+			name: "do not recreate parameters for network interface when Azure provisioning state is Deleting",
+			spec: &fakeStaticPrivateIPNICSpec,
+			existing: armnetwork.Interface{
+				ID:       ptr.To(""),
+				Name:     ptr.To("my-net-interface"),
+				Location: ptr.To("fake-location"),
+				Type:     ptr.To("Microsoft.Network/networkInterfaces"),
+				Properties: &armnetwork.InterfacePropertiesFormat{
+					ProvisioningState: ptr.To(armnetwork.ProvisioningStateDeleting),
+				},
+			},
+			expect: func(g *WithT, result interface{}) {
+				g.Expect(result).To(BeNil())
+			},
+			expectedError: "",
+		},
+		{
+			name: "do not recreate parameters for network interface when Azure provisioning state is Succeeded",
+			spec: &fakeStaticPrivateIPNICSpec,
+			existing: armnetwork.Interface{
+				ID:       ptr.To(""),
+				Name:     ptr.To("my-net-interface"),
+				Location: ptr.To("fake-location"),
+				Type:     ptr.To("Microsoft.Network/networkInterfaces"),
+				Properties: &armnetwork.InterfacePropertiesFormat{
+					ProvisioningState: ptr.To(armnetwork.ProvisioningStateSucceeded),
+				},
+			},
+			expect: func(g *WithT, result interface{}) {
+				g.Expect(result).To(BeNil())
+			},
+			expectedError: "",
+		},
+		{
+			name: "do not recreate parameters for network interface when Azure provisioning state is Updating",
+			spec: &fakeStaticPrivateIPNICSpec,
+			existing: armnetwork.Interface{
+				ID:       ptr.To(""),
+				Name:     ptr.To("my-net-interface"),
+				Location: ptr.To("fake-location"),
+				Type:     ptr.To("Microsoft.Network/networkInterfaces"),
+				Properties: &armnetwork.InterfacePropertiesFormat{
+					ProvisioningState: ptr.To(armnetwork.ProvisioningStateUpdating),
+				},
+			},
+			expect: func(g *WithT, result interface{}) {
+				g.Expect(result).To(BeNil())
+			},
+			expectedError: "",
+		},
+		{
+			name: "recreate parameters for network interface when Azure provisioning state nil",
+			spec: &fakeStaticPrivateIPNICSpec,
+			existing: armnetwork.Interface{
+				ID:       ptr.To(""),
+				Name:     ptr.To("my-net-interface"),
+				Location: ptr.To("fake-location"),
+				Type:     ptr.To("Microsoft.Network/networkInterfaces"),
+			},
+			expect: func(g *WithT, result interface{}) {
+				g.Expect(result).To(BeAssignableToTypeOf(armnetwork.Interface{}))
+				g.Expect(result.(armnetwork.Interface)).To(Equal(armnetwork.Interface{
+					Tags: map[string]*string{
+						"Name": ptr.To("my-net-interface"),
+						"sigs.k8s.io_cluster-api-provider-azure_cluster_my-cluster": ptr.To("owned"),
+					},
+					Location: ptr.To("fake-location"),
+					Properties: &armnetwork.InterfacePropertiesFormat{
+						Primary:                     nil,
+						EnableAcceleratedNetworking: ptr.To(true),
+						EnableIPForwarding:          ptr.To(false),
+						DNSSettings:                 &armnetwork.InterfaceDNSSettings{},
+						IPConfigurations: []*armnetwork.InterfaceIPConfiguration{
+							{
+								Name: ptr.To("pipConfig"),
+								Properties: &armnetwork.InterfaceIPConfigurationPropertiesFormat{
+									Primary:                         ptr.To(true),
+									LoadBalancerBackendAddressPools: []*armnetwork.BackendAddressPool{{ID: ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/loadBalancers/my-public-lb/backendAddressPools/cluster-name-outboundBackendPool")}},
+									PrivateIPAllocationMethod:       ptr.To(armnetwork.IPAllocationMethodStatic),
+									PrivateIPAddress:                ptr.To("fake.static.ip"),
+									Subnet:                          &armnetwork.Subnet{ID: ptr.To("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/virtualNetworks/my-vnet/subnets/my-subnet")},
+								},
+							},
+						},
+					},
+				}))
+			},
+			expectedError: "",
+		},
 	}
 	format.MaxLength = 10000
 	for _, tc := range testcases {


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
- This PR makes the NICSpec rebuild and `CreateOrUpdateAsync` itself if the existing NIC is in `ProvisioningFailed` state.
- This PR also adds additional unit test cases testing this code flow. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #5515 

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->


**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [x] cherry-pick candidate

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NIC should be try to fix itself when in ProvisioningFailed State
```
