### PR TITLE
feat: add additionalCapabilities spec to az MPs to support UltraSSDs

### DIFF
--- a/azure/scope/machinepool.go
+++ b/azure/scope/machinepool.go
@@ -200,6 +200,7 @@ func (m *MachinePoolScope) ScaleSetSpec(ctx context.Context) azure.ResourceSpecG
 		PublicLBName:                 m.OutboundLBName(infrav1.Node),
 		PublicLBAddressPoolName:      m.OutboundPoolName(infrav1.Node),
 		AcceleratedNetworking:        m.AzureMachinePool.Spec.Template.NetworkInterfaces[0].AcceleratedNetworking,
+		AdditionalCapabilities:       m.AzureMachinePool.Spec.Template.AdditionalCapabilities,
 		Identity:                     m.AzureMachinePool.Spec.Identity,
 		UserAssignedIdentities:       m.AzureMachinePool.Spec.UserAssignedIdentities,
 		DiagnosticsProfile:           m.AzureMachinePool.Spec.Template.Diagnostics,

--- a/azure/services/resourceskus/sku.go
+++ b/azure/services/resourceskus/sku.go
@@ -158,6 +158,12 @@ func (s SKU) HasLocationCapability(capabilityName, location, zone string) bool {
 
 			for _, capability := range zoneDetail.Capabilities {
 				if capability.Name != nil && *capability.Name == capabilityName {
+					// If capability is not limited to specific zones, return true
+					if zoneDetail.Name == nil {
+						return true
+					}
+
+					// Otherwise, we need to check listed zones to verify capability is available
 					for _, name := range zoneDetail.Name {
 						if ptr.Deref(name, "") == zone {
 							return true

--- a/azure/services/scalesets/spec.go
+++ b/azure/services/scalesets/spec.go
@@ -269,7 +269,9 @@ func (s *ScaleSetSpec) Parameters(ctx context.Context, existing interface{}) (pa
 	if s.AdditionalCapabilities != nil {
 		// Set UltraSSDEnabled if a specific value is set on the spec for it.
 		if s.AdditionalCapabilities.UltraSSDEnabled != nil {
-			vmss.Properties.AdditionalCapabilities.UltraSSDEnabled = s.AdditionalCapabilities.UltraSSDEnabled
+			vmss.Properties.AdditionalCapabilities = &armcompute.AdditionalCapabilities{
+				UltraSSDEnabled: s.AdditionalCapabilities.UltraSSDEnabled,
+			}
 		}
 	}
 

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremachinepools.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremachinepools.yaml
@@ -235,6 +235,17 @@ spec:
                     description: 'Deprecated: AcceleratedNetworking should be set
                       in the networkInterfaces field.'
                     type: boolean
+                  additionalCapabilities:
+                    description: AdditionalCapabilities specifies additional capabilities
+                      enabled or disabled on the virtual machine.
+                    properties:
+                      ultraSSDEnabled:
+                        description: |-
+                          UltraSSDEnabled enables or disables Azure UltraSSD capability for the virtual machine.
+                          Defaults to true if Ultra SSD data disks are specified,
+                          otherwise it doesn't set the capability on the VM.
+                        type: boolean
+                    type: object
                   dataDisks:
                     description: DataDisks specifies the list of data disks to be
                       created for a Virtual Machine

--- a/exp/api/v1beta1/azuremachinepool_types.go
+++ b/exp/api/v1beta1/azuremachinepool_types.go
@@ -71,6 +71,10 @@ type (
 		// +optional
 		AcceleratedNetworking *bool `json:"acceleratedNetworking,omitempty"`
 
+		// AdditionalCapabilities specifies additional capabilities enabled or disabled on the virtual machine.
+		// +optional
+		AdditionalCapabilities *infrav1.AdditionalCapabilities `json:"additionalCapabilities,omitempty"`
+
 		// Diagnostics specifies the diagnostics settings for a virtual machine.
 		// If not specified then Boot diagnostics (Managed) will be enabled.
 		// +optional

--- a/exp/api/v1beta1/zz_generated.deepcopy.go
+++ b/exp/api/v1beta1/zz_generated.deepcopy.go
@@ -269,6 +269,11 @@ func (in *AzureMachinePoolMachineTemplate) DeepCopyInto(out *AzureMachinePoolMac
 		*out = new(bool)
 		**out = **in
 	}
+	if in.AdditionalCapabilities != nil {
+		in, out := &in.AdditionalCapabilities, &out.AdditionalCapabilities
+		*out = new(apiv1beta1.AdditionalCapabilities)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.Diagnostics != nil {
 		in, out := &in.Diagnostics, &out.Diagnostics
 		*out = new(apiv1beta1.Diagnostics)


### PR DESCRIPTION
/kind feature

**What this PR does / why we need it**:
We would like to be able to attach UltraSSDs to our AzureMachinePool instances. This is currently not possible because the spec doesn't include any option to Enable Ultra Disk compatibility, which is required to attach UltraSSD PVCs to the machines. I would like to see parity with the MachineDeployment implementation which does allow you to specify the use of UltraSSDs via the AzureMachineSpec CRD.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #5627 

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->


**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] cherry-pick candidate

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add `additionalCapabilities` spec field to `AzureMachinePool.Spec.Template.AdditionalCapabilities`, allowing users to create MachinePools with UltraSSD capabilities
```
