### PR TITLE
test: don’t use removed AKS traefik extension

### DIFF
--- a/docs/book/src/managed/managedcluster.md
+++ b/docs/book/src/managed/managedcluster.md
@@ -331,11 +331,7 @@ metadata:
 spec:
   extensions:
   - name: my-extension
-    extensionType: "TraefikLabs.TraefikProxy"
-    plan:
-      name: "traefik-proxy"
-      product: "traefik-proxy"
-      publisher: "containous"
+    extensionType: "microsoft.flux"
 ```
 
 To list all of the available extensions for your cluster as well as its plan details, use the following az cli command:

--- a/test/e2e/aks_marketplace.go
+++ b/test/e2e/aks_marketplace.go
@@ -140,15 +140,6 @@ func AKSMarketplaceExtensionSpec(ctx context.Context, inputGetter func() AKSMark
 		g.Expect(err).NotTo(HaveOccurred())
 		infraControlPlane.Spec.Extensions = []infrav1.AKSExtension{
 			{
-				Name:          extensionName,
-				ExtensionType: ptr.To("TraefikLabs.TraefikProxy"),
-				Plan: &infrav1.ExtensionPlan{
-					Name:      "traefik-proxy",
-					Product:   "traefik-proxy",
-					Publisher: "containous",
-				},
-			},
-			{
 				Name:          officialExtensionName,
 				ExtensionType: ptr.To("microsoft.flux"),
 			},
@@ -164,7 +155,6 @@ func AKSMarketplaceExtensionSpec(ctx context.Context, inputGetter func() AKSMark
 	}, input.WaitIntervals...).Should(Succeed())
 
 	By("Ensuring the AKS Marketplace Extension is added to the AzureManagedControlPlane")
-	ensureAKSExtensionAdded(ctx, input, extensionName, "TraefikLabs.TraefikProxy", extensionClient, amcp)
 	ensureAKSExtensionAdded(ctx, input, officialExtensionName, "microsoft.flux", extensionClient, amcp)
 
 	By("Deleting the AKS Marketplace Extension")


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

/kind failing-test

**What this PR does / why we need it**:

This PR removes the traefik AKS extension from our E2E tests, as that extension appears to no longer be available.

According to the logs:

>  traefik-proxy was removed from the marketplace for new purchase.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->


**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] cherry-pick candidate

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
