### PR TITLE
CI: Always use AZURE_LOCATION

### DIFF
--- a/templates/test/dev/cluster-template-custom-builds-load-dra.yaml
+++ b/templates/test/dev/cluster-template-custom-builds-load-dra.yaml
@@ -40,7 +40,7 @@ spec:
     apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: AzureClusterIdentity
     name: ${CLUSTER_IDENTITY_NAME}
-  location: ${AZURE_LOCATION_LOAD}
+  location: ${AZURE_LOCATION}
   networkSpec:
     subnets:
     - name: control-plane-subnet

--- a/templates/test/dev/cluster-template-custom-builds-load.yaml
+++ b/templates/test/dev/cluster-template-custom-builds-load.yaml
@@ -40,7 +40,7 @@ spec:
     apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: AzureClusterIdentity
     name: ${CLUSTER_IDENTITY_NAME}
-  location: ${AZURE_LOCATION_LOAD}
+  location: ${AZURE_LOCATION}
   networkSpec:
     subnets:
     - name: control-plane-subnet

--- a/templates/test/dev/custom-builds-load/kustomization.yaml
+++ b/templates/test/dev/custom-builds-load/kustomization.yaml
@@ -5,7 +5,6 @@ resources:
 - ../custom-builds
 - storageclass-resource-set.yaml
 patches:
-- path: patches/location.yaml
 - path: patches/cluster-label-storageclass.yaml
 - path: patches/cluster-label-azuredisk.yaml
 - path: patches/kcp-scheduler.yaml

--- a/templates/test/dev/custom-builds-load/patches/location.yaml
+++ b/templates/test/dev/custom-builds-load/patches/location.yaml
@@ -1,6 +1,0 @@
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-kind: AzureCluster
-metadata:
-  name: ${CLUSTER_NAME}
-spec:
-  location: ${AZURE_LOCATION_LOAD}


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

/kind failing-test

**What this PR does / why we need it**:

This PR is a different approach to https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/5749.

@nojnhuh and I observed that the `AZURE_LOCATION` is being propagated to the azuredisk-csi-driver controller, and is being used to direct disk creations to a particular region. If we use a different region for VMs, then disk attachment operations fail.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->


**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] cherry-pick candidate

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
