### PR TITLE
[release-1.18] Only update the subnet spec if status ASO CIDRs not empty

### DIFF
--- a/azure/services/subnets/subnets.go
+++ b/azure/services/subnets/subnets.go
@@ -56,8 +56,11 @@ func postCreateOrUpdateResourceHook(_ context.Context, scope SubnetScope, subnet
 	}
 
 	name := subnet.AzureName()
-	scope.UpdateSubnetID(name, ptr.Deref(subnet.Status.Id, ""))
-	scope.UpdateSubnetCIDRs(name, converters.GetSubnetAddresses(*subnet))
+	statusASOCIDRs := converters.GetSubnetAddresses(*subnet)
+	if len(statusASOCIDRs) != 0 {
+		scope.UpdateSubnetID(name, ptr.Deref(subnet.Status.Id, ""))
+		scope.UpdateSubnetCIDRs(name, statusASOCIDRs)
+	}
 
 	return nil
 }

--- a/azure/services/subnets/subnets_test.go
+++ b/azure/services/subnets/subnets_test.go
@@ -55,4 +55,36 @@ func TestPostCreateOrUpdateResourceHook(t *testing.T) {
 		}
 		g.Expect(postCreateOrUpdateResourceHook(context.Background(), scope, subnet, nil)).To(Succeed())
 	})
+
+	t.Run("correctly handles empty and non-empty ASO Status CIDRBlocks", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		mockCtrl := gomock.NewController(t)
+		scope := mock_subnets.NewMockSubnetScope(mockCtrl)
+
+		emptyCIDRSubnet := &asonetworkv1.VirtualNetworksSubnet{
+			Spec: asonetworkv1.VirtualNetworks_Subnet_Spec{
+				AzureName: "empty-cidr-status-subnet",
+			},
+			Status: asonetworkv1.VirtualNetworks_Subnet_STATUS{
+				Id:              ptr.To("id-empty"),
+				AddressPrefixes: []string{},
+			},
+		}
+		scope.EXPECT().UpdateSubnetID("empty-cidr-status-subnet", "id-empty").Times(0)
+		scope.EXPECT().UpdateSubnetCIDRs("empty-cidr-status-subnet", []string{}).Times(0)
+		g.Expect(postCreateOrUpdateResourceHook(context.Background(), scope, emptyCIDRSubnet, nil)).To(Succeed())
+
+		nonEmptyCIDRSubnet := &asonetworkv1.VirtualNetworksSubnet{
+			Spec: asonetworkv1.VirtualNetworks_Subnet_Spec{
+				AzureName: "nonempty-cidr-status-subnet",
+			},
+			Status: asonetworkv1.VirtualNetworks_Subnet_STATUS{
+				Id:              ptr.To("id-nonempty"),
+				AddressPrefixes: []string{"cidr"},
+			},
+		}
+		scope.EXPECT().UpdateSubnetID("nonempty-cidr-status-subnet", "id-nonempty").Times(1)
+		scope.EXPECT().UpdateSubnetCIDRs("nonempty-cidr-status-subnet", []string{"cidr"}).Times(1)
+		g.Expect(postCreateOrUpdateResourceHook(context.Background(), scope, nonEmptyCIDRSubnet, nil)).To(Succeed())
+	})
 }

--- a/azure/services/virtualnetworks/virtualnetworks.go
+++ b/azure/services/virtualnetworks/virtualnetworks.go
@@ -71,7 +71,10 @@ func postCreateOrUpdateResourceHook(ctx context.Context, scope VNetScope, existi
 		return errors.Wrap(err, "failed to list subnets")
 	}
 	for _, subnet := range subnets.Items {
-		scope.UpdateSubnetCIDRs(subnet.AzureName(), converters.GetSubnetAddresses(subnet))
+		statusASOCIDRs := converters.GetSubnetAddresses(subnet)
+		if len(statusASOCIDRs) != 0 {
+			scope.UpdateSubnetCIDRs(subnet.AzureName(), statusASOCIDRs)
+		}
 	}
 	// Only update the vnet's CIDRBlocks when we also updated subnets' since the vnet is created before
 	// subnets to prevent an updated vnet CIDR from invalidating subnet CIDRs that were defaulted and do not


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This is a manual cherry-pick of #5584

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Subnet spec should not be updated if status ASO CIDRs are empty.
```
