### PR TITLE
Acknowledge all ASO resource types before creating

### DIFF
--- a/api/v1alpha1/azureasomanagedcluster_types.go
+++ b/api/v1alpha1/azureasomanagedcluster_types.go
@@ -79,11 +79,6 @@ type AzureASOManagedCluster struct {
 	Status AzureASOManagedClusterStatus `json:"status,omitempty"`
 }
 
-// GetResourceStatuses returns the status of resources.
-func (a *AzureASOManagedCluster) GetResourceStatuses() []ResourceStatus {
-	return a.Status.Resources
-}
-
 // SetResourceStatuses sets the status of resources.
 func (a *AzureASOManagedCluster) SetResourceStatuses(r []ResourceStatus) {
 	a.Status.Resources = r

--- a/api/v1alpha1/azureasomanagedcontrolplane_types.go
+++ b/api/v1alpha1/azureasomanagedcontrolplane_types.go
@@ -67,11 +67,6 @@ type AzureASOManagedControlPlane struct {
 	Status AzureASOManagedControlPlaneStatus `json:"status,omitempty"`
 }
 
-// GetResourceStatuses returns the status of resources.
-func (a *AzureASOManagedControlPlane) GetResourceStatuses() []ResourceStatus {
-	return a.Status.Resources
-}
-
 // SetResourceStatuses sets the status of resources.
 func (a *AzureASOManagedControlPlane) SetResourceStatuses(r []ResourceStatus) {
 	a.Status.Resources = r

--- a/api/v1alpha1/azureasomanagedmachinepool_types.go
+++ b/api/v1alpha1/azureasomanagedmachinepool_types.go
@@ -62,11 +62,6 @@ type AzureASOManagedMachinePool struct {
 	Status AzureASOManagedMachinePoolStatus `json:"status,omitempty"`
 }
 
-// GetResourceStatuses returns the status of resources.
-func (a *AzureASOManagedMachinePool) GetResourceStatuses() []ResourceStatus {
-	return a.Status.Resources
-}
-
 // SetResourceStatuses sets the status of resources.
 func (a *AzureASOManagedMachinePool) SetResourceStatuses(r []ResourceStatus) {
 	a.Status.Resources = r

--- a/controllers/azureasomanagedcluster_controller.go
+++ b/controllers/azureasomanagedcluster_controller.go
@@ -300,19 +300,15 @@ func (r *AzureASOManagedClusterReconciler) reconcileDelete(ctx context.Context, 
 	defer done()
 	log.V(4).Info("reconciling delete")
 
-	resources, err := mutators.ToUnstructured(ctx, asoManagedCluster.Spec.Resources)
-	if err != nil {
-		return ctrl.Result{}, err
-	}
-	resourceReconciler := r.newResourceReconciler(asoManagedCluster, resources)
-	err = resourceReconciler.Delete(ctx)
+	resourceReconciler := r.newResourceReconciler(asoManagedCluster, nil)
+	err := resourceReconciler.Delete(ctx)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to reconcile resources: %w", err)
 	}
-	if len(asoManagedCluster.Status.Resources) > 0 {
-		return ctrl.Result{}, nil
+
+	if len(asoManagedCluster.Status.Resources) == 0 {
+		controllerutil.RemoveFinalizer(asoManagedCluster, clusterv1.ClusterFinalizer)
 	}
 
-	controllerutil.RemoveFinalizer(asoManagedCluster, clusterv1.ClusterFinalizer)
 	return ctrl.Result{}, nil
 }

--- a/controllers/azureasomanagedcontrolplane_controller.go
+++ b/controllers/azureasomanagedcontrolplane_controller.go
@@ -379,20 +379,16 @@ func (r *AzureASOManagedControlPlaneReconciler) reconcileDelete(ctx context.Cont
 	defer done()
 	log.V(4).Info("reconciling delete")
 
-	resources, err := mutators.ToUnstructured(ctx, asoManagedControlPlane.Spec.Resources)
-	if err != nil {
-		return ctrl.Result{}, err
-	}
-	resourceReconciler := r.newResourceReconciler(asoManagedControlPlane, resources)
-	err = resourceReconciler.Delete(ctx)
+	resourceReconciler := r.newResourceReconciler(asoManagedControlPlane, nil)
+	err := resourceReconciler.Delete(ctx)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to reconcile resources: %w", err)
 	}
-	if len(asoManagedControlPlane.Status.Resources) > 0 {
-		return ctrl.Result{}, nil
+
+	if len(asoManagedControlPlane.Status.Resources) == 0 {
+		controllerutil.RemoveFinalizer(asoManagedControlPlane, infrav1.AzureASOManagedControlPlaneFinalizer)
 	}
 
-	controllerutil.RemoveFinalizer(asoManagedControlPlane, infrav1.AzureASOManagedControlPlaneFinalizer)
 	return ctrl.Result{}, nil
 }
 

--- a/controllers/azureasomanagedcontrolplane_controller_test.go
+++ b/controllers/azureasomanagedcontrolplane_controller_test.go
@@ -435,7 +435,10 @@ func TestAzureASOManagedControlPlaneReconcile(t *testing.T) {
 			Client: &FakeClient{
 				Client: c,
 				patchFunc: func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) error {
-					kubeconfigSecret := obj.(*corev1.Secret)
+					kubeconfigSecret, ok := obj.(*corev1.Secret)
+					if !ok {
+						return nil
+					}
 					g.Expect(kubeconfigSecret.Data[secret.KubeconfigDataName]).NotTo(BeEmpty())
 					kubeConfigPatched = true
 
@@ -571,7 +574,10 @@ func TestAzureASOManagedControlPlaneReconcile(t *testing.T) {
 			Client: &FakeClient{
 				Client: c,
 				patchFunc: func(_ context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) error {
-					kubeconfigSecret := obj.(*corev1.Secret)
+					kubeconfigSecret, ok := obj.(*corev1.Secret)
+					if !ok {
+						return nil
+					}
 					g.Expect(kubeconfigSecret.Data[secret.KubeconfigDataName]).NotTo(BeEmpty())
 					kubeConfigPatched = true
 

--- a/controllers/azureasomanagedmachinepool_controller.go
+++ b/controllers/azureasomanagedmachinepool_controller.go
@@ -333,12 +333,8 @@ func (r *AzureASOManagedMachinePoolReconciler) reconcileDelete(ctx context.Conte
 	// If the entire cluster is being deleted, this ASO ManagedClustersAgentPool will be deleted with the rest
 	// of the ManagedCluster.
 	if cluster.DeletionTimestamp.IsZero() {
-		resources, err := mutators.ToUnstructured(ctx, asoManagedMachinePool.Spec.Resources)
-		if err != nil {
-			return ctrl.Result{}, err
-		}
-		resourceReconciler := r.newResourceReconciler(asoManagedMachinePool, resources)
-		err = resourceReconciler.Delete(ctx)
+		resourceReconciler := r.newResourceReconciler(asoManagedMachinePool, nil)
+		err := resourceReconciler.Delete(ctx)
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to reconcile resources: %w", err)
 		}

--- a/controllers/resource_reconciler.go
+++ b/controllers/resource_reconciler.go
@@ -20,13 +20,17 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
+	"strings"
 
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/conditions"
 	"github.com/go-logr/logr"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -37,6 +41,11 @@ import (
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/pkg/mutators"
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
+)
+
+const (
+	ownedKindsAnnotation = "sigs.k8s.io/cluster-api-provider-azure-owned-aso-kinds"
+	ownedKindsSep        = ";"
 )
 
 // ResourceReconciler reconciles a set of arbitrary ASO resources.
@@ -53,7 +62,6 @@ type watcher interface {
 
 type resourceStatusObject interface {
 	client.Object
-	GetResourceStatuses() []infrav1.ResourceStatus
 	SetResourceStatuses([]infrav1.ResourceStatus)
 }
 
@@ -62,69 +70,19 @@ func (r *ResourceReconciler) Reconcile(ctx context.Context) error {
 	ctx, log, done := tele.StartSpanWithLogger(ctx, "controllers.ResourceReconciler.Reconcile")
 	defer done()
 	log.V(4).Info("reconciling resources")
+	return r.reconcile(ctx)
+}
 
-	var newResourceStatuses []infrav1.ResourceStatus
+// Delete deletes the specified resources.
+func (r *ResourceReconciler) Delete(ctx context.Context) error {
+	ctx, log, done := tele.StartSpanWithLogger(ctx, "controllers.ResourceReconciler.Delete")
+	defer done()
+	log.V(4).Info("deleting resources")
 
-	for _, spec := range r.resources {
-		gvk := spec.GroupVersionKind()
-		spec.SetNamespace(r.owner.GetNamespace())
-
-		log := log.WithValues("resource", klog.KObj(spec), "resourceVersion", gvk.GroupVersion(), "resourceKind", gvk.Kind)
-
-		if err := controllerutil.SetControllerReference(r.owner, spec, r.Scheme()); err != nil {
-			return fmt.Errorf("failed to set owner reference: %w", err)
-		}
-
-		if err := r.watcher.Watch(log, spec, handler.EnqueueRequestForOwner(r.Client.Scheme(), r.Client.RESTMapper(), r.owner)); err != nil {
-			return fmt.Errorf("failed to watch resource: %w", err)
-		}
-
-		log.V(4).Info("applying resource")
-		err := r.Patch(ctx, spec, client.Apply, client.FieldOwner("capz-manager"), client.ForceOwnership)
-		if err != nil {
-			return fmt.Errorf("failed to apply resource: %w", err)
-		}
-
-		ready, err := readyStatus(ctx, spec)
-		if err != nil {
-			return fmt.Errorf("failed to get ready status: %w", err)
-		}
-		newResourceStatuses = append(newResourceStatuses, infrav1.ResourceStatus{
-			Resource: infrav1.StatusResource{
-				Group:   gvk.Group,
-				Version: gvk.Version,
-				Kind:    gvk.Kind,
-				Name:    spec.GetName(),
-			},
-			Ready: ready,
-		})
-	}
-
-	for _, oldStatus := range r.owner.GetResourceStatuses() {
-		needsDelete := true
-		for _, newStatus := range newResourceStatuses {
-			if oldStatus.Resource.Group == newStatus.Resource.Group &&
-				oldStatus.Resource.Kind == newStatus.Resource.Kind &&
-				oldStatus.Resource.Name == newStatus.Resource.Name {
-				needsDelete = false
-				break
-			}
-		}
-
-		if needsDelete {
-			updatedStatus, err := r.deleteResource(ctx, oldStatus.Resource)
-			if err != nil {
-				return err
-			}
-			if updatedStatus != nil {
-				newResourceStatuses = append(newResourceStatuses, *updatedStatus)
-			}
-		}
-	}
-
-	r.owner.SetResourceStatuses(newResourceStatuses)
-
-	return nil
+	// Delete is a special case of a normal reconciliation which is equivalent to all resources from spec
+	// being deleted.
+	r.resources = nil
+	return r.reconcile(ctx)
 }
 
 // Pause pauses reconciliation of the specified resources.
@@ -142,14 +100,11 @@ func (r *ResourceReconciler) Pause(ctx context.Context) error {
 	}
 
 	for _, spec := range r.resources {
-		gvk := spec.GroupVersionKind()
 		spec.SetNamespace(r.owner.GetNamespace())
-
-		log := log.WithValues("resource", klog.KObj(spec), "resourceVersion", gvk.GroupVersion(), "resourceKind", gvk.Kind)
-
-		log.V(4).Info("pausing resource")
+		gvk := spec.GroupVersionKind()
+		log.V(4).Info("pausing resource", "resource", klog.KObj(spec), "resourceVersion", gvk.GroupVersion(), "resourceKind", gvk.Kind)
 		err := r.Patch(ctx, spec, client.Apply, client.FieldOwner("capz-manager"))
-		if err != nil {
+		if client.IgnoreNotFound(err) != nil {
 			return fmt.Errorf("failed to patch resource: %w", err)
 		}
 	}
@@ -157,42 +112,110 @@ func (r *ResourceReconciler) Pause(ctx context.Context) error {
 	return nil
 }
 
-// Delete deletes the specified resources.
-func (r *ResourceReconciler) Delete(ctx context.Context) error {
-	ctx, log, done := tele.StartSpanWithLogger(ctx, "controllers.ResourceReconciler.Delete")
+func (r *ResourceReconciler) reconcile(ctx context.Context) error {
+	ctx, log, done := tele.StartSpanWithLogger(ctx, "controllers.ResourceReconciler.reconcile")
 	defer done()
-	log.V(4).Info("deleting resources")
 
 	var newResourceStatuses []infrav1.ResourceStatus
 
-	for _, spec := range r.owner.GetResourceStatuses() {
-		newStatus, err := r.deleteResource(ctx, spec.Resource)
+	ownedKindsValue := r.owner.GetAnnotations()[ownedKindsAnnotation]
+	ownedKinds, err := parseOwnedKinds(ownedKindsValue)
+	if err != nil {
+		return fmt.Errorf("failed to parse %s annotation: %s", ownedKindsAnnotation, ownedKindsValue)
+	}
+
+	ownedObjs, err := r.ownedObjs(ctx, ownedKinds)
+	if err != nil {
+		return fmt.Errorf("failed to get owned objects: %w", err)
+	}
+
+	unrecordedTypeResources, recordedTypeResources, toBeDeletedResources := partitionResources(ownedKinds, r.resources, ownedObjs)
+
+	// Newly-defined types in the CAPZ spec are first recorded in the annotation without performing a
+	// patch that would create resources of that type. CAPZ only patches resources whose kinds have
+	// already been recorded to ensure no resources are orphaned.
+	for _, spec := range unrecordedTypeResources {
+		newResourceStatuses = append(newResourceStatuses, infrav1.ResourceStatus{
+			Resource: statusResource(spec),
+			Ready:    false,
+		})
+	}
+
+	for _, spec := range recordedTypeResources {
+		spec.SetNamespace(r.owner.GetNamespace())
+
+		if err := controllerutil.SetControllerReference(r.owner, spec, r.Scheme()); err != nil {
+			return fmt.Errorf("failed to set owner reference: %w", err)
+		}
+
+		toWatch := meta.AsPartialObjectMetadata(spec)
+		toWatch.APIVersion = spec.GetAPIVersion()
+		toWatch.Kind = spec.GetKind()
+		if err := r.watcher.Watch(log, toWatch, handler.EnqueueRequestForOwner(r.Client.Scheme(), r.Client.RESTMapper(), r.owner)); err != nil {
+			return fmt.Errorf("failed to watch resource: %w", err)
+		}
+
+		gvk := spec.GroupVersionKind()
+		log.V(4).Info("applying resource", "resource", klog.KObj(spec), "resourceVersion", gvk.GroupVersion(), "resourceKind", gvk.Kind)
+		err := r.Patch(ctx, spec, client.Apply, client.FieldOwner("capz-manager"), client.ForceOwnership)
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to apply resource: %w", err)
+		}
+
+		ready, err := readyStatus(ctx, spec)
+		if err != nil {
+			return fmt.Errorf("failed to get ready status: %w", err)
+		}
+		newResourceStatuses = append(newResourceStatuses, infrav1.ResourceStatus{
+			Resource: statusResource(spec),
+			Ready:    ready,
+		})
+	}
+
+	for _, obj := range toBeDeletedResources {
+		newStatus, err := r.deleteResource(ctx, obj)
+		if err != nil {
+			return fmt.Errorf("failed to delete %s %s/%s", obj.GroupVersionKind(), obj.Namespace, obj.Name)
 		}
 		if newStatus != nil {
 			newResourceStatuses = append(newResourceStatuses, *newStatus)
 		}
 	}
 
+	newOwnedKinds := []schema.GroupVersionKind{}
+	for _, status := range newResourceStatuses {
+		gvk := schema.GroupVersionKind{
+			Group:   status.Resource.Group,
+			Version: status.Resource.Version,
+			Kind:    status.Resource.Kind,
+		}
+		if !slices.Contains(newOwnedKinds, gvk) {
+			newOwnedKinds = append(newOwnedKinds, gvk)
+		}
+	}
+	annotations := r.owner.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+	annotations[ownedKindsAnnotation] = getOwnedKindsValue(newOwnedKinds)
+	if annotations[ownedKindsAnnotation] == "" {
+		delete(annotations, ownedKindsAnnotation)
+	}
+	r.owner.SetAnnotations(annotations)
+
 	r.owner.SetResourceStatuses(newResourceStatuses)
 
 	return nil
 }
 
-func (r *ResourceReconciler) deleteResource(ctx context.Context, resource infrav1.StatusResource) (*infrav1.ResourceStatus, error) {
+func (r *ResourceReconciler) deleteResource(ctx context.Context, resource *metav1.PartialObjectMetadata) (*infrav1.ResourceStatus, error) {
 	ctx, log, done := tele.StartSpanWithLogger(ctx, "controllers.ResourceReconciler.deleteResource")
 	defer done()
 
-	spec := &unstructured.Unstructured{}
-	spec.SetGroupVersionKind(schema.GroupVersionKind{Group: resource.Group, Version: resource.Version, Kind: resource.Kind})
-	spec.SetNamespace(r.owner.GetNamespace())
-	spec.SetName(resource.Name)
-
-	log = log.WithValues("resource", klog.KObj(spec), "resourceVersion", spec.GroupVersionKind().GroupVersion(), "resourceKind", spec.GetKind())
+	log = log.WithValues("resource", klog.KObj(resource), "resourceVersion", resource.APIVersion, "resourceKind", resource.Kind)
 
 	log.V(4).Info("deleting resource")
-	err := r.Client.Delete(ctx, spec)
+	err := r.Client.Delete(ctx, resource)
 	if apierrors.IsNotFound(err) {
 		log.V(4).Info("resource has been deleted")
 		return nil, nil
@@ -201,7 +224,7 @@ func (r *ResourceReconciler) deleteResource(ctx context.Context, resource infrav
 		return nil, fmt.Errorf("failed to delete resource: %w", err)
 	}
 
-	err = r.Client.Get(ctx, client.ObjectKeyFromObject(spec), spec)
+	err = r.Client.Get(ctx, client.ObjectKeyFromObject(resource), resource)
 	if apierrors.IsNotFound(err) {
 		log.V(4).Info("resource has been deleted")
 		return nil, nil
@@ -209,15 +232,38 @@ func (r *ResourceReconciler) deleteResource(ctx context.Context, resource infrav
 	if err != nil {
 		return nil, fmt.Errorf("failed to get resource: %w", err)
 	}
-	ready, err := readyStatus(ctx, spec)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get ready status: %w", err)
+
+	gvk := resource.GroupVersionKind()
+	return &infrav1.ResourceStatus{
+		Resource: infrav1.StatusResource{
+			Group:   gvk.Group,
+			Version: gvk.Version,
+			Kind:    gvk.Kind,
+			Name:    resource.Name,
+		},
+		Ready: false,
+	}, nil
+}
+
+func (r *ResourceReconciler) ownedObjs(ctx context.Context, ownedTypes sets.Set[metav1.TypeMeta]) ([]*metav1.PartialObjectMetadata, error) {
+	var ownedObjs []*metav1.PartialObjectMetadata
+
+	for typeMeta := range ownedTypes {
+		objs := &metav1.PartialObjectMetadataList{TypeMeta: typeMeta}
+		err := r.List(ctx, objs, client.InNamespace(r.owner.GetNamespace()))
+		if err != nil {
+			return nil, fmt.Errorf("failed to list %s %s: %w", typeMeta.APIVersion, typeMeta.Kind, err)
+		}
+
+		for _, obj := range objs.Items {
+			controller := metav1.GetControllerOfNoCopy(&obj)
+			if controller != nil && controller.UID == r.owner.GetUID() {
+				ownedObjs = append(ownedObjs, &obj)
+			}
+		}
 	}
 
-	return &infrav1.ResourceStatus{
-		Resource: resource,
-		Ready:    ready,
-	}, nil
+	return ownedObjs, nil
 }
 
 func readyStatus(ctx context.Context, u *unstructured.Unstructured) (bool, error) {
@@ -260,4 +306,83 @@ func readyStatus(ctx context.Context, u *unstructured.Unstructured) (bool, error
 
 	// no ready condition is set
 	return false, nil
+}
+
+// partitionResources splits the sets of resources in spec and the current set
+// of owned, existing resources into three groups:
+// - unrecordedTypeResources are of a type not yet known to this owning CAPZ resource.
+// - recordedTypeResources are of a type already known to this owning CAPZ resource.
+// - toBeDeletedResources exist but are not defined in spec.
+func partitionResources(
+	ownedKinds sets.Set[metav1.TypeMeta],
+	specs []*unstructured.Unstructured,
+	ownedObjs []*metav1.PartialObjectMetadata,
+) (
+	unrecordedTypeResources []*unstructured.Unstructured,
+	recordedTypeResources []*unstructured.Unstructured,
+	toBeDeletedResources []*metav1.PartialObjectMetadata,
+) {
+	for _, spec := range specs {
+		typeMeta := metav1.TypeMeta{
+			APIVersion: spec.GetAPIVersion(),
+			Kind:       spec.GetKind(),
+		}
+		if ownedKinds.Has(typeMeta) {
+			recordedTypeResources = append(recordedTypeResources, spec)
+		} else {
+			unrecordedTypeResources = append(unrecordedTypeResources, spec)
+		}
+	}
+
+	for _, owned := range ownedObjs {
+		if !slices.ContainsFunc(specs, metadataRefersToResource(owned)) {
+			toBeDeletedResources = append(toBeDeletedResources, owned)
+		}
+	}
+	return
+}
+
+func statusResource(resource *unstructured.Unstructured) infrav1.StatusResource {
+	gvk := resource.GroupVersionKind()
+	return infrav1.StatusResource{
+		Group:   gvk.Group,
+		Version: gvk.Version,
+		Kind:    gvk.Kind,
+		Name:    resource.GetName(),
+	}
+}
+
+func metadataRefersToResource(metadata *metav1.PartialObjectMetadata) func(*unstructured.Unstructured) bool {
+	return func(u *unstructured.Unstructured) bool {
+		// Version is not a stable property of a particular resource. The API version of an ASO resource may
+		// change in the CAPZ spec from v1 to v2 but that still represents the same underlying resource.
+		return metadata.GroupVersionKind().GroupKind() == u.GroupVersionKind().GroupKind() &&
+			metadata.Name == u.GetName()
+	}
+}
+
+func parseOwnedKinds(value string) (sets.Set[metav1.TypeMeta], error) {
+	ownedKinds := sets.Set[metav1.TypeMeta]{}
+	if value == "" {
+		return nil, nil
+	}
+	for _, ownedKind := range strings.Split(value, ownedKindsSep) {
+		gvk, _ := schema.ParseKindArg(ownedKind)
+		if gvk == nil {
+			return nil, fmt.Errorf("invalid field %q: expected Kind.version.group", ownedKind)
+		}
+		ownedKinds.Insert(metav1.TypeMeta{
+			APIVersion: gvk.GroupVersion().Identifier(),
+			Kind:       gvk.Kind,
+		})
+	}
+	return ownedKinds, nil
+}
+
+func getOwnedKindsValue(ownedKinds []schema.GroupVersionKind) string {
+	fields := make([]string, 0, len(ownedKinds))
+	for _, gvk := range ownedKinds {
+		fields = append(fields, strings.Join([]string{gvk.Kind, gvk.Version, gvk.Group}, "."))
+	}
+	return strings.Join(fields, ownedKindsSep)
 }


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

This PR fixes a potential issue where if CAPZ creates an ASO resource defined by an ASOAPI resource, then crashes or otherwise fails to record that resource in the PATCH to the CAPZ resource status at the end of the reconciliation loop, a quickly following delete of the CAPZ resource (or removing that ASO resource from `spec`) will not know to also delete that ASO resource if it's not recorded in `status`.

This change makes CAPZ record each ASO resource group/version/kind in a `sigs.k8s.io/cluster-api-provider-azure-owned-aso-kinds` annotation and send those changes to the API server before continuing to actually create resources of that type. This way, no matter when a CAPZ ASO API resource is deleted, CAPZ can rely on any ASO resource type that needs to be deleted to be in that annotation.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #


**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

I initially split this into a couple commits in case that's easier to review: one for the functional change and one to refactor things a bit.


**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] cherry-pick candidate

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
7. If no release note is required, just write "NONE".
-->
```release-note
ASOAPI: Fixed a possible bug that could leave ASO resources dangling when they should be deleted.
```
