### PR TITLE
Collect kube-apiserver logs from node

### DIFF
--- a/hack/create-dev-cluster.sh
+++ b/hack/create-dev-cluster.sh
@@ -66,7 +66,7 @@ capz::util::generate_ssh_key
 echo "================ DOCKER BUILD ==============="
 PULL_POLICY=IfNotPresent make modules docker-build
 
-setup() {
+create_cluster() {
     echo "================ MAKE CLEAN ==============="
     make clean
 
@@ -75,17 +75,14 @@ setup() {
 
     echo "================ INSTALL TOOLS ==============="
     make install-tools
-}
 
-create_cluster() {
     echo "================ CREATE CLUSTER ==============="
     make create-cluster
 }
 
 retries=$CLUSTER_CREATE_ATTEMPTS
-while ((retries > 0)); do
-    setup
-    create_cluster && break
-    sleep 5
-    ((retries --))
+until create_cluster; do
+  if ((--retries == 0)); then
+    exit 1
+  fi
 done


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind cleanup

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

It's currently basically impossible to debug a failing kube-apiserver based on the prow artifacts because gathering pod logs depends on kube-apiserver to be available. This change adds a command to gather the logs for kube-apiserver with `crictl` directly on the node.

This isn't needed for Windows nodes because kube-apiserver will only run on control plane nodes, which in turn are only Linux. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->


**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] cherry-pick candidate

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
