### PR TITLE
Bump cert-manager to v1.17.2

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -24,7 +24,7 @@ settings = {
     "kind_cluster_name": "capz",
     "capi_version": "v1.9.6",
     "caaph_version": "v0.2.5",
-    "cert_manager_version": "v1.16.4",
+    "cert_manager_version": "v1.17.2",
     "kubernetes_version": "v1.30.2",
     "aks_kubernetes_version": "v1.30.2",
     "flatcar_version": "3374.2.1",

--- a/hack/install-cert-manager.sh
+++ b/hack/install-cert-manager.sh
@@ -54,7 +54,7 @@ source "${REPO_ROOT}/hack/common-vars.sh"
 make --directory="${REPO_ROOT}" "${KUBECTL##*/}"
 
 ## Install cert manager and wait for availability
-"${KUBECTL}" apply -f https://github.com/jetstack/cert-manager/releases/download/v1.16.4/cert-manager.yaml
+"${KUBECTL}" apply -f https://github.com/jetstack/cert-manager/releases/download/v1.17.2/cert-manager.yaml
 "${KUBECTL}" wait --for=condition=Available --timeout=5m -n cert-manager deployment/cert-manager
 "${KUBECTL}" wait --for=condition=Available --timeout=5m -n cert-manager deployment/cert-manager-cainjector
 "${KUBECTL}" wait --for=condition=Available --timeout=5m -n cert-manager deployment/cert-manager-webhook


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Updates cert-manager to the current release [v1.17.2](https://github.com/cert-manager/cert-manager/releases/tag/v1.17.2) to sync with CAPI.

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:


**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [x] cherry-pick candidate

**Release note**:

```release-note
NONE
```
