### PR TITLE
Allow users to set the zone for NAT gateway

### DIFF
--- a/azure/services/natgateways/spec.go
+++ b/azure/services/natgateways/spec.go
@@ -36,6 +36,7 @@ type NatGatewaySpec struct {
 	Location       string
 	NatGatewayIP   infrav1.PublicIPSpec
 	ClusterName    string
+	Zone           string
 	AdditionalTags infrav1.Tags
 	IsVnetManaged  bool
 }
@@ -79,6 +80,7 @@ func (s *NatGatewaySpec) Parameters(_ context.Context, existingNatGateway *asone
 		Name:        ptr.To(s.Name),
 		Additional:  s.AdditionalTags,
 	})
+	natGateway.Spec.Zones = []string{s.Zone}
 
 	return natGateway, nil
 }

--- a/azure/services/natgateways/spec_test.go
+++ b/azure/services/natgateways/spec_test.go
@@ -36,6 +36,7 @@ var (
 		ResourceGroup:  "my-rg",
 		SubscriptionID: "123",
 		Location:       "eastus",
+		Zone:           "eastus-1",
 		NatGatewayIP: infrav1.PublicIPSpec{
 			Name:    "my-natgateway-ip",
 			DNSName: "Standard",
@@ -59,6 +60,7 @@ var (
 			AzureName:            "my-natgateway",
 			IdleTimeoutInMinutes: ptr.To(6),
 			Location:             locationPtr,
+			Zones:                []string{"eastus-1"},
 			Owner: &genruntime.KnownResourceReference{
 				Name: "my-rg",
 			},
@@ -114,6 +116,8 @@ func TestParameters(t *testing.T) {
 				g.Expect(parameters.Spec.Owner.Name).To(Equal("my-rg"))
 				g.Expect(parameters.Spec.Location).NotTo(BeNil())
 				g.Expect(parameters.Spec.Location).To(Equal(locationPtr))
+				g.Expect(parameters.Spec.Zones).To(HaveLen(1))
+				g.Expect(parameters.Spec.Zones[0]).To(Equal("eastus-1"))
 				g.Expect(parameters.Spec.Sku.Name).NotTo(BeNil())
 				g.Expect(parameters.Spec.Sku.Name).To(Equal(standardSKUPtr))
 				g.Expect(parameters.Spec.PublicIpAddresses).To(HaveLen(1))


### PR DESCRIPTION
Allow users to set the zone they need the created
NAT gateway to use. ASO allows the NAT gateway to
be set to a zone so enabling that here.

 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->


**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests
- [ ] cherry-pick candidate

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Adding a zone field to the NAT Gateway spec to allow users to specify the zone in which the created NAT Gateway needs to reside in.
```
