### PR TITLE
[release-1.20] Bump CAPI to v1.10.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -333,7 +333,7 @@ create-management-cluster: $(KUSTOMIZE) $(ENVSUBST) $(KUBECTL) $(KIND) ## Create
 	./hack/create-custom-cloud-provider-config.sh
 
 	# Deploy CAPI
-	timeout --foreground 300 bash -c "until curl --retry $(CURL_RETRIES) -sSL https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.10.3/cluster-api-components.yaml | $(ENVSUBST) | $(KUBECTL) apply -f -; do sleep 5; done"
+	timeout --foreground 300 bash -c "until curl --retry $(CURL_RETRIES) -sSL https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.10.4/cluster-api-components.yaml | $(ENVSUBST) | $(KUBECTL) apply -f -; do sleep 5; done"
 
 	# Deploy CAAPH
 	timeout --foreground 300 bash -c "until curl --retry $(CURL_RETRIES) -sSL https://github.com/kubernetes-sigs/cluster-api-addon-provider-helm/releases/download/v0.2.5/addon-components.yaml | $(ENVSUBST) | $(KUBECTL) apply -f -; do sleep 5; done"

--- a/Tiltfile
+++ b/Tiltfile
@@ -22,7 +22,7 @@ settings = {
     "deploy_cert_manager": True,
     "preload_images_for_kind": True,
     "kind_cluster_name": "capz",
-    "capi_version": "v1.10.3",
+    "capi_version": "v1.10.4",
     "caaph_version": "v0.2.5",
     "cert_manager_version": "v1.18.1",
     "kubernetes_version": "v1.32.2",

--- a/docs/book/src/developers/getting-started-with-capi-operator.md
+++ b/docs/book/src/developers/getting-started-with-capi-operator.md
@@ -120,7 +120,7 @@ helm install cert-manager jetstack/cert-manager --namespace cert-manager --creat
 Create a `values.yaml` file for the CAPI Operator Helm chart like so:
 
 ```yaml
-core: "cluster-api:v1.10.3"
+core: "cluster-api:v1.10.4"
 infrastructure: "azure:v1.17.2"
 addon: "helm:v0.2.5"
 manager:

--- a/go.mod
+++ b/go.mod
@@ -58,8 +58,8 @@ require (
 	k8s.io/kubectl v0.32.3
 	k8s.io/utils v0.0.0-20250321185631-1f6e0b77f77e
 	sigs.k8s.io/cloud-provider-azure v1.32.3
-	sigs.k8s.io/cluster-api v1.10.3
-	sigs.k8s.io/cluster-api/test v1.10.3
+	sigs.k8s.io/cluster-api v1.10.4
+	sigs.k8s.io/cluster-api/test v1.10.4
 	sigs.k8s.io/controller-runtime v0.20.4
 	sigs.k8s.io/kind v0.29.0
 )

--- a/go.sum
+++ b/go.sum
@@ -723,10 +723,10 @@ sigs.k8s.io/cloud-provider-azure/pkg/azclient v0.5.9 h1:+ngbNuuzAIy4mIA09/ALZxx0
 sigs.k8s.io/cloud-provider-azure/pkg/azclient v0.5.9/go.mod h1:wlb5KMXferSuS9asjIlqjU7yHnCUEtAGnwjYdDtqdmk=
 sigs.k8s.io/cloud-provider-azure/pkg/azclient/configloader v0.4.1 h1:F5qZPS35TGb0ghlLGcHrbwzoO3mFnCBMM4ADGAlY+rI=
 sigs.k8s.io/cloud-provider-azure/pkg/azclient/configloader v0.4.1/go.mod h1:rEQnoF3pmD1kmAFQCwA/SqHiiftLFeMwdQt0gsuKWbM=
-sigs.k8s.io/cluster-api v1.10.3 h1:7tE5xgQJutisgDyeLzaZ9JhDaHGuG3GjPltsFM89BoA=
-sigs.k8s.io/cluster-api v1.10.3/go.mod h1:pu1WDn+fdax9aC9ZtDDoXqnO7P3LLjxbKGU/Nzf/DF4=
-sigs.k8s.io/cluster-api/test v1.10.3 h1:NFdzowDNIY6Pq+3DQKOdpctnIMk4rWBZCxDyKgo6vzM=
-sigs.k8s.io/cluster-api/test v1.10.3/go.mod h1:reUcQ/HTpDDkTXqsZj1BEmn3VzAoABy2XhLaM2XlMQQ=
+sigs.k8s.io/cluster-api v1.10.4 h1:5mdyWLGbbwOowWrjqM/J9N600QnxTohu5J1/1YR6g7c=
+sigs.k8s.io/cluster-api v1.10.4/go.mod h1:68GJs286ZChsncp+TxYNj/vhy2NWokiPtH4+SA0afs0=
+sigs.k8s.io/cluster-api/test v1.10.4 h1:1CJp7yjh2XazaPFtZzxSby9Gip2yjW0dNxyyHR7VjDk=
+sigs.k8s.io/cluster-api/test v1.10.4/go.mod h1:n2LsLQxc4RSLDjUXhgzquSTagZTJpUcY7uwtQtCRmaY=
 sigs.k8s.io/controller-runtime v0.20.4 h1:X3c+Odnxz+iPTRobG4tp092+CvBU9UK0t/bRf+n0DGU=
 sigs.k8s.io/controller-runtime v0.20.4/go.mod h1:xg2XB0K5ShQzAgsoujxuKN4LNXR2LfwwHsPj7Iaw+XY=
 sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8 h1:gBQPwqORJ8d8/YNZWEjoZs7npUVDpVXUUOFfW6CgAqE=

--- a/test/e2e/config/azure-dev.yaml
+++ b/test/e2e/config/azure-dev.yaml
@@ -3,11 +3,11 @@ managementClusterName: capz-e2e
 images:
   - name: ${MANAGER_IMAGE}
     loadBehavior: mustLoad
-  - name: registry.k8s.io/cluster-api/cluster-api-controller:v1.10.3
+  - name: registry.k8s.io/cluster-api/cluster-api-controller:v1.10.4
     loadBehavior: tryLoad
-  - name: registry.k8s.io/cluster-api/kubeadm-bootstrap-controller:v1.10.3
+  - name: registry.k8s.io/cluster-api/kubeadm-bootstrap-controller:v1.10.4
     loadBehavior: tryLoad
-  - name: registry.k8s.io/cluster-api/kubeadm-control-plane-controller:v1.10.3
+  - name: registry.k8s.io/cluster-api/kubeadm-control-plane-controller:v1.10.4
     loadBehavior: tryLoad
   - name: registry.k8s.io/cluster-api-helm/cluster-api-helm-controller:v0.2.5
     loadBehavior: tryLoad
@@ -16,8 +16,8 @@ providers:
   - name: cluster-api
     type: CoreProvider
     versions:
-    - name: v1.9.7 # latest patch of earliest minor in supported v1beta1 releases; this is used for v1beta1 old --> v1beta1 latest clusterctl upgrades test only.
-      value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.9.7/core-components.yaml"
+    - name: v1.9.10 # latest patch of earliest minor in supported v1beta1 releases; this is used for v1beta1 old --> v1beta1 latest clusterctl upgrades test only.
+      value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.9.10/core-components.yaml"
       type: "url"
       contract: v1beta1
       replacements:
@@ -25,8 +25,8 @@ providers:
           new: --metrics-addr=:8080
       files:
         - sourcePath: "../data/shared/v1beta1/metadata.yaml"
-    - name: v1.10.3
-      value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.10.3/core-components.yaml
+    - name: v1.10.4
+      value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.10.4/core-components.yaml
       type: url
       contract: v1beta1
       files:
@@ -39,8 +39,8 @@ providers:
   - name: kubeadm
     type: BootstrapProvider
     versions:
-    - name: v1.9.7 # latest patch of earliest minor in supported v1beta1 releases; this is used for v1beta1 old --> v1beta1 latest clusterctl upgrades test only.
-      value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.9.7/bootstrap-components.yaml"
+    - name: v1.9.10 # latest patch of earliest minor in supported v1beta1 releases; this is used for v1beta1 old --> v1beta1 latest clusterctl upgrades test only.
+      value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.9.10/bootstrap-components.yaml"
       type: "url"
       contract: v1beta1
       replacements:
@@ -48,8 +48,8 @@ providers:
           new: --metrics-addr=:8080
       files:
         - sourcePath: "../data/shared/v1beta1/metadata.yaml"
-    - name: v1.10.3
-      value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.10.3/bootstrap-components.yaml
+    - name: v1.10.4
+      value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.10.4/bootstrap-components.yaml
       type: url
       contract: v1beta1
       files:
@@ -61,8 +61,8 @@ providers:
   - name: kubeadm
     type: ControlPlaneProvider
     versions:
-    - name: v1.9.7 # latest patch of earliest minor in supported v1beta1 releases; this is used for v1beta1 old --> v1beta1 latest clusterctl upgrades test only.
-      value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.9.7/control-plane-components.yaml"
+    - name: v1.9.10 # latest patch of earliest minor in supported v1beta1 releases; this is used for v1beta1 old --> v1beta1 latest clusterctl upgrades test only.
+      value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.9.10/control-plane-components.yaml"
       type: "url"
       contract: v1beta1
       replacements:
@@ -70,8 +70,8 @@ providers:
           new: --metrics-addr=:8080
       files:
         - sourcePath: "../data/shared/v1beta1/metadata.yaml"
-    - name: v1.10.3
-      value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.10.3/control-plane-components.yaml
+    - name: v1.10.4
+      value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.10.4/control-plane-components.yaml
       type: url
       contract: v1beta1
       files:
@@ -242,8 +242,8 @@ variables:
   KUBETEST_CONFIGURATION: "./data/kubetest/conformance.yaml"
   WINDOWS_CONTAINERD_URL: "${WINDOWS_CONTAINERD_URL:-}"
   AZURE_CNI_V1_MANIFEST_PATH: "${PWD}/templates/addons/azure-cni-v1.yaml"
-  OLD_CAPI_UPGRADE_VERSION: "v1.9.7"
-  LATEST_CAPI_UPGRADE_VERSION: "v1.10.3"
+  OLD_CAPI_UPGRADE_VERSION: "v1.9.10"
+  LATEST_CAPI_UPGRADE_VERSION: "v1.10.4"
   OLD_PROVIDER_UPGRADE_VERSION: "v1.18.5"
   LATEST_PROVIDER_UPGRADE_VERSION: "v1.19.4"
   OLD_CAAPH_UPGRADE_VERSION: "v0.1.0-alpha.10"


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

Manual cherry-pick of #5761

**What this PR does / why we need it**:

Updates the Cluster API dependency to [v1.10.4](https://github.com/kubernetes-sigs/cluster-api/releases/tag/v1.10.4).

**Which issue(s) this PR fixes**:

N/A, but see #5712 for prior art.

**Special notes for your reviewer**:

**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] cherry-pick candidate

**Release note**:

```release-note
Bump CAPI to v1.10.4
```
