### PR TITLE
fix(observability): configure ServiceMonitor for ASO secure metrics authentication

### DIFF
--- a/hack/observability/prometheus/resources/prometheus.yaml
+++ b/hack/observability/prometheus/resources/prometheus.yaml
@@ -105,7 +105,10 @@ spec:
   endpoints:
     - path: /metrics
       port: metrics
-      scheme: http
+      scheme: https
+      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      tlsConfig:
+        insecureSkipVerify: true
   selector:
     matchLabels:
       control-plane: controller-manager


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

/kind bug

**What this PR does / why we need it**:
This PR:
- Update azureserviceoperator-controller-manager-metrics-monitor to use HTTPS scheme
- Add bearerTokenFile authentication using ServiceAccount token
- Configure TLS with insecureSkipVerify for self-signed certificates
- Resolves 401 Unauthorized errors when Prometheus scrapes ASO metrics

The Azure Service Operator exposes secure metrics by default on HTTPS port 8443 requiring proper authentication. This change aligns with ASO documentation at https://azure.github.io/azure-service-operator/guide/metrics/ which states "A ServiceAccount token is required to scrape metrics securely".

Fixes: ASO metrics like go_memstats_sys_bytes not appearing in Prometheus


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #5601

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->


**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] cherry-pick candidate

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
