### PR TITLE
Replace docker.io with quay for calico

### DIFF
--- a/templates/addons/calico-dual-stack/values.yaml
+++ b/templates/addons/calico-dual-stack/values.yaml
@@ -17,3 +17,10 @@ installation:
       encapsulation: None
       natOutgoing: Enabled
       nodeSelector: all()
+    registry: quay.io
+# Image and registry configuration for the tigera/operator pod.
+tigeraOperator:
+  image: tigera/operator
+  registry: quay.io
+calicoctl:
+  image: quay.io/calico/ctl

--- a/templates/addons/calico-ipv6/values.yaml
+++ b/templates/addons/calico-ipv6/values.yaml
@@ -12,3 +12,10 @@ installation:
       encapsulation: None
       natOutgoing: Enabled
       nodeSelector: all()
+    registry: quay.io
+# Image and registry configuration for the tigera/operator pod.Add commentMore actions
+tigeraOperator:
+  image: tigera/operator
+  registry: quay.io
+calicoctl:
+  image: quay.io/calico/ctl

--- a/templates/addons/calico.yaml
+++ b/templates/addons/calico.yaml
@@ -6063,7 +6063,7 @@ spec:
           value: node
         - name: DATASTORE_TYPE
           value: kubernetes
-        image: docker.io/calico/kube-controllers:v3.29.4
+        image: quay.io/calico/kube-controllers:v3.29.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           exec:
@@ -6181,7 +6181,7 @@ spec:
         - configMapRef:
             name: kubernetes-services-endpoint
             optional: true
-        image: docker.io/calico/node:v3.29.4
+        image: quay.io/calico/node:v3.29.4
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -6253,7 +6253,7 @@ spec:
         - configMapRef:
             name: kubernetes-services-endpoint
             optional: true
-        image: docker.io/calico/cni:v3.29.4
+        image: quay.io/calico/cni:v3.29.4
         imagePullPolicy: IfNotPresent
         name: upgrade-ipam
         securityContext:
@@ -6288,7 +6288,7 @@ spec:
         - configMapRef:
             name: kubernetes-services-endpoint
             optional: true
-        image: docker.io/calico/cni:v3.29.4
+        image: quay.io/calico/cni:v3.29.4
         imagePullPolicy: IfNotPresent
         name: install-cni
         securityContext:
@@ -6302,7 +6302,7 @@ spec:
         - calico-node
         - -init
         - -best-effort
-        image: docker.io/calico/node:v3.29.4
+        image: quay.io/calico/node:v3.29.4
         imagePullPolicy: IfNotPresent
         name: mount-bpffs
         securityContext:

--- a/templates/addons/calico/kustomization.yaml
+++ b/templates/addons/calico/kustomization.yaml
@@ -12,3 +12,4 @@ patches:
     name: calico-kube-controllers
     namespace: kube-system
 - path: patches/azure-mtu.yaml
+- path: patches/replace-docker-with-quay.yaml

--- a/templates/addons/calico/patches/replace-docker-with-quay.yaml
+++ b/templates/addons/calico/patches/replace-docker-with-quay.yaml
@@ -1,0 +1,30 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: calico-node
+  namespace: kube-system
+spec:
+  template:
+    spec:
+      initContainers:
+      - name: upgrade-ipam
+        image: quay.io/calico/cni:v3.29.4
+      - name: install-cni
+        image: quay.io/calico/cni:v3.29.4
+      - name: mount-bpffs
+        image: quay.io/calico/node:v3.29.4
+      containers:
+      - name: calico-node
+        image: quay.io/calico/node:v3.29.4
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: calico-kube-controllers
+  namespace: kube-system
+spec:
+  template:
+    spec:
+      containers:
+      - name: calico-kube-controllers
+        image: quay.io/calico/kube-controllers:v3.29.4

--- a/templates/addons/cluster-api-helm/calico-dual-stack.yaml
+++ b/templates/addons/cluster-api-helm/calico-dual-stack.yaml
@@ -31,3 +31,10 @@ spec:
           encapsulation: None
           natOutgoing: Enabled
           nodeSelector: all()
+        registry: quay.io
+      # Image and registry configuration for the tigera/operator pod.Add commentMore actions
+      tigeraOperator:
+        image: tigera/operator
+        registry: quay.io
+      calicoctl:
+        image: quay.io/calico/ctl

--- a/templates/addons/cluster-api-helm/calico-ipv6.yaml
+++ b/templates/addons/cluster-api-helm/calico-ipv6.yaml
@@ -26,3 +26,10 @@ spec:
           encapsulation: None
           natOutgoing: Enabled
           nodeSelector: all(){{end}}
+        registry: quay.io
+      # Image and registry configuration for the tigera/operator pod.Add commentMore actions
+      tigeraOperator:
+        image: tigera/operator
+        registry: quay.io
+      calicoctl:
+        image: quay.io/calico/ctl

--- a/templates/addons/cluster-api-helm/calico.yaml
+++ b/templates/addons/cluster-api-helm/calico.yaml
@@ -22,8 +22,13 @@ spec:
         ipPools:{{range $i, $cidr := .Cluster.spec.clusterNetwork.pods.cidrBlocks }}
         - cidr: {{ $cidr }}
           encapsulation: VXLAN{{end}}
+        registry: quay.io
       serviceCIDRs:
         - 10.96.0.0/12 # must match cluster service CIDR (this is the default)
+      # Image and registry configuration for the tigera/operator pod
+      tigeraOperator:
+        image: tigera/operator
+        registry: quay.io
     # when kubernetesServiceEndpoint (required for windows) is added
     # DNS configuration is needed to look up the api server name properly
     # https://github.com/projectcalico/calico/issues/9536

--- a/templates/test/ci/cluster-template-prow-apiserver-ilb.yaml
+++ b/templates/test/ci/cluster-template-prow-apiserver-ilb.yaml
@@ -255,8 +255,13 @@ spec:
         ipPools:{{range $i, $cidr := .Cluster.spec.clusterNetwork.pods.cidrBlocks }}
         - cidr: {{ $cidr }}
           encapsulation: VXLAN{{end}}
+        registry: quay.io
       serviceCIDRs:
         - 10.96.0.0/12 # must match cluster service CIDR (this is the default)
+      # Image and registry configuration for the tigera/operator pod
+      tigeraOperator:
+        image: tigera/operator
+        registry: quay.io
     # when kubernetesServiceEndpoint (required for windows) is added
     # DNS configuration is needed to look up the api server name properly
     # https://github.com/projectcalico/calico/issues/9536

--- a/templates/test/ci/cluster-template-prow-ci-version-dra.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version-dra.yaml
@@ -683,8 +683,13 @@ spec:
         ipPools:{{range $i, $cidr := .Cluster.spec.clusterNetwork.pods.cidrBlocks }}
         - cidr: {{ $cidr }}
           encapsulation: VXLAN{{end}}
+        registry: quay.io
       serviceCIDRs:
         - 10.96.0.0/12 # must match cluster service CIDR (this is the default)
+      # Image and registry configuration for the tigera/operator pod
+      tigeraOperator:
+        image: tigera/operator
+        registry: quay.io
     # when kubernetesServiceEndpoint (required for windows) is added
     # DNS configuration is needed to look up the api server name properly
     # https://github.com/projectcalico/calico/issues/9536

--- a/templates/test/ci/cluster-template-prow-ci-version-dual-stack.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version-dual-stack.yaml
@@ -1000,4 +1000,11 @@ spec:
           encapsulation: None
           natOutgoing: Enabled
           nodeSelector: all()
+        registry: quay.io
+      # Image and registry configuration for the tigera/operator pod.Add commentMore actions
+      tigeraOperator:
+        image: tigera/operator
+        registry: quay.io
+      calicoctl:
+        image: quay.io/calico/ctl
   version: ${CALICO_VERSION}

--- a/templates/test/ci/cluster-template-prow-ci-version-ipv6.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version-ipv6.yaml
@@ -1013,4 +1013,11 @@ spec:
           encapsulation: None
           natOutgoing: Enabled
           nodeSelector: all(){{end}}
+        registry: quay.io
+      # Image and registry configuration for the tigera/operator pod.Add commentMore actions
+      tigeraOperator:
+        image: tigera/operator
+        registry: quay.io
+      calicoctl:
+        image: quay.io/calico/ctl
   version: ${CALICO_VERSION}

--- a/templates/test/ci/cluster-template-prow-ci-version-md-and-mp.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version-md-and-mp.yaml
@@ -712,8 +712,13 @@ spec:
         ipPools:{{range $i, $cidr := .Cluster.spec.clusterNetwork.pods.cidrBlocks }}
         - cidr: {{ $cidr }}
           encapsulation: VXLAN{{end}}
+        registry: quay.io
       serviceCIDRs:
         - 10.96.0.0/12 # must match cluster service CIDR (this is the default)
+      # Image and registry configuration for the tigera/operator pod
+      tigeraOperator:
+        image: tigera/operator
+        registry: quay.io
     # when kubernetesServiceEndpoint (required for windows) is added
     # DNS configuration is needed to look up the api server name properly
     # https://github.com/projectcalico/calico/issues/9536

--- a/templates/test/ci/cluster-template-prow-ci-version.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version.yaml
@@ -712,8 +712,13 @@ spec:
         ipPools:{{range $i, $cidr := .Cluster.spec.clusterNetwork.pods.cidrBlocks }}
         - cidr: {{ $cidr }}
           encapsulation: VXLAN{{end}}
+        registry: quay.io
       serviceCIDRs:
         - 10.96.0.0/12 # must match cluster service CIDR (this is the default)
+      # Image and registry configuration for the tigera/operator pod
+      tigeraOperator:
+        image: tigera/operator
+        registry: quay.io
     # when kubernetesServiceEndpoint (required for windows) is added
     # DNS configuration is needed to look up the api server name properly
     # https://github.com/projectcalico/calico/issues/9536

--- a/templates/test/ci/cluster-template-prow-clusterclass-ci-rke2.yaml
+++ b/templates/test/ci/cluster-template-prow-clusterclass-ci-rke2.yaml
@@ -425,8 +425,13 @@ spec:
         ipPools:{{range $i, $cidr := .Cluster.spec.clusterNetwork.pods.cidrBlocks }}
         - cidr: {{ $cidr }}
           encapsulation: VXLAN{{end}}
+        registry: quay.io
       serviceCIDRs:
         - 10.96.0.0/12 # must match cluster service CIDR (this is the default)
+      # Image and registry configuration for the tigera/operator pod
+      tigeraOperator:
+        image: tigera/operator
+        registry: quay.io
     # when kubernetesServiceEndpoint (required for windows) is added
     # DNS configuration is needed to look up the api server name properly
     # https://github.com/projectcalico/calico/issues/9536

--- a/templates/test/ci/cluster-template-prow-custom-vnet.yaml
+++ b/templates/test/ci/cluster-template-prow-custom-vnet.yaml
@@ -264,8 +264,13 @@ spec:
         ipPools:{{range $i, $cidr := .Cluster.spec.clusterNetwork.pods.cidrBlocks }}
         - cidr: {{ $cidr }}
           encapsulation: VXLAN{{end}}
+        registry: quay.io
       serviceCIDRs:
         - 10.96.0.0/12 # must match cluster service CIDR (this is the default)
+      # Image and registry configuration for the tigera/operator pod
+      tigeraOperator:
+        image: tigera/operator
+        registry: quay.io
     # when kubernetesServiceEndpoint (required for windows) is added
     # DNS configuration is needed to look up the api server name properly
     # https://github.com/projectcalico/calico/issues/9536

--- a/templates/test/ci/cluster-template-prow-dual-stack.yaml
+++ b/templates/test/ci/cluster-template-prow-dual-stack.yaml
@@ -337,6 +337,13 @@ spec:
           encapsulation: None
           natOutgoing: Enabled
           nodeSelector: all()
+        registry: quay.io
+      # Image and registry configuration for the tigera/operator pod.Add commentMore actions
+      tigeraOperator:
+        image: tigera/operator
+        registry: quay.io
+      calicoctl:
+        image: quay.io/calico/ctl
   version: ${CALICO_VERSION}
 ---
 apiVersion: addons.cluster.x-k8s.io/v1alpha1

--- a/templates/test/ci/cluster-template-prow-edgezone.yaml
+++ b/templates/test/ci/cluster-template-prow-edgezone.yaml
@@ -247,8 +247,13 @@ spec:
         ipPools:{{range $i, $cidr := .Cluster.spec.clusterNetwork.pods.cidrBlocks }}
         - cidr: {{ $cidr }}
           encapsulation: VXLAN{{end}}
+        registry: quay.io
       serviceCIDRs:
         - 10.96.0.0/12 # must match cluster service CIDR (this is the default)
+      # Image and registry configuration for the tigera/operator pod
+      tigeraOperator:
+        image: tigera/operator
+        registry: quay.io
     # when kubernetesServiceEndpoint (required for windows) is added
     # DNS configuration is needed to look up the api server name properly
     # https://github.com/projectcalico/calico/issues/9536

--- a/templates/test/ci/cluster-template-prow-flatcar-sysext.yaml
+++ b/templates/test/ci/cluster-template-prow-flatcar-sysext.yaml
@@ -42,8 +42,13 @@ spec:
         ipPools:{{range $i, $cidr := .Cluster.spec.clusterNetwork.pods.cidrBlocks }}
         - cidr: {{ $cidr }}
           encapsulation: VXLAN{{end}}
+        registry: quay.io
       serviceCIDRs:
         - 10.96.0.0/12 # must match cluster service CIDR (this is the default)
+      # Image and registry configuration for the tigera/operator pod
+      tigeraOperator:
+        image: tigera/operator
+        registry: quay.io
     # when kubernetesServiceEndpoint (required for windows) is added
     # DNS configuration is needed to look up the api server name properly
     # https://github.com/projectcalico/calico/issues/9536

--- a/templates/test/ci/cluster-template-prow-flatcar.yaml
+++ b/templates/test/ci/cluster-template-prow-flatcar.yaml
@@ -278,8 +278,13 @@ spec:
         ipPools:{{range $i, $cidr := .Cluster.spec.clusterNetwork.pods.cidrBlocks }}
         - cidr: {{ $cidr }}
           encapsulation: VXLAN{{end}}
+        registry: quay.io
       serviceCIDRs:
         - 10.96.0.0/12 # must match cluster service CIDR (this is the default)
+      # Image and registry configuration for the tigera/operator pod
+      tigeraOperator:
+        image: tigera/operator
+        registry: quay.io
     # when kubernetesServiceEndpoint (required for windows) is added
     # DNS configuration is needed to look up the api server name properly
     # https://github.com/projectcalico/calico/issues/9536

--- a/templates/test/ci/cluster-template-prow-ipv6.yaml
+++ b/templates/test/ci/cluster-template-prow-ipv6.yaml
@@ -357,6 +357,13 @@ spec:
           encapsulation: None
           natOutgoing: Enabled
           nodeSelector: all(){{end}}
+        registry: quay.io
+      # Image and registry configuration for the tigera/operator pod.Add commentMore actions
+      tigeraOperator:
+        image: tigera/operator
+        registry: quay.io
+      calicoctl:
+        image: quay.io/calico/ctl
   version: ${CALICO_VERSION}
 ---
 apiVersion: addons.cluster.x-k8s.io/v1alpha1

--- a/templates/test/ci/cluster-template-prow-machine-pool-ci-version.yaml
+++ b/templates/test/ci/cluster-template-prow-machine-pool-ci-version.yaml
@@ -643,8 +643,13 @@ spec:
         ipPools:{{range $i, $cidr := .Cluster.spec.clusterNetwork.pods.cidrBlocks }}
         - cidr: {{ $cidr }}
           encapsulation: VXLAN{{end}}
+        registry: quay.io
       serviceCIDRs:
         - 10.96.0.0/12 # must match cluster service CIDR (this is the default)
+      # Image and registry configuration for the tigera/operator pod
+      tigeraOperator:
+        image: tigera/operator
+        registry: quay.io
     # when kubernetesServiceEndpoint (required for windows) is added
     # DNS configuration is needed to look up the api server name properly
     # https://github.com/projectcalico/calico/issues/9536

--- a/templates/test/ci/cluster-template-prow-machine-pool-flex.yaml
+++ b/templates/test/ci/cluster-template-prow-machine-pool-flex.yaml
@@ -376,8 +376,13 @@ spec:
         ipPools:{{range $i, $cidr := .Cluster.spec.clusterNetwork.pods.cidrBlocks }}
         - cidr: {{ $cidr }}
           encapsulation: VXLAN{{end}}
+        registry: quay.io
       serviceCIDRs:
         - 10.96.0.0/12 # must match cluster service CIDR (this is the default)
+      # Image and registry configuration for the tigera/operator pod
+      tigeraOperator:
+        image: tigera/operator
+        registry: quay.io
     # when kubernetesServiceEndpoint (required for windows) is added
     # DNS configuration is needed to look up the api server name properly
     # https://github.com/projectcalico/calico/issues/9536

--- a/templates/test/ci/cluster-template-prow-machine-pool.yaml
+++ b/templates/test/ci/cluster-template-prow-machine-pool.yaml
@@ -370,8 +370,13 @@ spec:
         ipPools:{{range $i, $cidr := .Cluster.spec.clusterNetwork.pods.cidrBlocks }}
         - cidr: {{ $cidr }}
           encapsulation: VXLAN{{end}}
+        registry: quay.io
       serviceCIDRs:
         - 10.96.0.0/12 # must match cluster service CIDR (this is the default)
+      # Image and registry configuration for the tigera/operator pod
+      tigeraOperator:
+        image: tigera/operator
+        registry: quay.io
     # when kubernetesServiceEndpoint (required for windows) is added
     # DNS configuration is needed to look up the api server name properly
     # https://github.com/projectcalico/calico/issues/9536

--- a/templates/test/ci/cluster-template-prow-nvidia-gpu.yaml
+++ b/templates/test/ci/cluster-template-prow-nvidia-gpu.yaml
@@ -237,8 +237,13 @@ spec:
         ipPools:{{range $i, $cidr := .Cluster.spec.clusterNetwork.pods.cidrBlocks }}
         - cidr: {{ $cidr }}
           encapsulation: VXLAN{{end}}
+        registry: quay.io
       serviceCIDRs:
         - 10.96.0.0/12 # must match cluster service CIDR (this is the default)
+      # Image and registry configuration for the tigera/operator pod
+      tigeraOperator:
+        image: tigera/operator
+        registry: quay.io
     # when kubernetesServiceEndpoint (required for windows) is added
     # DNS configuration is needed to look up the api server name properly
     # https://github.com/projectcalico/calico/issues/9536

--- a/templates/test/ci/cluster-template-prow-private.yaml
+++ b/templates/test/ci/cluster-template-prow-private.yaml
@@ -6442,7 +6442,7 @@ data:
               value: node
             - name: DATASTORE_TYPE
               value: kubernetes
-            image: docker.io/calico/kube-controllers:v3.29.4
+            image: quay.io/calico/kube-controllers:v3.29.4
             imagePullPolicy: IfNotPresent
             livenessProbe:
               exec:
@@ -6560,7 +6560,7 @@ data:
             - configMapRef:
                 name: kubernetes-services-endpoint
                 optional: true
-            image: docker.io/calico/node:v3.29.4
+            image: quay.io/calico/node:v3.29.4
             imagePullPolicy: IfNotPresent
             lifecycle:
               preStop:
@@ -6632,7 +6632,7 @@ data:
             - configMapRef:
                 name: kubernetes-services-endpoint
                 optional: true
-            image: docker.io/calico/cni:v3.29.4
+            image: quay.io/calico/cni:v3.29.4
             imagePullPolicy: IfNotPresent
             name: upgrade-ipam
             securityContext:
@@ -6667,7 +6667,7 @@ data:
             - configMapRef:
                 name: kubernetes-services-endpoint
                 optional: true
-            image: docker.io/calico/cni:v3.29.4
+            image: quay.io/calico/cni:v3.29.4
             imagePullPolicy: IfNotPresent
             name: install-cni
             securityContext:
@@ -6681,7 +6681,7 @@ data:
             - calico-node
             - -init
             - -best-effort
-            image: docker.io/calico/node:v3.29.4
+            image: quay.io/calico/node:v3.29.4
             imagePullPolicy: IfNotPresent
             name: mount-bpffs
             securityContext:

--- a/templates/test/ci/cluster-template-prow-private.yaml
+++ b/templates/test/ci/cluster-template-prow-private.yaml
@@ -289,8 +289,13 @@ spec:
         ipPools:{{range $i, $cidr := .Cluster.spec.clusterNetwork.pods.cidrBlocks }}
         - cidr: {{ $cidr }}
           encapsulation: VXLAN{{end}}
+        registry: quay.io
       serviceCIDRs:
         - 10.96.0.0/12 # must match cluster service CIDR (this is the default)
+      # Image and registry configuration for the tigera/operator pod
+      tigeraOperator:
+        image: tigera/operator
+        registry: quay.io
     # when kubernetesServiceEndpoint (required for windows) is added
     # DNS configuration is needed to look up the api server name properly
     # https://github.com/projectcalico/calico/issues/9536

--- a/templates/test/ci/cluster-template-prow-spot.yaml
+++ b/templates/test/ci/cluster-template-prow-spot.yaml
@@ -260,8 +260,13 @@ spec:
         ipPools:{{range $i, $cidr := .Cluster.spec.clusterNetwork.pods.cidrBlocks }}
         - cidr: {{ $cidr }}
           encapsulation: VXLAN{{end}}
+        registry: quay.io
       serviceCIDRs:
         - 10.96.0.0/12 # must match cluster service CIDR (this is the default)
+      # Image and registry configuration for the tigera/operator pod
+      tigeraOperator:
+        image: tigera/operator
+        registry: quay.io
     # when kubernetesServiceEndpoint (required for windows) is added
     # DNS configuration is needed to look up the api server name properly
     # https://github.com/projectcalico/calico/issues/9536

--- a/templates/test/ci/cluster-template-prow-topology.yaml
+++ b/templates/test/ci/cluster-template-prow-topology.yaml
@@ -105,8 +105,13 @@ spec:
         ipPools:{{range $i, $cidr := .Cluster.spec.clusterNetwork.pods.cidrBlocks }}
         - cidr: {{ $cidr }}
           encapsulation: VXLAN{{end}}
+        registry: quay.io
       serviceCIDRs:
         - 10.96.0.0/12 # must match cluster service CIDR (this is the default)
+      # Image and registry configuration for the tigera/operator pod
+      tigeraOperator:
+        image: tigera/operator
+        registry: quay.io
     # when kubernetesServiceEndpoint (required for windows) is added
     # DNS configuration is needed to look up the api server name properly
     # https://github.com/projectcalico/calico/issues/9536

--- a/templates/test/ci/cluster-template-prow.yaml
+++ b/templates/test/ci/cluster-template-prow.yaml
@@ -444,8 +444,13 @@ spec:
         ipPools:{{range $i, $cidr := .Cluster.spec.clusterNetwork.pods.cidrBlocks }}
         - cidr: {{ $cidr }}
           encapsulation: VXLAN{{end}}
+        registry: quay.io
       serviceCIDRs:
         - 10.96.0.0/12 # must match cluster service CIDR (this is the default)
+      # Image and registry configuration for the tigera/operator pod
+      tigeraOperator:
+        image: tigera/operator
+        registry: quay.io
     # when kubernetesServiceEndpoint (required for windows) is added
     # DNS configuration is needed to look up the api server name properly
     # https://github.com/projectcalico/calico/issues/9536

--- a/templates/test/dev/cluster-template-custom-builds-dra.yaml
+++ b/templates/test/dev/cluster-template-custom-builds-dra.yaml
@@ -637,8 +637,13 @@ spec:
         ipPools:{{range $i, $cidr := .Cluster.spec.clusterNetwork.pods.cidrBlocks }}
         - cidr: {{ $cidr }}
           encapsulation: VXLAN{{end}}
+        registry: quay.io
       serviceCIDRs:
         - 10.96.0.0/12 # must match cluster service CIDR (this is the default)
+      # Image and registry configuration for the tigera/operator pod
+      tigeraOperator:
+        image: tigera/operator
+        registry: quay.io
     # when kubernetesServiceEndpoint (required for windows) is added
     # DNS configuration is needed to look up the api server name properly
     # https://github.com/projectcalico/calico/issues/9536

--- a/templates/test/dev/cluster-template-custom-builds-load-dra.yaml
+++ b/templates/test/dev/cluster-template-custom-builds-load-dra.yaml
@@ -720,8 +720,13 @@ spec:
         ipPools:{{range $i, $cidr := .Cluster.spec.clusterNetwork.pods.cidrBlocks }}
         - cidr: {{ $cidr }}
           encapsulation: VXLAN{{end}}
+        registry: quay.io
       serviceCIDRs:
         - 10.96.0.0/12 # must match cluster service CIDR (this is the default)
+      # Image and registry configuration for the tigera/operator pod
+      tigeraOperator:
+        image: tigera/operator
+        registry: quay.io
     # when kubernetesServiceEndpoint (required for windows) is added
     # DNS configuration is needed to look up the api server name properly
     # https://github.com/projectcalico/calico/issues/9536

--- a/templates/test/dev/cluster-template-custom-builds-load.yaml
+++ b/templates/test/dev/cluster-template-custom-builds-load.yaml
@@ -684,8 +684,13 @@ spec:
         ipPools:{{range $i, $cidr := .Cluster.spec.clusterNetwork.pods.cidrBlocks }}
         - cidr: {{ $cidr }}
           encapsulation: VXLAN{{end}}
+        registry: quay.io
       serviceCIDRs:
         - 10.96.0.0/12 # must match cluster service CIDR (this is the default)
+      # Image and registry configuration for the tigera/operator pod
+      tigeraOperator:
+        image: tigera/operator
+        registry: quay.io
     # when kubernetesServiceEndpoint (required for windows) is added
     # DNS configuration is needed to look up the api server name properly
     # https://github.com/projectcalico/calico/issues/9536

--- a/templates/test/dev/cluster-template-custom-builds-machine-pool.yaml
+++ b/templates/test/dev/cluster-template-custom-builds-machine-pool.yaml
@@ -597,8 +597,13 @@ spec:
         ipPools:{{range $i, $cidr := .Cluster.spec.clusterNetwork.pods.cidrBlocks }}
         - cidr: {{ $cidr }}
           encapsulation: VXLAN{{end}}
+        registry: quay.io
       serviceCIDRs:
         - 10.96.0.0/12 # must match cluster service CIDR (this is the default)
+      # Image and registry configuration for the tigera/operator pod
+      tigeraOperator:
+        image: tigera/operator
+        registry: quay.io
     # when kubernetesServiceEndpoint (required for windows) is added
     # DNS configuration is needed to look up the api server name properly
     # https://github.com/projectcalico/calico/issues/9536

--- a/templates/test/dev/cluster-template-custom-builds.yaml
+++ b/templates/test/dev/cluster-template-custom-builds.yaml
@@ -678,8 +678,13 @@ spec:
         ipPools:{{range $i, $cidr := .Cluster.spec.clusterNetwork.pods.cidrBlocks }}
         - cidr: {{ $cidr }}
           encapsulation: VXLAN{{end}}
+        registry: quay.io
       serviceCIDRs:
         - 10.96.0.0/12 # must match cluster service CIDR (this is the default)
+      # Image and registry configuration for the tigera/operator pod
+      tigeraOperator:
+        image: tigera/operator
+        registry: quay.io
     # when kubernetesServiceEndpoint (required for windows) is added
     # DNS configuration is needed to look up the api server name properly
     # https://github.com/projectcalico/calico/issues/9536

--- a/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-kcp-remediation.yaml
+++ b/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-kcp-remediation.yaml
@@ -40,8 +40,13 @@ spec:
         ipPools:{{range $i, $cidr := .Cluster.spec.clusterNetwork.pods.cidrBlocks }}
         - cidr: {{ $cidr }}
           encapsulation: VXLAN{{end}}
+        registry: quay.io
       serviceCIDRs:
         - 10.96.0.0/12 # must match cluster service CIDR (this is the default)
+      # Image and registry configuration for the tigera/operator pod
+      tigeraOperator:
+        image: tigera/operator
+        registry: quay.io
     # when kubernetesServiceEndpoint (required for windows) is added
     # DNS configuration is needed to look up the api server name properly
     # https://github.com/projectcalico/calico/issues/9536

--- a/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-kcp-scale-in.yaml
+++ b/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-kcp-scale-in.yaml
@@ -40,8 +40,13 @@ spec:
         ipPools:{{range $i, $cidr := .Cluster.spec.clusterNetwork.pods.cidrBlocks }}
         - cidr: {{ $cidr }}
           encapsulation: VXLAN{{end}}
+        registry: quay.io
       serviceCIDRs:
         - 10.96.0.0/12 # must match cluster service CIDR (this is the default)
+      # Image and registry configuration for the tigera/operator pod
+      tigeraOperator:
+        image: tigera/operator
+        registry: quay.io
     # when kubernetesServiceEndpoint (required for windows) is added
     # DNS configuration is needed to look up the api server name properly
     # https://github.com/projectcalico/calico/issues/9536

--- a/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-machine-and-machine-pool.yaml
+++ b/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-machine-and-machine-pool.yaml
@@ -40,8 +40,13 @@ spec:
         ipPools:{{range $i, $cidr := .Cluster.spec.clusterNetwork.pods.cidrBlocks }}
         - cidr: {{ $cidr }}
           encapsulation: VXLAN{{end}}
+        registry: quay.io
       serviceCIDRs:
         - 10.96.0.0/12 # must match cluster service CIDR (this is the default)
+      # Image and registry configuration for the tigera/operator pod
+      tigeraOperator:
+        image: tigera/operator
+        registry: quay.io
     # when kubernetesServiceEndpoint (required for windows) is added
     # DNS configuration is needed to look up the api server name properly
     # https://github.com/projectcalico/calico/issues/9536

--- a/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-machine-pool.yaml
+++ b/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-machine-pool.yaml
@@ -40,8 +40,13 @@ spec:
         ipPools:{{range $i, $cidr := .Cluster.spec.clusterNetwork.pods.cidrBlocks }}
         - cidr: {{ $cidr }}
           encapsulation: VXLAN{{end}}
+        registry: quay.io
       serviceCIDRs:
         - 10.96.0.0/12 # must match cluster service CIDR (this is the default)
+      # Image and registry configuration for the tigera/operator pod
+      tigeraOperator:
+        image: tigera/operator
+        registry: quay.io
     # when kubernetesServiceEndpoint (required for windows) is added
     # DNS configuration is needed to look up the api server name properly
     # https://github.com/projectcalico/calico/issues/9536

--- a/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-md-remediation.yaml
+++ b/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-md-remediation.yaml
@@ -40,8 +40,13 @@ spec:
         ipPools:{{range $i, $cidr := .Cluster.spec.clusterNetwork.pods.cidrBlocks }}
         - cidr: {{ $cidr }}
           encapsulation: VXLAN{{end}}
+        registry: quay.io
       serviceCIDRs:
         - 10.96.0.0/12 # must match cluster service CIDR (this is the default)
+      # Image and registry configuration for the tigera/operator pod
+      tigeraOperator:
+        image: tigera/operator
+        registry: quay.io
     # when kubernetesServiceEndpoint (required for windows) is added
     # DNS configuration is needed to look up the api server name properly
     # https://github.com/projectcalico/calico/issues/9536

--- a/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-node-drain.yaml
+++ b/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-node-drain.yaml
@@ -40,8 +40,13 @@ spec:
         ipPools:{{range $i, $cidr := .Cluster.spec.clusterNetwork.pods.cidrBlocks }}
         - cidr: {{ $cidr }}
           encapsulation: VXLAN{{end}}
+        registry: quay.io
       serviceCIDRs:
         - 10.96.0.0/12 # must match cluster service CIDR (this is the default)
+      # Image and registry configuration for the tigera/operator pod
+      tigeraOperator:
+        image: tigera/operator
+        registry: quay.io
     # when kubernetesServiceEndpoint (required for windows) is added
     # DNS configuration is needed to look up the api server name properly
     # https://github.com/projectcalico/calico/issues/9536

--- a/test/e2e/data/infrastructure-azure/v1beta1/cluster-template.yaml
+++ b/test/e2e/data/infrastructure-azure/v1beta1/cluster-template.yaml
@@ -40,8 +40,13 @@ spec:
         ipPools:{{range $i, $cidr := .Cluster.spec.clusterNetwork.pods.cidrBlocks }}
         - cidr: {{ $cidr }}
           encapsulation: VXLAN{{end}}
+        registry: quay.io
       serviceCIDRs:
         - 10.96.0.0/12 # must match cluster service CIDR (this is the default)
+      # Image and registry configuration for the tigera/operator pod
+      tigeraOperator:
+        image: tigera/operator
+        registry: quay.io
     # when kubernetesServiceEndpoint (required for windows) is added
     # DNS configuration is needed to look up the api server name properly
     # https://github.com/projectcalico/calico/issues/9536


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind failing-test

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
This PR replaces Calico image references from docker.io to quay.io due to rate limiting issues.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->


**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] cherry-pick candidate

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
