### PR TITLE
Fix disabling NAT gateway creation for `cluster` role subnets

### DIFF
--- a/api/v1beta1/azurecluster_default.go
+++ b/api/v1beta1/azurecluster_default.go
@@ -202,11 +202,13 @@ func (s *SubnetSpec) setClusterSubnetDefaults(clusterName string) {
 	if s.RouteTable.Name == "" {
 		s.RouteTable.Name = generateClusterRouteTableName(clusterName)
 	}
-	if s.NatGateway.Name == "" {
-		s.NatGateway.Name = generateClusterNatGatewayName(clusterName)
-	}
-	if !s.IsIPv6Enabled() && s.ID == "" && s.NatGateway.NatGatewayIP.Name == "" {
-		s.NatGateway.NatGatewayIP.Name = generateNatGatewayIPName(s.NatGateway.Name)
+	if s.ID == "" {
+		if s.NatGateway.Name == "" {
+			s.NatGateway.Name = generateClusterNatGatewayName(clusterName)
+		}
+		if !s.IsIPv6Enabled() && s.NatGateway.NatGatewayIP.Name == "" {
+			s.NatGateway.NatGatewayIP.Name = generateNatGatewayIPName(s.NatGateway.Name)
+		}
 	}
 	s.setDefaults(DefaultClusterSubnetCIDR)
 	s.SecurityGroup.SecurityGroupClass.setDefaults()

--- a/api/v1beta1/azurecluster_default_test.go
+++ b/api/v1beta1/azurecluster_default_test.go
@@ -1098,6 +1098,50 @@ func TestSubnetDefaults(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "don't default NAT Gateway for cluster subnet if subnet already exists",
+			cluster: &AzureCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cluster-test",
+				},
+				Spec: AzureClusterSpec{
+					ControlPlaneEnabled: true,
+					NetworkSpec: NetworkSpec{
+						Subnets: Subnets{
+							{
+								SubnetClassSpec: SubnetClassSpec{
+									Role: SubnetCluster,
+									Name: "cluster-test-cluster-subnet",
+								},
+								ID: "my-subnet-id",
+							},
+						},
+					},
+				},
+			},
+			output: &AzureCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cluster-test",
+				},
+				Spec: AzureClusterSpec{
+					ControlPlaneEnabled: true,
+					NetworkSpec: NetworkSpec{
+						Subnets: Subnets{
+							{
+								SubnetClassSpec: SubnetClassSpec{
+									Role:       SubnetCluster,
+									CIDRBlocks: []string{DefaultClusterSubnetCIDR},
+									Name:       "cluster-test-cluster-subnet",
+								},
+								ID:            "my-subnet-id",
+								SecurityGroup: SecurityGroup{Name: "cluster-test-nsg"},
+								RouteTable:    RouteTable{Name: "cluster-test-routetable"},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

When creating an `AzureCluster` with a pre-existing single subnet shared by both control plane and worker nodes (`role: cluster`), the AzureCluster reconciler attempts to erroneously create a NAT gateway, eventually failing with a `publicips failed to create or update. err: failed to get existing resource (service: publicips): parameter publicIPAddressName cannot be empty` error.

This is a result of the defaulting webhook always setting the NAT gateway name even when a subnet ID is specified, resulting in an empty `NATGatewayIP.Name`.

The webhook updates this `networkSpec`
```yaml
networkSpec:
  subnets:
  - name: cluster-subnet
    id: subnet-id
    cidrBlocks:
      - 10.0.1.0/24
    role: cluster
```
to
```yaml
networkSpec:
  subnets:
  - name: cluster-subnet
    id: subnet-id
    cidrBlocks:
      - 10.0.1.0/24
    role: cluster
    natGateway:
      ip:
        name: ""
      name: cluster-nat-gateway
```

This changelist fixes the issue by setting a default NAT Gateway name only when `subnet.ID` is empty. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #5815


**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [x] adds unit tests
- [ ] cherry-pick candidate

**Release note**:
```release-note
Fixes disabling NAT gateway for `cluster` role subnets
```
