### PR TITLE
Bump QPS and burst for kube-controller-manager in DRA load test

### DIFF
--- a/templates/test/ci/patches/dra-kubeadmcontrolplane-load.yaml
+++ b/templates/test/ci/patches/dra-kubeadmcontrolplane-load.yaml
@@ -1,0 +1,12 @@
+apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+kind: KubeadmControlPlane
+metadata:
+  name: ${CLUSTER_NAME}-control-plane
+  namespace: default
+spec:
+  kubeadmConfigSpec:
+    clusterConfiguration:
+      controllerManager:
+        extraArgs:
+          kube-api-qps: "200"
+          kube-api-burst: "400"

--- a/templates/test/dev/cluster-template-custom-builds-load-dra.yaml
+++ b/templates/test/dev/cluster-template-custom-builds-load-dra.yaml
@@ -73,6 +73,8 @@ spec:
           cloud-provider: external
           cluster-name: ${CLUSTER_NAME}
           feature-gates: DynamicResourceAllocation=true
+          kube-api-burst: "400"
+          kube-api-qps: "200"
           v: "4"
       etcd:
         local:

--- a/templates/test/dev/custom-builds-load-dra/kustomization.yaml
+++ b/templates/test/dev/custom-builds-load-dra/kustomization.yaml
@@ -7,6 +7,7 @@ patches:
 - path: ../../ci/patches/dra-kubeadmcontrolplane.yaml
   target:
     kind: KubeadmControlPlane
+- path: ../../ci/patches/dra-kubeadmcontrolplane-load.yaml
 - path: ../../ci/patches/dra-kubeadmconfig.yaml
   target:
     kind: KubeadmConfig


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind cleanup

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

Bumps QPS and burst for kube-controller-manager to meet load test demands.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #5745

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->


**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] cherry-pick candidate

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
