### PR TITLE
Add MachineHealthChecks for KCP and Windows Machines in e2e

### DIFF
--- a/templates/test/ci/cluster-template-prow-ci-version-dra.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version-dra.yaml
@@ -478,6 +478,9 @@ spec:
   clusterName: ${CLUSTER_NAME}
   replicas: ${WINDOWS_WORKER_MACHINE_COUNT:-0}
   template:
+    metadata:
+      labels:
+        windows-healthcheck: "true"
     spec:
       bootstrap:
         configRef:
@@ -616,6 +619,45 @@ spec:
     name: capi
     sshAuthorizedKeys:
     - ${AZURE_SSH_PUBLIC_KEY:=""}
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineHealthCheck
+metadata:
+  name: ${CLUSTER_NAME}-control-plane
+  namespace: default
+spec:
+  clusterName: ${CLUSTER_NAME}
+  maxUnhealthy: 100%
+  selector:
+    matchLabels:
+      cluster.x-k8s.io/control-plane: ""
+  unhealthyConditions:
+  - status: Unknown
+    timeout: 300s
+    type: Ready
+  - status: "False"
+    timeout: 300s
+    type: Ready
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineHealthCheck
+metadata:
+  name: ${CLUSTER_NAME}-mhc-windows
+  namespace: default
+spec:
+  clusterName: ${CLUSTER_NAME}
+  maxUnhealthy: 100%
+  nodeStartupTimeout: 10m
+  selector:
+    matchLabels:
+      windows-healthcheck: "true"
+  unhealthyConditions:
+  - status: "false"
+    timeout: 300s
+    type: Ready
+  - status: Unknown
+    timeout: 300s
+    type: Ready
 ---
 apiVersion: addons.cluster.x-k8s.io/v1beta1
 kind: ClusterResourceSet

--- a/templates/test/ci/cluster-template-prow-ci-version-dual-stack.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version-dual-stack.yaml
@@ -456,6 +456,25 @@ spec:
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineHealthCheck
 metadata:
+  name: ${CLUSTER_NAME}-control-plane
+  namespace: default
+spec:
+  clusterName: ${CLUSTER_NAME}
+  maxUnhealthy: 100%
+  selector:
+    matchLabels:
+      cluster.x-k8s.io/control-plane: ""
+  unhealthyConditions:
+  - status: Unknown
+    timeout: 300s
+    type: Ready
+  - status: "False"
+    timeout: 300s
+    type: Ready
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineHealthCheck
+metadata:
   name: ${CLUSTER_NAME}-mhc-0
   namespace: default
 spec:

--- a/templates/test/ci/cluster-template-prow-ci-version-ipv6.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version-ipv6.yaml
@@ -474,6 +474,25 @@ spec:
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineHealthCheck
 metadata:
+  name: ${CLUSTER_NAME}-control-plane
+  namespace: default
+spec:
+  clusterName: ${CLUSTER_NAME}
+  maxUnhealthy: 100%
+  selector:
+    matchLabels:
+      cluster.x-k8s.io/control-plane: ""
+  unhealthyConditions:
+  - status: Unknown
+    timeout: 300s
+    type: Ready
+  - status: "False"
+    timeout: 300s
+    type: Ready
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineHealthCheck
+metadata:
   name: ${CLUSTER_NAME}-mhc-0
   namespace: default
 spec:

--- a/templates/test/ci/cluster-template-prow-ci-version-md-and-mp.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version-md-and-mp.yaml
@@ -440,6 +440,9 @@ spec:
   replicas: ${WINDOWS_WORKER_MACHINE_COUNT:-0}
   selector: {}
   template:
+    metadata:
+      labels:
+        windows-healthcheck: "true"
     spec:
       bootstrap:
         configRef:
@@ -620,6 +623,25 @@ spec:
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineHealthCheck
 metadata:
+  name: ${CLUSTER_NAME}-control-plane
+  namespace: default
+spec:
+  clusterName: ${CLUSTER_NAME}
+  maxUnhealthy: 100%
+  selector:
+    matchLabels:
+      cluster.x-k8s.io/control-plane: ""
+  unhealthyConditions:
+  - status: Unknown
+    timeout: 300s
+    type: Ready
+  - status: "False"
+    timeout: 300s
+    type: Ready
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineHealthCheck
+metadata:
   name: ${CLUSTER_NAME}-mhc-0
   namespace: default
 spec:
@@ -632,6 +654,26 @@ spec:
   - status: "True"
     timeout: 30s
     type: E2ENodeUnhealthy
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineHealthCheck
+metadata:
+  name: ${CLUSTER_NAME}-mhc-windows
+  namespace: default
+spec:
+  clusterName: ${CLUSTER_NAME}
+  maxUnhealthy: 100%
+  nodeStartupTimeout: 10m
+  selector:
+    matchLabels:
+      windows-healthcheck: "true"
+  unhealthyConditions:
+  - status: "false"
+    timeout: 300s
+    type: Ready
+  - status: Unknown
+    timeout: 300s
+    type: Ready
 ---
 apiVersion: addons.cluster.x-k8s.io/v1beta1
 kind: ClusterResourceSet

--- a/templates/test/ci/cluster-template-prow-ci-version.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version.yaml
@@ -440,6 +440,9 @@ spec:
   replicas: ${WINDOWS_WORKER_MACHINE_COUNT:-0}
   selector: {}
   template:
+    metadata:
+      labels:
+        windows-healthcheck: "true"
     spec:
       bootstrap:
         configRef:
@@ -620,6 +623,25 @@ spec:
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineHealthCheck
 metadata:
+  name: ${CLUSTER_NAME}-control-plane
+  namespace: default
+spec:
+  clusterName: ${CLUSTER_NAME}
+  maxUnhealthy: 100%
+  selector:
+    matchLabels:
+      cluster.x-k8s.io/control-plane: ""
+  unhealthyConditions:
+  - status: Unknown
+    timeout: 300s
+    type: Ready
+  - status: "False"
+    timeout: 300s
+    type: Ready
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineHealthCheck
+metadata:
   name: ${CLUSTER_NAME}-mhc-0
   namespace: default
 spec:
@@ -632,6 +654,26 @@ spec:
   - status: "True"
     timeout: 30s
     type: E2ENodeUnhealthy
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineHealthCheck
+metadata:
+  name: ${CLUSTER_NAME}-mhc-windows
+  namespace: default
+spec:
+  clusterName: ${CLUSTER_NAME}
+  maxUnhealthy: 100%
+  nodeStartupTimeout: 10m
+  selector:
+    matchLabels:
+      windows-healthcheck: "true"
+  unhealthyConditions:
+  - status: "false"
+    timeout: 300s
+    type: Ready
+  - status: Unknown
+    timeout: 300s
+    type: Ready
 ---
 apiVersion: addons.cluster.x-k8s.io/v1beta1
 kind: ClusterResourceSet

--- a/templates/test/ci/cluster-template-prow-machine-pool-ci-version.yaml
+++ b/templates/test/ci/cluster-template-prow-machine-pool-ci-version.yaml
@@ -449,6 +449,9 @@ spec:
   clusterName: ${CLUSTER_NAME}
   replicas: ${WINDOWS_WORKER_MACHINE_COUNT:-0}
   template:
+    metadata:
+      labels:
+        windows-healthcheck: "true"
     spec:
       bootstrap:
         configRef:
@@ -576,6 +579,45 @@ spec:
     name: capi
     sshAuthorizedKeys:
     - ${AZURE_SSH_PUBLIC_KEY:=""}
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineHealthCheck
+metadata:
+  name: ${CLUSTER_NAME}-control-plane
+  namespace: default
+spec:
+  clusterName: ${CLUSTER_NAME}
+  maxUnhealthy: 100%
+  selector:
+    matchLabels:
+      cluster.x-k8s.io/control-plane: ""
+  unhealthyConditions:
+  - status: Unknown
+    timeout: 300s
+    type: Ready
+  - status: "False"
+    timeout: 300s
+    type: Ready
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineHealthCheck
+metadata:
+  name: ${CLUSTER_NAME}-mhc-windows
+  namespace: default
+spec:
+  clusterName: ${CLUSTER_NAME}
+  maxUnhealthy: 100%
+  nodeStartupTimeout: 10m
+  selector:
+    matchLabels:
+      windows-healthcheck: "true"
+  unhealthyConditions:
+  - status: "false"
+    timeout: 300s
+    type: Ready
+  - status: Unknown
+    timeout: 300s
+    type: Ready
 ---
 apiVersion: addons.cluster.x-k8s.io/v1beta1
 kind: ClusterResourceSet

--- a/templates/test/ci/cluster-template-prow-machine-pool-flex.yaml
+++ b/templates/test/ci/cluster-template-prow-machine-pool-flex.yaml
@@ -237,6 +237,9 @@ spec:
   clusterName: ${CLUSTER_NAME}
   replicas: ${WINDOWS_WORKER_MACHINE_COUNT:-0}
   template:
+    metadata:
+      labels:
+        windows-healthcheck: "true"
     spec:
       bootstrap:
         configRef:
@@ -309,6 +312,45 @@ spec:
     name: capi
     sshAuthorizedKeys:
     - ${AZURE_SSH_PUBLIC_KEY:=""}
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineHealthCheck
+metadata:
+  name: ${CLUSTER_NAME}-control-plane
+  namespace: default
+spec:
+  clusterName: ${CLUSTER_NAME}
+  maxUnhealthy: 100%
+  selector:
+    matchLabels:
+      cluster.x-k8s.io/control-plane: ""
+  unhealthyConditions:
+  - status: Unknown
+    timeout: 300s
+    type: Ready
+  - status: "False"
+    timeout: 300s
+    type: Ready
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineHealthCheck
+metadata:
+  name: ${CLUSTER_NAME}-mhc-windows
+  namespace: default
+spec:
+  clusterName: ${CLUSTER_NAME}
+  maxUnhealthy: 100%
+  nodeStartupTimeout: 10m
+  selector:
+    matchLabels:
+      windows-healthcheck: "true"
+  unhealthyConditions:
+  - status: "false"
+    timeout: 300s
+    type: Ready
+  - status: Unknown
+    timeout: 300s
+    type: Ready
 ---
 apiVersion: addons.cluster.x-k8s.io/v1beta1
 kind: ClusterResourceSet

--- a/templates/test/ci/cluster-template-prow-machine-pool.yaml
+++ b/templates/test/ci/cluster-template-prow-machine-pool.yaml
@@ -237,6 +237,9 @@ spec:
   clusterName: ${CLUSTER_NAME}
   replicas: ${WINDOWS_WORKER_MACHINE_COUNT:-0}
   template:
+    metadata:
+      labels:
+        windows-healthcheck: "true"
     spec:
       bootstrap:
         configRef:
@@ -303,6 +306,45 @@ spec:
     name: capi
     sshAuthorizedKeys:
     - ${AZURE_SSH_PUBLIC_KEY:=""}
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineHealthCheck
+metadata:
+  name: ${CLUSTER_NAME}-control-plane
+  namespace: default
+spec:
+  clusterName: ${CLUSTER_NAME}
+  maxUnhealthy: 100%
+  selector:
+    matchLabels:
+      cluster.x-k8s.io/control-plane: ""
+  unhealthyConditions:
+  - status: Unknown
+    timeout: 300s
+    type: Ready
+  - status: "False"
+    timeout: 300s
+    type: Ready
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineHealthCheck
+metadata:
+  name: ${CLUSTER_NAME}-mhc-windows
+  namespace: default
+spec:
+  clusterName: ${CLUSTER_NAME}
+  maxUnhealthy: 100%
+  nodeStartupTimeout: 10m
+  selector:
+    matchLabels:
+      windows-healthcheck: "true"
+  unhealthyConditions:
+  - status: "false"
+    timeout: 300s
+    type: Ready
+  - status: Unknown
+    timeout: 300s
+    type: Ready
 ---
 apiVersion: addons.cluster.x-k8s.io/v1beta1
 kind: ClusterResourceSet

--- a/templates/test/ci/cluster-template-prow.yaml
+++ b/templates/test/ci/cluster-template-prow.yaml
@@ -231,6 +231,9 @@ spec:
   replicas: ${WINDOWS_WORKER_MACHINE_COUNT:-0}
   selector: {}
   template:
+    metadata:
+      labels:
+        windows-healthcheck: "true"
     spec:
       bootstrap:
         configRef:
@@ -352,6 +355,25 @@ spec:
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineHealthCheck
 metadata:
+  name: ${CLUSTER_NAME}-control-plane
+  namespace: default
+spec:
+  clusterName: ${CLUSTER_NAME}
+  maxUnhealthy: 100%
+  selector:
+    matchLabels:
+      cluster.x-k8s.io/control-plane: ""
+  unhealthyConditions:
+  - status: Unknown
+    timeout: 300s
+    type: Ready
+  - status: "False"
+    timeout: 300s
+    type: Ready
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineHealthCheck
+metadata:
   name: ${CLUSTER_NAME}-mhc-0
   namespace: default
 spec:
@@ -364,6 +386,26 @@ spec:
   - status: "True"
     timeout: 30s
     type: E2ENodeUnhealthy
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineHealthCheck
+metadata:
+  name: ${CLUSTER_NAME}-mhc-windows
+  namespace: default
+spec:
+  clusterName: ${CLUSTER_NAME}
+  maxUnhealthy: 100%
+  nodeStartupTimeout: 10m
+  selector:
+    matchLabels:
+      windows-healthcheck: "true"
+  unhealthyConditions:
+  - status: "false"
+    timeout: 300s
+    type: Ready
+  - status: Unknown
+    timeout: 300s
+    type: Ready
 ---
 apiVersion: addons.cluster.x-k8s.io/v1beta1
 kind: ClusterResourceSet

--- a/templates/test/ci/patches/mhc-windows-md.yaml
+++ b/templates/test/ci/patches/mhc-windows-md.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineDeployment
+metadata:
+  name: ${CLUSTER_NAME}-md-win
+  namespace: default
+spec:
+  template:
+    metadata:
+      labels:
+        "windows-healthcheck": "true"

--- a/templates/test/ci/patches/mhc-windows-mp.yaml
+++ b/templates/test/ci/patches/mhc-windows-mp.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachinePool
+metadata:
+  name: ${CLUSTER_NAME}-mp-win
+  namespace: default
+spec:
+  template:
+    metadata:
+      labels:
+        "windows-healthcheck": "true"

--- a/templates/test/ci/prow-machine-pool/kustomization.yaml
+++ b/templates/test/ci/prow-machine-pool/kustomization.yaml
@@ -3,6 +3,8 @@ kind: Kustomization
 namespace: default
 resources:
 - ../../../flavors/machinepool-windows
+- ../prow/mhc-kubeadmcontrolplane.yaml
+- ../prow/mhc-windows.yaml
 - ../prow/cni-resource-set.yaml
 - ../../../addons/windows/csi-proxy/csi-proxy-resource-set.yaml
 - ../../../addons/windows/containerd-logging/containerd-logger-resource-set.yaml
@@ -35,6 +37,7 @@ patches:
 - path: ../patches/windows-containerd-labels.yaml
 - path: ../patches/cluster-label-calico.yaml
 - path: ../patches/cluster-label-cloud-provider-azure.yaml
+- path: ../patches/mhc-windows-mp.yaml
 
 sortOptions:
   order: fifo

--- a/templates/test/ci/prow/kustomization.yaml
+++ b/templates/test/ci/prow/kustomization.yaml
@@ -5,7 +5,9 @@ resources:
 - ../../../flavors/base
 - ../../../flavors/default/machine-deployment.yaml
 - ../../../flavors/windows/machine-deployment-windows.yaml
+- mhc-kubeadmcontrolplane.yaml
 - mhc.yaml
+- mhc-windows.yaml
 - cni-resource-set.yaml
 - ../../../azure-cluster-identity
 - ../../../addons/windows/csi-proxy/csi-proxy-resource-set.yaml
@@ -38,6 +40,7 @@ patches:
     version: v1beta1
 - path: ../patches/tags.yaml
 - path: ../patches/mhc.yaml
+- path: ../patches/mhc-windows-md.yaml
 - path: ../patches/controller-manager.yaml
 - path: ../patches/windows-machine-deployment-replicas.yaml
 - path: ../../../azure-cluster-identity/azurecluster-identity-ref.yaml

--- a/templates/test/ci/prow/mhc-kubeadmcontrolplane.yaml
+++ b/templates/test/ci/prow/mhc-kubeadmcontrolplane.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineHealthCheck
+metadata:
+  name: "${CLUSTER_NAME}-control-plane"
+spec:
+  clusterName: "${CLUSTER_NAME}"
+  maxUnhealthy: 100%
+  selector:
+    matchLabels:
+      cluster.x-k8s.io/control-plane: ""
+  unhealthyConditions:
+    - type: Ready
+      status: Unknown
+      timeout: 300s
+    - type: Ready
+      status: "False"
+      timeout: 300s

--- a/templates/test/dev/cluster-template-custom-builds-dra.yaml
+++ b/templates/test/dev/cluster-template-custom-builds-dra.yaml
@@ -434,6 +434,9 @@ spec:
   clusterName: ${CLUSTER_NAME}
   replicas: ${WINDOWS_WORKER_MACHINE_COUNT:-0}
   template:
+    metadata:
+      labels:
+        windows-healthcheck: "true"
     spec:
       bootstrap:
         configRef:
@@ -570,6 +573,45 @@ spec:
     name: capi
     sshAuthorizedKeys:
     - ${AZURE_SSH_PUBLIC_KEY:=""}
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineHealthCheck
+metadata:
+  name: ${CLUSTER_NAME}-control-plane
+  namespace: default
+spec:
+  clusterName: ${CLUSTER_NAME}
+  maxUnhealthy: 100%
+  selector:
+    matchLabels:
+      cluster.x-k8s.io/control-plane: ""
+  unhealthyConditions:
+  - status: Unknown
+    timeout: 300s
+    type: Ready
+  - status: "False"
+    timeout: 300s
+    type: Ready
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineHealthCheck
+metadata:
+  name: ${CLUSTER_NAME}-mhc-windows
+  namespace: default
+spec:
+  clusterName: ${CLUSTER_NAME}
+  maxUnhealthy: 100%
+  nodeStartupTimeout: 10m
+  selector:
+    matchLabels:
+      windows-healthcheck: "true"
+  unhealthyConditions:
+  - status: "false"
+    timeout: 300s
+    type: Ready
+  - status: Unknown
+    timeout: 300s
+    type: Ready
 ---
 apiVersion: addons.cluster.x-k8s.io/v1beta1
 kind: ClusterResourceSet

--- a/templates/test/dev/cluster-template-custom-builds-load-dra.yaml
+++ b/templates/test/dev/cluster-template-custom-builds-load-dra.yaml
@@ -421,6 +421,9 @@ spec:
   replicas: ${WINDOWS_WORKER_MACHINE_COUNT:-0}
   selector: {}
   template:
+    metadata:
+      labels:
+        windows-healthcheck: "true"
     spec:
       bootstrap:
         configRef:
@@ -628,6 +631,25 @@ spec:
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineHealthCheck
 metadata:
+  name: ${CLUSTER_NAME}-control-plane
+  namespace: default
+spec:
+  clusterName: ${CLUSTER_NAME}
+  maxUnhealthy: 100%
+  selector:
+    matchLabels:
+      cluster.x-k8s.io/control-plane: ""
+  unhealthyConditions:
+  - status: Unknown
+    timeout: 300s
+    type: Ready
+  - status: "False"
+    timeout: 300s
+    type: Ready
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineHealthCheck
+metadata:
   name: ${CLUSTER_NAME}-mhc-0
   namespace: default
 spec:
@@ -640,6 +662,26 @@ spec:
   - status: "True"
     timeout: 30s
     type: E2ENodeUnhealthy
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineHealthCheck
+metadata:
+  name: ${CLUSTER_NAME}-mhc-windows
+  namespace: default
+spec:
+  clusterName: ${CLUSTER_NAME}
+  maxUnhealthy: 100%
+  nodeStartupTimeout: 10m
+  selector:
+    matchLabels:
+      windows-healthcheck: "true"
+  unhealthyConditions:
+  - status: "false"
+    timeout: 300s
+    type: Ready
+  - status: Unknown
+    timeout: 300s
+    type: Ready
 ---
 apiVersion: addons.cluster.x-k8s.io/v1beta1
 kind: ClusterResourceSet

--- a/templates/test/dev/cluster-template-custom-builds-load.yaml
+++ b/templates/test/dev/cluster-template-custom-builds-load.yaml
@@ -395,6 +395,9 @@ spec:
   replicas: ${WINDOWS_WORKER_MACHINE_COUNT:-0}
   selector: {}
   template:
+    metadata:
+      labels:
+        windows-healthcheck: "true"
     spec:
       bootstrap:
         configRef:
@@ -592,6 +595,25 @@ spec:
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineHealthCheck
 metadata:
+  name: ${CLUSTER_NAME}-control-plane
+  namespace: default
+spec:
+  clusterName: ${CLUSTER_NAME}
+  maxUnhealthy: 100%
+  selector:
+    matchLabels:
+      cluster.x-k8s.io/control-plane: ""
+  unhealthyConditions:
+  - status: Unknown
+    timeout: 300s
+    type: Ready
+  - status: "False"
+    timeout: 300s
+    type: Ready
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineHealthCheck
+metadata:
   name: ${CLUSTER_NAME}-mhc-0
   namespace: default
 spec:
@@ -604,6 +626,26 @@ spec:
   - status: "True"
     timeout: 30s
     type: E2ENodeUnhealthy
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineHealthCheck
+metadata:
+  name: ${CLUSTER_NAME}-mhc-windows
+  namespace: default
+spec:
+  clusterName: ${CLUSTER_NAME}
+  maxUnhealthy: 100%
+  nodeStartupTimeout: 10m
+  selector:
+    matchLabels:
+      windows-healthcheck: "true"
+  unhealthyConditions:
+  - status: "false"
+    timeout: 300s
+    type: Ready
+  - status: Unknown
+    timeout: 300s
+    type: Ready
 ---
 apiVersion: addons.cluster.x-k8s.io/v1beta1
 kind: ClusterResourceSet

--- a/templates/test/dev/cluster-template-custom-builds-machine-pool.yaml
+++ b/templates/test/dev/cluster-template-custom-builds-machine-pool.yaml
@@ -405,6 +405,9 @@ spec:
   clusterName: ${CLUSTER_NAME}
   replicas: ${WINDOWS_WORKER_MACHINE_COUNT:-0}
   template:
+    metadata:
+      labels:
+        windows-healthcheck: "true"
     spec:
       bootstrap:
         configRef:
@@ -530,6 +533,45 @@ spec:
     name: capi
     sshAuthorizedKeys:
     - ${AZURE_SSH_PUBLIC_KEY:=""}
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineHealthCheck
+metadata:
+  name: ${CLUSTER_NAME}-control-plane
+  namespace: default
+spec:
+  clusterName: ${CLUSTER_NAME}
+  maxUnhealthy: 100%
+  selector:
+    matchLabels:
+      cluster.x-k8s.io/control-plane: ""
+  unhealthyConditions:
+  - status: Unknown
+    timeout: 300s
+    type: Ready
+  - status: "False"
+    timeout: 300s
+    type: Ready
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineHealthCheck
+metadata:
+  name: ${CLUSTER_NAME}-mhc-windows
+  namespace: default
+spec:
+  clusterName: ${CLUSTER_NAME}
+  maxUnhealthy: 100%
+  nodeStartupTimeout: 10m
+  selector:
+    matchLabels:
+      windows-healthcheck: "true"
+  unhealthyConditions:
+  - status: "false"
+    timeout: 300s
+    type: Ready
+  - status: Unknown
+    timeout: 300s
+    type: Ready
 ---
 apiVersion: addons.cluster.x-k8s.io/v1beta1
 kind: ClusterResourceSet

--- a/templates/test/dev/cluster-template-custom-builds.yaml
+++ b/templates/test/dev/cluster-template-custom-builds.yaml
@@ -389,6 +389,9 @@ spec:
   replicas: ${WINDOWS_WORKER_MACHINE_COUNT:-0}
   selector: {}
   template:
+    metadata:
+      labels:
+        windows-healthcheck: "true"
     spec:
       bootstrap:
         configRef:
@@ -586,6 +589,25 @@ spec:
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineHealthCheck
 metadata:
+  name: ${CLUSTER_NAME}-control-plane
+  namespace: default
+spec:
+  clusterName: ${CLUSTER_NAME}
+  maxUnhealthy: 100%
+  selector:
+    matchLabels:
+      cluster.x-k8s.io/control-plane: ""
+  unhealthyConditions:
+  - status: Unknown
+    timeout: 300s
+    type: Ready
+  - status: "False"
+    timeout: 300s
+    type: Ready
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineHealthCheck
+metadata:
   name: ${CLUSTER_NAME}-mhc-0
   namespace: default
 spec:
@@ -598,6 +620,26 @@ spec:
   - status: "True"
     timeout: 30s
     type: E2ENodeUnhealthy
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineHealthCheck
+metadata:
+  name: ${CLUSTER_NAME}-mhc-windows
+  namespace: default
+spec:
+  clusterName: ${CLUSTER_NAME}
+  maxUnhealthy: 100%
+  nodeStartupTimeout: 10m
+  selector:
+    matchLabels:
+      windows-healthcheck: "true"
+  unhealthyConditions:
+  - status: "false"
+    timeout: 300s
+    type: Ready
+  - status: Unknown
+    timeout: 300s
+    type: Ready
 ---
 apiVersion: addons.cluster.x-k8s.io/v1beta1
 kind: ClusterResourceSet

--- a/test/e2e/data/infrastructure-azure/v1.18.5/cluster-template-prow-machine-and-machine-pool.yaml
+++ b/test/e2e/data/infrastructure-azure/v1.18.5/cluster-template-prow-machine-and-machine-pool.yaml
@@ -281,6 +281,9 @@ spec:
   replicas: ${WINDOWS_WORKER_MACHINE_COUNT:-0}
   selector: {}
   template:
+    metadata:
+      labels:
+        windows-healthcheck: "true"
     spec:
       bootstrap:
         configRef:
@@ -402,6 +405,25 @@ spec:
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineHealthCheck
 metadata:
+  name: ${CLUSTER_NAME}-control-plane
+  namespace: default
+spec:
+  clusterName: ${CLUSTER_NAME}
+  maxUnhealthy: 100%
+  selector:
+    matchLabels:
+      cluster.x-k8s.io/control-plane: ""
+  unhealthyConditions:
+  - status: Unknown
+    timeout: 300s
+    type: Ready
+  - status: "False"
+    timeout: 300s
+    type: Ready
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineHealthCheck
+metadata:
   name: ${CLUSTER_NAME}-mhc-0
   namespace: default
 spec:
@@ -414,6 +436,26 @@ spec:
   - status: "True"
     timeout: 30s
     type: E2ENodeUnhealthy
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineHealthCheck
+metadata:
+  name: ${CLUSTER_NAME}-mhc-windows
+  namespace: default
+spec:
+  clusterName: ${CLUSTER_NAME}
+  maxUnhealthy: 100%
+  nodeStartupTimeout: 10m
+  selector:
+    matchLabels:
+      windows-healthcheck: "true"
+  unhealthyConditions:
+  - status: "false"
+    timeout: 300s
+    type: Ready
+  - status: Unknown
+    timeout: 300s
+    type: Ready
 ---
 apiVersion: addons.cluster.x-k8s.io/v1beta1
 kind: ClusterResourceSet

--- a/test/e2e/data/infrastructure-azure/v1.18.5/cluster-template-prow.yaml
+++ b/test/e2e/data/infrastructure-azure/v1.18.5/cluster-template-prow.yaml
@@ -223,6 +223,9 @@ spec:
   replicas: ${WINDOWS_WORKER_MACHINE_COUNT:-0}
   selector: {}
   template:
+    metadata:
+      labels:
+        windows-healthcheck: "true"
     spec:
       bootstrap:
         configRef:
@@ -344,6 +347,25 @@ spec:
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineHealthCheck
 metadata:
+  name: ${CLUSTER_NAME}-control-plane
+  namespace: default
+spec:
+  clusterName: ${CLUSTER_NAME}
+  maxUnhealthy: 100%
+  selector:
+    matchLabels:
+      cluster.x-k8s.io/control-plane: ""
+  unhealthyConditions:
+  - status: Unknown
+    timeout: 300s
+    type: Ready
+  - status: "False"
+    timeout: 300s
+    type: Ready
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineHealthCheck
+metadata:
   name: ${CLUSTER_NAME}-mhc-0
   namespace: default
 spec:
@@ -356,6 +378,26 @@ spec:
   - status: "True"
     timeout: 30s
     type: E2ENodeUnhealthy
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineHealthCheck
+metadata:
+  name: ${CLUSTER_NAME}-mhc-windows
+  namespace: default
+spec:
+  clusterName: ${CLUSTER_NAME}
+  maxUnhealthy: 100%
+  nodeStartupTimeout: 10m
+  selector:
+    matchLabels:
+      windows-healthcheck: "true"
+  unhealthyConditions:
+  - status: "false"
+    timeout: 300s
+    type: Ready
+  - status: Unknown
+    timeout: 300s
+    type: Ready
 ---
 apiVersion: addons.cluster.x-k8s.io/v1beta1
 kind: ClusterResourceSet

--- a/test/e2e/data/infrastructure-azure/v1.19.4/cluster-template-prow-machine-and-machine-pool.yaml
+++ b/test/e2e/data/infrastructure-azure/v1.19.4/cluster-template-prow-machine-and-machine-pool.yaml
@@ -281,6 +281,9 @@ spec:
   replicas: ${WINDOWS_WORKER_MACHINE_COUNT:-0}
   selector: {}
   template:
+    metadata:
+      labels:
+        windows-healthcheck: "true"
     spec:
       bootstrap:
         configRef:
@@ -402,6 +405,25 @@ spec:
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineHealthCheck
 metadata:
+  name: ${CLUSTER_NAME}-control-plane
+  namespace: default
+spec:
+  clusterName: ${CLUSTER_NAME}
+  maxUnhealthy: 100%
+  selector:
+    matchLabels:
+      cluster.x-k8s.io/control-plane: ""
+  unhealthyConditions:
+  - status: Unknown
+    timeout: 300s
+    type: Ready
+  - status: "False"
+    timeout: 300s
+    type: Ready
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineHealthCheck
+metadata:
   name: ${CLUSTER_NAME}-mhc-0
   namespace: default
 spec:
@@ -414,6 +436,26 @@ spec:
   - status: "True"
     timeout: 30s
     type: E2ENodeUnhealthy
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineHealthCheck
+metadata:
+  name: ${CLUSTER_NAME}-mhc-windows
+  namespace: default
+spec:
+  clusterName: ${CLUSTER_NAME}
+  maxUnhealthy: 100%
+  nodeStartupTimeout: 10m
+  selector:
+    matchLabels:
+      windows-healthcheck: "true"
+  unhealthyConditions:
+  - status: "false"
+    timeout: 300s
+    type: Ready
+  - status: Unknown
+    timeout: 300s
+    type: Ready
 ---
 apiVersion: addons.cluster.x-k8s.io/v1beta1
 kind: ClusterResourceSet

--- a/test/e2e/data/infrastructure-azure/v1.19.4/cluster-template-prow.yaml
+++ b/test/e2e/data/infrastructure-azure/v1.19.4/cluster-template-prow.yaml
@@ -223,6 +223,9 @@ spec:
   replicas: ${WINDOWS_WORKER_MACHINE_COUNT:-0}
   selector: {}
   template:
+    metadata:
+      labels:
+        windows-healthcheck: "true"
     spec:
       bootstrap:
         configRef:
@@ -344,6 +347,25 @@ spec:
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineHealthCheck
 metadata:
+  name: ${CLUSTER_NAME}-control-plane
+  namespace: default
+spec:
+  clusterName: ${CLUSTER_NAME}
+  maxUnhealthy: 100%
+  selector:
+    matchLabels:
+      cluster.x-k8s.io/control-plane: ""
+  unhealthyConditions:
+  - status: Unknown
+    timeout: 300s
+    type: Ready
+  - status: "False"
+    timeout: 300s
+    type: Ready
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineHealthCheck
+metadata:
   name: ${CLUSTER_NAME}-mhc-0
   namespace: default
 spec:
@@ -356,6 +378,26 @@ spec:
   - status: "True"
     timeout: 30s
     type: E2ENodeUnhealthy
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineHealthCheck
+metadata:
+  name: ${CLUSTER_NAME}-mhc-windows
+  namespace: default
+spec:
+  clusterName: ${CLUSTER_NAME}
+  maxUnhealthy: 100%
+  nodeStartupTimeout: 10m
+  selector:
+    matchLabels:
+      windows-healthcheck: "true"
+  unhealthyConditions:
+  - status: "false"
+    timeout: 300s
+    type: Ready
+  - status: Unknown
+    timeout: 300s
+    type: Ready
 ---
 apiVersion: addons.cluster.x-k8s.io/v1beta1
 kind: ClusterResourceSet


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind flake

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

This PR adds MachineHealthChecks which will remediate nodes that fail to bootstrap in e2e tests, which we've seen recently for KubeadmControlPlane Machines in HA clusters (#5687) and Windows Machines (#5686).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #5687
Fixes #5686

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->


**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] cherry-pick candidate

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
