### PR TITLE
Fix issue with MANAGER_IMAGE being overwritten in conformance tests

### DIFF
--- a/conformance.mk
+++ b/conformance.mk
@@ -11,7 +11,11 @@ CONFORMANCE_E2E_ARGS += $(E2E_ARGS)
 
 .PHONY: test-conformance
 test-conformance: ## Run conformance test on workload cluster.
+ifeq ($(MANAGER_IMAGE),)
 	$(MAKE) test-e2e-skip-push GINKGO_FOCUS="Conformance" E2E_ARGS='$(CONFORMANCE_E2E_ARGS)' CONFORMANCE_FLAVOR='$(CONFORMANCE_FLAVOR)'
+else ## If MANAGER_IMAGE is set, use it for the conformance test (test-e2e-skip-push overwrites it).
+	$(MAKE) test-e2e-custom-image GINKGO_FOCUS="Conformance" E2E_ARGS='$(CONFORMANCE_E2E_ARGS)' CONFORMANCE_FLAVOR='$(CONFORMANCE_FLAVOR)'
+endif
 
 test-conformance-fast: ## Run conformance test on workload cluster using a subset of the conformance suite in parallel.
 	$(MAKE) test-conformance CONFORMANCE_E2E_ARGS="-kubetest.config-file=$(KUBETEST_FAST_CONF_PATH) -kubetest.ginkgo-nodes=5 $(E2E_ARGS)"


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
This PR fixes `test-conformance` to run `test-e2e-custom-image` if `MANAGER_IMAGE` is set. This is to fix the issue where `test-e2e-skip-push` and `MANAGER_IMAGE` is set to `$(CONTROLLER_IMG)-$(ARCH):$(TAG)` regardless of whether the manager images were built or not. https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/e2e.mk#L32

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->


**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] cherry-pick candidate

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
