### PR TITLE
Add startupProbe to ASO

### DIFF
--- a/config/aso/kustomization.yaml
+++ b/config/aso/kustomization.yaml
@@ -30,6 +30,24 @@ patches:
     - op: replace # Users can specify additional ASO CRDs. CRDs should be appended with ';'
       path: /spec/template/spec/containers/0/args/6
       value: --crd-pattern=${ADDITIONAL_ASO_CRDS:= }
+
+    # ASO will provide a startupProbe starting in v2.14.0.
+    # These patches should be removed when the upstream probe is set.
+    - op: test
+      path: /spec/template/spec/containers/0/startupProbe
+      value: null
+    - op: add
+      path: /spec/template/spec/containers/0/startupProbe
+      value:
+        httpGet:
+          path: /healthz
+          port: 8081
+        periodSeconds: 10
+        failureThreshold: 12
+    - op: remove
+      path: /spec/template/spec/containers/0/livenessProbe/initialDelaySeconds
+    - op: remove
+      path: /spec/template/spec/containers/0/readinessProbe/initialDelaySeconds
   target:
     group: apps
     kind: Deployment


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind cleanup

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

This PR ports https://github.com/Azure/azure-service-operator/pull/4791 to the older version of ASO bundled with CAPZ to improve ASO startup times by about 45s.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->


**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] cherry-pick candidate

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
