### PR TITLE
Add ability to disable creation of dns zone for unmanaged installs

### DIFF
--- a/api/v1beta1/azurecluster_webhook.go
+++ b/api/v1beta1/azurecluster_webhook.go
@@ -147,6 +147,13 @@ func (*AzureClusterWebhook) ValidateUpdate(_ context.Context, oldRaw, newObj run
 		allErrs = append(allErrs, err)
 	}
 
+	if err := webhookutils.ValidateImmutable(
+		field.NewPath("spec", "networkSpec", "privateDNSZone"),
+		old.Spec.NetworkSpec.PrivateDNSZone,
+		c.Spec.NetworkSpec.PrivateDNSZone); err != nil {
+		allErrs = append(allErrs, err)
+	}
+
 	// Allow enabling azure bastion but avoid disabling it.
 	if old.Spec.BastionSpec.AzureBastion != nil && !reflect.DeepEqual(old.Spec.BastionSpec.AzureBastion, c.Spec.BastionSpec.AzureBastion) {
 		allErrs = append(allErrs,

--- a/api/v1beta1/azuremanagedcontrolplane_types.go
+++ b/api/v1beta1/azuremanagedcontrolplane_types.go
@@ -25,12 +25,19 @@ const (
 	// ManagedClusterFinalizer allows Reconcile to clean up Azure resources associated with the AzureManagedControlPlane before
 	// removing it from the apiserver.
 	ManagedClusterFinalizer = "azuremanagedcontrolplane.infrastructure.cluster.x-k8s.io"
+)
 
-	// PrivateDNSZoneModeSystem represents mode System for azuremanagedcontrolplane.
-	PrivateDNSZoneModeSystem string = "System"
+// PrivateDNSZoneMode determines the creation of Private DNS Zones in a private cluster.
+// When unset or set to the default value of PrivateDNSZoneModeSystem, Private DNS Zones are created.
+// When set to PrivateDNSZoneModeNone, Private DNS Zones are not created in a private cluster.
+type PrivateDNSZoneMode string
 
-	// PrivateDNSZoneModeNone represents mode None for azuremanagedcontrolplane.
-	PrivateDNSZoneModeNone string = "None"
+const (
+	// PrivateDNSZoneModeSystem represents mode System for Private DNS Zones.
+	PrivateDNSZoneModeSystem PrivateDNSZoneMode = "System"
+
+	// PrivateDNSZoneModeNone represents mode None for Private DNS Zones.
+	PrivateDNSZoneModeNone PrivateDNSZoneMode = "None"
 )
 
 // UpgradeChannel determines the type of upgrade channel for automatically upgrading the cluster.

--- a/api/v1beta1/types.go
+++ b/api/v1beta1/types.go
@@ -116,6 +116,12 @@ type NetworkSpec struct {
 	// +optional
 	AdditionalAPIServerLBPorts []LoadBalancerPort `json:"additionalAPIServerLBPorts,omitempty"`
 
+	// PrivateDNSZone enables private dns zone creation modes for a private cluster.
+	// When unspecified, it defaults to PrivateDNSZoneModeSystem which creates a private DNS zone.
+	// +kubebuilder:validation:Enum=System;None
+	// +optional
+	PrivateDNSZone *PrivateDNSZoneMode `json:"privateDNSZone,omitempty"`
+
 	NetworkClassSpec `json:",inline"`
 }
 

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -3784,6 +3784,11 @@ func (in *NetworkSpec) DeepCopyInto(out *NetworkSpec) {
 		*out = make([]LoadBalancerPort, len(*in))
 		copy(*out, *in)
 	}
+	if in.PrivateDNSZone != nil {
+		in, out := &in.PrivateDNSZone, &out.PrivateDNSZone
+		*out = new(PrivateDNSZoneMode)
+		**out = **in
+	}
 	out.NetworkClassSpec = in.NetworkClassSpec
 }
 

--- a/azure/scope/cluster.go
+++ b/azure/scope/cluster.go
@@ -559,7 +559,7 @@ func (s *ClusterScope) VNetSpec() azure.ASOResourceSpecGetter[*asonetworkv1api20
 
 // PrivateDNSSpec returns the private dns zone spec.
 func (s *ClusterScope) PrivateDNSSpec() (zoneSpec azure.ResourceSpecGetter, linkSpec, recordSpec []azure.ResourceSpecGetter) {
-	if s.IsAPIServerPrivate() {
+	if s.IsAPIServerPrivate() && s.PrivateDNSZoneMode() != infrav1.PrivateDNSZoneModeNone {
 		resourceGroup := s.ResourceGroup()
 		if s.AzureCluster.Spec.NetworkSpec.PrivateDNSZoneResourceGroup != "" {
 			resourceGroup = s.AzureCluster.Spec.NetworkSpec.PrivateDNSZoneResourceGroup
@@ -1250,4 +1250,14 @@ func (s *ClusterScope) getLastAppliedSecurityRules(nsgName string) map[string]in
 		lastAppliedSecurityRules = map[string]interface{}{}
 	}
 	return lastAppliedSecurityRules
+}
+
+// PrivateDNSZoneMode returns the current Private DNS Zone mode.
+// When unconfigured, the method returns the default.
+// Returned value is used to determine if the Private DNS Zone should be created.
+func (s *ClusterScope) PrivateDNSZoneMode() infrav1.PrivateDNSZoneMode {
+	if s.AzureCluster.Spec.NetworkSpec.PrivateDNSZone == nil {
+		return infrav1.PrivateDNSZoneModeSystem
+	}
+	return *s.AzureCluster.Spec.NetworkSpec.PrivateDNSZone
 }

--- a/azure/scope/cluster_test.go
+++ b/azure/scope/cluster_test.go
@@ -216,6 +216,58 @@ func TestAPIServerHost(t *testing.T) {
 			},
 			want: "apiserver.example.private",
 		},
+		{
+			name: "private apiserver without private dns zone",
+			azureCluster: infrav1.AzureCluster{
+				Spec: infrav1.AzureClusterSpec{
+					AzureClusterClassSpec: infrav1.AzureClusterClassSpec{
+						SubscriptionID: fakeSubscriptionID,
+						IdentityRef: &corev1.ObjectReference{
+							Kind: infrav1.AzureClusterIdentityKind,
+						},
+					},
+					ControlPlaneEnabled: true,
+					NetworkSpec: infrav1.NetworkSpec{
+						PrivateDNSZone: ptr.To(infrav1.PrivateDNSZoneModeNone),
+						NetworkClassSpec: infrav1.NetworkClassSpec{
+							PrivateDNSZoneName: "",
+						},
+						APIServerLB: &infrav1.LoadBalancerSpec{
+							LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{
+								Type: infrav1.Internal,
+							},
+						},
+					},
+				},
+			},
+			want: "apiserver.my-cluster.capz.io",
+		},
+		{
+			name: "private apiserver with private dns zone",
+			azureCluster: infrav1.AzureCluster{
+				Spec: infrav1.AzureClusterSpec{
+					AzureClusterClassSpec: infrav1.AzureClusterClassSpec{
+						SubscriptionID: fakeSubscriptionID,
+						IdentityRef: &corev1.ObjectReference{
+							Kind: infrav1.AzureClusterIdentityKind,
+						},
+					},
+					ControlPlaneEnabled: true,
+					NetworkSpec: infrav1.NetworkSpec{
+						PrivateDNSZone: ptr.To(infrav1.PrivateDNSZoneModeSystem),
+						NetworkClassSpec: infrav1.NetworkClassSpec{
+							PrivateDNSZoneName: "",
+						},
+						APIServerLB: &infrav1.LoadBalancerSpec{
+							LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{
+								Type: infrav1.Internal,
+							},
+						},
+					},
+				},
+			},
+			want: "apiserver.my-cluster.capz.io",
+		},
 	}
 
 	for _, tc := range tests {
@@ -4134,6 +4186,98 @@ func TestAPIServerLBName(t *testing.T) {
 			g := NewWithT(t)
 			result := tt.cluster.APIServerLBName()
 			g.Expect(result).To(Equal(tt.expected))
+		})
+	}
+}
+
+func TestPrivateDNSSpec(t *testing.T) {
+	tests := []struct {
+		name                    string
+		clusterName             string
+		azureClusterNetworkSpec infrav1.NetworkSpec
+		expectPrivateDNSSpec    bool
+	}{
+		{
+			name:        "Default PrivateDNSZone (PrivateDNSZoneModeSystem)",
+			clusterName: "private-default",
+			azureClusterNetworkSpec: infrav1.NetworkSpec{
+				NetworkClassSpec: infrav1.NetworkClassSpec{
+					PrivateDNSZoneName: "fake-privateDNSZoneName",
+				},
+				APIServerLB: &infrav1.LoadBalancerSpec{
+					FrontendIPs: []infrav1.FrontendIP{
+						{
+							Name: "api-server-lb-internal-ip",
+							FrontendIPClass: infrav1.FrontendIPClass{
+								PrivateIPAddress: infrav1.DefaultInternalLBIPAddress,
+							},
+						},
+					},
+					LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{
+						Type: infrav1.Internal,
+					},
+				},
+			},
+			expectPrivateDNSSpec: true,
+		},
+		{
+			name:        "PrivateDNSZone set to PrivateDNSZoneModeNone",
+			clusterName: "private-none",
+			azureClusterNetworkSpec: infrav1.NetworkSpec{
+				PrivateDNSZone: ptr.To(infrav1.PrivateDNSZoneModeNone),
+				NetworkClassSpec: infrav1.NetworkClassSpec{
+					PrivateDNSZoneName: "fake-privateDNSZoneName",
+				},
+				APIServerLB: &infrav1.LoadBalancerSpec{
+					LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{
+						Type: infrav1.Internal,
+					},
+				},
+			},
+			expectPrivateDNSSpec: false,
+		},
+		{
+			name:        "Public LB",
+			clusterName: "public-none",
+			azureClusterNetworkSpec: infrav1.NetworkSpec{
+				PrivateDNSZone: ptr.To(infrav1.PrivateDNSZoneModeNone),
+				NetworkClassSpec: infrav1.NetworkClassSpec{
+					PrivateDNSZoneName: "fake-privateDNSZoneName",
+				},
+				APIServerLB: &infrav1.LoadBalancerSpec{
+					LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{
+						Type: infrav1.Public,
+					},
+				},
+			},
+			expectPrivateDNSSpec: false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			cluster := &clusterv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      tc.clusterName,
+					Namespace: "default",
+				},
+			}
+			azureCluster := &infrav1.AzureCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: tc.clusterName,
+				},
+				Spec: infrav1.AzureClusterSpec{
+					NetworkSpec: tc.azureClusterNetworkSpec,
+				},
+			}
+
+			clusterScope := &ClusterScope{
+				Cluster:      cluster,
+				AzureCluster: azureCluster,
+			}
+			zoneSpec, _, _ := clusterScope.PrivateDNSSpec()
+			g.Expect(zoneSpec != nil).Should(Equal(tc.expectPrivateDNSSpec))
 		})
 	}
 }

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azureclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azureclusters.yaml
@@ -926,6 +926,14 @@ spec:
                         description: LBType defines an Azure load balancer Type.
                         type: string
                     type: object
+                  privateDNSZone:
+                    description: |-
+                      PrivateDNSZone enables private dns zone creation modes for a private cluster.
+                      When unspecified, it defaults to PrivateDNSZoneModeSystem which creates a private DNS zone.
+                    enum:
+                    - System
+                    - None
+                    type: string
                   privateDNSZoneName:
                     description: PrivateDNSZoneName defines the zone name for the
                       Azure Private DNS.


### PR DESCRIPTION
Similar to managed installs, add ability to optionally create DNS zones for unmanged installs.

 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind feature


**What this PR does / why we need it**:
This PR adds the ability to optionally create private DNS zones for unmanaged clusters. Without this feature they are always created. There are some instances we would like to use a DNS service other than Azure DNS and would like CAPI to withhold creation of private DNS Zones at those times. This feature adds a new field to NetworkSpec that allows us to skip creation of the DNS zone. Default behavior remains unchanged where DNS zones are created during cluster creation.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->


**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] cherry-pick candidate

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add ability to optionally create the Private DNS Zone for unmanaged clusters instead of always creating one. Setting `PrivateDNSZone` within the `NetworkSpec` to `PrivateDNSZoneiCreationModeNone` will skip creating the Private DNS zone.
```
