### PR TITLE
Remove community AKS marketplace extension from e2e tests because no longer valid

### DIFF
--- a/docs/book/src/managed/managedcluster.md
+++ b/docs/book/src/managed/managedcluster.md
@@ -331,11 +331,7 @@ metadata:
 spec:
   extensions:
   - name: my-extension
-    extensionType: "TraefikLabs.TraefikProxy"
-    plan:
-      name: "traefik-proxy"
-      product: "traefik-proxy"
-      publisher: "containous"
+    extensionType: "microsoft.flux"
 ```
 
 To list all of the available extensions for your cluster as well as its plan details, use the following az cli command:

--- a/test/e2e/aks_marketplace.go
+++ b/test/e2e/aks_marketplace.go
@@ -45,7 +45,6 @@ type AKSMarketplaceExtensionSpecInput struct {
 }
 
 const (
-	extensionName         = "AKS-marketplace-extension" // Test that upper case name is allowed
 	officialExtensionName = "official-aks-extension"
 )
 
@@ -130,7 +129,7 @@ func AKSMarketplaceExtensionSpec(ctx context.Context, inputGetter func() AKSMark
 	}, input.WaitIntervals...).Should(Succeed())
 	Eventually(checkTaints, input.WaitIntervals...).Should(Succeed())
 
-	By("Adding an official AKS Extension & AKS Marketplace Extension to the AzureManagedControlPlane")
+	By("Adding an official AKS Extension to the AzureManagedControlPlane")
 	var infraControlPlane = &infrav1.AzureManagedControlPlane{}
 	Eventually(func(g Gomega) {
 		err = mgmtClient.Get(ctx, client.ObjectKey{
@@ -139,15 +138,6 @@ func AKSMarketplaceExtensionSpec(ctx context.Context, inputGetter func() AKSMark
 		}, infraControlPlane)
 		g.Expect(err).NotTo(HaveOccurred())
 		infraControlPlane.Spec.Extensions = []infrav1.AKSExtension{
-			{
-				Name:          extensionName,
-				ExtensionType: ptr.To("TraefikLabs.TraefikProxy"),
-				Plan: &infrav1.ExtensionPlan{
-					Name:      "traefik-proxy",
-					Product:   "traefik-proxy",
-					Publisher: "containous",
-				},
-			},
 			{
 				Name:          officialExtensionName,
 				ExtensionType: ptr.To("microsoft.flux"),
@@ -164,7 +154,6 @@ func AKSMarketplaceExtensionSpec(ctx context.Context, inputGetter func() AKSMark
 	}, input.WaitIntervals...).Should(Succeed())
 
 	By("Ensuring the AKS Marketplace Extension is added to the AzureManagedControlPlane")
-	ensureAKSExtensionAdded(ctx, input, extensionName, "TraefikLabs.TraefikProxy", extensionClient, amcp)
 	ensureAKSExtensionAdded(ctx, input, officialExtensionName, "microsoft.flux", extensionClient, amcp)
 
 	By("Deleting the AKS Marketplace Extension")
@@ -179,7 +168,6 @@ func AKSMarketplaceExtensionSpec(ctx context.Context, inputGetter func() AKSMark
 	}, input.WaitIntervals...).Should(Succeed())
 
 	By("Ensuring the AKS Marketplace Extension is deleted from the AzureManagedControlPlane")
-	ensureAKSExtensionDeleted(ctx, input, extensionName, extensionClient, amcp)
 	ensureAKSExtensionDeleted(ctx, input, officialExtensionName, extensionClient, amcp)
 
 	By("Restoring initial taints for Windows machine pool")


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind failing-test
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
AKS marketplace extension test failing because the TraefikLabs.TraefikProxy community extension no longer valid. Removed this AKS marketplace extension because we have an official aks extension in the tests already. 

Failing Test: https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/periodic-cluster-api-provider-azure-e2e-aks-main/1922878194831069184

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->


**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [X] cherry-pick candidate

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Remove community AKS marketplace extension from e2e tests because no longer valid```
