### PR TITLE
Bump Go toolchain to v1.23.10

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module sigs.k8s.io/cluster-api-provider-azure
 
 go 1.23.2
 
-toolchain go1.23.8
+toolchain go1.23.10
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.18.0

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -2,7 +2,7 @@ module sigs.k8s.io/cluster-api-provider-azure/hack/tools
 
 go 1.23.0
 
-toolchain go1.23.8
+toolchain go1.23.10
 
 require sigs.k8s.io/cluster-api/hack/tools v0.0.0-20250520093716-525566440a77
 


### PR DESCRIPTION
/kind cleanup

**What this PR does / why we need it**:

Updates the Go toolchain to [v1.23.10](https://go.dev/doc/devel/release#go1.23.minor). List of changes is here: https://github.com/golang/go/issues?q=milestone%3AGo1.23.10+label%3ACherryPickApproved

**Which issue(s) this PR fixes**:

Refs #5620

**Special notes for your reviewer**:

This issue that prevented us from upgrading to v1.23.9 was fixed and backported in this release:
- https://github.com/golang/go/issues/73617

**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] cherry-pick candidate

**Release note**:

```release-note
NONE
```
