### PR TITLE
fix: nil pointer when deleting MachinePool

### DIFF
--- a/azure/scope/machinepool.go
+++ b/azure/scope/machinepool.go
@@ -746,6 +746,9 @@ func (m *MachinePoolScope) GetBootstrapData(ctx context.Context) (string, error)
 
 // calculateBootstrapDataHash calculates the sha256 hash of the bootstrap data.
 func (m *MachinePoolScope) calculateBootstrapDataHash(_ context.Context) (string, error) {
+	if m.cache == nil {
+		return "", fmt.Errorf("machinepool cache is nil")
+	}
 	bootstrapData := m.cache.BootstrapData
 	h := sha256.New()
 	n, err := io.WriteString(h, bootstrapData)


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
fixes a nil pointer when deleting MachinePools as `cache` is only initialized in `reconcileNormal`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
didn't open an issue

**Special notes for your reviewer**:
related panic:

```
goroutine 1016 [running]:
k8s.io/apimachinery/pkg/util/runtime.logPanic({0x3cc73f8, 0xc002cf4c90}, {0x31770a0, 0x5974ad0})
        /go/pkg/mod/k8s.io/apimachinery@v0.31.3/pkg/util/runtime/runtime.go:107 +0xbc
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Reconcile.func1()
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.6/pkg/internal/controller/controller.go:105 +0x112
panic({0x31770a0?, 0x5974ad0?})
        /usr/local/go/src/runtime/panic.go:770 +0x132
sigs.k8s.io/cluster-api-provider-azure/azure/scope.(*MachinePoolScope).calculateBootstrapDataHash(0x0?, {0x0?, 0x0?})
        /workspace/azure/scope/machinepool.go:749 +0x1b
sigs.k8s.io/cluster-api-provider-azure/azure/scope.(*MachinePoolScope).updateCustomDataHash(0xc001d33ce0, {0x3cc73f8?, 0xc0020b90e0?})
        /workspace/azure/scope/machinepool.go:769 +0x26
sigs.k8s.io/cluster-api-provider-azure/azure/scope.(*MachinePoolScope).Close(0xc001d33ce0, {0x3cc74a0?, 0xc000481500?})
        /workspace/azure/scope/machinepool.go:710 +0x112
sigs.k8s.io/cluster-api-provider-azure/exp/controllers.(*AzureMachinePoolReconciler).Reconcile.func1()
        /workspace/exp/controllers/azuremachinepool_controller.go:243 +0x28
sigs.k8s.io/cluster-api-provider-azure/exp/controllers.(*AzureMachinePoolReconciler).Reconcile(0xc00001a540, {0x3cc73f8?, 0xc002cf4d80?}, {{{0xc0063daba0?, 0xa?}, {0xc0063dab67?, 0x0?}}})
        /workspace/exp/controllers/azuremachinepool_controller.go:256 +0xe2c
sigs.k8s.io/cluster-api-provider-azure/pkg/coalescing.(*reconciler).Reconcile(0xc0006131c0, {0x3cc73f8?, 0xc002cf4c90?}, {{{0xc0063daba0?, 0x69ad39?}, {0xc0063dab67?, 0x0?}}})
        /workspace/pkg/coalescing/reconciler.go:110 +0x3bc
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Reconcile(0xc0039d1c80?, {0x3cc73f8?, 0xc002cf4c90?}, {{{0xc0063daba0?, 0x0?}, {0xc0063dab67?, 0x0?}}})
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.6/pkg/internal/controller/controller.go:116 +0xd4
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler(0x3ce9d00, {0x3cc7430, 0xc00055b9a0}, {{{0xc0063daba0, 0xe}, {0xc0063dab67, 0x9}}})
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.6/pkg/internal/controller/controller.go:303 +0x3bc
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem(0x3ce9d00, {0x3cc7430, 0xc00055b9a0})
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.6/pkg/internal/controller/controller.go:263 +0x21d
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func2.2()
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.6/pkg/internal/controller/controller.go:224 +0x8a
created by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func2 in goroutine 229
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.6/pkg/internal/controller/controller.go:220 +0x510
```

**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [x] cherry-pick candidate

**Release note**:

```release-note
fixes potential nil pointer when deleting MachinePool
```
