### PR TITLE
Work around tigera-operator validation/defaulting race

### DIFF
--- a/templates/addons/cluster-api-helm/calico.yaml
+++ b/templates/addons/cluster-api-helm/calico.yaml
@@ -15,6 +15,8 @@ spec:
     installation:
       cni:
         type: Calico
+        ipam:
+          type: Calico
       calicoNetwork:
         bgp: Disabled
         windowsDataplane: HNS

--- a/templates/test/ci/cluster-template-prow-apiserver-ilb.yaml
+++ b/templates/test/ci/cluster-template-prow-apiserver-ilb.yaml
@@ -248,6 +248,8 @@ spec:
     installation:
       cni:
         type: Calico
+        ipam:
+          type: Calico
       calicoNetwork:
         bgp: Disabled
         windowsDataplane: HNS

--- a/templates/test/ci/cluster-template-prow-ci-version-dra.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version-dra.yaml
@@ -676,6 +676,8 @@ spec:
     installation:
       cni:
         type: Calico
+        ipam:
+          type: Calico
       calicoNetwork:
         bgp: Disabled
         windowsDataplane: HNS

--- a/templates/test/ci/cluster-template-prow-ci-version-md-and-mp.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version-md-and-mp.yaml
@@ -705,6 +705,8 @@ spec:
     installation:
       cni:
         type: Calico
+        ipam:
+          type: Calico
       calicoNetwork:
         bgp: Disabled
         windowsDataplane: HNS

--- a/templates/test/ci/cluster-template-prow-ci-version.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version.yaml
@@ -705,6 +705,8 @@ spec:
     installation:
       cni:
         type: Calico
+        ipam:
+          type: Calico
       calicoNetwork:
         bgp: Disabled
         windowsDataplane: HNS

--- a/templates/test/ci/cluster-template-prow-clusterclass-ci-rke2.yaml
+++ b/templates/test/ci/cluster-template-prow-clusterclass-ci-rke2.yaml
@@ -418,6 +418,8 @@ spec:
     installation:
       cni:
         type: Calico
+        ipam:
+          type: Calico
       calicoNetwork:
         bgp: Disabled
         windowsDataplane: HNS

--- a/templates/test/ci/cluster-template-prow-custom-vnet.yaml
+++ b/templates/test/ci/cluster-template-prow-custom-vnet.yaml
@@ -257,6 +257,8 @@ spec:
     installation:
       cni:
         type: Calico
+        ipam:
+          type: Calico
       calicoNetwork:
         bgp: Disabled
         windowsDataplane: HNS

--- a/templates/test/ci/cluster-template-prow-edgezone.yaml
+++ b/templates/test/ci/cluster-template-prow-edgezone.yaml
@@ -240,6 +240,8 @@ spec:
     installation:
       cni:
         type: Calico
+        ipam:
+          type: Calico
       calicoNetwork:
         bgp: Disabled
         windowsDataplane: HNS

--- a/templates/test/ci/cluster-template-prow-flatcar-sysext.yaml
+++ b/templates/test/ci/cluster-template-prow-flatcar-sysext.yaml
@@ -35,6 +35,8 @@ spec:
     installation:
       cni:
         type: Calico
+        ipam:
+          type: Calico
       calicoNetwork:
         bgp: Disabled
         windowsDataplane: HNS

--- a/templates/test/ci/cluster-template-prow-flatcar.yaml
+++ b/templates/test/ci/cluster-template-prow-flatcar.yaml
@@ -271,6 +271,8 @@ spec:
     installation:
       cni:
         type: Calico
+        ipam:
+          type: Calico
       calicoNetwork:
         bgp: Disabled
         windowsDataplane: HNS

--- a/templates/test/ci/cluster-template-prow-machine-pool-ci-version.yaml
+++ b/templates/test/ci/cluster-template-prow-machine-pool-ci-version.yaml
@@ -636,6 +636,8 @@ spec:
     installation:
       cni:
         type: Calico
+        ipam:
+          type: Calico
       calicoNetwork:
         bgp: Disabled
         windowsDataplane: HNS

--- a/templates/test/ci/cluster-template-prow-machine-pool-flex.yaml
+++ b/templates/test/ci/cluster-template-prow-machine-pool-flex.yaml
@@ -369,6 +369,8 @@ spec:
     installation:
       cni:
         type: Calico
+        ipam:
+          type: Calico
       calicoNetwork:
         bgp: Disabled
         windowsDataplane: HNS

--- a/templates/test/ci/cluster-template-prow-machine-pool.yaml
+++ b/templates/test/ci/cluster-template-prow-machine-pool.yaml
@@ -363,6 +363,8 @@ spec:
     installation:
       cni:
         type: Calico
+        ipam:
+          type: Calico
       calicoNetwork:
         bgp: Disabled
         windowsDataplane: HNS

--- a/templates/test/ci/cluster-template-prow-nvidia-gpu.yaml
+++ b/templates/test/ci/cluster-template-prow-nvidia-gpu.yaml
@@ -230,6 +230,8 @@ spec:
     installation:
       cni:
         type: Calico
+        ipam:
+          type: Calico
       calicoNetwork:
         bgp: Disabled
         windowsDataplane: HNS

--- a/templates/test/ci/cluster-template-prow-private.yaml
+++ b/templates/test/ci/cluster-template-prow-private.yaml
@@ -282,6 +282,8 @@ spec:
     installation:
       cni:
         type: Calico
+        ipam:
+          type: Calico
       calicoNetwork:
         bgp: Disabled
         windowsDataplane: HNS

--- a/templates/test/ci/cluster-template-prow-spot.yaml
+++ b/templates/test/ci/cluster-template-prow-spot.yaml
@@ -253,6 +253,8 @@ spec:
     installation:
       cni:
         type: Calico
+        ipam:
+          type: Calico
       calicoNetwork:
         bgp: Disabled
         windowsDataplane: HNS

--- a/templates/test/ci/cluster-template-prow-topology.yaml
+++ b/templates/test/ci/cluster-template-prow-topology.yaml
@@ -98,6 +98,8 @@ spec:
     installation:
       cni:
         type: Calico
+        ipam:
+          type: Calico
       calicoNetwork:
         bgp: Disabled
         windowsDataplane: HNS

--- a/templates/test/ci/cluster-template-prow.yaml
+++ b/templates/test/ci/cluster-template-prow.yaml
@@ -437,6 +437,8 @@ spec:
     installation:
       cni:
         type: Calico
+        ipam:
+          type: Calico
       calicoNetwork:
         bgp: Disabled
         windowsDataplane: HNS

--- a/templates/test/dev/cluster-template-custom-builds-dra.yaml
+++ b/templates/test/dev/cluster-template-custom-builds-dra.yaml
@@ -630,6 +630,8 @@ spec:
     installation:
       cni:
         type: Calico
+        ipam:
+          type: Calico
       calicoNetwork:
         bgp: Disabled
         windowsDataplane: HNS

--- a/templates/test/dev/cluster-template-custom-builds-load-dra.yaml
+++ b/templates/test/dev/cluster-template-custom-builds-load-dra.yaml
@@ -713,6 +713,8 @@ spec:
     installation:
       cni:
         type: Calico
+        ipam:
+          type: Calico
       calicoNetwork:
         bgp: Disabled
         windowsDataplane: HNS

--- a/templates/test/dev/cluster-template-custom-builds-load.yaml
+++ b/templates/test/dev/cluster-template-custom-builds-load.yaml
@@ -677,6 +677,8 @@ spec:
     installation:
       cni:
         type: Calico
+        ipam:
+          type: Calico
       calicoNetwork:
         bgp: Disabled
         windowsDataplane: HNS

--- a/templates/test/dev/cluster-template-custom-builds-machine-pool.yaml
+++ b/templates/test/dev/cluster-template-custom-builds-machine-pool.yaml
@@ -590,6 +590,8 @@ spec:
     installation:
       cni:
         type: Calico
+        ipam:
+          type: Calico
       calicoNetwork:
         bgp: Disabled
         windowsDataplane: HNS

--- a/templates/test/dev/cluster-template-custom-builds.yaml
+++ b/templates/test/dev/cluster-template-custom-builds.yaml
@@ -671,6 +671,8 @@ spec:
     installation:
       cni:
         type: Calico
+        ipam:
+          type: Calico
       calicoNetwork:
         bgp: Disabled
         windowsDataplane: HNS

--- a/test/e2e/data/infrastructure-azure/v1.18.2/cluster-template-prow-machine-and-machine-pool.yaml
+++ b/test/e2e/data/infrastructure-azure/v1.18.2/cluster-template-prow-machine-and-machine-pool.yaml
@@ -488,6 +488,8 @@ spec:
     installation:
       cni:
         type: Calico
+        ipam:
+          type: Calico
       calicoNetwork:
         bgp: Disabled
         mtu: 1350

--- a/test/e2e/data/infrastructure-azure/v1.18.2/cluster-template-prow.yaml
+++ b/test/e2e/data/infrastructure-azure/v1.18.2/cluster-template-prow.yaml
@@ -430,6 +430,8 @@ spec:
     installation:
       cni:
         type: Calico
+        ipam:
+          type: Calico
       calicoNetwork:
         bgp: Disabled
         mtu: 1350

--- a/test/e2e/data/infrastructure-azure/v1.19.1/cluster-template-prow-machine-and-machine-pool.yaml
+++ b/test/e2e/data/infrastructure-azure/v1.19.1/cluster-template-prow-machine-and-machine-pool.yaml
@@ -488,6 +488,8 @@ spec:
     installation:
       cni:
         type: Calico
+        ipam:
+          type: Calico
       calicoNetwork:
         bgp: Disabled
         mtu: 1350

--- a/test/e2e/data/infrastructure-azure/v1.19.1/cluster-template-prow.yaml
+++ b/test/e2e/data/infrastructure-azure/v1.19.1/cluster-template-prow.yaml
@@ -430,6 +430,8 @@ spec:
     installation:
       cni:
         type: Calico
+        ipam:
+          type: Calico
       calicoNetwork:
         bgp: Disabled
         mtu: 1350

--- a/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-kcp-remediation.yaml
+++ b/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-kcp-remediation.yaml
@@ -33,6 +33,8 @@ spec:
     installation:
       cni:
         type: Calico
+        ipam:
+          type: Calico
       calicoNetwork:
         bgp: Disabled
         windowsDataplane: HNS

--- a/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-kcp-scale-in.yaml
+++ b/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-kcp-scale-in.yaml
@@ -33,6 +33,8 @@ spec:
     installation:
       cni:
         type: Calico
+        ipam:
+          type: Calico
       calicoNetwork:
         bgp: Disabled
         windowsDataplane: HNS

--- a/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-machine-and-machine-pool.yaml
+++ b/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-machine-and-machine-pool.yaml
@@ -33,6 +33,8 @@ spec:
     installation:
       cni:
         type: Calico
+        ipam:
+          type: Calico
       calicoNetwork:
         bgp: Disabled
         windowsDataplane: HNS

--- a/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-machine-pool.yaml
+++ b/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-machine-pool.yaml
@@ -33,6 +33,8 @@ spec:
     installation:
       cni:
         type: Calico
+        ipam:
+          type: Calico
       calicoNetwork:
         bgp: Disabled
         windowsDataplane: HNS

--- a/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-md-remediation.yaml
+++ b/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-md-remediation.yaml
@@ -33,6 +33,8 @@ spec:
     installation:
       cni:
         type: Calico
+        ipam:
+          type: Calico
       calicoNetwork:
         bgp: Disabled
         windowsDataplane: HNS

--- a/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-node-drain.yaml
+++ b/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-node-drain.yaml
@@ -33,6 +33,8 @@ spec:
     installation:
       cni:
         type: Calico
+        ipam:
+          type: Calico
       calicoNetwork:
         bgp: Disabled
         windowsDataplane: HNS

--- a/test/e2e/data/infrastructure-azure/v1beta1/cluster-template.yaml
+++ b/test/e2e/data/infrastructure-azure/v1beta1/cluster-template.yaml
@@ -33,6 +33,8 @@ spec:
     installation:
       cni:
         type: Calico
+        ipam:
+          type: Calico
       calicoNetwork:
         bgp: Disabled
         windowsDataplane: HNS


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind flake


<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

Following up from #5523, this PR adds some extra configuration for tigera-operator that matches the implicit default to get around https://github.com/tigera/operator/issues/3850. I'm hoping this solves a large swath of the CI flakes we've been seeing lately.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->


**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] cherry-pick candidate

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
