### PR TITLE
Add make test target for custom manager image

### DIFF
--- a/e2e.mk
+++ b/e2e.mk
@@ -39,3 +39,13 @@ test-e2e-skip-build-and-push:
 	$(MAKE) set-manifest-pull-policy TARGET_RESOURCE="./config/capz/manager_pull_policy.yaml" PULL_POLICY=IfNotPresent
 	MANAGER_IMAGE=$(CONTROLLER_IMG)-$(ARCH):$(TAG) \
 	$(MAKE) test-e2e-run
+
+.PHONY: test-e2e-custom-image
+test-e2e-custom-image: ## Run e2e tests with a custom image format (use MANAGER_IMAGE env var).
+	@if [ -z "$(MANAGER_IMAGE)" ]; then \
+		echo "MANAGER_IMAGE must be set"; \
+		exit 1; \
+	fi
+	$(MAKE) set-manifest-image MANIFEST_IMG=$(shell echo $(MANAGER_IMAGE) | cut -d: -f1) MANIFEST_TAG=$(shell echo $(MANAGER_IMAGE) | cut -d: -f2) TARGET_RESOURCE="./config/capz/manager_image_patch.yaml"
+	$(MAKE) set-manifest-pull-policy TARGET_RESOURCE="./config/capz/manager_pull_policy.yaml" PULL_POLICY=IfNotPresent
+	$(MAKE) test-e2e-run

--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -82,7 +82,14 @@ trap capz::ci-e2e::cleanup EXIT
 # Image is configured as `${CONTROLLER_IMG}-${ARCH}:${TAG}` where `CONTROLLER_IMG` is defaulted to `${REGISTRY}/${IMAGE_NAME}`.
 if [[ "${BUILD_MANAGER_IMAGE}" == "false" ]]; then
   # Load an existing image, skip docker-build and docker-push.
-  make test-e2e-skip-build-and-push
+  if [[ -n "${CUSTOM_MANAGER_IMAGE:-}" ]]; then
+    # Use custom image format when CUSTOM_MANAGER_IMAGE is set
+    export MANAGER_IMAGE="${CUSTOM_MANAGER_IMAGE}"
+    make test-e2e-custom-image
+  else
+    # Use default image format
+    make test-e2e-skip-build-and-push
+  fi
 elif [[ "${USE_LOCAL_KIND_REGISTRY}" == "true" ]]; then
   # Build an image with kind local registry, skip docker-push. REGISTRY is set to `localhost:5000/ci-e2e`. TAG is set to `$(date -u '+%Y%m%d%H%M%S')`.
   make test-e2e-skip-push


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind cleanup

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
This PR adds a make target to add the ability for the user to specify a custom manager image instead of it being hard-coded in the existing e2e.mk targets.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->


**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [x] cherry-pick candidate

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
