### PR TITLE
Define AZURE_LOCATION_LOAD for load test regions

### DIFF
--- a/hack/util.sh
+++ b/hack/util.sh
@@ -76,6 +76,11 @@ capz::util::get_random_region_edgezone() {
     local REGIONS=("canadacentral")
     echo "${REGIONS[${RANDOM} % ${#REGIONS[@]}]}"
 }
+# all regions below must have sufficient quota to run load tests
+capz::util::get_random_region_load() {
+    local REGIONS=("canadacentral" "francecentral" "northeurope")
+    echo "${REGIONS[${RANDOM} % ${#REGIONS[@]}]}"
+}
 
 capz::util::generate_ssh_key() {
     # Generate SSH key.

--- a/scripts/ci-conformance.sh
+++ b/scripts/ci-conformance.sh
@@ -68,6 +68,7 @@ export GINKGO_NODES=1
 export AZURE_LOCATION="${AZURE_LOCATION:-$(capz::util::get_random_region)}"
 export AZURE_LOCATION_GPU="${AZURE_LOCATION_GPU:-$(capz::util::get_random_region_gpu)}"
 export AZURE_LOCATION_EDGEZONE="${AZURE_LOCATION_EDGEZONE:-$(capz::util::get_random_region_edgezone)}"
+export AZURE_LOCATION_LOAD="${AZURE_LOCATION_LOAD:-$(capz::util::get_random_region_load)}"
 export AZURE_CONTROL_PLANE_MACHINE_TYPE="${AZURE_CONTROL_PLANE_MACHINE_TYPE:-"Standard_B2s"}"
 export AZURE_NODE_MACHINE_TYPE="${AZURE_NODE_MACHINE_TYPE:-"Standard_B2s"}"
 export WINDOWS="${WINDOWS:-false}"

--- a/scripts/ci-entrypoint.sh
+++ b/scripts/ci-entrypoint.sh
@@ -100,6 +100,8 @@ setup() {
     echo "Using AZURE_LOCATION_GPU: ${AZURE_LOCATION_GPU}"
     export AZURE_LOCATION_EDGEZONE="${AZURE_LOCATION_EDGEZONE:-$(capz::util::get_random_region_edgezone)}"
     echo "Using AZURE_LOCATION_EDGEZONE: ${AZURE_LOCATION_EDGEZONE}"
+    export AZURE_LOCATION_LOAD="${AZURE_LOCATION_LOAD:-$(capz::util::get_random_region_load)}"
+    echo "Using AZURE_LOCATION_LOAD: ${AZURE_LOCATION_LOAD}"
     # Need a cluster with at least 2 nodes
     export CONTROL_PLANE_MACHINE_COUNT="${CONTROL_PLANE_MACHINE_COUNT:-1}"
     export CCM_COUNT="${CCM_COUNT:-1}"

--- a/templates/test/dev/cluster-template-custom-builds-load-dra.yaml
+++ b/templates/test/dev/cluster-template-custom-builds-load-dra.yaml
@@ -40,7 +40,7 @@ spec:
     apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: AzureClusterIdentity
     name: ${CLUSTER_IDENTITY_NAME}
-  location: ${AZURE_LOCATION}
+  location: ${AZURE_LOCATION_LOAD}
   networkSpec:
     subnets:
     - name: control-plane-subnet

--- a/templates/test/dev/cluster-template-custom-builds-load.yaml
+++ b/templates/test/dev/cluster-template-custom-builds-load.yaml
@@ -40,7 +40,7 @@ spec:
     apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: AzureClusterIdentity
     name: ${CLUSTER_IDENTITY_NAME}
-  location: ${AZURE_LOCATION}
+  location: ${AZURE_LOCATION_LOAD}
   networkSpec:
     subnets:
     - name: control-plane-subnet

--- a/templates/test/dev/custom-builds-load/kustomization.yaml
+++ b/templates/test/dev/custom-builds-load/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
 - ../custom-builds
 - storageclass-resource-set.yaml
 patches:
+- path: patches/location.yaml
 - path: patches/cluster-label-storageclass.yaml
 - path: patches/cluster-label-azuredisk.yaml
 - path: patches/kcp-scheduler.yaml

--- a/templates/test/dev/custom-builds-load/patches/location.yaml
+++ b/templates/test/dev/custom-builds-load/patches/location.yaml
@@ -1,0 +1,6 @@
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: AzureCluster
+metadata:
+  name: ${CLUSTER_NAME}
+spec:
+  location: ${AZURE_LOCATION_LOAD}


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind cleanup


<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

This PR copies the approach used for other kinds of cluster templates that require specific regions. A new helper selects a random region from a list of regions known to have sufficient quota for running large scale testing jobs and is referenced in templates by the `AZURE_LOCATION_LOAD` environment variable.

The current set of load testing jobs are all defining `AZURE_LOCATION` to be `northeurope` but there are more regions in the sub with just as much quota, so let's use them. This change shouldn't break existing jobs, but that hardcoded value is now misleading so we should still remove it from the jobs in test-infra.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->


**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] cherry-pick candidate

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
