### PR TITLE
[release-1.19] Bump CAPI to v1.9.9

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -328,7 +328,7 @@ create-management-cluster: $(KUSTOMIZE) $(ENVSUBST) $(KUBECTL) $(KIND) ## Create
 	./hack/create-custom-cloud-provider-config.sh
 
 	# Deploy CAPI
-	timeout --foreground 300 bash -c "until curl --retry $(CURL_RETRIES) -sSL https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.9.8/cluster-api-components.yaml | $(ENVSUBST) | $(KUBECTL) apply -f -; do sleep 5; done"
+	timeout --foreground 300 bash -c "until curl --retry $(CURL_RETRIES) -sSL https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.9.9/cluster-api-components.yaml | $(ENVSUBST) | $(KUBECTL) apply -f -; do sleep 5; done"
 
 	# Deploy CAAPH
 	timeout --foreground 300 bash -c "until curl --retry $(CURL_RETRIES) -sSL https://github.com/kubernetes-sigs/cluster-api-addon-provider-helm/releases/download/v0.2.5/addon-components.yaml | $(ENVSUBST) | $(KUBECTL) apply -f -; do sleep 5; done"

--- a/Tiltfile
+++ b/Tiltfile
@@ -22,7 +22,7 @@ settings = {
     "deploy_cert_manager": True,
     "preload_images_for_kind": True,
     "kind_cluster_name": "capz",
-    "capi_version": "v1.9.8",
+    "capi_version": "v1.9.9",
     "caaph_version": "v0.2.5",
     "cert_manager_version": "v1.17.2",
     "kubernetes_version": "v1.30.2",

--- a/docs/book/src/getting-started.md
+++ b/docs/book/src/getting-started.md
@@ -120,7 +120,7 @@ helm install cert-manager jetstack/cert-manager --namespace cert-manager --creat
 Create a `values.yaml` file for the CAPI Operator Helm chart like so:
 
 ```yaml
-core: "cluster-api:v1.9.8"
+core: "cluster-api:v1.9.9"
 infrastructure: "azure:v1.17.2"
 addon: "helm:v0.2.5"
 manager:

--- a/go.mod
+++ b/go.mod
@@ -56,8 +56,8 @@ require (
 	k8s.io/kubectl v0.30.3
 	k8s.io/utils v0.0.0-20240821151609-f90d01438635
 	sigs.k8s.io/cloud-provider-azure v1.30.4
-	sigs.k8s.io/cluster-api v1.9.8
-	sigs.k8s.io/cluster-api/test v1.9.8
+	sigs.k8s.io/cluster-api v1.9.9
+	sigs.k8s.io/cluster-api/test v1.9.9
 	sigs.k8s.io/controller-runtime v0.19.6
 	sigs.k8s.io/kind v0.27.0
 )
@@ -119,7 +119,7 @@ require (
 	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
-	github.com/cloudflare/circl v1.3.7 // indirect
+	github.com/cloudflare/circl v1.6.1 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/dimchansky/utfbom v1.1.1 // indirect
 	github.com/distribution/reference v0.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -169,8 +169,8 @@ github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5P
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudflare/circl v1.1.0/go.mod h1:prBCrKB9DV4poKZY1l9zBXg2QJY7mvgRvtMxxK7fi4I=
-github.com/cloudflare/circl v1.3.7 h1:qlCDlTPz2n9fu58M0Nh1J/JzcFpfgkFHHX3O35r5vcU=
-github.com/cloudflare/circl v1.3.7/go.mod h1:sRTcRWXGLrKw6yIGJ+l7amYJFfAXbZG0kBSc8r4zxgA=
+github.com/cloudflare/circl v1.6.1 h1:zqIqSPIndyBh1bjLVVDHMPpVKqp8Su/V+6MeDzzQBQ0=
+github.com/cloudflare/circl v1.6.1/go.mod h1:uddAzsPgqdMAYatqJ0lsjX1oECcQLIlRpzZh3pJrofs=
 github.com/containerd/log v0.1.0 h1:TCJt7ioM2cr/tfR8GPbGf9/VRAX8D2B4PjzCpfX540I=
 github.com/containerd/log v0.1.0/go.mod h1:VRRf09a7mHDIRezVKTRCrOq78v577GXq3bSa3EhrzVo=
 github.com/coredns/caddy v1.1.1 h1:2eYKZT7i6yxIfGP3qLJoJ7HAsDJqYB+X68g4NYjSrE0=
@@ -743,10 +743,10 @@ sigs.k8s.io/cloud-provider-azure/pkg/azclient v0.0.29 h1:qiifAaaBqV3d/EcN9dKJaJI
 sigs.k8s.io/cloud-provider-azure/pkg/azclient v0.0.29/go.mod h1:ZFAt0qF1kR+w8nBVJK56s6CFvLrlosN1i2c+Sxb7LBk=
 sigs.k8s.io/cloud-provider-azure/pkg/azclient/configloader v0.0.16 h1:Fm/Yjv4nXjUtJ90uXKSKwPwaTWYuDFMhDNNOd77PlOg=
 sigs.k8s.io/cloud-provider-azure/pkg/azclient/configloader v0.0.16/go.mod h1:+kl90flu4+WCP6HBGVYbKVQR+5ztDzUNrWJz8rsnvRU=
-sigs.k8s.io/cluster-api v1.9.8 h1:VtgUzUgiE16d3P/XP7tIwPgkRXkdLvVj055o7wIQpaI=
-sigs.k8s.io/cluster-api v1.9.8/go.mod h1:6N73nqXbB1qTD3Z7zJc5WsRBen35JOflBdP73f23M2g=
-sigs.k8s.io/cluster-api/test v1.9.8 h1:WERh3yx0aHQRGoQdWZB7WvHY+xgOhWFxFzw6u9TGKXA=
-sigs.k8s.io/cluster-api/test v1.9.8/go.mod h1:YL2wANe8TFWFBka9CDkxjPj7KALqUtK+PtKa4ChNIok=
+sigs.k8s.io/cluster-api v1.9.9 h1:ZwrhTmIetan8Axceh+cuDbATrprntN6QmKRSQx7D5VU=
+sigs.k8s.io/cluster-api v1.9.9/go.mod h1:wii7FBtUW8x6nemHTpXlbmN73nN7M9k4weGcr/X0QBI=
+sigs.k8s.io/cluster-api/test v1.9.9 h1:oycgwiOC0SJesyqnN1or7Hr6v3w8H34gEwvR58YWjRY=
+sigs.k8s.io/cluster-api/test v1.9.9/go.mod h1:TqB13BF6sHHIMN9Dss5o9Stxcqwn3gQiBTYKq7zYQ+Q=
 sigs.k8s.io/controller-runtime v0.19.6 h1:fuq53qTLQ7aJTA7aNsklNnu7eQtSFqJUomOyM+phPLk=
 sigs.k8s.io/controller-runtime v0.19.6/go.mod h1:iRmWllt8IlaLjvTTDLhRBXIEtkCK6hwVBJJsYS9Ajf4=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd h1:EDPBXCAspyGV4jQlpZSudPeMmr1bNJefnuqLsRAsHZo=

--- a/test/e2e/config/azure-dev.yaml
+++ b/test/e2e/config/azure-dev.yaml
@@ -3,11 +3,11 @@ managementClusterName: capz-e2e
 images:
   - name: ${MANAGER_IMAGE}
     loadBehavior: mustLoad
-  - name: registry.k8s.io/cluster-api/cluster-api-controller:v1.9.8
+  - name: registry.k8s.io/cluster-api/cluster-api-controller:v1.9.9
     loadBehavior: tryLoad
-  - name: registry.k8s.io/cluster-api/kubeadm-bootstrap-controller:v1.9.8
+  - name: registry.k8s.io/cluster-api/kubeadm-bootstrap-controller:v1.9.9
     loadBehavior: tryLoad
-  - name: registry.k8s.io/cluster-api/kubeadm-control-plane-controller:v1.9.8
+  - name: registry.k8s.io/cluster-api/kubeadm-control-plane-controller:v1.9.9
     loadBehavior: tryLoad
   - name: registry.k8s.io/cluster-api-helm/cluster-api-helm-controller:v0.2.5
     loadBehavior: tryLoad
@@ -25,8 +25,8 @@ providers:
           new: --metrics-addr=:8080
       files:
         - sourcePath: "../data/shared/v1beta1/metadata.yaml"
-    - name: v1.9.8
-      value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.9.8/core-components.yaml
+    - name: v1.9.9
+      value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.9.9/core-components.yaml
       type: url
       contract: v1beta1
       files:
@@ -48,8 +48,8 @@ providers:
           new: --metrics-addr=:8080
       files:
         - sourcePath: "../data/shared/v1beta1/metadata.yaml"
-    - name: v1.9.8
-      value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.9.8/bootstrap-components.yaml
+    - name: v1.9.9
+      value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.9.9/bootstrap-components.yaml
       type: url
       contract: v1beta1
       files:
@@ -70,8 +70,8 @@ providers:
           new: --metrics-addr=:8080
       files:
         - sourcePath: "../data/shared/v1beta1/metadata.yaml"
-    - name: v1.9.8
-      value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.9.8/control-plane-components.yaml
+    - name: v1.9.9
+      value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.9.9/control-plane-components.yaml
       type: url
       contract: v1beta1
       files:
@@ -235,7 +235,7 @@ variables:
   WINDOWS_CONTAINERD_URL: "${WINDOWS_CONTAINERD_URL:-}"
   AZURE_CNI_V1_MANIFEST_PATH: "${PWD}/templates/addons/azure-cni-v1.yaml"
   OLD_CAPI_UPGRADE_VERSION: "v1.8.11"
-  LATEST_CAPI_UPGRADE_VERSION: "v1.9.8"
+  LATEST_CAPI_UPGRADE_VERSION: "v1.9.9"
   OLD_PROVIDER_UPGRADE_VERSION: "v1.17.3"
   LATEST_PROVIDER_UPGRADE_VERSION: "v1.18.0"
   OLD_CAAPH_UPGRADE_VERSION: "v0.1.0-alpha.10"


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Updates the Cluster API dependency to [v1.9.9](https://github.com/kubernetes-sigs/cluster-api/releases/tag/v1.9.9).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:


**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] cherry-pick candidate

**Release note**:

```release-note
Bump CAPI to v1.9.9
```
