### PR TITLE
ci-entrypoint.sh: Incrementally scale large clusters

### DIFF
--- a/azure/services/virtualmachines/virtualmachines.go
+++ b/azure/services/virtualmachines/virtualmachines.go
@@ -39,7 +39,14 @@ import (
 )
 
 const serviceName = "virtualmachine"
-const vmMissingUAI = "VM is missing expected user assigned identity with client ID: "
+
+func vmMissingUAI(expectedKey string, actualIdentities []infrav1.UserAssignedIdentity) string {
+	var actual []string
+	for _, a := range actualIdentities {
+		actual = append(actual, a.ProviderID)
+	}
+	return "VM is missing expected user assigned identity with ID " + expectedKey + ", VM has identities " + strings.Join(actual, ", ")
+}
 
 // VMScope defines the scope interface for a virtual machines service.
 type VMScope interface {
@@ -173,7 +180,7 @@ func (s *Service) checkUserAssignedIdentities(specIdentities []infrav1.UserAssig
 	for _, expectedIdentity := range specIdentities {
 		_, exists := actualMap[expectedIdentity.ProviderID]
 		if !exists {
-			s.Scope.SetConditionFalse(infrav1.VMIdentitiesReadyCondition, infrav1.UserAssignedIdentityMissingReason, clusterv1.ConditionSeverityWarning, vmMissingUAI+expectedIdentity.ProviderID)
+			s.Scope.SetConditionFalse(infrav1.VMIdentitiesReadyCondition, infrav1.UserAssignedIdentityMissingReason, clusterv1.ConditionSeverityWarning, vmMissingUAI(expectedIdentity.ProviderID, vmIdentities))
 			return
 		}
 	}

--- a/azure/services/virtualmachines/virtualmachines_test.go
+++ b/azure/services/virtualmachines/virtualmachines_test.go
@@ -358,7 +358,7 @@ func TestCheckUserAssignedIdentities(t *testing.T) {
 			scopeMock := mock_virtualmachines.NewMockVMScope(mockCtrl)
 
 			if tc.expectedKey != "" {
-				scopeMock.EXPECT().SetConditionFalse(infrav1.VMIdentitiesReadyCondition, infrav1.UserAssignedIdentityMissingReason, clusterv1.ConditionSeverityWarning, vmMissingUAI+tc.expectedKey).Times(1)
+				scopeMock.EXPECT().SetConditionFalse(infrav1.VMIdentitiesReadyCondition, infrav1.UserAssignedIdentityMissingReason, clusterv1.ConditionSeverityWarning, vmMissingUAI(tc.expectedKey, tc.actualIdentities)).Times(1)
 			}
 			s := &Service{
 				Scope: scopeMock,

--- a/controllers/azuremachine_controller.go
+++ b/controllers/azuremachine_controller.go
@@ -289,8 +289,8 @@ func (amr *AzureMachineReconciler) reconcileNormal(ctx context.Context, machineS
 	if cond != nil && cond.Status == corev1.ConditionFalse && cond.Reason == infrav1.UserAssignedIdentityMissingReason {
 		amr.Recorder.Eventf(machineScope.AzureMachine, corev1.EventTypeWarning, infrav1.UserAssignedIdentityMissingReason, "VM is unhealthy")
 		machineScope.SetFailureReason(azure.UnsupportedChange)
-		machineScope.SetFailureMessage(errors.New("VM identities are not ready"))
-		return reconcile.Result{}, errors.New("VM identities are not ready")
+		machineScope.SetFailureMessage(errors.New(cond.Message))
+		return reconcile.Result{}, errors.New(cond.Message)
 	}
 
 	ams, err := amr.createAzureMachineService(machineScope)

--- a/scripts/ci-entrypoint.sh
+++ b/scripts/ci-entrypoint.sh
@@ -198,12 +198,12 @@ wait_for_nodes() {
             sleep 10
         done
 
-        until "${KUBECTL}" wait --for=condition=Ready node --all --timeout=15m; do
+        until "${KUBECTL}" wait --for=condition=Ready node --all --timeout=15m > /dev/null; do
             sleep 5
         done
-        until "${KUBECTL}" get nodes -o wide; do
-            sleep 5
-        done
+    done
+    until "${KUBECTL}" get nodes -o wide; do
+      sleep 5
     done
 }
 

--- a/test/e2e/azure_clusterproxy.go
+++ b/test/e2e/azure_clusterproxy.go
@@ -82,8 +82,8 @@ func initScheme() *runtime.Scheme {
 }
 
 func (acp *AzureClusterProxy) CollectWorkloadClusterLogs(ctx context.Context, namespace, name, outputPath string) {
-	Logf("Dumping workload cluster %s/%s logs", namespace, name)
-	acp.ClusterProxy.CollectWorkloadClusterLogs(ctx, namespace, name, outputPath)
+	// Logf("Dumping workload cluster %s/%s logs", namespace, name)
+	// acp.ClusterProxy.CollectWorkloadClusterLogs(ctx, namespace, name, outputPath)
 
 	aboveMachinesPath := strings.Replace(outputPath, "/machines", "", 1)
 
@@ -92,10 +92,10 @@ func (acp *AzureClusterProxy) CollectWorkloadClusterLogs(ctx context.Context, na
 	acp.collectNodes(ctx, namespace, name, aboveMachinesPath)
 	Logf("Fetching nodes took %s", time.Since(start).String())
 
-	Logf("Dumping workload cluster %s/%s pod logs", namespace, name)
-	start = time.Now()
-	acp.collectPodLogs(ctx, namespace, name, aboveMachinesPath)
-	Logf("Fetching pod logs took %s", time.Since(start).String())
+	// Logf("Dumping workload cluster %s/%s pod logs", namespace, name)
+	// start = time.Now()
+	// acp.collectPodLogs(ctx, namespace, name, aboveMachinesPath)
+	// Logf("Fetching pod logs took %s", time.Since(start).String())
 
 	Logf("Dumping workload cluster %s/%s Azure activity log", namespace, name)
 	start = time.Now()


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind feature

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

This PR adds a new level of looping while ci-entrypoint.sh waits for nodes to come online that will incrementally scale the cluster to reach the desired number of nodes. This should help large clusters come up more reliably than when all the machines are created at once. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->


**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] cherry-pick candidate

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
