### PR TITLE
Bump Go toolchain to v1.24.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@
 ARG ARCH
 
 # Build the manager binary
-FROM golang:1.23 AS builder
+FROM golang:1.24 AS builder
 WORKDIR /workspace
 
 # Run this with docker build --build_arg $(go env GOPROXY) to override the goproxy

--- a/Tiltfile
+++ b/Tiltfile
@@ -173,7 +173,7 @@ def validate_auth():
 
 tilt_helper_dockerfile_header = """
 # Tilt image
-FROM golang:1.23 AS tilt-helper
+FROM golang:1.24 AS tilt-helper
 # Support live reloading with Tilt
 RUN wget --output-document /restart.sh --quiet https://raw.githubusercontent.com/windmilleng/rerun-process-wrapper/master/restart.sh  && \
     wget --output-document /start.sh --quiet https://raw.githubusercontent.com/windmilleng/rerun-process-wrapper/master/start.sh && \

--- a/api/v1beta1/azurecluster_webhook_test.go
+++ b/api/v1beta1/azurecluster_webhook_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package v1beta1
 
 import (
-	"context"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -109,7 +108,7 @@ func TestAzureCluster_ValidateCreate(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			g := NewWithT(t)
-			_, err := (&AzureClusterWebhook{}).ValidateCreate(context.Background(), tc.cluster)
+			_, err := (&AzureClusterWebhook{}).ValidateCreate(t.Context(), tc.cluster)
 			if tc.wantErr {
 				g.Expect(err).To(HaveOccurred())
 			} else {
@@ -345,7 +344,7 @@ func TestAzureCluster_ValidateUpdate(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			g := NewWithT(t)
-			_, err := (&AzureClusterWebhook{}).ValidateUpdate(context.Background(), tc.oldCluster, tc.cluster)
+			_, err := (&AzureClusterWebhook{}).ValidateUpdate(t.Context(), tc.oldCluster, tc.cluster)
 			if tc.wantErr {
 				g.Expect(err).To(HaveOccurred())
 			} else {

--- a/api/v1beta1/azureclusteridentity_webhook_test.go
+++ b/api/v1beta1/azureclusteridentity_webhook_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package v1beta1
 
 import (
-	"context"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -84,7 +83,7 @@ func TestAzureClusterIdentity_ValidateCreate(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			g := NewWithT(t)
-			_, err := (&azureClusterIdentityWebhook{}).ValidateCreate(context.Background(), tc.clusterIdentity)
+			_, err := (&azureClusterIdentityWebhook{}).ValidateCreate(t.Context(), tc.clusterIdentity)
 			if tc.wantErr {
 				g.Expect(err).To(HaveOccurred())
 			} else {
@@ -164,7 +163,7 @@ func TestAzureClusterIdentity_ValidateUpdate(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			g := NewWithT(t)
-			_, err := (&azureClusterIdentityWebhook{}).ValidateUpdate(context.Background(), tc.oldClusterIdentity, tc.clusterIdentity)
+			_, err := (&azureClusterIdentityWebhook{}).ValidateUpdate(t.Context(), tc.oldClusterIdentity, tc.clusterIdentity)
 			if tc.wantErr {
 				g.Expect(err).To(HaveOccurred())
 			} else {

--- a/api/v1beta1/azureclustertemplate_webhook_test.go
+++ b/api/v1beta1/azureclustertemplate_webhook_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package v1beta1
 
 import (
-	"context"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -58,7 +57,7 @@ func TestValidateUpdate(t *testing.T) {
 
 	t.Run("template is immutable", func(t *testing.T) {
 		g := NewWithT(t)
-		_, err := (&azureClusterTemplateWebhook{}).ValidateUpdate(context.Background(), oldClusterTemplate, newClusterTemplate)
+		_, err := (&azureClusterTemplateWebhook{}).ValidateUpdate(t.Context(), oldClusterTemplate, newClusterTemplate)
 		g.Expect(err).To(HaveOccurred())
 	})
 }

--- a/api/v1beta1/azuremachine_webhook_test.go
+++ b/api/v1beta1/azuremachine_webhook_test.go
@@ -253,7 +253,7 @@ func TestAzureMachine_ValidateCreate(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			g := NewWithT(t)
 			mw := &azureMachineWebhook{}
-			_, err := mw.ValidateCreate(context.Background(), tc.machine)
+			_, err := mw.ValidateCreate(t.Context(), tc.machine)
 			if tc.wantErr {
 				g.Expect(err).To(HaveOccurred())
 			} else {
@@ -928,7 +928,7 @@ func TestAzureMachine_ValidateUpdate(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			g := NewWithT(t)
 			mw := &azureMachineWebhook{}
-			_, err := mw.ValidateUpdate(context.Background(), tc.oldMachine, tc.newMachine)
+			_, err := mw.ValidateUpdate(t.Context(), tc.oldMachine, tc.newMachine)
 			if tc.wantErr {
 				g.Expect(err).To(HaveOccurred())
 			} else {
@@ -980,17 +980,17 @@ func TestAzureMachine_Default(t *testing.T) {
 		Client: mockClient,
 	}
 
-	err := mw.Default(context.Background(), publicKeyExistTest.machine)
+	err := mw.Default(t.Context(), publicKeyExistTest.machine)
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(publicKeyExistTest.machine.Spec.SSHPublicKey).To(Equal(existingPublicKey))
 
-	err = mw.Default(context.Background(), publicKeyNotExistTest.machine)
+	err = mw.Default(t.Context(), publicKeyNotExistTest.machine)
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(publicKeyNotExistTest.machine.Spec.SSHPublicKey).To(Not(BeEmpty()))
 
 	for _, possibleCachingType := range armcompute.PossibleCachingTypesValues() {
 		cacheTypeSpecifiedTest := test{machine: &AzureMachine{ObjectMeta: testObjectMeta, Spec: AzureMachineSpec{OSDisk: OSDisk{CachingType: string(possibleCachingType)}}}}
-		err = mw.Default(context.Background(), cacheTypeSpecifiedTest.machine)
+		err = mw.Default(t.Context(), cacheTypeSpecifiedTest.machine)
 		g.Expect(err).NotTo(HaveOccurred())
 		g.Expect(cacheTypeSpecifiedTest.machine.Spec.OSDisk.CachingType).To(Equal(string(possibleCachingType)))
 	}

--- a/api/v1beta1/azuremachinetemplate_webhook_test.go
+++ b/api/v1beta1/azuremachinetemplate_webhook_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package v1beta1
 
 import (
-	"context"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
@@ -248,7 +247,7 @@ func TestAzureMachineTemplate_ValidateCreate(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			g := NewWithT(t)
-			ctx := context.Background()
+			ctx := t.Context()
 			_, err := (&azureMachineTemplateWebhook{}).ValidateCreate(ctx, test.machineTemplate)
 			if test.wantErr {
 				g.Expect(err).To(HaveOccurred())
@@ -547,7 +546,7 @@ func TestAzureMachineTemplate_ValidateUpdate(t *testing.T) {
 	for _, amt := range tests {
 		t.Run(amt.name, func(t *testing.T) {
 			g := NewWithT(t)
-			ctx := admission.NewContextWithRequest(context.Background(), admission.Request{AdmissionRequest: admissionv1.AdmissionRequest{DryRun: ptr.To(true)}})
+			ctx := admission.NewContextWithRequest(t.Context(), admission.Request{AdmissionRequest: admissionv1.AdmissionRequest{DryRun: ptr.To(true)}})
 			_, err := (&azureMachineTemplateWebhook{}).ValidateUpdate(ctx, amt.oldTemplate, amt.template)
 			if amt.wantErr {
 				g.Expect(err).To(HaveOccurred())
@@ -561,7 +560,7 @@ func TestAzureMachineTemplate_ValidateUpdate(t *testing.T) {
 		t.Run(amt.name, func(t *testing.T) {
 			t.Parallel()
 			g := NewWithT(t)
-			ctx := admission.NewContextWithRequest(context.Background(), admission.Request{AdmissionRequest: admissionv1.AdmissionRequest{DryRun: ptr.To(false)}})
+			ctx := admission.NewContextWithRequest(t.Context(), admission.Request{AdmissionRequest: admissionv1.AdmissionRequest{DryRun: ptr.To(false)}})
 			_, err := (&azureMachineTemplateWebhook{}).ValidateUpdate(ctx, amt.oldTemplate, amt.template)
 			if amt.wantErr {
 				g.Expect(err).To(HaveOccurred())

--- a/api/v1beta1/azuremanagedcluster_webhook_test.go
+++ b/api/v1beta1/azuremanagedcluster_webhook_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package v1beta1
 
 import (
-	"context"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -82,7 +81,7 @@ func TestAzureManagedCluster_ValidateUpdate(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			g := NewWithT(t)
-			_, err := (&azureManagedClusterWebhook{}).ValidateUpdate(context.Background(), tc.oldAMC, tc.amc)
+			_, err := (&azureManagedClusterWebhook{}).ValidateUpdate(t.Context(), tc.oldAMC, tc.amc)
 			if tc.wantErr {
 				g.Expect(err).To(HaveOccurred())
 			} else {
@@ -125,7 +124,7 @@ func TestAzureManagedCluster_ValidateCreate(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			g := NewWithT(t)
-			_, err := (&azureManagedClusterWebhook{}).ValidateCreate(context.Background(), tc.amc)
+			_, err := (&azureManagedClusterWebhook{}).ValidateCreate(t.Context(), tc.amc)
 			if tc.wantErr {
 				g.Expect(err).To(HaveOccurred())
 			} else {
@@ -155,7 +154,7 @@ func TestAzureManagedCluster_ValidateCreateFailure(t *testing.T) {
 				utilfeature.SetFeatureGateDuringTest(t, feature.Gates, capifeature.MachinePool, *tc.featureGateEnabled)
 			}
 			g := NewWithT(t)
-			_, err := (&azureManagedClusterWebhook{}).ValidateCreate(context.Background(), tc.amc)
+			_, err := (&azureManagedClusterWebhook{}).ValidateCreate(t.Context(), tc.amc)
 			if tc.expectError {
 				g.Expect(err).To(HaveOccurred())
 			} else {

--- a/api/v1beta1/azuremanagedcontrolplane_webhook_test.go
+++ b/api/v1beta1/azuremanagedcontrolplane_webhook_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package v1beta1
 
 import (
-	"context"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -61,7 +60,7 @@ func TestDefaultingWebhook(t *testing.T) {
 		},
 	}
 	mcpw := &azureManagedControlPlaneWebhook{}
-	err := mcpw.Default(context.Background(), amcp)
+	err := mcpw.Default(t.Context(), amcp)
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(amcp.Spec.ResourceGroupName).To(Equal("fooCluster"))
 	g.Expect(amcp.Spec.Version).To(Equal("v1.17.5"))
@@ -104,7 +103,7 @@ func TestDefaultingWebhook(t *testing.T) {
 	}
 	amcp.Spec.EnablePreviewFeatures = ptr.To(true)
 
-	err = mcpw.Default(context.Background(), amcp)
+	err = mcpw.Default(t.Context(), amcp)
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(*amcp.Spec.NetworkPlugin).To(Equal(netPlug))
 	g.Expect(*amcp.Spec.NetworkPolicy).To(Equal(netPol))
@@ -160,7 +159,7 @@ func TestDefaultingWebhook(t *testing.T) {
 			SSHPublicKey: ptr.To(""),
 		},
 	}
-	err = mcpw.Default(context.Background(), amcp)
+	err = mcpw.Default(t.Context(), amcp)
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(amcp.Spec.VirtualNetwork.CIDRBlock).To(Equal(defaultAKSVnetCIDRForOverlay))
 	g.Expect(amcp.Spec.VirtualNetwork.Subnet.CIDRBlock).To(Equal(defaultAKSNodeSubnetCIDRForOverlay))
@@ -1387,7 +1386,7 @@ func TestValidatingWebhook(t *testing.T) {
 			mcpw := &azureManagedControlPlaneWebhook{
 				Client: client,
 			}
-			_, err := mcpw.ValidateCreate(context.Background(), &tt.amcp)
+			_, err := mcpw.ValidateCreate(t.Context(), &tt.amcp)
 			if tt.expectErr {
 				g.Expect(err).To(HaveOccurred())
 			} else {
@@ -1637,7 +1636,7 @@ func TestAzureManagedControlPlane_ValidateCreate(t *testing.T) {
 			mcpw := &azureManagedControlPlaneWebhook{
 				Client: client,
 			}
-			_, err := mcpw.ValidateCreate(context.Background(), tc.amcp)
+			_, err := mcpw.ValidateCreate(t.Context(), tc.amcp)
 			if tc.wantErr {
 				g.Expect(err).To(HaveOccurred())
 				if tc.errorLen > 0 {
@@ -1674,7 +1673,7 @@ func TestAzureManagedControlPlane_ValidateCreateFailure(t *testing.T) {
 			mcpw := &azureManagedControlPlaneWebhook{
 				Client: client,
 			}
-			_, err := mcpw.ValidateCreate(context.Background(), tc.amcp)
+			_, err := mcpw.ValidateCreate(t.Context(), tc.amcp)
 			if tc.expectError {
 				g.Expect(err).To(HaveOccurred())
 			} else {
@@ -3184,7 +3183,7 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 			mcpw := &azureManagedControlPlaneWebhook{
 				Client: client,
 			}
-			_, err := mcpw.ValidateUpdate(context.Background(), tc.oldAMCP, tc.amcp)
+			_, err := mcpw.ValidateUpdate(t.Context(), tc.oldAMCP, tc.amcp)
 			if tc.wantErr {
 				g.Expect(err).To(HaveOccurred())
 			} else {
@@ -3365,7 +3364,7 @@ func TestAzureManagedClusterSecurityProfileValidateCreate(t *testing.T) {
 			mcpw := &azureManagedControlPlaneWebhook{
 				Client: client,
 			}
-			_, err := mcpw.ValidateCreate(context.Background(), tc.amcp)
+			_, err := mcpw.ValidateCreate(t.Context(), tc.amcp)
 			if tc.wantErr != "" {
 				g.Expect(err).To(HaveOccurred())
 				g.Expect(err.Error()).To(Equal(tc.wantErr))
@@ -3866,7 +3865,7 @@ func TestAzureClusterSecurityProfileValidateUpdate(t *testing.T) {
 			mcpw := &azureManagedControlPlaneWebhook{
 				Client: client,
 			}
-			_, err := mcpw.ValidateUpdate(context.Background(), tc.oldAMCP, tc.amcp)
+			_, err := mcpw.ValidateUpdate(t.Context(), tc.oldAMCP, tc.amcp)
 			if tc.wantErr != "" {
 				g.Expect(err).To(HaveOccurred())
 				g.Expect(err.Error()).To(Equal(tc.wantErr))
@@ -4154,7 +4153,7 @@ func TestValidateAMCPVirtualNetwork(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			g := NewWithT(t)
 			mcpw := &azureManagedControlPlaneWebhook{}
-			err := mcpw.Default(context.Background(), tc.amcp)
+			err := mcpw.Default(t.Context(), tc.amcp)
 			g.Expect(err).NotTo(HaveOccurred())
 
 			errs := validateAMCPVirtualNetwork(tc.amcp.Spec.VirtualNetwork, field.NewPath("spec", "virtualNetwork"))

--- a/api/v1beta1/azuremanagedcontrolplanetemplate_webhook_test.go
+++ b/api/v1beta1/azuremanagedcontrolplanetemplate_webhook_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package v1beta1
 
 import (
-	"context"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -31,7 +30,7 @@ func TestControlPlaneTemplateDefaultingWebhook(t *testing.T) {
 	t.Logf("Testing amcp defaulting webhook with no baseline")
 	amcpt := getAzureManagedControlPlaneTemplate()
 	mcptw := &azureManagedControlPlaneTemplateWebhook{}
-	err := mcptw.Default(context.Background(), amcpt)
+	err := mcptw.Default(t.Context(), amcpt)
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(*amcpt.Spec.Template.Spec.NetworkPlugin).To(Equal("azure"))
 	g.Expect(*amcpt.Spec.Template.Spec.LoadBalancerSKU).To(Equal("Standard"))
@@ -54,7 +53,7 @@ func TestControlPlaneTemplateDefaultingWebhook(t *testing.T) {
 	amcpt.Spec.Template.Spec.SKU.Tier = PaidManagedControlPlaneTier
 	amcpt.Spec.Template.Spec.EnablePreviewFeatures = ptr.To(true)
 
-	err = mcptw.Default(context.Background(), amcpt)
+	err = mcptw.Default(t.Context(), amcpt)
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(*amcpt.Spec.Template.Spec.NetworkPlugin).To(Equal(netPlug))
 	g.Expect(*amcpt.Spec.Template.Spec.LoadBalancerSKU).To(Equal(lbSKU))
@@ -274,7 +273,7 @@ func TestControlPlaneTemplateUpdateWebhook(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			g := NewWithT(t)
 			cpw := &azureManagedControlPlaneTemplateWebhook{}
-			_, err := cpw.ValidateUpdate(context.Background(), tc.oldControlPlaneTemplate, tc.controlPlaneTemplate)
+			_, err := cpw.ValidateUpdate(t.Context(), tc.oldControlPlaneTemplate, tc.controlPlaneTemplate)
 			if tc.wantErr {
 				g.Expect(err).To(HaveOccurred())
 			} else {

--- a/api/v1beta1/azuremanagedmachinepool_webhook_test.go
+++ b/api/v1beta1/azuremanagedmachinepool_webhook_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package v1beta1
 
 import (
-	"context"
 	"testing"
 
 	asocontainerservicev1 "github.com/Azure/azure-service-operator/v2/api/containerservice/v1api20231001"
@@ -55,7 +54,7 @@ func TestAzureManagedMachinePoolDefaultingWebhook(t *testing.T) {
 	mw := &azureManagedMachinePoolWebhook{
 		Client: client,
 	}
-	err := mw.Default(context.Background(), ammp)
+	err := mw.Default(t.Context(), ammp)
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(ammp.Labels).NotTo(BeNil())
 	val, ok := ammp.Labels[LabelAgentPoolMode]
@@ -66,21 +65,21 @@ func TestAzureManagedMachinePoolDefaultingWebhook(t *testing.T) {
 	t.Logf("Testing ammp defaulting webhook with empty string name specified in Spec")
 	emptyName := ""
 	ammp.Spec.Name = &emptyName
-	err = mw.Default(context.Background(), ammp)
+	err = mw.Default(t.Context(), ammp)
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(*ammp.Spec.Name).To(Equal("fooname"))
 
 	t.Logf("Testing ammp defaulting webhook with normal name specified in Spec")
 	normalName := "barname"
 	ammp.Spec.Name = &normalName
-	err = mw.Default(context.Background(), ammp)
+	err = mw.Default(t.Context(), ammp)
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(*ammp.Spec.Name).To(Equal("barname"))
 
 	t.Logf("Testing ammp defaulting webhook with normal OsDiskType specified in Spec")
 	normalOsDiskType := "Ephemeral"
 	ammp.Spec.OsDiskType = &normalOsDiskType
-	err = mw.Default(context.Background(), ammp)
+	err = mw.Default(t.Context(), ammp)
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(*ammp.Spec.OsDiskType).To(Equal("Ephemeral"))
 }
@@ -642,7 +641,7 @@ func TestAzureManagedMachinePoolUpdatingWebhook(t *testing.T) {
 			mw := &azureManagedMachinePoolWebhook{
 				Client: client,
 			}
-			_, err := mw.ValidateUpdate(context.Background(), tc.old, tc.new)
+			_, err := mw.ValidateUpdate(t.Context(), tc.old, tc.new)
 			if tc.wantErr {
 				g.Expect(err).To(HaveOccurred())
 			} else {
@@ -1293,7 +1292,7 @@ func TestAzureManagedMachinePool_ValidateCreate(t *testing.T) {
 			mw := &azureManagedMachinePoolWebhook{
 				Client: client,
 			}
-			_, err := mw.ValidateCreate(context.Background(), tc.ammp)
+			_, err := mw.ValidateCreate(t.Context(), tc.ammp)
 			if tc.wantErr {
 				g.Expect(err).To(HaveOccurred())
 				g.Expect(err).To(HaveLen(tc.errorLen))
@@ -1325,7 +1324,7 @@ func TestAzureManagedMachinePool_ValidateCreateFailure(t *testing.T) {
 			}
 			g := NewWithT(t)
 			mw := &azureManagedMachinePoolWebhook{}
-			_, err := mw.ValidateCreate(context.Background(), tc.ammp)
+			_, err := mw.ValidateCreate(t.Context(), tc.ammp)
 			if tc.expectError {
 				g.Expect(err).To(HaveOccurred())
 			} else {

--- a/api/v1beta1/azuremanagedmachinepooltemplate_webhook_test.go
+++ b/api/v1beta1/azuremanagedmachinepooltemplate_webhook_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package v1beta1
 
 import (
-	"context"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -33,7 +32,7 @@ func TestManagedMachinePoolTemplateDefaultingWebhook(t *testing.T) {
 	t.Logf("Testing ammpt defaulting webhook with no baseline")
 	ammpt := getAzureManagedMachinePoolTemplate()
 	mmptw := &azureManagedMachinePoolTemplateWebhook{}
-	err := mmptw.Default(context.Background(), ammpt)
+	err := mmptw.Default(t.Context(), ammpt)
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(ammpt.Labels).To(Equal(map[string]string{
 		LabelAgentPoolMode: "System",
@@ -47,7 +46,7 @@ func TestManagedMachinePoolTemplateDefaultingWebhook(t *testing.T) {
 		ammpt.Spec.Template.Spec.Name = ptr.To("barName")
 		ammpt.Spec.Template.Spec.OSType = ptr.To("Windows")
 	})
-	err = mmptw.Default(context.Background(), ammpt)
+	err = mmptw.Default(t.Context(), ammpt)
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(ammpt.Labels).To(Equal(map[string]string{
 		LabelAgentPoolMode: "User",
@@ -236,7 +235,7 @@ func TestManagedMachinePoolTemplateUpdateWebhook(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			g := NewWithT(t)
 			mpw := &azureManagedMachinePoolTemplateWebhook{}
-			_, err := mpw.ValidateUpdate(context.Background(), tc.oldMachinePoolTemplate, tc.machinePoolTemplate)
+			_, err := mpw.ValidateUpdate(t.Context(), tc.oldMachinePoolTemplate, tc.machinePoolTemplate)
 			if tc.wantErr {
 				g.Expect(err).To(HaveOccurred())
 			} else {

--- a/azure/converters/resourcehealth.go
+++ b/azure/converters/resourcehealth.go
@@ -67,5 +67,5 @@ func SDKAvailabilityStatusToCondition(availStatus armresourcehealth.Availability
 		message = *availStatus.Properties.Summary
 	}
 
-	return conditions.FalseCondition(infrav1.AzureResourceAvailableCondition, reason.String(), severity, message)
+	return conditions.FalseCondition(infrav1.AzureResourceAvailableCondition, reason.String(), severity, "%s", message)
 }

--- a/azure/defaults_test.go
+++ b/azure/defaults_test.go
@@ -106,7 +106,7 @@ func TestPerCallPolicies(t *testing.T) {
 	g.Expect(opts.PerCallPolicies).To(ContainElement(BeAssignableToTypeOf(userAgentPolicy{})))
 
 	// Create a request with a correlation ID.
-	ctx := context.WithValue(context.Background(), tele.CorrIDKeyVal, tele.CorrID(corrID))
+	ctx := context.WithValue(t.Context(), tele.CorrIDKeyVal, tele.CorrID(corrID))
 	req, err := runtime.NewRequest(ctx, http.MethodGet, server.URL)
 	g.Expect(err).NotTo(HaveOccurred())
 
@@ -188,7 +188,7 @@ func TestCustomPutPatchHeaderPolicy(t *testing.T) {
 			g.Expect(err).NotTo(HaveOccurred())
 
 			// Create a request
-			req, err := runtime.NewRequest(context.Background(), tc.method, server.URL)
+			req, err := runtime.NewRequest(t.Context(), tc.method, server.URL)
 			g.Expect(err).NotTo(HaveOccurred())
 
 			// Create a pipeline and send the request to the test server for validation.

--- a/azure/errors_test.go
+++ b/azure/errors_test.go
@@ -35,7 +35,7 @@ func TestIsContextDeadlineExceededOrCanceled(t *testing.T) {
 		{
 			name: "Context deadline exceeded error",
 			err: func() error {
-				ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-7*time.Hour))
+				ctx, cancel := context.WithDeadline(t.Context(), time.Now().Add(-7*time.Hour))
 				defer cancel()
 				return ctx.Err()
 			}(),
@@ -44,7 +44,7 @@ func TestIsContextDeadlineExceededOrCanceled(t *testing.T) {
 		{
 			name: "Context canceled exceeded error",
 			err: func() error {
-				ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(1*time.Hour))
+				ctx, cancel := context.WithDeadline(t.Context(), time.Now().Add(1*time.Hour))
 				cancel()
 				return ctx.Err()
 			}(),

--- a/azure/scope/cluster_test.go
+++ b/azure/scope/cluster_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package scope
 
 import (
-	"context"
 	"fmt"
 	"reflect"
 	"strings"
@@ -103,7 +102,7 @@ func TestNewClusterScope(t *testing.T) {
 			},
 		},
 	}
-	err := (&infrav1.AzureClusterWebhook{}).Default(context.Background(), azureCluster)
+	err := (&infrav1.AzureClusterWebhook{}).Default(t.Context(), azureCluster)
 	g.Expect(err).NotTo(HaveOccurred())
 
 	fakeIdentity := &infrav1.AzureClusterIdentity{
@@ -118,7 +117,7 @@ func TestNewClusterScope(t *testing.T) {
 	initObjects := []runtime.Object{cluster, azureCluster, fakeIdentity, fakeSecret}
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(initObjects...).Build()
 
-	_, err = NewClusterScope(context.TODO(), ClusterScopeParams{
+	_, err = NewClusterScope(t.Context(), ClusterScopeParams{
 		Cluster:         cluster,
 		AzureCluster:    azureCluster,
 		Client:          fakeClient,
@@ -283,7 +282,7 @@ func TestAPIServerHost(t *testing.T) {
 		tc.azureCluster.ObjectMeta = metav1.ObjectMeta{
 			Name: cluster.Name,
 		}
-		err := (&infrav1.AzureClusterWebhook{}).Default(context.Background(), &tc.azureCluster)
+		err := (&infrav1.AzureClusterWebhook{}).Default(t.Context(), &tc.azureCluster)
 		g.Expect(err).NotTo(HaveOccurred())
 
 		clusterScope := &ClusterScope{
@@ -442,7 +441,7 @@ func TestGettingSecurityRules(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
 
-			err := (&infrav1.AzureClusterWebhook{}).Default(context.Background(), tt.azureCluster)
+			err := (&infrav1.AzureClusterWebhook{}).Default(t.Context(), tt.azureCluster)
 			g.Expect(err).NotTo(HaveOccurred())
 
 			clusterScope := &ClusterScope{
@@ -2331,7 +2330,7 @@ func TestOutboundLBName(t *testing.T) {
 				azureCluster.Spec.NetworkSpec.NodeOutboundLB = tc.nodeOutboundLB
 			}
 
-			err := (&infrav1.AzureClusterWebhook{}).Default(context.Background(), azureCluster)
+			err := (&infrav1.AzureClusterWebhook{}).Default(t.Context(), azureCluster)
 			g.Expect(err).NotTo(HaveOccurred())
 
 			clusterScope := &ClusterScope{
@@ -2446,7 +2445,7 @@ func TestBackendPoolName(t *testing.T) {
 				},
 			}
 
-			err := (&infrav1.AzureClusterWebhook{}).Default(context.Background(), azureCluster)
+			err := (&infrav1.AzureClusterWebhook{}).Default(t.Context(), azureCluster)
 			g.Expect(err).NotTo(HaveOccurred())
 
 			if tc.customAPIServerBackendPoolName != "" {
@@ -2560,7 +2559,7 @@ func TestOutboundPoolName(t *testing.T) {
 				}
 			}
 
-			err := (&infrav1.AzureClusterWebhook{}).Default(context.Background(), azureCluster)
+			err := (&infrav1.AzureClusterWebhook{}).Default(t.Context(), azureCluster)
 			g.Expect(err).NotTo(HaveOccurred())
 
 			clusterScope := &ClusterScope{

--- a/azure/scope/identity_test.go
+++ b/azure/scope/identity_test.go
@@ -134,7 +134,7 @@ func TestAllowedNamespaces(t *testing.T) {
 			initObjects := []runtime.Object{tc.identity, fakeNamespace}
 			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(initObjects...).Build()
 
-			actual := IsClusterNamespaceAllowed(context.TODO(), fakeClient, tc.identity.Spec.AllowedNamespaces, tc.clusterNamespace)
+			actual := IsClusterNamespaceAllowed(t.Context(), fakeClient, tc.identity.Spec.AllowedNamespaces, tc.clusterNamespace)
 			g.Expect(actual).To(Equal(tc.expected))
 		})
 	}
@@ -439,7 +439,7 @@ func TestGetTokenCredential(t *testing.T) {
 				},
 			},
 			cacheExpect: func(cache *mock_azure.MockCredentialCache) {
-				ctx := context.Background()
+				ctx := context.Background()                      //nolint:usetesting
 				credsPath := "../../test/setup/credentials.json" //nolint:gosec
 				clientOptions := azcore.ClientOptions{
 					Cloud: cloud.Configuration{
@@ -481,9 +481,9 @@ func TestGetTokenCredential(t *testing.T) {
 			cache := mock_azure.NewMockCredentialCache(mockCtrl)
 			tt.cacheExpect(cache)
 
-			provider, err := NewAzureCredentialsProvider(context.Background(), cache, fakeClient, tt.cluster.Spec.IdentityRef, "")
+			provider, err := NewAzureCredentialsProvider(t.Context(), cache, fakeClient, tt.cluster.Spec.IdentityRef, "")
 			g.Expect(err).NotTo(HaveOccurred())
-			_, err = provider.GetTokenCredential(context.Background(), "", tt.ActiveDirectoryAuthorityHost, "")
+			_, err = provider.GetTokenCredential(t.Context(), "", tt.ActiveDirectoryAuthorityHost, "")
 			g.Expect(err).NotTo(HaveOccurred())
 		})
 	}

--- a/azure/scope/machine.go
+++ b/azure/scope/machine.go
@@ -611,7 +611,7 @@ func (m *MachineScope) SetFailureReason(v string) {
 
 // SetConditionFalse sets the specified AzureMachine condition to false.
 func (m *MachineScope) SetConditionFalse(conditionType clusterv1.ConditionType, reason string, severity clusterv1.ConditionSeverity, message string) {
-	conditions.MarkFalse(m.AzureMachine, conditionType, reason, severity, message)
+	conditions.MarkFalse(m.AzureMachine, conditionType, reason, severity, "%s", message)
 }
 
 // SetAnnotation sets a key value annotation on the AzureMachine.

--- a/azure/scope/machine_test.go
+++ b/azure/scope/machine_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package scope
 
 import (
-	"context"
 	"reflect"
 	"testing"
 
@@ -1659,7 +1658,7 @@ func TestMachineScope_GetVMImage(t *testing.T) {
 				ClusterScoper: clusterMock,
 			},
 			want: func() *infrav1.Image {
-				image, _ := svc.GetDefaultWindowsImage(context.TODO(), "", "1.20.1", "containerd", "")
+				image, _ := svc.GetDefaultWindowsImage(t.Context(), "", "1.20.1", "containerd", "")
 				return image
 			}(),
 			expectedErr: "",
@@ -1691,7 +1690,7 @@ func TestMachineScope_GetVMImage(t *testing.T) {
 				ClusterScoper: clusterMock,
 			},
 			want: func() *infrav1.Image {
-				image, _ := svc.GetDefaultWindowsImage(context.TODO(), "", "1.22.1", "dockershim", "")
+				image, _ := svc.GetDefaultWindowsImage(t.Context(), "", "1.22.1", "dockershim", "")
 				return image
 			}(),
 			expectedErr: "unsupported runtime dockershim",
@@ -1723,7 +1722,7 @@ func TestMachineScope_GetVMImage(t *testing.T) {
 				ClusterScoper: clusterMock,
 			},
 			want: func() *infrav1.Image {
-				image, _ := svc.GetDefaultWindowsImage(context.TODO(), "", "1.23.3", "", "windows-2019")
+				image, _ := svc.GetDefaultWindowsImage(t.Context(), "", "1.23.3", "", "windows-2019")
 				return image
 			}(),
 			expectedErr: "",
@@ -1755,7 +1754,7 @@ func TestMachineScope_GetVMImage(t *testing.T) {
 				ClusterScoper: clusterMock,
 			},
 			want: func() *infrav1.Image {
-				image, _ := svc.GetDefaultWindowsImage(context.TODO(), "", "1.23.3", "", "windows-2022")
+				image, _ := svc.GetDefaultWindowsImage(t.Context(), "", "1.23.3", "", "windows-2022")
 				return image
 			}(),
 			expectedErr: "",
@@ -1779,7 +1778,7 @@ func TestMachineScope_GetVMImage(t *testing.T) {
 				ClusterScoper: clusterMock,
 			},
 			want: func() *infrav1.Image {
-				image, _ := svc.GetDefaultLinuxImage(context.TODO(), "", "1.20.1")
+				image, _ := svc.GetDefaultLinuxImage(t.Context(), "", "1.20.1")
 				return image
 			}(),
 			expectedErr: "",
@@ -1787,7 +1786,7 @@ func TestMachineScope_GetVMImage(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotImage, err := tt.machineScope.GetVMImage(context.TODO())
+			gotImage, err := tt.machineScope.GetVMImage(t.Context())
 			if (err == nil && tt.expectedErr != "") || (err != nil && tt.expectedErr != err.Error()) {
 				t.Errorf("expected error %v, got %v", tt.expectedErr, err)
 			}

--- a/azure/scope/machinepool_test.go
+++ b/azure/scope/machinepool_test.go
@@ -507,7 +507,7 @@ func TestMachinePoolScope_GetVMImage(t *testing.T) {
 				AzureMachinePool: amp,
 				ClusterScoper:    clusterMock,
 			}
-			image, err := s.GetVMImage(context.TODO())
+			image, err := s.GetVMImage(t.Context())
 			c.Verify(g, amp, image, err)
 		})
 	}
@@ -741,7 +741,7 @@ func TestMachinePoolScope_updateReplicasAndProviderIDs(t *testing.T) {
 				AzureMachinePool: amp,
 				MachinePool:      mp,
 			}
-			err := s.updateReplicasAndProviderIDs(context.TODO())
+			err := s.updateReplicasAndProviderIDs(t.Context())
 			c.Verify(g, s.AzureMachinePool, err)
 		})
 	}
@@ -1347,7 +1347,7 @@ func TestMachinePoolScope_SetInfrastructureMachineKind(t *testing.T) {
 }
 
 func TestMachinePoolScope_applyAzureMachinePoolMachines(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 	scheme := runtime.NewScheme()
 	_ = clusterv1.AddToScheme(scheme)
@@ -1752,7 +1752,7 @@ func TestMachinePoolScope_setProvisioningStateAndConditions(t *testing.T) {
 }
 
 func TestBootstrapDataChanges(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 	scheme := runtime.NewScheme()
 	_ = clusterv1.AddToScheme(scheme)

--- a/azure/scope/machinepoolmachine_test.go
+++ b/azure/scope/machinepoolmachine_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package scope
 
 import (
-	"context"
 	"reflect"
 	"testing"
 
@@ -449,7 +448,7 @@ func TestMachineScope_UpdateNodeStatus(t *testing.T) {
 			s.instance = instance
 			s.workloadNodeGetter = mockClient
 
-			err = s.UpdateNodeStatus(context.TODO())
+			err = s.UpdateNodeStatus(t.Context())
 			if c.Err == "" {
 				g.Expect(err).To(Succeed())
 			} else {

--- a/azure/scope/managedcontrolplane_test.go
+++ b/azure/scope/managedcontrolplane_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package scope
 
 import (
-	"context"
 	"reflect"
 	"testing"
 
@@ -88,7 +87,7 @@ func TestNewManagedControlPlaneScope(t *testing.T) {
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(initObjects...).Build()
 
 	input.Client = fakeClient
-	_, err := NewManagedControlPlaneScope(context.TODO(), input)
+	_, err := NewManagedControlPlaneScope(t.Context(), input)
 	g.Expect(err).NotTo(HaveOccurred())
 }
 

--- a/azure/scope/managedmachinepool_test.go
+++ b/azure/scope/managedmachinepool_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package scope
 
 import (
-	"context"
 	"reflect"
 	"testing"
 
@@ -69,7 +68,7 @@ func TestNewManagedMachinePoolScope(t *testing.T) {
 	g := NewWithT(t)
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(input.MachinePool, input.InfraMachinePool, input.ControlPlane).Build()
 	input.Client = fakeClient
-	_, err := NewManagedMachinePoolScope(context.TODO(), input)
+	_, err := NewManagedMachinePoolScope(t.Context(), input)
 	g.Expect(err).To(Succeed())
 }
 

--- a/azure/scope/strategies/machinepool_deployments/machinepool_deployment_strategy_test.go
+++ b/azure/scope/strategies/machinepool_deployments/machinepool_deployment_strategy_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package machinepool
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -401,7 +400,7 @@ func TestMachinePoolRollingUpdateStrategy_SelectMachinesToDelete(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
-			got, err := tt.strategy.SelectMachinesToDelete(context.Background(), tt.desiredReplicas, tt.input)
+			got, err := tt.strategy.SelectMachinesToDelete(t.Context(), tt.desiredReplicas, tt.input)
 			if tt.errStr == "" {
 				g.Expect(err).To(Succeed())
 				g.Expect(got).To(tt.want)

--- a/azure/services/agentpools/agentpools_test.go
+++ b/azure/services/agentpools/agentpools_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package agentpools
 
 import (
-	"context"
 	"testing"
 
 	asocontainerservicev1 "github.com/Azure/azure-service-operator/v2/api/containerservice/v1api20231001"
@@ -37,7 +36,7 @@ func TestPostCreateOrUpdateResourceHook(t *testing.T) {
 		mockCtrl := gomock.NewController(t)
 		scope := mock_agentpools.NewMockAgentPoolScope(mockCtrl)
 
-		err := postCreateOrUpdateResourceHook(context.Background(), scope, nil, errors.New("an error"))
+		err := postCreateOrUpdateResourceHook(t.Context(), scope, nil, errors.New("an error"))
 		g.Expect(err).To(HaveOccurred())
 	})
 
@@ -54,7 +53,7 @@ func TestPostCreateOrUpdateResourceHook(t *testing.T) {
 			},
 		}
 
-		err := postCreateOrUpdateResourceHook(context.Background(), scope, managedCluster, nil)
+		err := postCreateOrUpdateResourceHook(t.Context(), scope, managedCluster, nil)
 		g.Expect(err).NotTo(HaveOccurred())
 	})
 
@@ -73,7 +72,7 @@ func TestPostCreateOrUpdateResourceHook(t *testing.T) {
 			},
 		}
 
-		err := postCreateOrUpdateResourceHook(context.Background(), scope, managedCluster, nil)
+		err := postCreateOrUpdateResourceHook(t.Context(), scope, managedCluster, nil)
 		g.Expect(err).NotTo(HaveOccurred())
 	})
 
@@ -92,6 +91,6 @@ func TestPostCreateOrUpdateResourceHook(t *testing.T) {
 			},
 		}
 
-		g.Expect(postCreateOrUpdateResourceHook(context.Background(), scope, agentPool, nil)).To(Succeed())
+		g.Expect(postCreateOrUpdateResourceHook(t.Context(), scope, agentPool, nil)).To(Succeed())
 	})
 }

--- a/azure/services/agentpools/spec_test.go
+++ b/azure/services/agentpools/spec_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package agentpools
 
 import (
-	"context"
 	"testing"
 
 	asocontainerservicev1 "github.com/Azure/azure-service-operator/v2/api/containerservice/v1api20231001"
@@ -121,7 +120,7 @@ func TestParameters(t *testing.T) {
 			},
 		}
 
-		actual, err := spec.Parameters(context.Background(), nil)
+		actual, err := spec.Parameters(t.Context(), nil)
 
 		g.Expect(err).NotTo(HaveOccurred())
 		g.Expect(cmp.Diff(actual, expected)).To(BeEmpty())
@@ -217,7 +216,7 @@ func TestParameters(t *testing.T) {
 			},
 		}
 
-		actual, err := spec.Parameters(context.Background(), nil)
+		actual, err := spec.Parameters(t.Context(), nil)
 
 		g.Expect(err).NotTo(HaveOccurred())
 		g.Expect(cmp.Diff(actual, expected)).To(BeEmpty())
@@ -245,7 +244,7 @@ func TestParameters(t *testing.T) {
 			},
 		}
 
-		actual, err := spec.Parameters(context.Background(), existing)
+		actual, err := spec.Parameters(t.Context(), existing)
 		actualTyped, ok := actual.(*asocontainerservicev1.ManagedClustersAgentPool)
 		g.Expect(ok).To(BeTrue())
 
@@ -280,7 +279,7 @@ func TestParameters(t *testing.T) {
 			},
 		}
 
-		actual, err := spec.Parameters(context.Background(), existing)
+		actual, err := spec.Parameters(t.Context(), existing)
 		actualTyped, ok := actual.(*asocontainerservicev1preview.ManagedClustersAgentPool)
 		g.Expect(ok).To(BeTrue())
 

--- a/azure/services/aksextensions/spec_test.go
+++ b/azure/services/aksextensions/spec_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package aksextensions
 
 import (
-	"context"
 	"testing"
 
 	asokubernetesconfigurationv1 "github.com/Azure/azure-service-operator/v2/api/kubernetesconfiguration/v1api20230501"
@@ -142,7 +141,7 @@ func TestAzureAKSExtensionSpec_Parameters(t *testing.T) {
 			g := NewWithT(t)
 			t.Parallel()
 
-			result, err := tc.spec.Parameters(context.TODO(), tc.existing)
+			result, err := tc.spec.Parameters(t.Context(), tc.existing)
 			if tc.expectedError != "" {
 				g.Expect(err).To(HaveOccurred())
 				g.Expect(err).To(MatchError(tc.expectedError))

--- a/azure/services/aso/aso_test.go
+++ b/azure/services/aso/aso_test.go
@@ -118,7 +118,7 @@ func TestCreateOrUpdateResource(t *testing.T) {
 			},
 		})
 
-		ctx := context.Background()
+		ctx := t.Context()
 		g.Expect(c.Create(ctx, &asoresourcesv1.ResourceGroup{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:            "name",
@@ -160,7 +160,7 @@ func TestCreateOrUpdateResource(t *testing.T) {
 			},
 		}, nil)
 
-		ctx := context.Background()
+		ctx := t.Context()
 		result, err := s.CreateOrUpdateResource(ctx, specMock, "service")
 		g.Expect(result).To(BeNil())
 		g.Expect(err).To(HaveOccurred())
@@ -205,7 +205,7 @@ func TestCreateOrUpdateResource(t *testing.T) {
 		})
 		specMock.EXPECT().WasManaged(gomock.Any()).Return(false)
 
-		ctx := context.Background()
+		ctx := t.Context()
 		g.Expect(c.Create(ctx, &asoresourcesv1.ResourceGroup{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:            "name",
@@ -261,7 +261,7 @@ func TestCreateOrUpdateResource(t *testing.T) {
 		})
 		specMock.EXPECT().WasManaged(gomock.Any()).Return(false)
 
-		ctx := context.Background()
+		ctx := t.Context()
 		g.Expect(c.Create(ctx, &asoresourcesv1.ResourceGroup{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:            "name",
@@ -313,7 +313,7 @@ func TestCreateOrUpdateResource(t *testing.T) {
 		})
 		specMock.EXPECT().WasManaged(gomock.Any()).Return(false)
 
-		ctx := context.Background()
+		ctx := t.Context()
 		g.Expect(c.Create(ctx, &asoresourcesv1.ResourceGroup{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:            "name",
@@ -365,7 +365,7 @@ func TestCreateOrUpdateResource(t *testing.T) {
 			},
 		})
 
-		ctx := context.Background()
+		ctx := t.Context()
 		result, err := s.CreateOrUpdateResource(ctx, specMock, "service")
 		g.Expect(result).To(BeNil())
 		g.Expect(err).To(HaveOccurred())
@@ -395,7 +395,7 @@ func TestCreateOrUpdateResource(t *testing.T) {
 		})
 		specMock.EXPECT().WasManaged(gomock.Any()).Return(false)
 
-		ctx := context.Background()
+		ctx := t.Context()
 		g.Expect(c.Create(ctx, &asoresourcesv1.ResourceGroup{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:            "name",
@@ -442,7 +442,7 @@ func TestCreateOrUpdateResource(t *testing.T) {
 			return group, nil
 		})
 
-		ctx := context.Background()
+		ctx := t.Context()
 		g.Expect(c.Create(ctx, &asoresourcesv1.ResourceGroup{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:            "name",
@@ -501,7 +501,7 @@ func TestCreateOrUpdateResource(t *testing.T) {
 		})
 		specMock.EXPECT().WasManaged(gomock.Any()).Return(true)
 
-		ctx := context.Background()
+		ctx := t.Context()
 		g.Expect(c.Create(ctx, &asoresourcesv1.ResourceGroup{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:            "name",
@@ -559,7 +559,7 @@ func TestCreateOrUpdateResource(t *testing.T) {
 		})
 		specMock.EXPECT().WasManaged(gomock.Any()).Return(true)
 
-		ctx := context.Background()
+		ctx := t.Context()
 		g.Expect(c.Create(ctx, &asoresourcesv1.ResourceGroup{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "name",
@@ -614,7 +614,7 @@ func TestCreateOrUpdateResource(t *testing.T) {
 		})
 		specMock.EXPECT().Parameters(gomockinternal.AContext(), gomock.Not(gomock.Nil())).Return(nil, errors.New("parameters error"))
 
-		ctx := context.Background()
+		ctx := t.Context()
 		g.Expect(c.Create(ctx, &asoresourcesv1.ResourceGroup{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:            "name",
@@ -658,7 +658,7 @@ func TestCreateOrUpdateResource(t *testing.T) {
 			},
 		})
 
-		ctx := context.Background()
+		ctx := t.Context()
 		g.Expect(c.Create(ctx, &asoresourcesv1.ResourceGroup{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "name",
@@ -704,7 +704,7 @@ func TestCreateOrUpdateResource(t *testing.T) {
 		})
 		specMock.EXPECT().WasManaged(gomock.Any()).Return(false)
 
-		ctx := context.Background()
+		ctx := t.Context()
 		g.Expect(c.Create(ctx, &asoresourcesv1.ResourceGroup{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:            "name",
@@ -763,7 +763,7 @@ func TestCreateOrUpdateResource(t *testing.T) {
 		})
 		specMock.EXPECT().WasManaged(gomock.Any()).Return(false)
 
-		ctx := context.Background()
+		ctx := t.Context()
 		g.Expect(c.Create(ctx, &asoresourcesv1.ResourceGroup{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:            "name",
@@ -821,7 +821,7 @@ func TestCreateOrUpdateResource(t *testing.T) {
 		specMock.MockTagsGetterSetter.EXPECT().GetDesiredTags(gomock.Any()).Return(nil).Times(2)
 		specMock.MockTagsGetterSetter.EXPECT().SetTags(gomock.Any(), gomock.Any())
 
-		ctx := context.Background()
+		ctx := t.Context()
 		g.Expect(c.Create(ctx, &asoresourcesv1.ResourceGroup{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:            "name",
@@ -880,7 +880,7 @@ func TestCreateOrUpdateResource(t *testing.T) {
 			return group, nil
 		})
 
-		ctx := context.Background()
+		ctx := t.Context()
 		g.Expect(c.Create(ctx, &asoresourcesv1.ResourceGroup{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:            "name",
@@ -931,7 +931,7 @@ func TestCreateOrUpdateResource(t *testing.T) {
 		})
 		specMock.EXPECT().WasManaged(gomock.Any()).Return(false)
 
-		ctx := context.Background()
+		ctx := t.Context()
 		g.Expect(c.Create(ctx, &asoresourcesv1.ResourceGroup{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:            "name",
@@ -1005,7 +1005,7 @@ func TestCreateOrUpdateResource(t *testing.T) {
 			`{"metadata": {"labels": {"another": "label"}}}`,
 		})
 
-		ctx := context.Background()
+		ctx := t.Context()
 
 		result, err := s.CreateOrUpdateResource(ctx, specMock, "service")
 		g.Expect(result).To(BeNil())
@@ -1053,7 +1053,7 @@ func TestCreateOrUpdateResource(t *testing.T) {
 			`{"metadata": {"labels": {"another": "label"}}}`,
 		})
 
-		ctx := context.Background()
+		ctx := t.Context()
 		g.Expect(c.Create(ctx, &asoresourcesv1.ResourceGroup{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:            "name",
@@ -1109,7 +1109,7 @@ func TestDeleteResource(t *testing.T) {
 			},
 		}
 
-		ctx := context.Background()
+		ctx := t.Context()
 		g.Expect(s.DeleteResource(ctx, resource, "service")).To(Succeed())
 	})
 
@@ -1123,7 +1123,7 @@ func TestDeleteResource(t *testing.T) {
 			Build()
 		s := New[*asoresourcesv1.ResourceGroup](c, clusterName, newOwner())
 
-		ctx := context.Background()
+		ctx := t.Context()
 		resource := &asoresourcesv1.ResourceGroup{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:            "name",
@@ -1158,7 +1158,7 @@ func TestDeleteResource(t *testing.T) {
 			},
 		}
 
-		ctx := context.Background()
+		ctx := t.Context()
 		g.Expect(c.Create(ctx, resource)).To(Succeed())
 
 		g.Expect(s.DeleteResource(ctx, resource, "service")).To(Succeed())
@@ -1181,7 +1181,7 @@ func TestDeleteResource(t *testing.T) {
 			},
 		}
 
-		ctx := context.Background()
+		ctx := t.Context()
 		g.Expect(c.Create(ctx, resource)).To(Succeed())
 
 		err := s.DeleteResource(ctx, resource, "service")
@@ -1206,7 +1206,7 @@ func TestDeleteResource(t *testing.T) {
 			},
 		}
 
-		ctx := context.Background()
+		ctx := t.Context()
 		g.Expect(c.Create(ctx, resource)).To(Succeed())
 
 		err := s.DeleteResource(ctx, resource, "service")
@@ -1248,7 +1248,7 @@ func TestPauseResource(t *testing.T) {
 					Build()
 			},
 			verify: func(g Gomega, ctrlClient client.Client, resource *asoresourcesv1.ResourceGroup) {
-				ctx := context.Background()
+				ctx := t.Context()
 				actual := &asoresourcesv1.ResourceGroup{}
 				g.Expect(ctrlClient.Get(ctx, client.ObjectKeyFromObject(resource), actual)).To(Succeed())
 				g.Expect(actual.Annotations).To(HaveKeyWithValue(prePauseReconcilePolicyAnnotation, string(asoannotations.ReconcilePolicyManage)))
@@ -1280,7 +1280,7 @@ func TestPauseResource(t *testing.T) {
 					Build()
 			},
 			verify: func(g Gomega, ctrlClient client.Client, resource *asoresourcesv1.ResourceGroup) {
-				ctx := context.Background()
+				ctx := t.Context()
 				actual := &asoresourcesv1.ResourceGroup{}
 				g.Expect(ctrlClient.Get(ctx, client.ObjectKeyFromObject(resource), actual)).To(Succeed())
 				g.Expect(actual.Annotations).To(HaveKeyWithValue(prePauseReconcilePolicyAnnotation, string(asoannotations.ReconcilePolicySkip)))
@@ -1383,7 +1383,7 @@ func TestPauseResource(t *testing.T) {
 					Build()
 			},
 			verify: func(g Gomega, ctrlClient client.Client, resource *asoresourcesv1.ResourceGroup) {
-				ctx := context.Background()
+				ctx := t.Context()
 				actual := &asoresourcesv1.ResourceGroup{}
 				g.Expect(ctrlClient.Get(ctx, client.ObjectKeyFromObject(resource), actual)).To(Succeed())
 				g.Expect(actual.Annotations).NotTo(HaveKey(prePauseReconcilePolicyAnnotation))
@@ -1396,7 +1396,7 @@ func TestPauseResource(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			g := NewWithT(t)
 
-			ctx := context.Background()
+			ctx := t.Context()
 			svcName := "service"
 
 			ctrlClient := test.clientBuilder(g)

--- a/azure/services/aso/service_test.go
+++ b/azure/services/aso/service_test.go
@@ -65,7 +65,7 @@ func TestServiceReconcile(t *testing.T) {
 			},
 		}
 
-		err := s.Reconcile(context.Background())
+		err := s.Reconcile(t.Context())
 		g.Expect(err).To(MatchError(postReconcileErr))
 	})
 
@@ -93,7 +93,7 @@ func TestServiceReconcile(t *testing.T) {
 			ConditionType: conditionType,
 		}
 
-		err := s.Reconcile(context.Background())
+		err := s.Reconcile(t.Context())
 		g.Expect(err).To(MatchError(reconcileErr))
 	})
 
@@ -124,7 +124,7 @@ func TestServiceReconcile(t *testing.T) {
 			ConditionType: conditionType,
 		}
 
-		err := s.Reconcile(context.Background())
+		err := s.Reconcile(t.Context())
 		g.Expect(err).NotTo(HaveOccurred())
 	})
 
@@ -156,7 +156,7 @@ func TestServiceReconcile(t *testing.T) {
 			ConditionType: conditionType,
 		}
 
-		err := s.Reconcile(context.Background())
+		err := s.Reconcile(t.Context())
 		g.Expect(azure.IsOperationNotDoneError(err)).To(BeTrue())
 	})
 
@@ -188,7 +188,7 @@ func TestServiceReconcile(t *testing.T) {
 			ConditionType: conditionType,
 		}
 
-		err := s.Reconcile(context.Background())
+		err := s.Reconcile(t.Context())
 		g.Expect(err).To(MatchError(reconcileErr))
 	})
 
@@ -233,7 +233,7 @@ func TestServiceReconcile(t *testing.T) {
 			},
 		}
 
-		err := s.Reconcile(context.Background())
+		err := s.Reconcile(t.Context())
 		g.Expect(err).To(MatchError(postReconcileErr))
 	})
 
@@ -299,7 +299,7 @@ func TestServiceReconcile(t *testing.T) {
 			ConditionType: conditionType,
 		}
 
-		err := s.Reconcile(context.Background())
+		err := s.Reconcile(t.Context())
 		g.Expect(err).To(MatchError(deleteErr))
 	})
 }
@@ -324,7 +324,7 @@ func TestServiceDelete(t *testing.T) {
 			},
 		}
 
-		err := s.Delete(context.Background())
+		err := s.Delete(t.Context())
 		g.Expect(err).NotTo(HaveOccurred())
 	})
 
@@ -352,7 +352,7 @@ func TestServiceDelete(t *testing.T) {
 			ConditionType: conditionType,
 		}
 
-		err := s.Delete(context.Background())
+		err := s.Delete(t.Context())
 		g.Expect(err).To(MatchError(deleteErr))
 	})
 
@@ -383,7 +383,7 @@ func TestServiceDelete(t *testing.T) {
 			ConditionType: conditionType,
 		}
 
-		err := s.Delete(context.Background())
+		err := s.Delete(t.Context())
 		g.Expect(err).NotTo(HaveOccurred())
 	})
 
@@ -415,7 +415,7 @@ func TestServiceDelete(t *testing.T) {
 			ConditionType: conditionType,
 		}
 
-		err := s.Delete(context.Background())
+		err := s.Delete(t.Context())
 		g.Expect(azure.IsOperationNotDoneError(err)).To(BeTrue())
 	})
 
@@ -447,7 +447,7 @@ func TestServiceDelete(t *testing.T) {
 			ConditionType: conditionType,
 		}
 
-		err := s.Delete(context.Background())
+		err := s.Delete(t.Context())
 		g.Expect(err).To(MatchError(deleteErr))
 	})
 
@@ -481,7 +481,7 @@ func TestServiceDelete(t *testing.T) {
 			},
 		}
 
-		err := s.Delete(context.Background())
+		err := s.Delete(t.Context())
 		g.Expect(err).To(MatchError(postErr))
 	})
 }
@@ -512,7 +512,7 @@ func TestServicePause(t *testing.T) {
 			ConditionType: conditionType,
 		}
 
-		err := s.Pause(context.Background())
+		err := s.Pause(t.Context())
 		g.Expect(err).NotTo(HaveOccurred())
 	})
 
@@ -547,7 +547,7 @@ func TestServicePause(t *testing.T) {
 			ConditionType: conditionType,
 		}
 
-		err := s.Pause(context.Background())
+		err := s.Pause(t.Context())
 		g.Expect(err).To(MatchError(pauseErr))
 	})
 }

--- a/azure/services/async/async_test.go
+++ b/azure/services/async/async_test.go
@@ -182,7 +182,7 @@ func TestServiceCreateOrUpdateResource(t *testing.T) {
 
 			tc.expect(g, scopeMock.EXPECT(), creatorMock.EXPECT(), specMock.EXPECT())
 
-			result, err := svc.CreateOrUpdateResource(context.TODO(), specMock, serviceName)
+			result, err := svc.CreateOrUpdateResource(t.Context(), specMock, serviceName)
 			if tc.expectedError != "" {
 				g.Expect(err).To(HaveOccurred())
 				g.Expect(err.Error()).To(ContainSubstring(tc.expectedError))
@@ -278,7 +278,7 @@ func TestServiceDeleteResource(t *testing.T) {
 
 			tc.expect(g, scopeMock.EXPECT(), deleterMock.EXPECT(), specMock.EXPECT())
 
-			err := svc.DeleteResource(context.TODO(), specMock, tc.serviceName)
+			err := svc.DeleteResource(t.Context(), specMock, tc.serviceName)
 			if tc.expectedError != "" {
 				g.Expect(err).To(HaveOccurred())
 				g.Expect(err.Error()).To(ContainSubstring(tc.expectedError))

--- a/azure/services/availabilitysets/availabilitysets_test.go
+++ b/azure/services/availabilitysets/availabilitysets_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package availabilitysets
 
 import (
-	"context"
 	"io"
 	"net/http"
 	"strconv"
@@ -147,7 +146,7 @@ func TestReconcileAvailabilitySets(t *testing.T) {
 				Reconciler: asyncMock,
 			}
 
-			err := s.Reconcile(context.TODO())
+			err := s.Reconcile(t.Context())
 			if tc.expectedError != "" {
 				g.Expect(err).To(HaveOccurred())
 				g.Expect(err.Error()).To(ContainSubstring(tc.expectedError))
@@ -279,7 +278,7 @@ func TestDeleteAvailabilitySets(t *testing.T) {
 				Reconciler: asyncMock,
 			}
 
-			err := s.Delete(context.TODO())
+			err := s.Delete(t.Context())
 			if tc.expectedError != "" {
 				g.Expect(err).To(HaveOccurred())
 				g.Expect(strings.ReplaceAll(err.Error(), "\n", "")).To(MatchRegexp(tc.expectedError))

--- a/azure/services/availabilitysets/spec_test.go
+++ b/azure/services/availabilitysets/spec_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package availabilitysets
 
 import (
-	"context"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
@@ -80,7 +79,7 @@ func TestParameters(t *testing.T) {
 			g := NewWithT(t)
 			t.Parallel()
 
-			result, err := tc.spec.Parameters(context.TODO(), tc.existing)
+			result, err := tc.spec.Parameters(t.Context(), tc.existing)
 			if tc.expectedError != "" {
 				g.Expect(err).To(HaveOccurred())
 				g.Expect(err).To(MatchError(tc.expectedError))

--- a/azure/services/bastionhosts/spec_test.go
+++ b/azure/services/bastionhosts/spec_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package bastionhosts
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
@@ -187,7 +186,7 @@ func TestAzureBastionSpec_Parameters(t *testing.T) {
 			g := NewWithT(t)
 			t.Parallel()
 
-			result, err := tc.spec.Parameters(context.TODO(), tc.existing)
+			result, err := tc.spec.Parameters(t.Context(), tc.existing)
 			if tc.expectedError != "" {
 				g.Expect(err).To(HaveOccurred())
 				g.Expect(err).To(MatchError(tc.expectedError))

--- a/azure/services/disks/disks_test.go
+++ b/azure/services/disks/disks_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package disks
 
 import (
-	"context"
 	"io"
 	"net/http"
 	"strings"
@@ -131,7 +130,7 @@ func TestDeleteDisk(t *testing.T) {
 				Reconciler: asyncMock,
 			}
 
-			err := s.Delete(context.TODO())
+			err := s.Delete(t.Context())
 			if tc.expectedError != "" {
 				g.Expect(err).To(HaveOccurred())
 				g.Expect(err.Error()).To(ContainSubstring(tc.expectedError))

--- a/azure/services/fleetsmembers/spec_test.go
+++ b/azure/services/fleetsmembers/spec_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package fleetsmembers
 
 import (
-	"context"
 	"testing"
 
 	asocontainerservicev1 "github.com/Azure/azure-service-operator/v2/api/containerservice/v1api20230315preview"
@@ -120,7 +119,7 @@ func TestAzureFleetsMemberSpec_Parameters(t *testing.T) {
 			g := NewWithT(t)
 			t.Parallel()
 
-			result, err := tc.spec.Parameters(context.TODO(), tc.existing)
+			result, err := tc.spec.Parameters(t.Context(), tc.existing)
 			if tc.expectedError != "" {
 				g.Expect(err).To(HaveOccurred())
 				g.Expect(err).To(MatchError(tc.expectedError))

--- a/azure/services/groups/groups_test.go
+++ b/azure/services/groups/groups_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package groups
 
 import (
-	"context"
 	"testing"
 
 	asoresourcesv1 "github.com/Azure/azure-service-operator/v2/api/resources/v1api20200601"
@@ -169,7 +168,7 @@ func TestIsManaged(t *testing.T) {
 			scopeMock.EXPECT().ASOOwner().Return(newOwner()).AnyTimes()
 			test.expect(scopeMock.EXPECT())
 
-			actual, err := New(scopeMock).IsManaged(context.Background())
+			actual, err := New(scopeMock).IsManaged(t.Context())
 			if test.expectedError {
 				g.Expect(err).To(HaveOccurred())
 			} else {

--- a/azure/services/groups/spec_test.go
+++ b/azure/services/groups/spec_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package groups
 
 import (
-	"context"
 	"testing"
 
 	asoresourcesv1 "github.com/Azure/azure-service-operator/v2/api/resources/v1api20200601"
@@ -72,7 +71,7 @@ func TestParameters(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			g := NewWithT(t)
 
-			actual, err := test.spec.Parameters(context.Background(), test.existing)
+			actual, err := test.spec.Parameters(t.Context(), test.existing)
 			g.Expect(err).NotTo(HaveOccurred())
 			if test.expected == nil {
 				g.Expect(actual).To(BeNil())

--- a/azure/services/inboundnatrules/inboundnatrules_test.go
+++ b/azure/services/inboundnatrules/inboundnatrules_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package inboundnatrules
 
 import (
-	"context"
 	"io"
 	"net/http"
 	"strings"
@@ -207,7 +206,7 @@ func TestReconcileInboundNATRule(t *testing.T) {
 				Reconciler: asyncMock,
 			}
 
-			err := s.Reconcile(context.TODO())
+			err := s.Reconcile(t.Context())
 			if tc.expectedError != "" {
 				g.Expect(err).To(HaveOccurred())
 				g.Expect(strings.ReplaceAll(err.Error(), "\n", "")).To(MatchRegexp(tc.expectedError))
@@ -284,7 +283,7 @@ func TestDeleteNetworkInterface(t *testing.T) {
 				Reconciler: asyncMock,
 			}
 
-			err := s.Delete(context.TODO())
+			err := s.Delete(t.Context())
 			if tc.expectedError != "" {
 				g.Expect(err).To(HaveOccurred())
 				g.Expect(strings.ReplaceAll(err.Error(), "\n", "")).To(MatchRegexp(tc.expectedError))

--- a/azure/services/inboundnatrules/spec_test.go
+++ b/azure/services/inboundnatrules/spec_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package inboundnatrules
 
 import (
-	"context"
 	"reflect"
 	"testing"
 
@@ -65,7 +64,7 @@ func TestParameters(t *testing.T) {
 			g := NewWithT(t)
 			t.Parallel()
 
-			result, err := tc.spec.Parameters(context.Background(), tc.existing)
+			result, err := tc.spec.Parameters(t.Context(), tc.existing)
 			if tc.errorMsg != "" {
 				g.Expect(err).To(HaveOccurred())
 				g.Expect(err.Error()).To(ContainSubstring(tc.errorMsg))

--- a/azure/services/loadbalancers/loadbalancers_test.go
+++ b/azure/services/loadbalancers/loadbalancers_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package loadbalancers
 
 import (
-	"context"
 	"io"
 	"net/http"
 	"strings"
@@ -226,7 +225,7 @@ func TestReconcileLoadBalancer(t *testing.T) {
 				Scope:      scopeMock,
 				Reconciler: asyncMock,
 			}
-			err := s.Reconcile(context.TODO())
+			err := s.Reconcile(t.Context())
 			if tc.expectedError != "" {
 				g.Expect(err).To(HaveOccurred())
 				g.Expect(err.Error()).To(ContainSubstring(tc.expectedError))
@@ -303,7 +302,7 @@ func TestDeleteLoadBalancer(t *testing.T) {
 				Reconciler: asyncMock,
 			}
 
-			err := s.Delete(context.TODO())
+			err := s.Delete(t.Context())
 			if tc.expectedError != "" {
 				g.Expect(err).To(HaveOccurred())
 				g.Expect(err.Error()).To(ContainSubstring(tc.expectedError))

--- a/azure/services/loadbalancers/spec_test.go
+++ b/azure/services/loadbalancers/spec_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package loadbalancers
 
 import (
-	"context"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v4"
@@ -185,7 +184,7 @@ func TestParameters(t *testing.T) {
 			g := NewWithT(t)
 			t.Parallel()
 
-			result, err := tc.spec.Parameters(context.TODO(), tc.existing)
+			result, err := tc.spec.Parameters(t.Context(), tc.existing)
 			if tc.expectedError != "" {
 				g.Expect(err).To(HaveOccurred())
 				g.Expect(err).To(MatchError(tc.expectedError))

--- a/azure/services/managedclusters/managedclusters_test.go
+++ b/azure/services/managedclusters/managedclusters_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package managedclusters
 
 import (
-	"context"
 	"errors"
 	"testing"
 
@@ -42,7 +41,7 @@ func TestPostCreateOrUpdateResourceHook(t *testing.T) {
 		mockCtrl := gomock.NewController(t)
 		scope := mock_managedclusters.NewMockManagedClusterScope(mockCtrl)
 
-		err := postCreateOrUpdateResourceHook(context.Background(), scope, nil, errors.New("an error"))
+		err := postCreateOrUpdateResourceHook(t.Context(), scope, nil, errors.New("an error"))
 		g.Expect(err).To(HaveOccurred())
 	})
 
@@ -71,7 +70,7 @@ func TestPostCreateOrUpdateResourceHook(t *testing.T) {
 			},
 		}
 
-		err := postCreateOrUpdateResourceHook(context.Background(), scope, managedCluster, nil)
+		err := postCreateOrUpdateResourceHook(t.Context(), scope, managedCluster, nil)
 		g.Expect(err).NotTo(HaveOccurred())
 	})
 
@@ -100,7 +99,7 @@ func TestPostCreateOrUpdateResourceHook(t *testing.T) {
 			},
 		}
 
-		err := postCreateOrUpdateResourceHook(context.Background(), scope, managedCluster, nil)
+		err := postCreateOrUpdateResourceHook(t.Context(), scope, managedCluster, nil)
 		g.Expect(err).NotTo(HaveOccurred())
 	})
 
@@ -136,7 +135,7 @@ func TestPostCreateOrUpdateResourceHook(t *testing.T) {
 			},
 		}
 
-		err := postCreateOrUpdateResourceHook(context.Background(), scope, managedCluster, nil)
+		err := postCreateOrUpdateResourceHook(t.Context(), scope, managedCluster, nil)
 		g.Expect(err).To(HaveOccurred())
 	})
 }

--- a/azure/services/managedclusters/spec_test.go
+++ b/azure/services/managedclusters/spec_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package managedclusters
 
 import (
-	"context"
 	"encoding/base64"
 	"testing"
 
@@ -300,7 +299,7 @@ func TestParameters(t *testing.T) {
 			},
 		}
 
-		actual, err := spec.Parameters(context.Background(), nil)
+		actual, err := spec.Parameters(t.Context(), nil)
 
 		g.Expect(err).NotTo(HaveOccurred())
 		g.Expect(cmp.Diff(actual, expected)).To(BeEmpty())
@@ -325,7 +324,7 @@ func TestParameters(t *testing.T) {
 			},
 		}
 
-		actual, err := spec.Parameters(context.Background(), nil)
+		actual, err := spec.Parameters(t.Context(), nil)
 		g.Expect(err).NotTo(HaveOccurred())
 		_, ok := actual.(*asocontainerservicev1preview.ManagedCluster)
 		g.Expect(ok).To(BeTrue())
@@ -351,7 +350,7 @@ func TestParameters(t *testing.T) {
 			},
 		}
 
-		actualObj, err := spec.Parameters(context.Background(), existing)
+		actualObj, err := spec.Parameters(t.Context(), existing)
 		actual := actualObj.(*asocontainerservicev1.ManagedCluster)
 
 		g.Expect(err).NotTo(HaveOccurred())
@@ -384,7 +383,7 @@ func TestParameters(t *testing.T) {
 			},
 		}
 
-		actualObj, err := spec.Parameters(context.Background(), existing)
+		actualObj, err := spec.Parameters(t.Context(), existing)
 		actual := actualObj.(*asocontainerservicev1.ManagedCluster)
 
 		g.Expect(err).NotTo(HaveOccurred())

--- a/azure/services/natgateways/natgateways_test.go
+++ b/azure/services/natgateways/natgateways_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package natgateways
 
 import (
-	"context"
 	"testing"
 
 	asonetworkv1 "github.com/Azure/azure-service-operator/v2/api/network/v1api20220701"
@@ -36,7 +35,7 @@ func TestPostCreateOrUpdateResourceHook(t *testing.T) {
 		mockCtrl := gomock.NewController(t)
 		scope := mock_natgateways.NewMockNatGatewayScope(mockCtrl)
 
-		err := postCreateOrUpdateResourceHook(context.Background(), scope, nil, errors.New("an error"))
+		err := postCreateOrUpdateResourceHook(t.Context(), scope, nil, errors.New("an error"))
 		g.Expect(err).To(HaveOccurred())
 	})
 
@@ -57,7 +56,7 @@ func TestPostCreateOrUpdateResourceHook(t *testing.T) {
 			},
 		}
 
-		err := postCreateOrUpdateResourceHook(context.Background(), scope, natGateway, nil)
+		err := postCreateOrUpdateResourceHook(t.Context(), scope, natGateway, nil)
 		g.Expect(err).NotTo(HaveOccurred())
 	})
 }

--- a/azure/services/natgateways/spec_test.go
+++ b/azure/services/natgateways/spec_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package natgateways
 
 import (
-	"context"
 	"testing"
 
 	asonetworkv1 "github.com/Azure/azure-service-operator/v2/api/network/v1api20220701"
@@ -138,7 +137,7 @@ func TestParameters(t *testing.T) {
 			g := NewWithT(t)
 			t.Parallel()
 
-			result, _ := tc.spec.Parameters(context.TODO(), tc.existingSpec.DeepCopy())
+			result, _ := tc.spec.Parameters(t.Context(), tc.existingSpec.DeepCopy())
 			tc.expect(g, tc.existingSpec, result)
 		})
 	}

--- a/azure/services/networkinterfaces/networkinterfaces_test.go
+++ b/azure/services/networkinterfaces/networkinterfaces_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package networkinterfaces
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -156,7 +155,7 @@ func TestReconcileNetworkInterface(t *testing.T) {
 				Reconciler: asyncMock,
 			}
 
-			err := s.Reconcile(context.TODO())
+			err := s.Reconcile(t.Context())
 			if tc.expectedError != "" {
 				g.Expect(err).To(HaveOccurred())
 				fmt.Print(cmp.Diff(err.Error(), tc.expectedError))
@@ -233,7 +232,7 @@ func TestDeleteNetworkInterface(t *testing.T) {
 				Reconciler: asyncMock,
 			}
 
-			err := s.Delete(context.TODO())
+			err := s.Delete(t.Context())
 			if tc.expectedError != "" {
 				g.Expect(err).To(HaveOccurred())
 				g.Expect(err).To(MatchError(tc.expectedError))

--- a/azure/services/networkinterfaces/spec_test.go
+++ b/azure/services/networkinterfaces/spec_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package networkinterfaces
 
 import (
-	"context"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
@@ -823,7 +822,7 @@ func TestParameters(t *testing.T) {
 			g := NewWithT(t)
 			t.Parallel()
 
-			result, err := tc.spec.Parameters(context.TODO(), tc.existing)
+			result, err := tc.spec.Parameters(t.Context(), tc.existing)
 			if tc.expectedError != "" {
 				g.Expect(err).To(HaveOccurred())
 				g.Expect(err).To(MatchError(tc.expectedError))

--- a/azure/services/privatedns/link_spec_test.go
+++ b/azure/services/privatedns/link_spec_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package privatedns
 
 import (
-	"context"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/privatedns/armprivatedns"
@@ -115,7 +114,7 @@ func TestLinkSpec_Parameters(t *testing.T) {
 			g := NewWithT(t)
 			t.Parallel()
 
-			result, err := tc.spec.Parameters(context.TODO(), tc.existing)
+			result, err := tc.spec.Parameters(t.Context(), tc.existing)
 			if tc.expectedError != "" {
 				g.Expect(err).To(HaveOccurred())
 				g.Expect(err).To(MatchError(tc.expectedError))

--- a/azure/services/privatedns/privatedns_test.go
+++ b/azure/services/privatedns/privatedns_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package privatedns
 
 import (
-	"context"
 	"net/http"
 	"testing"
 
@@ -354,7 +353,7 @@ func TestReconcilePrivateDNS(t *testing.T) {
 				TagsGetter:         tagsGetterMock,
 			}
 
-			err := s.Reconcile(context.TODO())
+			err := s.Reconcile(t.Context())
 			if tc.expectedError != "" {
 				g.Expect(err).To(HaveOccurred())
 				g.Expect(err).To(MatchError(tc.expectedError))
@@ -579,7 +578,7 @@ func TestDeletePrivateDNS(t *testing.T) {
 				TagsGetter:         tagsGetterMock,
 			}
 
-			err := s.Delete(context.TODO())
+			err := s.Delete(t.Context())
 			if tc.expectedError != "" {
 				g.Expect(err).To(HaveOccurred())
 				g.Expect(err).To(MatchError(tc.expectedError))

--- a/azure/services/privatedns/record_spec_test.go
+++ b/azure/services/privatedns/record_spec_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package privatedns
 
 import (
-	"context"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/privatedns/armprivatedns"
@@ -105,7 +104,7 @@ func TestRecordSpec_Parameters(t *testing.T) {
 			g := NewWithT(t)
 			t.Parallel()
 
-			result, err := tc.spec.Parameters(context.TODO(), tc.existing)
+			result, err := tc.spec.Parameters(t.Context(), tc.existing)
 			if tc.expectedError != "" {
 				g.Expect(err).To(HaveOccurred())
 				g.Expect(err).To(MatchError(tc.expectedError))

--- a/azure/services/privatedns/zone_spec_test.go
+++ b/azure/services/privatedns/zone_spec_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package privatedns
 
 import (
-	"context"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/privatedns/armprivatedns"
@@ -105,7 +104,7 @@ func TestZoneSpec_Parameters(t *testing.T) {
 			g := NewWithT(t)
 			t.Parallel()
 
-			result, err := tc.spec.Parameters(context.TODO(), tc.existing)
+			result, err := tc.spec.Parameters(t.Context(), tc.existing)
 			if tc.expectedError != "" {
 				g.Expect(err).To(HaveOccurred())
 				g.Expect(err).To(MatchError(tc.expectedError))

--- a/azure/services/privateendpoints/spec_test.go
+++ b/azure/services/privateendpoints/spec_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package privateendpoints
 
 import (
-	"context"
 	"testing"
 
 	asonetworkv1 "github.com/Azure/azure-service-operator/v2/api/network/v1api20220701"
@@ -227,7 +226,7 @@ func TestParameters(t *testing.T) {
 			g := NewWithT(t)
 			t.Parallel()
 
-			result, err := tc.spec.Parameters(context.TODO(), tc.existing)
+			result, err := tc.spec.Parameters(t.Context(), tc.existing)
 			if tc.expectedError != "" {
 				g.Expect(err).To(HaveOccurred())
 				g.Expect(err).To(MatchError(tc.expectedError))

--- a/azure/services/publicips/publicips_test.go
+++ b/azure/services/publicips/publicips_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package publicips
 
 import (
-	"context"
 	"io"
 	"net/http"
 	"strings"
@@ -186,7 +185,7 @@ func TestReconcilePublicIP(t *testing.T) {
 				Reconciler: reconcilerMock,
 			}
 
-			err := s.Reconcile(context.TODO())
+			err := s.Reconcile(t.Context())
 			if tc.expectedError != "" {
 				g.Expect(err).To(HaveOccurred())
 				g.Expect(err).To(MatchError(tc.expectedError))
@@ -316,7 +315,7 @@ func TestDeletePublicIP(t *testing.T) {
 				Reconciler: reconcilerMock,
 			}
 
-			err := s.Delete(context.TODO())
+			err := s.Delete(t.Context())
 			if tc.expectedError != "" {
 				g.Expect(err).To(HaveOccurred())
 				g.Expect(err).To(MatchError(tc.expectedError))

--- a/azure/services/publicips/spec_test.go
+++ b/azure/services/publicips/spec_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package publicips
 
 import (
-	"context"
 	"reflect"
 	"testing"
 
@@ -151,7 +150,7 @@ func TestParameters(t *testing.T) {
 			g := NewWithT(t)
 			t.Parallel()
 
-			result, err := tc.spec.Parameters(context.TODO(), tc.existing)
+			result, err := tc.spec.Parameters(t.Context(), tc.existing)
 			if tc.expectedError != "" {
 				g.Expect(err).To(HaveOccurred())
 				g.Expect(err).To(MatchError(tc.expectedError))

--- a/azure/services/resourcehealth/resourcehealth_test.go
+++ b/azure/services/resourcehealth/resourcehealth_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package resourcehealth
 
 import (
-	"context"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcehealth/armresourcehealth"
@@ -128,7 +127,7 @@ func TestReconcileResourceHealth(t *testing.T) {
 
 			utilfeature.SetFeatureGateDuringTest(t, feature.Gates, feature.AKSResourceHealth, !tc.featureDisabled)
 
-			err := s.Reconcile(context.TODO())
+			err := s.Reconcile(t.Context())
 
 			if tc.expectedError != "" {
 				g.Expect(err).To(HaveOccurred())

--- a/azure/services/resourceskus/cache_test.go
+++ b/azure/services/resourceskus/cache_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package resourceskus
 
 import (
-	"context"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
@@ -71,7 +70,7 @@ func TestCacheGet(t *testing.T) {
 				location: tc.location,
 			}
 
-			val, err := cache.Get(context.Background(), tc.sku, tc.resourceType)
+			val, err := cache.Get(t.Context(), tc.sku, tc.resourceType)
 			if tc.err != "" {
 				if err == nil {
 					t.Fatalf("expected cache.get to fail with error %s, but actual error was nil", tc.err)
@@ -233,7 +232,7 @@ func TestCacheGetZones(t *testing.T) {
 				data: tc.have,
 			}
 
-			zones, err := cache.GetZones(context.Background(), "baz")
+			zones, err := cache.GetZones(t.Context(), "baz")
 			if err != nil {
 				t.Error(err)
 			}
@@ -381,7 +380,7 @@ func TestCacheGetZonesWithVMSize(t *testing.T) {
 				data: tc.have,
 			}
 
-			zones, err := cache.GetZonesWithVMSize(context.Background(), "foo", "baz")
+			zones, err := cache.GetZonesWithVMSize(t.Context(), "foo", "baz")
 			if err != nil {
 				t.Error(err)
 			}

--- a/azure/services/roleassignments/roleassignments_test.go
+++ b/azure/services/roleassignments/roleassignments_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package roleassignments
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -159,7 +158,7 @@ func TestReconcileRoleAssignmentsVM(t *testing.T) {
 				Reconciler:            asyncMock,
 			}
 
-			err := s.Reconcile(context.TODO())
+			err := s.Reconcile(t.Context())
 			if tc.expectedError != "" {
 				g.Expect(err).To(HaveOccurred())
 				g.Expect(strings.ReplaceAll(err.Error(), "\n", "")).To(MatchRegexp(tc.expectedError))
@@ -253,7 +252,7 @@ func TestReconcileRoleAssignmentsVMSS(t *testing.T) {
 				virtualMachineScaleSetGetter: vmMock,
 			}
 
-			err := s.Reconcile(context.TODO())
+			err := s.Reconcile(t.Context())
 			if tc.expectedError != "" {
 				g.Expect(err).To(HaveOccurred())
 				g.Expect(strings.ReplaceAll(err.Error(), "\n", "")).To(MatchRegexp(tc.expectedError))

--- a/azure/services/roleassignments/spec_test.go
+++ b/azure/services/roleassignments/spec_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package roleassignments
 
 import (
-	"context"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v2"
@@ -89,7 +88,7 @@ func TestRoleAssignmentSpec_Parameters(t *testing.T) {
 			g := NewWithT(t)
 			t.Parallel()
 
-			result, err := tc.spec.Parameters(context.TODO(), tc.existing)
+			result, err := tc.spec.Parameters(t.Context(), tc.existing)
 			if tc.expectedError != "" {
 				g.Expect(err).To(HaveOccurred())
 				g.Expect(err).To(MatchError(tc.expectedError))

--- a/azure/services/routetables/routetables_test.go
+++ b/azure/services/routetables/routetables_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package routetables
 
 import (
-	"context"
 	"errors"
 	"testing"
 
@@ -130,7 +129,7 @@ func TestReconcileRouteTables(t *testing.T) {
 				Reconciler: reconcilerMock,
 			}
 
-			err := s.Reconcile(context.TODO())
+			err := s.Reconcile(t.Context())
 			if tc.expectedError != "" {
 				g.Expect(err).To(HaveOccurred())
 				g.Expect(err).To(MatchError(tc.expectedError))
@@ -219,7 +218,7 @@ func TestDeleteRouteTable(t *testing.T) {
 				Reconciler: reconcilerMock,
 			}
 
-			err := s.Delete(context.TODO())
+			err := s.Delete(t.Context())
 			if tc.expectedError != "" {
 				g.Expect(err).To(HaveOccurred())
 				g.Expect(err).To(MatchError(tc.expectedError))

--- a/azure/services/routetables/spec_test.go
+++ b/azure/services/routetables/spec_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package routetables
 
 import (
-	"context"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v4"
@@ -98,7 +97,7 @@ func TestRouteTableSpec_Parameters(t *testing.T) {
 			g := NewWithT(t)
 			t.Parallel()
 
-			result, err := tc.spec.Parameters(context.TODO(), tc.existing)
+			result, err := tc.spec.Parameters(t.Context(), tc.existing)
 			if tc.expectedError != "" {
 				g.Expect(err).To(HaveOccurred())
 				g.Expect(err).To(MatchError(tc.expectedError))

--- a/azure/services/scalesets/scalesets_test.go
+++ b/azure/services/scalesets/scalesets_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package scalesets
 
 import (
-	"context"
 	"io"
 	"net/http"
 	"strings"
@@ -348,7 +347,7 @@ func TestReconcileVMSS(t *testing.T) {
 				resourceSKUCache: resourceskus.NewStaticCache(getFakeSkus(), "test-location"),
 			}
 
-			err := s.Reconcile(context.TODO())
+			err := s.Reconcile(t.Context())
 			if tc.expectedError != "" {
 				g.Expect(err).To(HaveOccurred())
 				g.Expect(strings.ReplaceAll(err.Error(), "\n", "")).To(MatchRegexp(tc.expectedError), err.Error())
@@ -428,7 +427,7 @@ func TestDeleteVMSS(t *testing.T) {
 				Client:     mockClient,
 			}
 
-			err := s.Delete(context.TODO())
+			err := s.Delete(t.Context())
 			if tc.expectedError != "" {
 				g.Expect(err).To(HaveOccurred())
 				g.Expect(err.Error()).To(ContainSubstring(tc.expectedError))

--- a/azure/services/scalesets/spec_test.go
+++ b/azure/services/scalesets/spec_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package scalesets
 
 import (
-	"context"
 	"reflect"
 	"testing"
 
@@ -769,7 +768,7 @@ func TestScaleSetParameters(t *testing.T) {
 			g := NewWithT(t)
 			t.Parallel()
 
-			param, err := tc.spec.Parameters(context.TODO(), tc.existing)
+			param, err := tc.spec.Parameters(t.Context(), tc.existing)
 			if tc.expectedError != "" {
 				g.Expect(err).To(HaveOccurred())
 				g.Expect(err).To(MatchError(tc.expectedError))

--- a/azure/services/scalesets/vmssextension_spec_test.go
+++ b/azure/services/scalesets/vmssextension_spec_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package scalesets
 
 import (
-	"context"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
@@ -84,7 +83,7 @@ func TestVMSSExtensionParameters(t *testing.T) {
 			g := NewWithT(t)
 			t.Parallel()
 
-			result, err := tc.spec.Parameters(context.TODO(), tc.existing)
+			result, err := tc.spec.Parameters(t.Context(), tc.existing)
 			if tc.expectedError != "" {
 				g.Expect(err).To(HaveOccurred())
 				g.Expect(err).To(MatchError(tc.expectedError))

--- a/azure/services/scalesetvms/scalesetvms_test.go
+++ b/azure/services/scalesetvms/scalesetvms_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package scalesetvms
 
 import (
-	"context"
 	"io"
 	"net/http"
 	"strings"
@@ -153,7 +152,7 @@ func TestReconcileVMSS(t *testing.T) {
 				VMReconciler: vmAsyncMock,
 			}
 
-			err := s.Reconcile(context.TODO())
+			err := s.Reconcile(t.Context())
 			if tc.expectedError != "" {
 				g.Expect(err).To(HaveOccurred())
 				g.Expect(err.Error()).To(ContainSubstring(tc.expectedError), err.Error())
@@ -227,7 +226,7 @@ func TestDeleteVMSS(t *testing.T) {
 				VMReconciler: vmAsyncMock,
 			}
 
-			err := s.Delete(context.TODO())
+			err := s.Delete(t.Context())
 			if tc.expectedError != "" {
 				g.Expect(err).To(HaveOccurred())
 				g.Expect(err.Error()).To(ContainSubstring(tc.expectedError), err.Error())

--- a/azure/services/securitygroups/securitygroups_test.go
+++ b/azure/services/securitygroups/securitygroups_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package securitygroups
 
 import (
-	"context"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v4"
@@ -197,7 +196,7 @@ func TestReconcileSecurityGroups(t *testing.T) {
 				Reconciler: reconcilerMock,
 			}
 
-			err := s.Reconcile(context.TODO())
+			err := s.Reconcile(t.Context())
 			if tc.expectedError != "" {
 				g.Expect(err).To(HaveOccurred())
 				g.Expect(err).To(MatchError(tc.expectedError))
@@ -287,7 +286,7 @@ func TestDeleteSecurityGroups(t *testing.T) {
 				Reconciler: reconcilerMock,
 			}
 
-			err := s.Delete(context.TODO())
+			err := s.Delete(t.Context())
 			if tc.expectedError != "" {
 				g.Expect(err).To(HaveOccurred())
 				g.Expect(err).To(MatchError(tc.expectedError))

--- a/azure/services/securitygroups/spec_test.go
+++ b/azure/services/securitygroups/spec_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package securitygroups
 
 import (
-	"context"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v4"
@@ -359,7 +358,7 @@ func TestParameters(t *testing.T) {
 			g := NewWithT(t)
 			t.Parallel()
 
-			result, err := tc.spec.Parameters(context.TODO(), tc.existing)
+			result, err := tc.spec.Parameters(t.Context(), tc.existing)
 			if tc.expectedError != "" {
 				g.Expect(err).To(HaveOccurred())
 				g.Expect(err).To(MatchError(tc.expectedError))

--- a/azure/services/subnets/spec_test.go
+++ b/azure/services/subnets/spec_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package subnets
 
 import (
-	"context"
 	"testing"
 
 	asonetworkv1 "github.com/Azure/azure-service-operator/v2/api/network/v1api20201101"
@@ -155,7 +154,7 @@ func TestParameters(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			g := NewGomegaWithT(t)
 
-			result, err := test.spec.Parameters(context.Background(), test.existing)
+			result, err := test.spec.Parameters(t.Context(), test.existing)
 			g.Expect(err).NotTo(HaveOccurred())
 			g.Expect(cmp.Diff(test.expected, result)).To(BeEmpty())
 		})

--- a/azure/services/subnets/subnets_test.go
+++ b/azure/services/subnets/subnets_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package subnets
 
 import (
-	"context"
 	"testing"
 
 	asonetworkv1 "github.com/Azure/azure-service-operator/v2/api/network/v1api20201101"
@@ -35,7 +34,7 @@ func TestPostCreateOrUpdateResourceHook(t *testing.T) {
 		mockCtrl := gomock.NewController(t)
 		scope := mock_subnets.NewMockSubnetScope(mockCtrl)
 		err := errors.New("an error")
-		g.Expect(postCreateOrUpdateResourceHook(context.Background(), scope, nil, err)).To(MatchError(err))
+		g.Expect(postCreateOrUpdateResourceHook(t.Context(), scope, nil, err)).To(MatchError(err))
 	})
 
 	t.Run("successfully created or updated", func(t *testing.T) {
@@ -53,7 +52,7 @@ func TestPostCreateOrUpdateResourceHook(t *testing.T) {
 				AddressPrefixes: []string{"cidr"},
 			},
 		}
-		g.Expect(postCreateOrUpdateResourceHook(context.Background(), scope, subnet, nil)).To(Succeed())
+		g.Expect(postCreateOrUpdateResourceHook(t.Context(), scope, subnet, nil)).To(Succeed())
 	})
 
 	t.Run("correctly handles empty and non-empty ASO Status CIDRBlocks", func(t *testing.T) {
@@ -72,7 +71,7 @@ func TestPostCreateOrUpdateResourceHook(t *testing.T) {
 		}
 		scope.EXPECT().UpdateSubnetID("empty-cidr-status-subnet", "id-empty").Times(0)
 		scope.EXPECT().UpdateSubnetCIDRs("empty-cidr-status-subnet", []string{}).Times(0)
-		g.Expect(postCreateOrUpdateResourceHook(context.Background(), scope, emptyCIDRSubnet, nil)).To(Succeed())
+		g.Expect(postCreateOrUpdateResourceHook(t.Context(), scope, emptyCIDRSubnet, nil)).To(Succeed())
 
 		nonEmptyCIDRSubnet := &asonetworkv1.VirtualNetworksSubnet{
 			Spec: asonetworkv1.VirtualNetworksSubnet_Spec{
@@ -85,6 +84,6 @@ func TestPostCreateOrUpdateResourceHook(t *testing.T) {
 		}
 		scope.EXPECT().UpdateSubnetID("nonempty-cidr-status-subnet", "id-nonempty").Times(1)
 		scope.EXPECT().UpdateSubnetCIDRs("nonempty-cidr-status-subnet", []string{"cidr"}).Times(1)
-		g.Expect(postCreateOrUpdateResourceHook(context.Background(), scope, nonEmptyCIDRSubnet, nil)).To(Succeed())
+		g.Expect(postCreateOrUpdateResourceHook(t.Context(), scope, nonEmptyCIDRSubnet, nil)).To(Succeed())
 	})
 }

--- a/azure/services/tags/tags_test.go
+++ b/azure/services/tags/tags_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package tags
 
 import (
-	"context"
 	"io"
 	"net/http"
 	"strings"
@@ -283,7 +282,7 @@ func TestReconcileTags(t *testing.T) {
 				client: clientMock,
 			}
 
-			err := s.Reconcile(context.TODO())
+			err := s.Reconcile(t.Context())
 			if tc.expectedError != "" {
 				g.Expect(err).To(HaveOccurred())
 				g.Expect(strings.ReplaceAll(err.Error(), "\n", "")).To(MatchRegexp(tc.expectedError))

--- a/azure/services/virtualmachineimages/images_test.go
+++ b/azure/services/virtualmachineimages/images_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package virtualmachineimages
 
 import (
-	"context"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -91,7 +90,7 @@ func TestGetDefaultLinuxImage(t *testing.T) {
 
 			g := NewWithT(t)
 			svc := Service{}
-			image, err := svc.GetDefaultLinuxImage(context.TODO(), location, test.k8sVersion)
+			image, err := svc.GetDefaultLinuxImage(t.Context(), location, test.k8sVersion)
 			if test.expectErr {
 				g.Expect(err).To(HaveOccurred())
 			} else {
@@ -209,7 +208,7 @@ func TestGetDefaultWindowsImage(t *testing.T) {
 
 			g := NewWithT(t)
 			svc := Service{}
-			image, err := svc.GetDefaultWindowsImage(context.TODO(), location, test.k8sVersion, test.runtime, test.osAndVersion)
+			image, err := svc.GetDefaultWindowsImage(t.Context(), location, test.k8sVersion, test.runtime, test.osAndVersion)
 			if test.expectErr {
 				g.Expect(err).To(HaveOccurred())
 			} else {

--- a/azure/services/virtualmachines/spec_test.go
+++ b/azure/services/virtualmachines/spec_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package virtualmachines
 
 import (
-	"context"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
@@ -1423,7 +1422,7 @@ func TestParameters(t *testing.T) {
 			g := NewWithT(t)
 			t.Parallel()
 
-			result, err := tc.spec.Parameters(context.TODO(), tc.existing)
+			result, err := tc.spec.Parameters(t.Context(), tc.existing)
 			if tc.expectedError != "" {
 				g.Expect(err).To(HaveOccurred())
 				g.Expect(err).To(MatchError(tc.expectedError))

--- a/azure/services/virtualmachines/virtualmachines_test.go
+++ b/azure/services/virtualmachines/virtualmachines_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package virtualmachines
 
 import (
-	"context"
 	"io"
 	"net/http"
 	"strings"
@@ -223,7 +222,7 @@ func TestReconcileVM(t *testing.T) {
 				Reconciler:       asyncMock,
 			}
 
-			err := s.Reconcile(context.TODO())
+			err := s.Reconcile(t.Context())
 			if tc.expectedError != "" {
 				g.Expect(err).To(HaveOccurred())
 				g.Expect(strings.ReplaceAll(err.Error(), "\n", "")).To(MatchRegexp(tc.expectedError))
@@ -299,7 +298,7 @@ func TestDeleteVM(t *testing.T) {
 				Reconciler: asyncMock,
 			}
 
-			err := s.Delete(context.TODO())
+			err := s.Delete(t.Context())
 			if tc.expectedError != "" {
 				g.Expect(err).To(HaveOccurred())
 				g.Expect(err.Error()).To(ContainSubstring(tc.expectedError))

--- a/azure/services/virtualnetworks/spec_test.go
+++ b/azure/services/virtualnetworks/spec_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package virtualnetworks
 
 import (
-	"context"
 	"testing"
 
 	asonetworkv1 "github.com/Azure/azure-service-operator/v2/api/network/v1api20201101"
@@ -121,7 +120,7 @@ func TestParameters(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			g := NewGomegaWithT(t)
-			actual, err := test.spec.Parameters(context.Background(), test.existing)
+			actual, err := test.spec.Parameters(t.Context(), test.existing)
 			g.Expect(err).NotTo(HaveOccurred())
 			g.Expect(cmp.Diff(test.expected, actual)).To(BeEmpty())
 		})

--- a/azure/services/virtualnetworks/virtualnetworks_test.go
+++ b/azure/services/virtualnetworks/virtualnetworks_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package virtualnetworks
 
 import (
-	"context"
 	"errors"
 	"testing"
 
@@ -42,7 +41,7 @@ func TestPostCreateOrUpdateResourceHook(t *testing.T) {
 		mockCtrl := gomock.NewController(t)
 		scope := mock_virtualnetworks.NewMockVNetScope(mockCtrl)
 		err := errors.New("an error")
-		g.Expect(postCreateOrUpdateResourceHook(context.Background(), scope, nil, err)).To(MatchError(err))
+		g.Expect(postCreateOrUpdateResourceHook(t.Context(), scope, nil, err)).To(MatchError(err))
 	})
 
 	t.Run("successfully created or updated", func(t *testing.T) {
@@ -103,7 +102,7 @@ func TestPostCreateOrUpdateResourceHook(t *testing.T) {
 			Build()
 		scope.EXPECT().GetClient().Return(c)
 
-		g.Expect(postCreateOrUpdateResourceHook(context.Background(), scope, existing, nil)).To(Succeed())
+		g.Expect(postCreateOrUpdateResourceHook(t.Context(), scope, existing, nil)).To(Succeed())
 
 		g.Expect(vnet.ID).To(Equal("id"))
 		g.Expect(vnet.Tags).To(Equal(infrav1.Tags{"actual": "tags"}))
@@ -170,6 +169,6 @@ func TestPostCreateOrUpdateResourceHook(t *testing.T) {
 		scope.EXPECT().GetClient().Return(c)
 		scope.EXPECT().UpdateSubnetCIDRs("empty-cidr-status-subnet", []string{}).Times(0)
 		scope.EXPECT().UpdateSubnetCIDRs("nonempty-cidr-status-subnet", []string{"cidr"}).Times(1)
-		g.Expect(postCreateOrUpdateResourceHook(context.Background(), scope, existing, nil)).To(Succeed())
+		g.Expect(postCreateOrUpdateResourceHook(t.Context(), scope, existing, nil)).To(Succeed())
 	})
 }

--- a/azure/services/vmextensions/spec_test.go
+++ b/azure/services/vmextensions/spec_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package vmextensions
 
 import (
-	"context"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
@@ -85,7 +84,7 @@ func TestParameters(t *testing.T) {
 			g := NewWithT(t)
 			t.Parallel()
 
-			result, err := tc.spec.Parameters(context.TODO(), tc.existing)
+			result, err := tc.spec.Parameters(t.Context(), tc.existing)
 			if tc.expectedError != "" {
 				g.Expect(err).To(HaveOccurred())
 				g.Expect(err).To(MatchError(tc.expectedError))

--- a/azure/services/vmextensions/vmextensions_test.go
+++ b/azure/services/vmextensions/vmextensions_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package vmextensions
 
 import (
-	"context"
 	"io"
 	"net/http"
 	"strings"
@@ -152,7 +151,7 @@ func TestReconcileVMExtension(t *testing.T) {
 				Reconciler: asyncMock,
 			}
 
-			err := s.Reconcile(context.TODO())
+			err := s.Reconcile(t.Context())
 			if tc.expectedError != "" {
 				g.Expect(err).To(HaveOccurred())
 				g.Expect(err).To(MatchError(tc.expectedError))

--- a/azure/services/vnetpeerings/spec_test.go
+++ b/azure/services/vnetpeerings/spec_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package vnetpeerings
 
 import (
-	"context"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v4"
@@ -102,7 +101,7 @@ func TestVnetPeeringSpec_Parameters(t *testing.T) {
 			g := NewWithT(t)
 			t.Parallel()
 
-			result, err := tc.spec.Parameters(context.TODO(), tc.existing)
+			result, err := tc.spec.Parameters(t.Context(), tc.existing)
 			if tc.expectedError != "" {
 				g.Expect(err).To(HaveOccurred())
 				g.Expect(err).To(MatchError(tc.expectedError))

--- a/azure/services/vnetpeerings/vnetpeerings_test.go
+++ b/azure/services/vnetpeerings/vnetpeerings_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package vnetpeerings
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -257,7 +256,7 @@ func TestReconcileVnetPeerings(t *testing.T) {
 				Reconciler: asyncMock,
 			}
 
-			err := s.Reconcile(context.TODO())
+			err := s.Reconcile(t.Context())
 			if tc.expectedError != "" {
 				g.Expect(err).To(HaveOccurred())
 				g.Expect(err.Error()).To(ContainSubstring(tc.expectedError))
@@ -409,7 +408,7 @@ func TestDeleteVnetPeerings(t *testing.T) {
 				Reconciler: asyncMock,
 			}
 
-			err := s.Delete(context.TODO())
+			err := s.Delete(t.Context())
 			if tc.expectedError != "" {
 				fmt.Printf("\nExpected error:\t%s\n", tc.expectedError)
 				fmt.Printf("\nActual error:\t%s\n", err.Error())

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -4,7 +4,7 @@ options:
   substitution_option: ALLOW_LOOSE
   machineType: 'E2_HIGHCPU_8'
 steps:
-  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20250116-2a05ea7e3d' # Go 1.23
+  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20250513-9264efb079' # Go 1.24
     entrypoint: make
     env:
       - DOCKER_CLI_EXPERIMENTAL=enabled

--- a/controllers/agentpooladopt_controller_test.go
+++ b/controllers/agentpooladopt_controller_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package controllers
 
 import (
-	"context"
 	"testing"
 
 	asocontainerservicev1 "github.com/Azure/azure-service-operator/v2/api/containerservice/v1api20231001"
@@ -37,7 +36,7 @@ import (
 func TestAgentPoolAdoptController(t *testing.T) {
 	g := NewWithT(t)
 	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: "fake-agent-pool", Namespace: "fake-ns"}}
-	ctx := context.Background()
+	ctx := t.Context()
 	scheme, err := newScheme()
 	g.Expect(err).ToNot(HaveOccurred())
 

--- a/controllers/aso_credential_cache_test.go
+++ b/controllers/aso_credential_cache_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package controllers
 
 import (
-	"context"
 	"reflect"
 	"testing"
 
@@ -477,7 +476,7 @@ func TestAuthTokenForASOResource(t *testing.T) {
 				cache:  credCache,
 				client: c,
 			}
-			_, err := asoCache.authTokenForASOResource(context.Background(), test.resource)
+			_, err := asoCache.authTokenForASOResource(t.Context(), test.resource)
 			if test.expectedErr != nil {
 				g.Expect(err).To(MatchError(test.expectedErr))
 			} else {

--- a/controllers/asosecret_controller_test.go
+++ b/controllers/asosecret_controller_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package controllers
 
 import (
-	"context"
 	"os"
 	"testing"
 
@@ -323,7 +322,7 @@ func TestASOSecretReconcile(t *testing.T) {
 				CredentialCache: azure.NewCredentialCache(),
 			}
 
-			_, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+			_, err := reconciler.Reconcile(t.Context(), ctrl.Request{
 				NamespacedName: types.NamespacedName{
 					Namespace: "default",
 					Name:      tc.clusterName,
@@ -331,7 +330,7 @@ func TestASOSecretReconcile(t *testing.T) {
 			})
 
 			existingASOSecret := &corev1.Secret{}
-			asoSecretErr := clientBuilder.Get(context.Background(), types.NamespacedName{
+			asoSecretErr := clientBuilder.Get(t.Context(), types.NamespacedName{
 				Namespace: defaultASOSecret.Namespace,
 				Name:      defaultASOSecret.Name,
 			}, existingASOSecret)

--- a/controllers/azureasomanagedcluster_controller_test.go
+++ b/controllers/azureasomanagedcluster_controller_test.go
@@ -66,7 +66,7 @@ func (r *fakeResourceReconciler) Delete(ctx context.Context) error {
 }
 
 func TestAzureASOManagedClusterReconcile(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	s := runtime.NewScheme()
 	sb := runtime.NewSchemeBuilder(

--- a/controllers/azureasomanagedcontrolplane_controller_test.go
+++ b/controllers/azureasomanagedcontrolplane_controller_test.go
@@ -47,7 +47,7 @@ import (
 )
 
 func TestAzureASOManagedControlPlaneReconcile(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	s := runtime.NewScheme()
 	sb := runtime.NewSchemeBuilder(

--- a/controllers/azureasomanagedmachinepool_controller_test.go
+++ b/controllers/azureasomanagedmachinepool_controller_test.go
@@ -53,7 +53,7 @@ func (c *FakeClusterTracker) GetClient(ctx context.Context, name types.Namespace
 }
 
 func TestAzureASOManagedMachinePoolReconcile(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	s := runtime.NewScheme()
 	sb := runtime.NewSchemeBuilder(

--- a/controllers/azurecluster_controller.go
+++ b/controllers/azurecluster_controller.go
@@ -241,8 +241,8 @@ func (acr *AzureClusterReconciler) reconcileNormal(ctx context.Context, clusterS
 		}
 
 		wrappedErr := errors.Wrap(err, "failed to reconcile cluster services")
-		acr.Recorder.Eventf(azureCluster, corev1.EventTypeWarning, "ClusterReconcilerNormalFailed", wrappedErr.Error())
-		conditions.MarkFalse(azureCluster, infrav1.NetworkInfrastructureReadyCondition, infrav1.FailedReason, clusterv1.ConditionSeverityError, wrappedErr.Error())
+		acr.Recorder.Eventf(azureCluster, corev1.EventTypeWarning, "ClusterReconcilerNormalFailed", "%s", wrappedErr.Error())
+		conditions.MarkFalse(azureCluster, infrav1.NetworkInfrastructureReadyCondition, infrav1.FailedReason, clusterv1.ConditionSeverityError, "%s", wrappedErr.Error())
 		return reconcile.Result{}, wrappedErr
 	}
 
@@ -318,7 +318,7 @@ func (acr *AzureClusterReconciler) reconcileDelete(ctx context.Context, clusterS
 		}
 
 		wrappedErr := errors.Wrapf(err, "error deleting AzureCluster %s/%s", azureCluster.Namespace, azureCluster.Name)
-		acr.Recorder.Eventf(azureCluster, corev1.EventTypeWarning, "ClusterReconcilerDeleteFailed", wrappedErr.Error())
+		acr.Recorder.Eventf(azureCluster, corev1.EventTypeWarning, "ClusterReconcilerDeleteFailed", "%s", wrappedErr.Error())
 		conditions.MarkFalse(azureCluster, infrav1.NetworkInfrastructureReadyCondition, clusterv1.DeletionFailedReason, clusterv1.ConditionSeverityWarning, "%s", err.Error())
 		return reconcile.Result{}, wrappedErr
 	}

--- a/controllers/azurecluster_controller_test.go
+++ b/controllers/azurecluster_controller_test.go
@@ -137,7 +137,7 @@ func TestAzureClusterReconcile(t *testing.T) {
 				Recorder: record.NewFakeRecorder(128),
 			}
 
-			_, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+			_, err := reconciler.Reconcile(t.Context(), ctrl.Request{
 				NamespacedName: types.NamespacedName{
 					Namespace: namespace,
 					Name:      "my-azure-cluster",
@@ -225,7 +225,7 @@ func TestAzureClusterReconcileNormal(t *testing.T) {
 			reconciler, clusterScope, err := getClusterReconcileInputs(tc)
 			g.Expect(err).NotTo(HaveOccurred())
 
-			result, err := reconciler.reconcileNormal(context.Background(), clusterScope)
+			result, err := reconciler.reconcileNormal(t.Context(), clusterScope)
 			g.Expect(result).To(Equal(tc.expectedResult))
 
 			if tc.ready {
@@ -244,7 +244,7 @@ func TestAzureClusterReconcileNormal(t *testing.T) {
 func TestAzureClusterReconcilePaused(t *testing.T) {
 	g := NewWithT(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	sb := runtime.NewSchemeBuilder(
 		clusterv1.AddToScheme,
@@ -342,7 +342,7 @@ func TestAzureClusterReconcilePaused(t *testing.T) {
 	}
 	g.Expect(c.Create(ctx, vnet)).To(Succeed())
 
-	result, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+	result, err := reconciler.Reconcile(t.Context(), ctrl.Request{
 		NamespacedName: client.ObjectKey{
 			Namespace: instance.Namespace,
 			Name:      instance.Name,
@@ -418,7 +418,7 @@ func TestAzureClusterReconcileDelete(t *testing.T) {
 			reconciler, clusterScope, err := getClusterReconcileInputs(tc)
 			g.Expect(err).NotTo(HaveOccurred())
 
-			result, err := reconciler.reconcileDelete(context.Background(), clusterScope)
+			result, err := reconciler.reconcileDelete(t.Context(), clusterScope)
 			g.Expect(result).To(Equal(tc.expectedResult))
 
 			if tc.expectedErr != "" {

--- a/controllers/azurecluster_reconciler_test.go
+++ b/controllers/azurecluster_reconciler_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package controllers
 
 import (
-	"context"
 	"errors"
 	"testing"
 	"time"
@@ -95,7 +94,7 @@ func TestAzureClusterServiceReconcile(t *testing.T) {
 				skuCache: resourceskus.NewStaticCache([]armcompute.ResourceSKU{}, ""),
 			}
 
-			err := s.reconcile(context.TODO())
+			err := s.reconcile(t.Context())
 			if tc.expectedError != "" {
 				g.Expect(err).To(HaveOccurred())
 				g.Expect(err).To(MatchError(tc.expectedError))
@@ -164,7 +163,7 @@ func TestAzureClusterServicePause(t *testing.T) {
 				},
 			}
 
-			err := s.pause(context.TODO())
+			err := s.pause(t.Context())
 			if tc.expectedError != "" {
 				g.Expect(err).To(HaveOccurred())
 				g.Expect(err).To(MatchError(tc.expectedError))
@@ -377,7 +376,7 @@ func TestAzureClusterServiceDelete(t *testing.T) {
 				skuCache: resourceskus.NewStaticCache([]armcompute.ResourceSKU{}, ""),
 			}
 
-			err := s.delete(context.TODO())
+			err := s.delete(t.Context())
 			if tc.expectedError != "" {
 				g.Expect(err).To(HaveOccurred())
 				g.Expect(err).To(MatchError(tc.expectedError))

--- a/controllers/azurejson_machine_controller_test.go
+++ b/controllers/azurejson_machine_controller_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package controllers
 
 import (
-	"context"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -236,7 +235,7 @@ func TestAzureJSONMachineReconciler(t *testing.T) {
 				CredentialCache: azure.NewCredentialCache(),
 			}
 
-			_, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+			_, err := reconciler.Reconcile(t.Context(), ctrl.Request{
 				NamespacedName: types.NamespacedName{
 					Namespace: "",
 					Name:      "my-machine",

--- a/controllers/azurejson_machinepool_controller_test.go
+++ b/controllers/azurejson_machinepool_controller_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package controllers
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
@@ -225,7 +224,7 @@ func TestAzureJSONPoolReconciler(t *testing.T) {
 				CredentialCache: azure.NewCredentialCache(),
 			}
 
-			_, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+			_, err := reconciler.Reconcile(t.Context(), ctrl.Request{
 				NamespacedName: types.NamespacedName{
 					Namespace: "",
 					Name:      "my-azure-machine-pool",
@@ -250,7 +249,7 @@ func TestAzureJSONPoolReconcilerUserAssignedIdentities(t *testing.T) {
 	ctrlr := gomock.NewController(t)
 	defer ctrlr.Finish()
 	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: "fake-machine-pool", Namespace: "fake-ns"}}
-	ctx := context.Background()
+	ctx := t.Context()
 	scheme, err := newScheme()
 	g.Expect(err).NotTo(HaveOccurred())
 

--- a/controllers/azurejson_machinetemplate_controller_test.go
+++ b/controllers/azurejson_machinetemplate_controller_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package controllers
 
 import (
-	"context"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -169,7 +168,7 @@ func TestAzureJSONTemplateReconciler(t *testing.T) {
 				CredentialCache: azure.NewCredentialCache(),
 			}
 
-			_, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+			_, err := reconciler.Reconcile(t.Context(), ctrl.Request{
 				NamespacedName: types.NamespacedName{
 					Namespace: "",
 					Name:      "my-json-template",

--- a/controllers/azuremachine_controller_test.go
+++ b/controllers/azuremachine_controller_test.go
@@ -143,7 +143,7 @@ func TestAzureMachineReconcile(t *testing.T) {
 
 			resultIdentity := &infrav1.AzureClusterIdentity{}
 			key := client.ObjectKey{Name: defaultAzureClusterIdentity.Name, Namespace: defaultAzureClusterIdentity.Namespace}
-			g.Expect(fakeClient.Get(context.TODO(), key, resultIdentity)).To(Succeed())
+			g.Expect(fakeClient.Get(t.Context(), key, resultIdentity)).To(Succeed())
 
 			reconciler := &AzureMachineReconciler{
 				Client:          fakeClient,
@@ -151,7 +151,7 @@ func TestAzureMachineReconcile(t *testing.T) {
 				CredentialCache: azure.NewCredentialCache(),
 			}
 
-			_, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+			_, err := reconciler.Reconcile(t.Context(), ctrl.Request{
 				NamespacedName: types.NamespacedName{
 					Namespace: "default",
 					Name:      "my-machine",
@@ -246,7 +246,7 @@ func TestAzureMachineReconcileNormal(t *testing.T) {
 			reconciler, machineScope, clusterScope, err := getMachineReconcileInputs(tc)
 			g.Expect(err).NotTo(HaveOccurred())
 
-			result, err := reconciler.reconcileNormal(context.Background(), machineScope, clusterScope)
+			result, err := reconciler.reconcileNormal(t.Context(), machineScope, clusterScope)
 			g.Expect(result).To(Equal(tc.expectedResult))
 
 			if tc.ready {
@@ -292,7 +292,7 @@ func TestAzureMachineReconcilePause(t *testing.T) {
 			reconciler, machineScope, _, err := getMachineReconcileInputs(tc)
 			g.Expect(err).NotTo(HaveOccurred())
 
-			result, err := reconciler.reconcilePause(context.Background(), machineScope)
+			result, err := reconciler.reconcilePause(t.Context(), machineScope)
 			g.Expect(result).To(Equal(tc.expectedResult))
 
 			if tc.expectedErr != "" {
@@ -336,7 +336,7 @@ func TestAzureMachineReconcileDelete(t *testing.T) {
 			reconciler, machineScope, clusterScope, err := getMachineReconcileInputs(tc)
 			g.Expect(err).NotTo(HaveOccurred())
 
-			result, err := reconciler.reconcileDelete(context.Background(), machineScope, clusterScope)
+			result, err := reconciler.reconcileDelete(t.Context(), machineScope, clusterScope)
 			g.Expect(result).To(Equal(tc.expectedResult))
 
 			if tc.expectedErr != "" {
@@ -785,13 +785,13 @@ func TestConditions(t *testing.T) {
 			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(initObjects...).Build()
 			resultIdentity := &infrav1.AzureClusterIdentity{}
 			key := client.ObjectKey{Name: azureClusterIdentity.Name, Namespace: azureClusterIdentity.Namespace}
-			g.Expect(fakeClient.Get(context.TODO(), key, resultIdentity)).To(Succeed())
+			g.Expect(fakeClient.Get(t.Context(), key, resultIdentity)).To(Succeed())
 			recorder := record.NewFakeRecorder(10)
 
 			credCache := azure.NewCredentialCache()
 			reconciler := NewAzureMachineReconciler(fakeClient, recorder, reconciler.Timeouts{}, "", credCache)
 
-			clusterScope, err := scope.NewClusterScope(context.TODO(), scope.ClusterScopeParams{
+			clusterScope, err := scope.NewClusterScope(t.Context(), scope.ClusterScopeParams{
 				Client:          fakeClient,
 				Cluster:         cluster,
 				AzureCluster:    azureCluster,
@@ -808,7 +808,7 @@ func TestConditions(t *testing.T) {
 			})
 			g.Expect(err).NotTo(HaveOccurred())
 
-			_, err = reconciler.reconcileNormal(context.TODO(), machineScope, clusterScope)
+			_, err = reconciler.reconcileNormal(t.Context(), machineScope, clusterScope)
 			g.Expect(err).NotTo(HaveOccurred())
 
 			g.Expect(machineScope.AzureMachine.GetConditions()).To(HaveLen(len(tc.expectedConditions)))

--- a/controllers/azuremachine_reconciler_test.go
+++ b/controllers/azuremachine_reconciler_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package controllers
 
 import (
-	"context"
 	"errors"
 	"testing"
 
@@ -93,7 +92,7 @@ func TestAzureMachineServiceReconcile(t *testing.T) {
 				skuCache: resourceskus.NewStaticCache([]armcompute.ResourceSKU{}, ""),
 			}
 
-			err := s.reconcile(context.TODO())
+			err := s.reconcile(t.Context())
 			if tc.expectedError != "" {
 				g.Expect(err).To(HaveOccurred())
 				g.Expect(err).To(MatchError(tc.expectedError))
@@ -162,7 +161,7 @@ func TestAzureMachineServicePause(t *testing.T) {
 				},
 			}
 
-			err := s.pause(context.TODO())
+			err := s.pause(t.Context())
 			if tc.expectedError != "" {
 				g.Expect(err).To(HaveOccurred())
 				g.Expect(err).To(MatchError(tc.expectedError))
@@ -228,7 +227,7 @@ func TestAzureMachineServiceDelete(t *testing.T) {
 				skuCache: resourceskus.NewStaticCache([]armcompute.ResourceSKU{}, ""),
 			}
 
-			err := s.delete(context.TODO())
+			err := s.delete(t.Context())
 			if tc.expectedError != "" {
 				g.Expect(err).To(HaveOccurred())
 				g.Expect(err).To(MatchError(tc.expectedError))

--- a/controllers/azuremanagedcluster_controller_test.go
+++ b/controllers/azuremanagedcluster_controller_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package controllers
 
 import (
-	"context"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -37,7 +36,7 @@ import (
 
 func TestAzureManagedClusterController(t *testing.T) {
 	g := NewWithT(t)
-	ctx := context.Background()
+	ctx := t.Context()
 	scheme := runtime.NewScheme()
 	g.Expect(infrav1.AddToScheme(scheme)).To(Succeed())
 	g.Expect(clusterv1.AddToScheme(scheme)).To(Succeed())

--- a/controllers/azuremanagedcontrolplane_controller_test.go
+++ b/controllers/azuremanagedcontrolplane_controller_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package controllers
 
 import (
-	"context"
 	"testing"
 
 	asocontainerservicev1preview "github.com/Azure/azure-service-operator/v2/api/containerservice/v1api20230315preview"
@@ -84,7 +83,7 @@ func TestClusterToAzureManagedControlPlane(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			g := NewWithT(t)
-			actual := (&AzureManagedControlPlaneReconciler{}).ClusterToAzureManagedControlPlane(context.TODO(), &clusterv1.Cluster{
+			actual := (&AzureManagedControlPlaneReconciler{}).ClusterToAzureManagedControlPlane(t.Context(), &clusterv1.Cluster{
 				Spec: clusterv1.ClusterSpec{
 					ControlPlaneRef: test.controlPlaneRef,
 				},
@@ -101,7 +100,7 @@ func TestClusterToAzureManagedControlPlane(t *testing.T) {
 func TestAzureManagedControlPlaneReconcilePaused(t *testing.T) {
 	g := NewWithT(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	sb := runtime.NewSchemeBuilder(
 		clusterv1.AddToScheme,
@@ -247,7 +246,7 @@ func TestAzureManagedControlPlaneReconcilePaused(t *testing.T) {
 	}
 	g.Expect(c.Create(ctx, subnet)).To(Succeed())
 
-	result, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+	result, err := reconciler.Reconcile(t.Context(), ctrl.Request{
 		NamespacedName: client.ObjectKey{
 			Namespace: instance.Namespace,
 			Name:      instance.Name,
@@ -260,7 +259,7 @@ func TestAzureManagedControlPlaneReconcilePaused(t *testing.T) {
 
 func TestAzureManagedControlPlaneReconcileNormal(t *testing.T) {
 	g := NewWithT(t)
-	ctx := context.Background()
+	ctx := t.Context()
 	cp := &infrav1.AzureManagedControlPlane{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "fake-azmp",

--- a/controllers/azuremanagedcontrolplane_reconciler_test.go
+++ b/controllers/azuremanagedcontrolplane_reconciler_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package controllers
 
 import (
-	"context"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -87,7 +86,7 @@ func TestAzureManagedControlPlaneServicePause(t *testing.T) {
 				},
 			}
 
-			err := s.Pause(context.TODO())
+			err := s.Pause(t.Context())
 			if tc.expectedError != "" {
 				g.Expect(err).To(HaveOccurred())
 				g.Expect(err).To(MatchError(tc.expectedError))

--- a/controllers/azuremanagedmachinepool_controller_test.go
+++ b/controllers/azuremanagedmachinepool_controller_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package controllers
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -185,7 +184,7 @@ func TestAzureManagedMachinePoolReconcile(t *testing.T) {
 					scaleSetsSvc:  nodelister,
 				}, nil
 			}
-			res, err := controller.Reconcile(context.TODO(), ctrl.Request{
+			res, err := controller.Reconcile(t.Context(), ctrl.Request{
 				NamespacedName: types.NamespacedName{
 					Name:      "foo-ammp",
 					Namespace: "foobar",

--- a/controllers/azuremanagedmachinepool_reconciler_test.go
+++ b/controllers/azuremanagedmachinepool_reconciler_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package controllers
 
 import (
-	"context"
 	"testing"
 
 	"github.com/onsi/gomega"
@@ -125,7 +124,7 @@ func TestAzureManagedMachinePoolServicePause(t *testing.T) {
 				},
 			}
 
-			err := s.Pause(context.TODO())
+			err := s.Pause(t.Context())
 			if tc.expectedError != "" {
 				g.Expect(err).To(gomega.HaveOccurred())
 				g.Expect(err).To(gomega.MatchError(tc.expectedError))

--- a/controllers/managedclusteradopt_controller_test.go
+++ b/controllers/managedclusteradopt_controller_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package controllers
 
 import (
-	"context"
 	"testing"
 
 	asocontainerservicev1 "github.com/Azure/azure-service-operator/v2/api/containerservice/v1api20231001"
@@ -35,7 +34,7 @@ import (
 )
 
 func TestManagedClusterAdoptReconcile(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	g := NewWithT(t)
 	req := ctrl.Request{
 		NamespacedName: types.NamespacedName{

--- a/controllers/resource_reconciler_test.go
+++ b/controllers/resource_reconciler_test.go
@@ -67,7 +67,7 @@ func (w *FakeWatcher) Watch(_ logr.Logger, obj client.Object, _ handler.EventHan
 }
 
 func TestResourceReconcilerReconcile(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	s := runtime.NewScheme()
 	sb := runtime.NewSchemeBuilder(
@@ -325,7 +325,7 @@ func TestResourceReconcilerReconcile(t *testing.T) {
 }
 
 func TestResourceReconcilerPause(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	s := runtime.NewScheme()
 	sb := runtime.NewSchemeBuilder(
@@ -435,7 +435,7 @@ func TestResourceReconcilerPause(t *testing.T) {
 }
 
 func TestResourceReconcilerDelete(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	s := runtime.NewScheme()
 	sb := runtime.NewSchemeBuilder(
@@ -548,7 +548,7 @@ func TestResourceReconcilerDelete(t *testing.T) {
 }
 
 func TestReadyStatus(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	t.Run("unstructured", func(t *testing.T) {
 		tests := []struct {

--- a/exp/api/v1beta1/azuremachinepool_webhook_test.go
+++ b/exp/api/v1beta1/azuremachinepool_webhook_test.go
@@ -258,7 +258,7 @@ func TestAzureMachinePool_ValidateCreate(t *testing.T) {
 			ampw := &azureMachinePoolWebhook{
 				Client: client,
 			}
-			_, err := ampw.ValidateCreate(context.Background(), tc.amp)
+			_, err := ampw.ValidateCreate(t.Context(), tc.amp)
 			if tc.wantErr {
 				g.Expect(err).To(HaveOccurred())
 			} else {
@@ -394,7 +394,7 @@ func TestAzureMachinePool_ValidateUpdate(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			g := NewWithT(t)
 			ampw := &azureMachinePoolWebhook{}
-			_, err := ampw.ValidateUpdate(context.Background(), tc.oldAMP, tc.amp)
+			_, err := ampw.ValidateUpdate(t.Context(), tc.oldAMP, tc.amp)
 			if tc.wantErr {
 				g.Expect(err).To(HaveOccurred())
 			} else {
@@ -463,24 +463,24 @@ func TestAzureMachinePool_Default(t *testing.T) {
 		Client: mockClient,
 	}
 
-	err := ampw.Default(context.Background(), roleAssignmentExistTest.amp)
+	err := ampw.Default(t.Context(), roleAssignmentExistTest.amp)
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(roleAssignmentExistTest.amp.Spec.SystemAssignedIdentityRole.Name).To(Equal(existingRoleAssignmentName))
 
-	err = ampw.Default(context.Background(), publicKeyExistTest.amp)
+	err = ampw.Default(t.Context(), publicKeyExistTest.amp)
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(publicKeyExistTest.amp.Spec.Template.SSHPublicKey).To(Equal(existingPublicKey))
 
-	err = ampw.Default(context.Background(), publicKeyNotExistTest.amp)
+	err = ampw.Default(t.Context(), publicKeyNotExistTest.amp)
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(publicKeyNotExistTest.amp.Spec.Template.SSHPublicKey).NotTo(BeEmpty())
 
-	err = ampw.Default(context.Background(), systemAssignedIdentityRoleExistTest.amp)
+	err = ampw.Default(t.Context(), systemAssignedIdentityRoleExistTest.amp)
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(systemAssignedIdentityRoleExistTest.amp.Spec.SystemAssignedIdentityRole.DefinitionID).To(Equal("testroledefinitionid"))
 	g.Expect(systemAssignedIdentityRoleExistTest.amp.Spec.SystemAssignedIdentityRole.Scope).To(Equal("testscope"))
 
-	err = ampw.Default(context.Background(), emptyTest.amp)
+	err = ampw.Default(t.Context(), emptyTest.amp)
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(emptyTest.amp.Spec.SystemAssignedIdentityRole.Name).To(Not(BeEmpty()))
 	_, err = guuid.Parse(emptyTest.amp.Spec.SystemAssignedIdentityRole.Name)
@@ -719,7 +719,7 @@ func TestAzureMachinePool_ValidateCreateFailure(t *testing.T) {
 				utilfeature.SetFeatureGateDuringTest(t, feature.Gates, capifeature.MachinePool, *tc.featureGateEnabled)
 			}
 			ampw := &azureMachinePoolWebhook{}
-			_, err := ampw.ValidateCreate(context.Background(), tc.amp)
+			_, err := ampw.ValidateCreate(t.Context(), tc.amp)
 			if tc.expectError {
 				g.Expect(err).To(HaveOccurred())
 			} else {

--- a/exp/controllers/azuremachinepool_controller_test.go
+++ b/exp/controllers/azuremachinepool_controller_test.go
@@ -64,7 +64,7 @@ var _ = Describe("AzureMachinePoolReconciler", func() {
 func TestAzureMachinePoolReconcilePaused(t *testing.T) {
 	g := NewWithT(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	sb := runtime.NewSchemeBuilder(
 		clusterv1.AddToScheme,
@@ -179,7 +179,7 @@ func TestAzureMachinePoolReconcilePaused(t *testing.T) {
 	}
 	g.Expect(c.Create(ctx, instance)).To(Succeed())
 
-	result, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+	result, err := reconciler.Reconcile(t.Context(), ctrl.Request{
 		NamespacedName: client.ObjectKey{
 			Namespace: instance.Namespace,
 			Name:      instance.Name,

--- a/exp/controllers/azuremachinepool_reconciler_test.go
+++ b/exp/controllers/azuremachinepool_reconciler_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package controllers
 
 import (
-	"context"
 	"errors"
 	"testing"
 
@@ -97,7 +96,7 @@ func TestAzureMachinePoolServiceReconcile(t *testing.T) {
 				skuCache: resourceskus.NewStaticCache([]armcompute.ResourceSKU{}, ""),
 			}
 
-			err := s.Reconcile(context.TODO())
+			err := s.Reconcile(t.Context())
 			if tc.expectedError != "" {
 				g.Expect(err).To(HaveOccurred())
 				g.Expect(err).To(MatchError(tc.expectedError))
@@ -166,7 +165,7 @@ func TestAzureMachinePoolServicePause(t *testing.T) {
 				},
 			}
 
-			err := s.Pause(context.TODO())
+			err := s.Pause(t.Context())
 			if tc.expectedError != "" {
 				g.Expect(err).To(HaveOccurred())
 				g.Expect(err).To(MatchError(tc.expectedError))
@@ -232,7 +231,7 @@ func TestAzureMachinePoolServiceDelete(t *testing.T) {
 				skuCache: resourceskus.NewStaticCache([]armcompute.ResourceSKU{}, ""),
 			}
 
-			err := s.Delete(context.TODO())
+			err := s.Delete(t.Context())
 			if tc.expectedError != "" {
 				g.Expect(err).To(HaveOccurred())
 				g.Expect(err).To(MatchError(tc.expectedError))

--- a/exp/controllers/azuremachinepoolmachine_controller_test.go
+++ b/exp/controllers/azuremachinepoolmachine_controller_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package controllers
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -72,7 +71,7 @@ func TestAzureMachinePoolMachineReconciler_Reconcile(t *testing.T) {
 				g.Expect(err).NotTo(HaveOccurred())
 
 				ampm := &infrav1exp.AzureMachinePoolMachine{}
-				err = c.Get(context.Background(), types.NamespacedName{
+				err = c.Get(t.Context(), types.NamespacedName{
 					Name:      "ampm1",
 					Namespace: "default",
 				}, ampm)
@@ -103,7 +102,7 @@ func TestAzureMachinePoolMachineReconciler_Reconcile(t *testing.T) {
 				g.Expect(err).NotTo(HaveOccurred())
 
 				machine := &clusterv1.Machine{}
-				err = c.Get(context.Background(), types.NamespacedName{
+				err = c.Get(t.Context(), types.NamespacedName{
 					Name:      "ma1",
 					Namespace: "default",
 				}, machine)
@@ -121,7 +120,7 @@ func TestAzureMachinePoolMachineReconciler_Reconcile(t *testing.T) {
 				g.Expect(err).NotTo(HaveOccurred())
 
 				ampm := &infrav1exp.AzureMachinePoolMachine{}
-				err = c.Get(context.Background(), types.NamespacedName{
+				err = c.Get(t.Context(), types.NamespacedName{
 					Name:      "ampm1",
 					Namespace: "default",
 				}, ampm)
@@ -161,7 +160,7 @@ func TestAzureMachinePoolMachineReconciler_Reconcile(t *testing.T) {
 			controller.reconcilerFactory = func(_ *scope.MachinePoolMachineScope) (azure.Reconciler, error) {
 				return reconciler, nil
 			}
-			res, err := controller.Reconcile(context.TODO(), ctrl.Request{
+			res, err := controller.Reconcile(t.Context(), ctrl.Request{
 				NamespacedName: types.NamespacedName{
 					Name:      "ampm1",
 					Namespace: "default",

--- a/exp/controllers/helpers_test.go
+++ b/exp/controllers/helpers_test.go
@@ -157,10 +157,10 @@ func TestAzureClusterToAzureMachinePoolsMapper(t *testing.T) {
 	sink.EXPECT().Enabled(4).Return(true)
 	sink.EXPECT().WithValues("AzureCluster", "my-cluster", "Namespace", "default").Return(sink)
 	sink.EXPECT().Info(4, "gk does not match", "gk", gomock.Any(), "infraGK", gomock.Any())
-	mapper, err := AzureClusterToAzureMachinePoolsMapper(context.Background(), fakeClient, scheme, logr.New(sink))
+	mapper, err := AzureClusterToAzureMachinePoolsMapper(t.Context(), fakeClient, scheme, logr.New(sink))
 	g.Expect(err).NotTo(HaveOccurred())
 
-	requests := mapper(context.Background(), &infrav1.AzureCluster{
+	requests := mapper(t.Context(), &infrav1.AzureCluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      clusterName,
 			Namespace: "default",
@@ -244,7 +244,7 @@ func Test_MachinePoolToInfrastructureMapFunc(t *testing.T) {
 				c.Setup(sink)
 			}
 			f := MachinePoolToInfrastructureMapFunc(infrav1exp.GroupVersion.WithKind(infrav1.AzureMachinePoolKind), logr.New(sink))
-			reqs := f(context.TODO(), c.MapObjectFactory(g))
+			reqs := f(t.Context(), c.MapObjectFactory(g))
 			c.Expect(g, reqs)
 		})
 	}
@@ -388,8 +388,8 @@ func Test_azureClusterToAzureMachinePoolsFunc(t *testing.T) {
 			sink, mockctrl, fakeClient := c.Setup(t, g)
 			defer mockctrl.Finish()
 
-			f := AzureClusterToAzureMachinePoolsFunc(context.Background(), fakeClient, logr.New(sink))
-			reqs := f(context.TODO(), c.MapObjectFactory(g))
+			f := AzureClusterToAzureMachinePoolsFunc(t.Context(), fakeClient, logr.New(sink))
+			reqs := f(t.Context(), c.MapObjectFactory(g))
 			c.Expect(g, reqs)
 		})
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module sigs.k8s.io/cluster-api-provider-azure
 
-go 1.23.2
+go 1.24.0
 
-toolchain go1.23.12
+toolchain go1.24.6
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.18.2

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -1,8 +1,8 @@
 module sigs.k8s.io/cluster-api-provider-azure/hack/tools
 
-go 1.23.0
+go 1.24.0
 
-toolchain go1.23.12
+toolchain go1.24.6
 
 require sigs.k8s.io/cluster-api/hack/tools v0.0.0-20250520093716-525566440a77
 

--- a/pkg/coalescing/reconciler_test.go
+++ b/pkg/coalescing/reconciler_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package coalescing
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -93,7 +92,7 @@ func TestCoalescingReconciler_Reconcile(t *testing.T) {
 			cacherMock := mock_coalescing.NewMockReconcileCacher(mockCtrl)
 			reconcilerMock := mock_coalescing.NewMockReconciler[reconcile.Request](mockCtrl)
 			subject := c.Reconciler(g, cacherMock, reconcilerMock)
-			result, err := subject.Reconcile(context.Background(), c.Request)
+			result, err := subject.Reconcile(t.Context(), c.Request)
 			if c.Error != "" || err != nil {
 				g.Expect(err).To(And(HaveOccurred(), MatchError(c.Error)))
 				return

--- a/pkg/mutators/azureasomanagedcontrolplane_test.go
+++ b/pkg/mutators/azureasomanagedcontrolplane_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package mutators
 
 import (
-	"context"
 	"encoding/json"
 	"testing"
 
@@ -40,7 +39,7 @@ import (
 )
 
 func TestSetManagedClusterDefaults(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	g := NewGomegaWithT(t)
 
 	tests := []struct {
@@ -136,7 +135,7 @@ func TestSetManagedClusterDefaults(t *testing.T) {
 }
 
 func TestSetManagedClusterKubernetesVersion(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	tests := []struct {
 		name                   string
@@ -244,7 +243,7 @@ func TestSetManagedClusterKubernetesVersion(t *testing.T) {
 }
 
 func TestSetManagedClusterServiceCIDR(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	tests := []struct {
 		name           string
@@ -374,7 +373,7 @@ func TestSetManagedClusterServiceCIDR(t *testing.T) {
 }
 
 func TestSetManagedClusterPodCIDR(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	tests := []struct {
 		name           string
@@ -505,7 +504,7 @@ func TestSetManagedClusterPodCIDR(t *testing.T) {
 
 func TestSetManagedClusterAgentPoolProfiles(t *testing.T) {
 	g := NewGomegaWithT(t)
-	ctx := context.Background()
+	ctx := t.Context()
 	s := runtime.NewScheme()
 	g.Expect(asocontainerservicev1.AddToScheme(s)).To(Succeed())
 	g.Expect(infrav1.AddToScheme(s)).To(Succeed())

--- a/pkg/mutators/azureasomanagedmachinepool_test.go
+++ b/pkg/mutators/azureasomanagedmachinepool_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package mutators
 
 import (
-	"context"
 	"errors"
 	"testing"
 
@@ -37,7 +36,7 @@ import (
 )
 
 func TestSetAgentPoolDefaults(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	g := NewGomegaWithT(t)
 
 	tests := []struct {
@@ -109,7 +108,7 @@ func TestSetAgentPoolDefaults(t *testing.T) {
 }
 
 func TestSetAgentPoolOrchestratorVersion(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	tests := []struct {
 		name        string
@@ -351,7 +350,7 @@ func TestReconcileAutoscaling(t *testing.T) {
 }
 
 func TestSetAgentPoolCount(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	tests := []struct {
 		name              string

--- a/pkg/mutators/mutator_test.go
+++ b/pkg/mutators/mutator_test.go
@@ -30,7 +30,7 @@ import (
 )
 
 func TestApplyMutators(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	tests := []struct {
 		name        string
@@ -120,7 +120,7 @@ func TestApplyMutators(t *testing.T) {
 }
 
 func TestPause(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	tests := []struct {
 		name           string


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Updates the Go compiler and tools to v1.24.6.

I separated this out from #5661 because it's XL-sized on its own.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:


**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests
- [ ] cherry-pick candidate

**Release note**:

```release-note
NONE
```
