### PR TITLE
chore(deps): bump tj-actions/changed-files to v46.0.5

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,7 +29,7 @@ jobs:
           fetch-depth: 0
       - name: Get changed files
         id: changed-markdown-files
-        uses: tj-actions/changed-files@3981e4f74104e7a4c67a835e1e5dd5d9eb0f0a57 # tag=v45.0.7
+        uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # tag=v46.0.5
         with:
           files: CHANGELOG/**.md
       - name: Get release version


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Updates tj-actions/changed-files from 3981e4f74104e7a4c67a835e1e5dd5d9eb0f0a57 to ed68ef82c095e0d48ec87eccea555d944a631a4c. There was something odd about #5664 and the patch releases in the v45 series, so let's try a manual update.

**Which issue(s) this PR fixes**:

Refs #5664

**Special notes for your reviewer**:


**TODOs**:

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] cherry-pick candidate

**Release note**:

```release-note
NONE
```
