### PR TITLE
Enable resource.k8s.io/v1beta2 for DRA templates

### DIFF
--- a/templates/test/ci/cluster-template-prow-ci-version-dra.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version-dra.yaml
@@ -61,7 +61,7 @@ spec:
       apiServer:
         extraArgs:
           feature-gates: ${K8S_FEATURE_GATES:-"DynamicResourceAllocation=true"}
-          runtime-config: resource.k8s.io/v1beta1=true
+          runtime-config: resource.k8s.io/v1beta1=true,resource.k8s.io/v1beta2=true
         timeoutForControlPlane: 20m
       controllerManager:
         extraArgs:

--- a/templates/test/ci/patches/dra-kubeadmcontrolplane.yaml
+++ b/templates/test/ci/patches/dra-kubeadmcontrolplane.yaml
@@ -21,7 +21,7 @@
   value: DynamicResourceAllocation=true
 - op: add
   path: /spec/kubeadmConfigSpec/clusterConfiguration/apiServer/extraArgs/runtime-config
-  value: resource.k8s.io/v1beta1=true
+  value: resource.k8s.io/v1beta1=true,resource.k8s.io/v1beta2=true
 - op: add
   path: /spec/kubeadmConfigSpec/clusterConfiguration/scheduler/extraArgs/feature-gates
   value: DynamicResourceAllocation=true

--- a/templates/test/dev/cluster-template-custom-builds-dra.yaml
+++ b/templates/test/dev/cluster-template-custom-builds-dra.yaml
@@ -63,7 +63,7 @@ spec:
       apiServer:
         extraArgs:
           feature-gates: ${K8S_FEATURE_GATES:-"DynamicResourceAllocation=true"}
-          runtime-config: resource.k8s.io/v1beta1=true
+          runtime-config: resource.k8s.io/v1beta1=true,resource.k8s.io/v1beta2=true
         timeoutForControlPlane: 20m
       controllerManager:
         extraArgs:

--- a/templates/test/dev/cluster-template-custom-builds-load-dra.yaml
+++ b/templates/test/dev/cluster-template-custom-builds-load-dra.yaml
@@ -65,7 +65,7 @@ spec:
       apiServer:
         extraArgs:
           feature-gates: ${K8S_FEATURE_GATES:-"DynamicResourceAllocation=true"}
-          runtime-config: resource.k8s.io/v1beta1=true
+          runtime-config: resource.k8s.io/v1beta1=true,resource.k8s.io/v1beta2=true
         timeoutForControlPlane: 20m
       controllerManager:
         extraArgs:


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind cleanup


<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

This PR enables the v1beta2 API for the DRA-enabled templates in addition to v1beta1, which is still required. This means the implicit minimum Kubernetes version for these templates is 1.33. That shouldn't be an issue since we only test k/k at `master` with these templates IIRC.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->


**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [X] cherry-pick candidate

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
