### PR TITLE
Bump CAAPH to v0.3.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -336,7 +336,7 @@ create-management-cluster: $(KUSTOMIZE) $(ENVSUBST) $(KUBECTL) $(KIND) ## Create
 	timeout --foreground 300 bash -c "until curl --retry $(CURL_RETRIES) -sSL https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.10.4/cluster-api-components.yaml | $(ENVSUBST) | $(KUBECTL) apply -f -; do sleep 5; done"
 
 	# Deploy CAAPH
-	timeout --foreground 300 bash -c "until curl --retry $(CURL_RETRIES) -sSL https://github.com/kubernetes-sigs/cluster-api-addon-provider-helm/releases/download/v0.2.5/addon-components.yaml | $(ENVSUBST) | $(KUBECTL) apply -f -; do sleep 5; done"
+	timeout --foreground 300 bash -c "until curl --retry $(CURL_RETRIES) -sSL https://github.com/kubernetes-sigs/cluster-api-addon-provider-helm/releases/download/v0.3.2/addon-components.yaml | $(ENVSUBST) | $(KUBECTL) apply -f -; do sleep 5; done"
 
 	# Deploy CAPZ
 	if [ "$(MGMT_CLUSTER_TYPE)" != "aks" ]; then \

--- a/Tiltfile
+++ b/Tiltfile
@@ -23,7 +23,7 @@ settings = {
     "preload_images_for_kind": True,
     "kind_cluster_name": "capz",
     "capi_version": "v1.10.4",
-    "caaph_version": "v0.2.5",
+    "caaph_version": "v0.3.2",
     "cert_manager_version": "v1.18.1",
     "kubernetes_version": "v1.32.2",
     "aks_kubernetes_version": "v1.30.2",

--- a/docs/book/src/developers/getting-started-with-capi-operator.md
+++ b/docs/book/src/developers/getting-started-with-capi-operator.md
@@ -122,7 +122,7 @@ Create a `values.yaml` file for the CAPI Operator Helm chart like so:
 ```yaml
 core: "cluster-api:v1.10.4"
 infrastructure: "azure:v1.17.2"
-addon: "helm:v0.2.5"
+addon: "helm:v0.3.2"
 manager:
   featureGates:
     core:

--- a/test/e2e/config/azure-dev.yaml
+++ b/test/e2e/config/azure-dev.yaml
@@ -9,7 +9,7 @@ images:
     loadBehavior: tryLoad
   - name: registry.k8s.io/cluster-api/kubeadm-control-plane-controller:v1.10.4
     loadBehavior: tryLoad
-  - name: registry.k8s.io/cluster-api-helm/cluster-api-helm-controller:v0.2.5
+  - name: registry.k8s.io/cluster-api-helm/cluster-api-helm-controller:v0.3.2
     loadBehavior: tryLoad
 
 providers:
@@ -197,8 +197,8 @@ providers:
       replacements:
       - old: "imagePullPolicy: Always"
         new: "imagePullPolicy: IfNotPresent"
-    - name: v0.2.5
-      value: https://github.com/kubernetes-sigs/cluster-api-addon-provider-helm/releases/download/v0.2.5/addon-components.yaml
+    - name: v0.3.2
+      value: https://github.com/kubernetes-sigs/cluster-api-addon-provider-helm/releases/download/v0.3.2/addon-components.yaml
       type: url
       contract: v1beta1
       files:
@@ -247,7 +247,7 @@ variables:
   OLD_PROVIDER_UPGRADE_VERSION: "v1.19.6"
   LATEST_PROVIDER_UPGRADE_VERSION: "v1.20.2"
   OLD_CAAPH_UPGRADE_VERSION: "v0.1.0-alpha.10"
-  LATEST_CAAPH_UPGRADE_VERSION: "v0.2.5"
+  LATEST_CAAPH_UPGRADE_VERSION: "v0.3.2"
   CI_RG: "${CI_RG:-capz-ci}"
   USER_IDENTITY: "${USER_IDENTITY:-cloud-provider-user-identity}"
   EXP_APISERVER_ILB: "true"

--- a/test/e2e/data/shared/v1beta1_addon_provider/metadata.yaml
+++ b/test/e2e/data/shared/v1beta1_addon_provider/metadata.yaml
@@ -1,6 +1,9 @@
 apiVersion: clusterctl.cluster.x-k8s.io/v1alpha3
 releaseSeries:
   - major: 0
+    minor: 3
+    contract: v1beta1
+  - major: 0
     minor: 2
     contract: v1beta1
   - major: 0


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind cleanup

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

This PR bumps the version of CAAPH used in tests to v0.3.2.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->


**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] cherry-pick candidate

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
