### PR TITLE
Add release notes for CAPZ v1.19.6

### DIFF
--- a/CHANGELOG/v1.19.6.md
+++ b/CHANGELOG/v1.19.6.md
@@ -1,0 +1,26 @@
+## Changes by Kind
+
+### Bug or Regression
+
+- Adds the ability to disable CAPZ components through a manager flag. Flags added for disabling ASO Secret Controller and disabling Azure JSON Machine Controller. ([#5759](https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/5759), [@bryan-cox](https://github.com/bryan-cox))
+
+### Other (Cleanup or Flake)
+
+- Bump CAPI to v1.9.10 ([#5762](https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/5762), [@mboersma](https://github.com/mboersma))
+- Update default Kubernetes version to 1.32 ([#5764](https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/5764), [@jsturtevant](https://github.com/jsturtevant))
+
+## Dependencies
+
+### Added
+_Nothing has changed._
+
+### Changed
+- sigs.k8s.io/cluster-api/test: v1.9.9 → v1.9.10
+- sigs.k8s.io/cluster-api: v1.9.9 → v1.9.10
+
+### Removed
+_Nothing has changed._
+
+## Details
+<!-- markdown-link-check-disable-next-line -->
+https://github.com/kubernetes-sigs/cluster-api-provider-azure/compare/v1.19.5...v1.19.6


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

Adds release notes for the impending CAPZ release v1.19.6.


**Release note**:

```release-note
NONE
```
