### PR TITLE
Use more entropy for random WI storage account names

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -200,7 +200,7 @@ LDFLAGS := $(shell hack/version.sh)
 CLUSTER_TEMPLATE ?= cluster-template.yaml
 
 export KIND_CLUSTER_NAME ?= capz
-export RANDOM_SUFFIX := $(shell /bin/bash -c "echo $$RANDOM")
+export RANDOM_SUFFIX := $(shell od -An -N8 -tx8 /dev/urandom | tr -d ' ' | head -c 16)
 export AZWI_RESOURCE_GROUP ?= capz-wi-$(RANDOM_SUFFIX)
 export CI_RG ?= $(AZWI_RESOURCE_GROUP)
 export USER_IDENTITY ?= $(addsuffix $(RANDOM_SUFFIX),$(CI_RG))

--- a/scripts/kind-with-registry.sh
+++ b/scripts/kind-with-registry.sh
@@ -45,8 +45,8 @@ if [ -f "$TILT_SETTINGS_FILE" ]; then
 fi
 
 AZWI_ENABLED="${AZWI_ENABLED:-true}"
-RANDOM_SUFFIX="${RANDOM_SUFFIX:-$(od -An -N4 -tu4 /dev/urandom | tr -d ' ' | head -c 8)}"
-export AZWI_STORAGE_ACCOUNT="capzcioidcissuer${RANDOM_SUFFIX}"
+RANDOM_SUFFIX="${RANDOM_SUFFIX:-$(od -An -N8 -tx8 /dev/urandom | tr -d ' ' | head -c 16)}"
+export AZWI_STORAGE_ACCOUNT="capzoidc${RANDOM_SUFFIX}"
 export AZWI_STORAGE_CONTAINER="\$web"
 export AZWI_LOCATION="${AZURE_LOCATION:-southcentralus}"
 export SERVICE_ACCOUNT_ISSUER="${SERVICE_ACCOUNT_ISSUER:-}"


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind flake

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

The `$RANDOM` portion of the storage account name used for workload identity is not random enough to avoid name collisions reliably. This increases the randomness from 15 bits of entropy to 64 bits.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->


**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] cherry-pick candidate

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
