### PR TITLE
[release-1.20] Upgrade node delete timeout

### DIFF
--- a/templates/test/ci/patches/kcp-node-deletion-timeout.yaml
+++ b/templates/test/ci/patches/kcp-node-deletion-timeout.yaml
@@ -1,0 +1,7 @@
+apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+kind: KubeadmControlPlane
+metadata:
+  name: ${CLUSTER_NAME}-control-plane
+spec:
+  machineTemplate:
+    nodeDeletionTimeout: 600s

--- a/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-kcp-scale-in.yaml
+++ b/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-kcp-scale-in.yaml
@@ -239,6 +239,7 @@ spec:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
       kind: AzureMachineTemplate
       name: ${CLUSTER_NAME}-control-plane
+    nodeDeletionTimeout: 600s
   replicas: ${CONTROL_PLANE_MACHINE_COUNT}
   rolloutStrategy:
     rollingUpdate:

--- a/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-kcp-scale-in/kustomization.yaml
+++ b/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-kcp-scale-in/kustomization.yaml
@@ -13,3 +13,4 @@ patches:
 - path: ../../../../../../templates/azure-cluster-identity/azurecluster-identity-ref.yaml
 - path: ../../../../../../templates/test/ci/patches/cluster-label-calico.yaml
 - path: ../../../../../../templates/test/ci/patches/cluster-label-cloud-provider-azure.yaml
+- path: ../../../../../../templates/test/ci/patches/kcp-node-deletion-timeout.yaml

--- a/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-upgrades.yaml
+++ b/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-upgrades.yaml
@@ -178,6 +178,7 @@ spec:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
       kind: AzureMachineTemplate
       name: ${CLUSTER_NAME}-control-plane
+    nodeDeletionTimeout: 600s
   replicas: ${CONTROL_PLANE_MACHINE_COUNT}
   version: ${KUBERNETES_VERSION}
 ---

--- a/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-upgrades/kustomization.yaml
+++ b/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-upgrades/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
 - ../../../../../../templates/azure-cluster-identity/azure-cluster-identity.yaml
 patches:
 - path: ../../../../../../templates/azure-cluster-identity/azurecluster-identity-ref.yaml
+- path: ../../../../../../templates/test/ci/patches/kcp-node-deletion-timeout.yaml


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind flake

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

Manual cherry-pick of #5706:

> This PR adds a `nodeDeletionTimeout` to control planes nodes in workload-upgrade tests to increase the tolerance for failed node deletions.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->


**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] cherry-pick candidate

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
