### PR TITLE
Match AzureASOManaged references on group and kind, not version

### DIFF
--- a/controllers/agentpooladopt_controller.go
+++ b/controllers/agentpooladopt_controller.go
@@ -84,7 +84,7 @@ func (r *AgentPoolAdoptReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	}
 
 	for _, owner := range agentPool.GetOwnerReferences() {
-		if owner.APIVersion == infrav1alpha.GroupVersion.Identifier() &&
+		if matchesASOManagedAPIGroup(owner.APIVersion) &&
 			owner.Kind == infrav1alpha.AzureASOManagedMachinePoolKind {
 			return ctrl.Result{}, nil
 		}
@@ -126,7 +126,7 @@ func (r *AgentPoolAdoptReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	}
 	var managedControlPlaneOwner *metav1.OwnerReference
 	for _, owner := range managedCluster.GetOwnerReferences() {
-		if owner.APIVersion == infrav1alpha.GroupVersion.Identifier() &&
+		if matchesASOManagedAPIGroup(owner.APIVersion) &&
 			owner.Kind == infrav1alpha.AzureASOManagedControlPlaneKind &&
 			owner.Name == agentPool.Owner().Name {
 			managedControlPlaneOwner = ptr.To(owner)

--- a/controllers/azureasomanagedcluster_controller_test.go
+++ b/controllers/azureasomanagedcluster_controller_test.go
@@ -130,7 +130,7 @@ func TestAzureASOManagedClusterReconcile(t *testing.T) {
 			},
 			Spec: clusterv1.ClusterSpec{
 				ControlPlaneRef: &corev1.ObjectReference{
-					APIVersion: infrav1alpha.GroupVersion.Identifier(),
+					APIVersion: "infrastructure.cluster.x-k8s.io/v1somethingelse",
 					Kind:       infrav1alpha.AzureASOManagedControlPlaneKind,
 				},
 			},

--- a/controllers/azureasomanagedcontrolplane_controller.go
+++ b/controllers/azureasomanagedcontrolplane_controller.go
@@ -114,7 +114,7 @@ func (r *AzureASOManagedControlPlaneReconciler) SetupWithManager(ctx context.Con
 func clusterToAzureASOManagedControlPlane(_ context.Context, o client.Object) []ctrl.Request {
 	controlPlaneRef := o.(*clusterv1.Cluster).Spec.ControlPlaneRef
 	if controlPlaneRef != nil &&
-		controlPlaneRef.APIVersion == infrav1alpha.GroupVersion.Identifier() &&
+		matchesASOManagedAPIGroup(controlPlaneRef.APIVersion) &&
 		controlPlaneRef.Kind == infrav1alpha.AzureASOManagedControlPlaneKind {
 		return []ctrl.Request{{NamespacedName: client.ObjectKey{Namespace: controlPlaneRef.Namespace, Name: controlPlaneRef.Name}}}
 	}
@@ -198,7 +198,7 @@ func (r *AzureASOManagedControlPlaneReconciler) reconcileNormal(ctx context.Cont
 		return ctrl.Result{}, nil
 	}
 	if cluster.Spec.InfrastructureRef == nil ||
-		cluster.Spec.InfrastructureRef.APIVersion != infrav1alpha.GroupVersion.Identifier() ||
+		!matchesASOManagedAPIGroup(cluster.Spec.InfrastructureRef.APIVersion) ||
 		cluster.Spec.InfrastructureRef.Kind != infrav1alpha.AzureASOManagedClusterKind {
 		return ctrl.Result{}, reconcile.TerminalError(errInvalidClusterKind)
 	}

--- a/controllers/azureasomanagedcontrolplane_controller_test.go
+++ b/controllers/azureasomanagedcontrolplane_controller_test.go
@@ -112,7 +112,7 @@ func TestAzureASOManagedControlPlaneReconcile(t *testing.T) {
 			},
 			Spec: clusterv1.ClusterSpec{
 				InfrastructureRef: &corev1.ObjectReference{
-					APIVersion: infrav1alpha.GroupVersion.Identifier(),
+					APIVersion: "infrastructure.cluster.x-k8s.io/v1somethingelse",
 					Kind:       infrav1alpha.AzureASOManagedClusterKind,
 				},
 			},

--- a/controllers/azureasomanagedmachinepool_controller.go
+++ b/controllers/azureasomanagedmachinepool_controller.go
@@ -185,7 +185,7 @@ func (r *AzureASOManagedMachinePoolReconciler) Reconcile(ctx context.Context, re
 		return ctrl.Result{}, nil
 	}
 	if cluster.Spec.ControlPlaneRef == nil ||
-		cluster.Spec.ControlPlaneRef.APIVersion != infrav1alpha.GroupVersion.Identifier() ||
+		!matchesASOManagedAPIGroup(cluster.Spec.ControlPlaneRef.APIVersion) ||
 		cluster.Spec.ControlPlaneRef.Kind != infrav1alpha.AzureASOManagedControlPlaneKind {
 		return ctrl.Result{}, reconcile.TerminalError(fmt.Errorf("AzureASOManagedMachinePool cannot be used without AzureASOManagedControlPlane"))
 	}

--- a/controllers/azureasomanagedmachinepool_controller_test.go
+++ b/controllers/azureasomanagedmachinepool_controller_test.go
@@ -157,7 +157,7 @@ func TestAzureASOManagedMachinePoolReconcile(t *testing.T) {
 			},
 			Spec: clusterv1.ClusterSpec{
 				ControlPlaneRef: &corev1.ObjectReference{
-					APIVersion: infrav1alpha.GroupVersion.Identifier(),
+					APIVersion: "infrastructure.cluster.x-k8s.io/v1somethingelse",
 					Kind:       infrav1alpha.AzureASOManagedControlPlaneKind,
 				},
 			},

--- a/controllers/managedclusteradopt_controller.go
+++ b/controllers/managedclusteradopt_controller.go
@@ -88,7 +88,7 @@ func (r *ManagedClusterAdoptReconciler) Reconcile(ctx context.Context, req ctrl.
 	}
 
 	for _, owner := range managedCluster.GetOwnerReferences() {
-		if owner.APIVersion == infrav1alpha.GroupVersion.Identifier() &&
+		if matchesASOManagedAPIGroup(owner.APIVersion) &&
 			owner.Kind == infrav1alpha.AzureASOManagedControlPlaneKind {
 			return ctrl.Result{}, nil
 		}


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind cleanup

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

Places that check for references to AzureASOManaged resources were checking API group, version, and kind. As we prepare to additionally serve a v1beta1 version of those resources, those checks need to be adapted to accept either v1alpha1 or v1beta1 as expected versions. These changes skip checking the version entirely, since group and kind are sufficient to determine what the underlying type of an object is.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->


**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] cherry-pick candidate

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```