### PR TITLE
Bump installed ASO to v2.13.0

### DIFF
--- a/config/aso/crds.yaml
+++ b/config/aso/crds.yaml
@@ -6,7 +6,7 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.16.3
   labels:
     app.kubernetes.io/name: azure-service-operator
-    app.kubernetes.io/version: v2.11.0
+    app.kubernetes.io/version: v2.13.0
   name: bastionhosts.network.azure.com
 spec:
   conversion:
@@ -1703,7 +1703,7 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.16.3
   labels:
     app.kubernetes.io/name: azure-service-operator
-    app.kubernetes.io/version: v2.11.0
+    app.kubernetes.io/version: v2.13.0
   name: extensions.kubernetesconfiguration.azure.com
 spec:
   conversion:
@@ -2946,6 +2946,1224 @@ spec:
               type: object
           type: object
       served: true
+      storage: false
+      subresources:
+        status: {}
+    - additionalPrinterColumns:
+        - jsonPath: .status.conditions[?(@.type=='Ready')].status
+          name: Ready
+          type: string
+        - jsonPath: .status.conditions[?(@.type=='Ready')].severity
+          name: Severity
+          type: string
+        - jsonPath: .status.conditions[?(@.type=='Ready')].reason
+          name: Reason
+          type: string
+        - jsonPath: .status.conditions[?(@.type=='Ready')].message
+          name: Message
+          type: string
+      name: v1api20241101
+      schema:
+        openAPIV3Schema:
+          description: |-
+            Generator information:
+            - Generated from: /kubernetesconfiguration/resource-manager/Microsoft.KubernetesConfiguration/extensions/stable/2024-11-01/extensions.json
+            - ARM URI: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{clusterRp}/{clusterResourceName}/{clusterName}/providers/Microsoft.KubernetesConfiguration/extensions/{extensionName}
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                aksAssignedIdentity:
+                  description: 'AksAssignedIdentity: Identity of the Extension resource in an AKS cluster'
+                  properties:
+                    type:
+                      description: 'Type: The identity type.'
+                      enum:
+                        - SystemAssigned
+                        - UserAssigned
+                      type: string
+                  type: object
+                autoUpgradeMinorVersion:
+                  description: 'AutoUpgradeMinorVersion: Flag to note if this extension participates in auto upgrade of minor version, or not.'
+                  type: boolean
+                azureName:
+                  description: |-
+                    AzureName: The name of the resource in Azure. This is often the same as the name of the resource in Kubernetes but it
+                    doesn't have to be.
+                  type: string
+                configurationProtectedSettings:
+                  description: |-
+                    ConfigurationProtectedSettings: Configuration settings that are sensitive, as name-value pairs for configuring this
+                    extension.
+                  properties:
+                    name:
+                      description: |-
+                        Name is the name of the Kubernetes secret being referenced.
+                        The secret must be in the same namespace as the resource
+                      type: string
+                  required:
+                    - name
+                  type: object
+                configurationSettings:
+                  additionalProperties:
+                    type: string
+                  description: 'ConfigurationSettings: Configuration settings, as name-value pairs for configuring this extension.'
+                  type: object
+                extensionType:
+                  description: |-
+                    ExtensionType: Type of the Extension, of which this resource is an instance of.  It must be one of the Extension Types
+                    registered with Microsoft.KubernetesConfiguration by the Extension publisher.
+                  type: string
+                identity:
+                  description: 'Identity: Identity of the Extension resource'
+                  properties:
+                    type:
+                      description: 'Type: The identity type.'
+                      enum:
+                        - SystemAssigned
+                      type: string
+                  type: object
+                operatorSpec:
+                  description: |-
+                    OperatorSpec: The specification for configuring operator behavior. This field is interpreted by the operator and not
+                    passed directly to Azure
+                  properties:
+                    configMapExpressions:
+                      description: 'ConfigMapExpressions: configures where to place operator written dynamic ConfigMaps (created with CEL expressions).'
+                      items:
+                        description: |-
+                          DestinationExpression is a CEL expression and a destination to store the result in. The destination may
+                          be a secret or a configmap. The value of the expression is stored at the specified location in
+                          the destination.
+                        properties:
+                          key:
+                            description: |-
+                              Key is the key in the ConfigMap or Secret being written to. If the CEL expression in Value returns a string
+                              this is required to identify what key to write to. If the CEL expression in Value returns a map[string]string
+                              Key must not be set, instead the keys written will be determined dynamically based on the keys of the resulting
+                              map[string]string.
+                            type: string
+                          name:
+                            description: |-
+                              Name is the name of the Kubernetes configmap or secret to write to.
+                              The configmap or secret will be created in the same namespace as the resource.
+                            type: string
+                          value:
+                            description: |-
+                              Value is a CEL expression. The CEL expression may return a string or a map[string]string. For more information
+                              on CEL in ASO see https://azure.github.io/azure-service-operator/guide/expressions/
+                            type: string
+                        required:
+                          - name
+                          - value
+                        type: object
+                      type: array
+                    configMaps:
+                      description: 'ConfigMaps: configures where to place operator written ConfigMaps.'
+                      properties:
+                        principalId:
+                          description: 'PrincipalId: indicates where the PrincipalId config map should be placed. If omitted, no config map will be created.'
+                          properties:
+                            key:
+                              description: Key is the key in the ConfigMap being referenced
+                              type: string
+                            name:
+                              description: |-
+                                Name is the name of the Kubernetes ConfigMap to write to.
+                                The ConfigMap will be created in the same namespace as the resource.
+                              type: string
+                          required:
+                            - key
+                            - name
+                          type: object
+                      type: object
+                    secretExpressions:
+                      description: 'SecretExpressions: configures where to place operator written dynamic secrets (created with CEL expressions).'
+                      items:
+                        description: |-
+                          DestinationExpression is a CEL expression and a destination to store the result in. The destination may
+                          be a secret or a configmap. The value of the expression is stored at the specified location in
+                          the destination.
+                        properties:
+                          key:
+                            description: |-
+                              Key is the key in the ConfigMap or Secret being written to. If the CEL expression in Value returns a string
+                              this is required to identify what key to write to. If the CEL expression in Value returns a map[string]string
+                              Key must not be set, instead the keys written will be determined dynamically based on the keys of the resulting
+                              map[string]string.
+                            type: string
+                          name:
+                            description: |-
+                              Name is the name of the Kubernetes configmap or secret to write to.
+                              The configmap or secret will be created in the same namespace as the resource.
+                            type: string
+                          value:
+                            description: |-
+                              Value is a CEL expression. The CEL expression may return a string or a map[string]string. For more information
+                              on CEL in ASO see https://azure.github.io/azure-service-operator/guide/expressions/
+                            type: string
+                        required:
+                          - name
+                          - value
+                        type: object
+                      type: array
+                  type: object
+                owner:
+                  description: |-
+                    Owner: The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also
+                    controls the resources lifecycle. When the owner is deleted the resource will also be deleted. This resource is an
+                    extension resource, which means that any other Azure resource can be its owner.
+                  properties:
+                    armId:
+                      description: Ownership across namespaces is not supported.
+                      pattern: (?i)(^(/subscriptions/([^/]+)(/resourcegroups/([^/]+))?)?/providers/([^/]+)/([^/]+/[^/]+)(/([^/]+/[^/]+))*$|^/subscriptions/([^/]+)(/resourcegroups/([^/]+))?$)
+                      type: string
+                    group:
+                      description: Group is the Kubernetes group of the resource.
+                      type: string
+                    kind:
+                      description: Kind is the Kubernetes kind of the resource.
+                      type: string
+                    name:
+                      description: This is the name of the Kubernetes resource to reference.
+                      type: string
+                  type: object
+                plan:
+                  description: 'Plan: The plan information.'
+                  properties:
+                    name:
+                      description: 'Name: A user defined name of the 3rd Party Artifact that is being procured.'
+                      type: string
+                    product:
+                      description: |-
+                        Product: The 3rd Party artifact that is being procured. E.g. NewRelic. Product maps to the OfferID specified for the
+                        artifact at the time of Data Market onboarding.
+                      type: string
+                    promotionCode:
+                      description: 'PromotionCode: A publisher provided promotion code as provisioned in Data Market for the said product/artifact.'
+                      type: string
+                    publisher:
+                      description: 'Publisher: The publisher of the 3rd Party Artifact that is being bought. E.g. NewRelic'
+                      type: string
+                    version:
+                      description: 'Version: The version of the desired product/artifact.'
+                      type: string
+                  required:
+                    - name
+                    - product
+                    - publisher
+                  type: object
+                releaseTrain:
+                  description: |-
+                    ReleaseTrain: ReleaseTrain this extension participates in for auto-upgrade (e.g. Stable, Preview, etc.) - only if
+                    autoUpgradeMinorVersion is 'true'.
+                  type: string
+                scope:
+                  description: 'Scope: Scope at which the extension is installed.'
+                  properties:
+                    cluster:
+                      description: 'Cluster: Specifies that the scope of the extension is Cluster'
+                      properties:
+                        releaseNamespace:
+                          description: |-
+                            ReleaseNamespace: Namespace where the extension Release must be placed, for a Cluster scoped extension.  If this
+                            namespace does not exist, it will be created
+                          type: string
+                      type: object
+                    namespace:
+                      description: 'Namespace: Specifies that the scope of the extension is Namespace'
+                      properties:
+                        targetNamespace:
+                          description: |-
+                            TargetNamespace: Namespace where the extension will be created for an Namespace scoped extension.  If this namespace
+                            does not exist, it will be created
+                          type: string
+                      type: object
+                  type: object
+                systemData:
+                  description: |-
+                    SystemData: Top level metadata
+                    https://github.com/Azure/azure-resource-manager-rpc/blob/master/v1.0/common-api-contracts.md#system-metadata-for-all-azure-resources
+                  properties:
+                    createdAt:
+                      description: 'CreatedAt: The timestamp of resource creation (UTC).'
+                      type: string
+                    createdBy:
+                      description: 'CreatedBy: The identity that created the resource.'
+                      type: string
+                    createdByType:
+                      description: 'CreatedByType: The type of identity that created the resource.'
+                      enum:
+                        - Application
+                        - Key
+                        - ManagedIdentity
+                        - User
+                      type: string
+                    lastModifiedAt:
+                      description: 'LastModifiedAt: The timestamp of resource last modification (UTC)'
+                      type: string
+                    lastModifiedBy:
+                      description: 'LastModifiedBy: The identity that last modified the resource.'
+                      type: string
+                    lastModifiedByType:
+                      description: 'LastModifiedByType: The type of identity that last modified the resource.'
+                      enum:
+                        - Application
+                        - Key
+                        - ManagedIdentity
+                        - User
+                      type: string
+                  type: object
+                version:
+                  description: |-
+                    Version: User-specified version of the extension for this extension to 'pin'. To use 'version', autoUpgradeMinorVersion
+                    must be 'false'.
+                  type: string
+              required:
+                - owner
+              type: object
+            status:
+              description: The Extension object.
+              properties:
+                aksAssignedIdentity:
+                  description: 'AksAssignedIdentity: Identity of the Extension resource in an AKS cluster'
+                  properties:
+                    principalId:
+                      description: 'PrincipalId: The principal ID of resource identity.'
+                      type: string
+                    tenantId:
+                      description: 'TenantId: The tenant ID of resource.'
+                      type: string
+                    type:
+                      description: 'Type: The identity type.'
+                      type: string
+                  type: object
+                autoUpgradeMinorVersion:
+                  description: 'AutoUpgradeMinorVersion: Flag to note if this extension participates in auto upgrade of minor version, or not.'
+                  type: boolean
+                conditions:
+                  description: 'Conditions: The observed state of the resource'
+                  items:
+                    description: Condition defines an extension to status (an observation) of a resource
+                    properties:
+                      lastTransitionTime:
+                        description: LastTransitionTime is the last time the condition transitioned from one status to another.
+                        format: date-time
+                        type: string
+                      message:
+                        description: Message is a human readable message indicating details about the transition. This field may be empty.
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          ObservedGeneration is the .metadata.generation that the condition was set based upon. For instance, if
+                          .metadata.generation is currently 12, but the .status.condition[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        type: integer
+                      reason:
+                        description: |-
+                          Reason for the condition's last transition.
+                          Reasons are upper CamelCase (PascalCase) with no spaces. A reason is always provided, this field will not be empty.
+                        type: string
+                      severity:
+                        description: |-
+                          Severity with which to treat failures of this type of condition.
+                          For conditions which have positive polarity (Status == True is their normal/healthy state), this will be omitted when Status == True
+                          For conditions which have negative polarity (Status == False is their normal/healthy state), this will be omitted when Status == False.
+                          This is omitted in all cases when Status == Unknown
+                        type: string
+                      status:
+                        description: Status of the condition, one of True, False, or Unknown.
+                        type: string
+                      type:
+                        description: Type of condition.
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                configurationProtectedSettings:
+                  additionalProperties:
+                    type: string
+                  description: |-
+                    ConfigurationProtectedSettings: Configuration settings that are sensitive, as name-value pairs for configuring this
+                    extension.
+                  type: object
+                configurationSettings:
+                  additionalProperties:
+                    type: string
+                  description: 'ConfigurationSettings: Configuration settings, as name-value pairs for configuring this extension.'
+                  type: object
+                currentVersion:
+                  description: 'CurrentVersion: Currently installed version of the extension.'
+                  type: string
+                customLocationSettings:
+                  additionalProperties:
+                    type: string
+                  description: 'CustomLocationSettings: Custom Location settings properties.'
+                  type: object
+                errorInfo:
+                  description: 'ErrorInfo: Error information from the Agent - e.g. errors during installation.'
+                  properties:
+                    additionalInfo:
+                      description: 'AdditionalInfo: The error additional info.'
+                      items:
+                        description: The resource management error additional info.
+                        properties:
+                          info:
+                            additionalProperties:
+                              x-kubernetes-preserve-unknown-fields: true
+                            description: 'Info: The additional info.'
+                            type: object
+                          type:
+                            description: 'Type: The additional info type.'
+                            type: string
+                        type: object
+                      type: array
+                    code:
+                      description: 'Code: The error code.'
+                      type: string
+                    details:
+                      description: 'Details: The error details.'
+                      items:
+                        properties:
+                          additionalInfo:
+                            description: 'AdditionalInfo: The error additional info.'
+                            items:
+                              description: The resource management error additional info.
+                              properties:
+                                info:
+                                  additionalProperties:
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  description: 'Info: The additional info.'
+                                  type: object
+                                type:
+                                  description: 'Type: The additional info type.'
+                                  type: string
+                              type: object
+                            type: array
+                          code:
+                            description: 'Code: The error code.'
+                            type: string
+                          message:
+                            description: 'Message: The error message.'
+                            type: string
+                          target:
+                            description: 'Target: The error target.'
+                            type: string
+                        type: object
+                      type: array
+                    message:
+                      description: 'Message: The error message.'
+                      type: string
+                    target:
+                      description: 'Target: The error target.'
+                      type: string
+                  type: object
+                extensionType:
+                  description: |-
+                    ExtensionType: Type of the Extension, of which this resource is an instance of.  It must be one of the Extension Types
+                    registered with Microsoft.KubernetesConfiguration by the Extension publisher.
+                  type: string
+                id:
+                  description: |-
+                    Id: Fully qualified resource ID for the resource. Ex -
+                    /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}
+                  type: string
+                identity:
+                  description: 'Identity: Identity of the Extension resource'
+                  properties:
+                    principalId:
+                      description: 'PrincipalId: The principal ID of resource identity.'
+                      type: string
+                    tenantId:
+                      description: 'TenantId: The tenant ID of resource.'
+                      type: string
+                    type:
+                      description: 'Type: The identity type.'
+                      type: string
+                  type: object
+                isSystemExtension:
+                  description: 'IsSystemExtension: Flag to note if this extension is a system extension'
+                  type: boolean
+                name:
+                  description: 'Name: The name of the resource'
+                  type: string
+                packageUri:
+                  description: 'PackageUri: Uri of the Helm package'
+                  type: string
+                plan:
+                  description: 'Plan: The plan information.'
+                  properties:
+                    name:
+                      description: 'Name: A user defined name of the 3rd Party Artifact that is being procured.'
+                      type: string
+                    product:
+                      description: |-
+                        Product: The 3rd Party artifact that is being procured. E.g. NewRelic. Product maps to the OfferID specified for the
+                        artifact at the time of Data Market onboarding.
+                      type: string
+                    promotionCode:
+                      description: 'PromotionCode: A publisher provided promotion code as provisioned in Data Market for the said product/artifact.'
+                      type: string
+                    publisher:
+                      description: 'Publisher: The publisher of the 3rd Party Artifact that is being bought. E.g. NewRelic'
+                      type: string
+                    version:
+                      description: 'Version: The version of the desired product/artifact.'
+                      type: string
+                  type: object
+                releaseTrain:
+                  description: |-
+                    ReleaseTrain: ReleaseTrain this extension participates in for auto-upgrade (e.g. Stable, Preview, etc.) - only if
+                    autoUpgradeMinorVersion is 'true'.
+                  type: string
+                scope:
+                  description: 'Scope: Scope at which the extension is installed.'
+                  properties:
+                    cluster:
+                      description: 'Cluster: Specifies that the scope of the extension is Cluster'
+                      properties:
+                        releaseNamespace:
+                          description: |-
+                            ReleaseNamespace: Namespace where the extension Release must be placed, for a Cluster scoped extension.  If this
+                            namespace does not exist, it will be created
+                          type: string
+                      type: object
+                    namespace:
+                      description: 'Namespace: Specifies that the scope of the extension is Namespace'
+                      properties:
+                        targetNamespace:
+                          description: |-
+                            TargetNamespace: Namespace where the extension will be created for an Namespace scoped extension.  If this namespace
+                            does not exist, it will be created
+                          type: string
+                      type: object
+                  type: object
+                statuses:
+                  description: 'Statuses: Status from this extension.'
+                  items:
+                    description: Status from the extension.
+                    properties:
+                      code:
+                        description: 'Code: Status code provided by the Extension'
+                        type: string
+                      displayStatus:
+                        description: 'DisplayStatus: Short description of status of the extension.'
+                        type: string
+                      level:
+                        description: 'Level: Level of the status.'
+                        type: string
+                      message:
+                        description: 'Message: Detailed message of the status from the Extension.'
+                        type: string
+                      time:
+                        description: 'Time: DateLiteral (per ISO8601) noting the time of installation status.'
+                        type: string
+                    type: object
+                  type: array
+                systemData:
+                  description: |-
+                    SystemData: Top level metadata
+                    https://github.com/Azure/azure-resource-manager-rpc/blob/master/v1.0/common-api-contracts.md#system-metadata-for-all-azure-resources
+                  properties:
+                    createdAt:
+                      description: 'CreatedAt: The timestamp of resource creation (UTC).'
+                      type: string
+                    createdBy:
+                      description: 'CreatedBy: The identity that created the resource.'
+                      type: string
+                    createdByType:
+                      description: 'CreatedByType: The type of identity that created the resource.'
+                      type: string
+                    lastModifiedAt:
+                      description: 'LastModifiedAt: The timestamp of resource last modification (UTC)'
+                      type: string
+                    lastModifiedBy:
+                      description: 'LastModifiedBy: The identity that last modified the resource.'
+                      type: string
+                    lastModifiedByType:
+                      description: 'LastModifiedByType: The type of identity that last modified the resource.'
+                      type: string
+                  type: object
+                type:
+                  description: 'Type: The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"'
+                  type: string
+                version:
+                  description: |-
+                    Version: User-specified version of the extension for this extension to 'pin'. To use 'version', autoUpgradeMinorVersion
+                    must be 'false'.
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: false
+      subresources:
+        status: {}
+    - additionalPrinterColumns:
+        - jsonPath: .status.conditions[?(@.type=='Ready')].status
+          name: Ready
+          type: string
+        - jsonPath: .status.conditions[?(@.type=='Ready')].severity
+          name: Severity
+          type: string
+        - jsonPath: .status.conditions[?(@.type=='Ready')].reason
+          name: Reason
+          type: string
+        - jsonPath: .status.conditions[?(@.type=='Ready')].message
+          name: Message
+          type: string
+      name: v1api20241101storage
+      schema:
+        openAPIV3Schema:
+          description: |-
+            Storage version of v1api20241101.Extension
+            Generator information:
+            - Generated from: /kubernetesconfiguration/resource-manager/Microsoft.KubernetesConfiguration/extensions/stable/2024-11-01/extensions.json
+            - ARM URI: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{clusterRp}/{clusterResourceName}/{clusterName}/providers/Microsoft.KubernetesConfiguration/extensions/{extensionName}
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: Storage version of v1api20241101.Extension_Spec
+              properties:
+                $propertyBag:
+                  additionalProperties:
+                    type: string
+                  description: |-
+                    PropertyBag is an unordered set of stashed information that used for properties not directly supported by storage
+                    resources, allowing for full fidelity round trip conversions
+                  type: object
+                aksAssignedIdentity:
+                  description: Storage version of v1api20241101.Extension_Properties_AksAssignedIdentity_Spec
+                  properties:
+                    $propertyBag:
+                      additionalProperties:
+                        type: string
+                      description: |-
+                        PropertyBag is an unordered set of stashed information that used for properties not directly supported by storage
+                        resources, allowing for full fidelity round trip conversions
+                      type: object
+                    type:
+                      type: string
+                  type: object
+                autoUpgradeMinorVersion:
+                  type: boolean
+                azureName:
+                  description: |-
+                    AzureName: The name of the resource in Azure. This is often the same as the name of the resource in Kubernetes but it
+                    doesn't have to be.
+                  type: string
+                configurationProtectedSettings:
+                  description: |-
+                    SecretMapReference is a reference to a Kubernetes secret in the same namespace as
+                    the resource it is on.
+                  properties:
+                    name:
+                      description: |-
+                        Name is the name of the Kubernetes secret being referenced.
+                        The secret must be in the same namespace as the resource
+                      type: string
+                  required:
+                    - name
+                  type: object
+                configurationSettings:
+                  additionalProperties:
+                    type: string
+                  type: object
+                extensionType:
+                  type: string
+                identity:
+                  description: |-
+                    Storage version of v1api20241101.Identity
+                    Identity for the resource.
+                  properties:
+                    $propertyBag:
+                      additionalProperties:
+                        type: string
+                      description: |-
+                        PropertyBag is an unordered set of stashed information that used for properties not directly supported by storage
+                        resources, allowing for full fidelity round trip conversions
+                      type: object
+                    type:
+                      type: string
+                  type: object
+                operatorSpec:
+                  description: |-
+                    Storage version of v1api20241101.ExtensionOperatorSpec
+                    Details for configuring operator behavior. Fields in this struct are interpreted by the operator directly rather than being passed to Azure
+                  properties:
+                    $propertyBag:
+                      additionalProperties:
+                        type: string
+                      description: |-
+                        PropertyBag is an unordered set of stashed information that used for properties not directly supported by storage
+                        resources, allowing for full fidelity round trip conversions
+                      type: object
+                    configMapExpressions:
+                      items:
+                        description: |-
+                          DestinationExpression is a CEL expression and a destination to store the result in. The destination may
+                          be a secret or a configmap. The value of the expression is stored at the specified location in
+                          the destination.
+                        properties:
+                          key:
+                            description: |-
+                              Key is the key in the ConfigMap or Secret being written to. If the CEL expression in Value returns a string
+                              this is required to identify what key to write to. If the CEL expression in Value returns a map[string]string
+                              Key must not be set, instead the keys written will be determined dynamically based on the keys of the resulting
+                              map[string]string.
+                            type: string
+                          name:
+                            description: |-
+                              Name is the name of the Kubernetes configmap or secret to write to.
+                              The configmap or secret will be created in the same namespace as the resource.
+                            type: string
+                          value:
+                            description: |-
+                              Value is a CEL expression. The CEL expression may return a string or a map[string]string. For more information
+                              on CEL in ASO see https://azure.github.io/azure-service-operator/guide/expressions/
+                            type: string
+                        required:
+                          - name
+                          - value
+                        type: object
+                      type: array
+                    configMaps:
+                      description: Storage version of v1api20241101.ExtensionOperatorConfigMaps
+                      properties:
+                        $propertyBag:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            PropertyBag is an unordered set of stashed information that used for properties not directly supported by storage
+                            resources, allowing for full fidelity round trip conversions
+                          type: object
+                        principalId:
+                          description: |-
+                            ConfigMapDestination describes the location to store a single configmap value
+                            Note: This is similar to: SecretDestination in secrets.go.
+                            Changes to one may need to be made to the others as well.
+                          properties:
+                            key:
+                              description: Key is the key in the ConfigMap being referenced
+                              type: string
+                            name:
+                              description: |-
+                                Name is the name of the Kubernetes ConfigMap to write to.
+                                The ConfigMap will be created in the same namespace as the resource.
+                              type: string
+                          required:
+                            - key
+                            - name
+                          type: object
+                      type: object
+                    secretExpressions:
+                      items:
+                        description: |-
+                          DestinationExpression is a CEL expression and a destination to store the result in. The destination may
+                          be a secret or a configmap. The value of the expression is stored at the specified location in
+                          the destination.
+                        properties:
+                          key:
+                            description: |-
+                              Key is the key in the ConfigMap or Secret being written to. If the CEL expression in Value returns a string
+                              this is required to identify what key to write to. If the CEL expression in Value returns a map[string]string
+                              Key must not be set, instead the keys written will be determined dynamically based on the keys of the resulting
+                              map[string]string.
+                            type: string
+                          name:
+                            description: |-
+                              Name is the name of the Kubernetes configmap or secret to write to.
+                              The configmap or secret will be created in the same namespace as the resource.
+                            type: string
+                          value:
+                            description: |-
+                              Value is a CEL expression. The CEL expression may return a string or a map[string]string. For more information
+                              on CEL in ASO see https://azure.github.io/azure-service-operator/guide/expressions/
+                            type: string
+                        required:
+                          - name
+                          - value
+                        type: object
+                      type: array
+                  type: object
+                originalVersion:
+                  type: string
+                owner:
+                  description: |-
+                    Owner: The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also
+                    controls the resources lifecycle. When the owner is deleted the resource will also be deleted. This resource is an
+                    extension resource, which means that any other Azure resource can be its owner.
+                  properties:
+                    armId:
+                      description: Ownership across namespaces is not supported.
+                      pattern: (?i)(^(/subscriptions/([^/]+)(/resourcegroups/([^/]+))?)?/providers/([^/]+)/([^/]+/[^/]+)(/([^/]+/[^/]+))*$|^/subscriptions/([^/]+)(/resourcegroups/([^/]+))?$)
+                      type: string
+                    group:
+                      description: Group is the Kubernetes group of the resource.
+                      type: string
+                    kind:
+                      description: Kind is the Kubernetes kind of the resource.
+                      type: string
+                    name:
+                      description: This is the name of the Kubernetes resource to reference.
+                      type: string
+                  type: object
+                plan:
+                  description: |-
+                    Storage version of v1api20241101.Plan
+                    Plan for the resource.
+                  properties:
+                    $propertyBag:
+                      additionalProperties:
+                        type: string
+                      description: |-
+                        PropertyBag is an unordered set of stashed information that used for properties not directly supported by storage
+                        resources, allowing for full fidelity round trip conversions
+                      type: object
+                    name:
+                      type: string
+                    product:
+                      type: string
+                    promotionCode:
+                      type: string
+                    publisher:
+                      type: string
+                    version:
+                      type: string
+                  type: object
+                releaseTrain:
+                  type: string
+                scope:
+                  description: |-
+                    Storage version of v1api20241101.Scope
+                    Scope of the extension. It can be either Cluster or Namespace; but not both.
+                  properties:
+                    $propertyBag:
+                      additionalProperties:
+                        type: string
+                      description: |-
+                        PropertyBag is an unordered set of stashed information that used for properties not directly supported by storage
+                        resources, allowing for full fidelity round trip conversions
+                      type: object
+                    cluster:
+                      description: |-
+                        Storage version of v1api20241101.ScopeCluster
+                        Specifies that the scope of the extension is Cluster
+                      properties:
+                        $propertyBag:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            PropertyBag is an unordered set of stashed information that used for properties not directly supported by storage
+                            resources, allowing for full fidelity round trip conversions
+                          type: object
+                        releaseNamespace:
+                          type: string
+                      type: object
+                    namespace:
+                      description: |-
+                        Storage version of v1api20241101.ScopeNamespace
+                        Specifies that the scope of the extension is Namespace
+                      properties:
+                        $propertyBag:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            PropertyBag is an unordered set of stashed information that used for properties not directly supported by storage
+                            resources, allowing for full fidelity round trip conversions
+                          type: object
+                        targetNamespace:
+                          type: string
+                      type: object
+                  type: object
+                systemData:
+                  description: |-
+                    Storage version of v1api20241101.SystemData
+                    Metadata pertaining to creation and last modification of the resource.
+                  properties:
+                    $propertyBag:
+                      additionalProperties:
+                        type: string
+                      description: |-
+                        PropertyBag is an unordered set of stashed information that used for properties not directly supported by storage
+                        resources, allowing for full fidelity round trip conversions
+                      type: object
+                    createdAt:
+                      type: string
+                    createdBy:
+                      type: string
+                    createdByType:
+                      type: string
+                    lastModifiedAt:
+                      type: string
+                    lastModifiedBy:
+                      type: string
+                    lastModifiedByType:
+                      type: string
+                  type: object
+                version:
+                  type: string
+              required:
+                - owner
+              type: object
+            status:
+              description: |-
+                Storage version of v1api20241101.Extension_STATUS
+                The Extension object.
+              properties:
+                $propertyBag:
+                  additionalProperties:
+                    type: string
+                  description: |-
+                    PropertyBag is an unordered set of stashed information that used for properties not directly supported by storage
+                    resources, allowing for full fidelity round trip conversions
+                  type: object
+                aksAssignedIdentity:
+                  description: Storage version of v1api20241101.Extension_Properties_AksAssignedIdentity_STATUS
+                  properties:
+                    $propertyBag:
+                      additionalProperties:
+                        type: string
+                      description: |-
+                        PropertyBag is an unordered set of stashed information that used for properties not directly supported by storage
+                        resources, allowing for full fidelity round trip conversions
+                      type: object
+                    principalId:
+                      type: string
+                    tenantId:
+                      type: string
+                    type:
+                      type: string
+                  type: object
+                autoUpgradeMinorVersion:
+                  type: boolean
+                conditions:
+                  items:
+                    description: Condition defines an extension to status (an observation) of a resource
+                    properties:
+                      lastTransitionTime:
+                        description: LastTransitionTime is the last time the condition transitioned from one status to another.
+                        format: date-time
+                        type: string
+                      message:
+                        description: Message is a human readable message indicating details about the transition. This field may be empty.
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          ObservedGeneration is the .metadata.generation that the condition was set based upon. For instance, if
+                          .metadata.generation is currently 12, but the .status.condition[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        type: integer
+                      reason:
+                        description: |-
+                          Reason for the condition's last transition.
+                          Reasons are upper CamelCase (PascalCase) with no spaces. A reason is always provided, this field will not be empty.
+                        type: string
+                      severity:
+                        description: |-
+                          Severity with which to treat failures of this type of condition.
+                          For conditions which have positive polarity (Status == True is their normal/healthy state), this will be omitted when Status == True
+                          For conditions which have negative polarity (Status == False is their normal/healthy state), this will be omitted when Status == False.
+                          This is omitted in all cases when Status == Unknown
+                        type: string
+                      status:
+                        description: Status of the condition, one of True, False, or Unknown.
+                        type: string
+                      type:
+                        description: Type of condition.
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                configurationProtectedSettings:
+                  additionalProperties:
+                    type: string
+                  type: object
+                configurationSettings:
+                  additionalProperties:
+                    type: string
+                  type: object
+                currentVersion:
+                  type: string
+                customLocationSettings:
+                  additionalProperties:
+                    type: string
+                  type: object
+                errorInfo:
+                  description: |-
+                    Storage version of v1api20241101.ErrorDetail_STATUS
+                    The error detail.
+                  properties:
+                    $propertyBag:
+                      additionalProperties:
+                        type: string
+                      description: |-
+                        PropertyBag is an unordered set of stashed information that used for properties not directly supported by storage
+                        resources, allowing for full fidelity round trip conversions
+                      type: object
+                    additionalInfo:
+                      items:
+                        description: |-
+                          Storage version of v1api20241101.ErrorAdditionalInfo_STATUS
+                          The resource management error additional info.
+                        properties:
+                          $propertyBag:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              PropertyBag is an unordered set of stashed information that used for properties not directly supported by storage
+                              resources, allowing for full fidelity round trip conversions
+                            type: object
+                          info:
+                            additionalProperties:
+                              x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                          type:
+                            type: string
+                        type: object
+                      type: array
+                    code:
+                      type: string
+                    details:
+                      items:
+                        description: Storage version of v1api20241101.ErrorDetail_STATUS_Unrolled
+                        properties:
+                          $propertyBag:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              PropertyBag is an unordered set of stashed information that used for properties not directly supported by storage
+                              resources, allowing for full fidelity round trip conversions
+                            type: object
+                          additionalInfo:
+                            items:
+                              description: |-
+                                Storage version of v1api20241101.ErrorAdditionalInfo_STATUS
+                                The resource management error additional info.
+                              properties:
+                                $propertyBag:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    PropertyBag is an unordered set of stashed information that used for properties not directly supported by storage
+                                    resources, allowing for full fidelity round trip conversions
+                                  type: object
+                                info:
+                                  additionalProperties:
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  type: object
+                                type:
+                                  type: string
+                              type: object
+                            type: array
+                          code:
+                            type: string
+                          message:
+                            type: string
+                          target:
+                            type: string
+                        type: object
+                      type: array
+                    message:
+                      type: string
+                    target:
+                      type: string
+                  type: object
+                extensionType:
+                  type: string
+                id:
+                  type: string
+                identity:
+                  description: |-
+                    Storage version of v1api20241101.Identity_STATUS
+                    Identity for the resource.
+                  properties:
+                    $propertyBag:
+                      additionalProperties:
+                        type: string
+                      description: |-
+                        PropertyBag is an unordered set of stashed information that used for properties not directly supported by storage
+                        resources, allowing for full fidelity round trip conversions
+                      type: object
+                    principalId:
+                      type: string
+                    tenantId:
+                      type: string
+                    type:
+                      type: string
+                  type: object
+                isSystemExtension:
+                  type: boolean
+                name:
+                  type: string
+                packageUri:
+                  type: string
+                plan:
+                  description: |-
+                    Storage version of v1api20241101.Plan_STATUS
+                    Plan for the resource.
+                  properties:
+                    $propertyBag:
+                      additionalProperties:
+                        type: string
+                      description: |-
+                        PropertyBag is an unordered set of stashed information that used for properties not directly supported by storage
+                        resources, allowing for full fidelity round trip conversions
+                      type: object
+                    name:
+                      type: string
+                    product:
+                      type: string
+                    promotionCode:
+                      type: string
+                    publisher:
+                      type: string
+                    version:
+                      type: string
+                  type: object
+                releaseTrain:
+                  type: string
+                scope:
+                  description: |-
+                    Storage version of v1api20241101.Scope_STATUS
+                    Scope of the extension. It can be either Cluster or Namespace; but not both.
+                  properties:
+                    $propertyBag:
+                      additionalProperties:
+                        type: string
+                      description: |-
+                        PropertyBag is an unordered set of stashed information that used for properties not directly supported by storage
+                        resources, allowing for full fidelity round trip conversions
+                      type: object
+                    cluster:
+                      description: |-
+                        Storage version of v1api20241101.ScopeCluster_STATUS
+                        Specifies that the scope of the extension is Cluster
+                      properties:
+                        $propertyBag:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            PropertyBag is an unordered set of stashed information that used for properties not directly supported by storage
+                            resources, allowing for full fidelity round trip conversions
+                          type: object
+                        releaseNamespace:
+                          type: string
+                      type: object
+                    namespace:
+                      description: |-
+                        Storage version of v1api20241101.ScopeNamespace_STATUS
+                        Specifies that the scope of the extension is Namespace
+                      properties:
+                        $propertyBag:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            PropertyBag is an unordered set of stashed information that used for properties not directly supported by storage
+                            resources, allowing for full fidelity round trip conversions
+                          type: object
+                        targetNamespace:
+                          type: string
+                      type: object
+                  type: object
+                statuses:
+                  items:
+                    description: |-
+                      Storage version of v1api20241101.ExtensionStatus_STATUS
+                      Status from the extension.
+                    properties:
+                      $propertyBag:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          PropertyBag is an unordered set of stashed information that used for properties not directly supported by storage
+                          resources, allowing for full fidelity round trip conversions
+                        type: object
+                      code:
+                        type: string
+                      displayStatus:
+                        type: string
+                      level:
+                        type: string
+                      message:
+                        type: string
+                      time:
+                        type: string
+                    type: object
+                  type: array
+                systemData:
+                  description: |-
+                    Storage version of v1api20241101.SystemData_STATUS
+                    Metadata pertaining to creation and last modification of the resource.
+                  properties:
+                    $propertyBag:
+                      additionalProperties:
+                        type: string
+                      description: |-
+                        PropertyBag is an unordered set of stashed information that used for properties not directly supported by storage
+                        resources, allowing for full fidelity round trip conversions
+                      type: object
+                    createdAt:
+                      type: string
+                    createdBy:
+                      type: string
+                    createdByType:
+                      type: string
+                    lastModifiedAt:
+                      type: string
+                    lastModifiedBy:
+                      type: string
+                    lastModifiedByType:
+                      type: string
+                  type: object
+                type:
+                  type: string
+                version:
+                  type: string
+              type: object
+          type: object
+      served: true
       storage: true
       subresources:
         status: {}
@@ -2958,7 +4176,7 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.16.3
   labels:
     app.kubernetes.io/name: azure-service-operator
-    app.kubernetes.io/version: v2.11.0
+    app.kubernetes.io/version: v2.13.0
   name: fleetsmembers.containerservice.azure.com
 spec:
   conversion:
@@ -3520,7 +4738,7 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.16.3
   labels:
     app.kubernetes.io/name: azure-service-operator
-    app.kubernetes.io/version: v2.11.0
+    app.kubernetes.io/version: v2.13.0
   name: managedclusters.containerservice.azure.com
 spec:
   conversion:
@@ -44503,7 +45721,7 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.16.3
   labels:
     app.kubernetes.io/name: azure-service-operator
-    app.kubernetes.io/version: v2.11.0
+    app.kubernetes.io/version: v2.13.0
   name: managedclustersagentpools.containerservice.azure.com
 spec:
   conversion:
@@ -57400,7 +58618,7 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.16.3
   labels:
     app.kubernetes.io/name: azure-service-operator
-    app.kubernetes.io/version: v2.11.0
+    app.kubernetes.io/version: v2.13.0
   name: natgateways.network.azure.com
 spec:
   conversion:
@@ -58874,7 +60092,7 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.16.3
   labels:
     app.kubernetes.io/name: azure-service-operator
-    app.kubernetes.io/version: v2.11.0
+    app.kubernetes.io/version: v2.13.0
   name: privateendpoints.network.azure.com
 spec:
   conversion:
@@ -61554,7 +62772,7 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.16.3
   labels:
     app.kubernetes.io/name: azure-service-operator
-    app.kubernetes.io/version: v2.11.0
+    app.kubernetes.io/version: v2.13.0
   name: resourcegroups.resources.azure.com
 spec:
   conversion:
@@ -62023,7 +63241,7 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.16.3
   labels:
     app.kubernetes.io/name: azure-service-operator
-    app.kubernetes.io/version: v2.11.0
+    app.kubernetes.io/version: v2.13.0
   name: virtualnetworks.network.azure.com
 spec:
   conversion:
@@ -63869,7 +65087,7 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.16.3
   labels:
     app.kubernetes.io/name: azure-service-operator
-    app.kubernetes.io/version: v2.11.0
+    app.kubernetes.io/version: v2.13.0
   name: virtualnetworkssubnets.network.azure.com
 spec:
   conversion:
@@ -64341,7 +65559,9 @@ spec:
                     type: object
                   type: array
                 ipConfigurations:
-                  description: 'IpConfigurations: An array of references to the network interface IP configurations using subnet.'
+                  description: |-
+                    IpConfigurations: An array of references to the network interface IP configurations using subnet. This field is not
+                    included if there are more than 2000 entries.
                   items:
                     description: IP configuration.
                     properties:
@@ -65661,7 +66881,9 @@ spec:
                     type: object
                   type: array
                 ipConfigurations:
-                  description: 'IpConfigurations: An array of references to the network interface IP configurations using subnet.'
+                  description: |-
+                    IpConfigurations: An array of references to the network interface IP configurations using subnet. This field is not
+                    included if there are more than 2000 entries.
                   items:
                     description: IP configuration.
                     properties:

--- a/config/aso/kustomization.yaml
+++ b/config/aso/kustomization.yaml
@@ -2,81 +2,80 @@ apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 namespace: capz-system
 resources:
-- https://github.com/Azure/azure-service-operator/releases/download/v2.11.0/azureserviceoperator_v2.11.0.yaml
-- crds.yaml
-- settings.yaml
-
+  # The ASO version here is managed by `make generate-aso-crds`
+  - https://github.com/Azure/azure-service-operator/releases/download/v2.13.0/azureserviceoperator_v2.13.0.yaml
+  - crds.yaml
+  - settings.yaml
 patches:
-- path: patches/visualizer_label_in_bastionhosts.yaml
-- path: patches/visualizer_label_in_extensions.yaml
-- path: patches/visualizer_label_in_fleetmembers.yaml
-- path: patches/visualizer_label_in_managedclusteragentpools.yaml
-- path: patches/visualizer_label_in_managed_clusters.yaml
-- path: patches/visualizer_label_in_natgateways.yaml
-- path: patches/visualizer_label_in_privateendpoints.yaml
-- path: patches/visualizer_label_in_resourcegroups.yaml
-- path: patches/visualizer_label_in_subnets.yaml
-- path: patches/visualizer_label_in_virtualnetworks.yaml
-- patch: |- # default kustomization includes a namespace already
-    $patch: delete
-    apiVersion: v1
-    kind: Namespace
-    metadata:
-      name: azureserviceoperator-system
-- patch: |-
-    - op: test
-      path: /spec/template/spec/containers/0/args/6
-      value: --crd-pattern=
-    - op: replace # Users can specify additional ASO CRDs. CRDs should be appended with ';'
-      path: /spec/template/spec/containers/0/args/6
-      value: --crd-pattern=${ADDITIONAL_ASO_CRDS:= }
+  - path: patches/visualizer_label_in_bastionhosts.yaml
+  - path: patches/visualizer_label_in_extensions.yaml
+  - path: patches/visualizer_label_in_fleetmembers.yaml
+  - path: patches/visualizer_label_in_managedclusteragentpools.yaml
+  - path: patches/visualizer_label_in_managed_clusters.yaml
+  - path: patches/visualizer_label_in_natgateways.yaml
+  - path: patches/visualizer_label_in_privateendpoints.yaml
+  - path: patches/visualizer_label_in_resourcegroups.yaml
+  - path: patches/visualizer_label_in_subnets.yaml
+  - path: patches/visualizer_label_in_virtualnetworks.yaml
+  - patch: |- # default kustomization includes a namespace already
+      $patch: delete
+      apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: azureserviceoperator-system
+  - patch: |-
+      - op: test
+        path: /spec/template/spec/containers/0/args/6
+        value: --crd-pattern=
+      - op: replace # Users can specify additional ASO CRDs. CRDs should be appended with ';'
+        path: /spec/template/spec/containers/0/args/6
+        value: --crd-pattern=${ADDITIONAL_ASO_CRDS:= }
 
-    # ASO will provide a startupProbe starting in v2.14.0.
-    # These patches should be removed when the upstream probe is set.
-    - op: test
-      path: /spec/template/spec/containers/0/startupProbe
-      value: null
-    - op: add
-      path: /spec/template/spec/containers/0/startupProbe
-      value:
-        httpGet:
-          path: /healthz
-          port: 8081
-        periodSeconds: 10
-        failureThreshold: 12
-    - op: remove
-      path: /spec/template/spec/containers/0/livenessProbe/initialDelaySeconds
-    - op: remove
-      path: /spec/template/spec/containers/0/readinessProbe/initialDelaySeconds
-  target:
-    group: apps
-    kind: Deployment
-    name: azureserviceoperator-controller-manager
-    version: v1
-
-replacements:
-- source:
-    fieldPath: metadata.namespace
-    group: cert-manager.io
-    kind: Certificate
-    name: azureserviceoperator-serving-cert
-    version: v1
-  targets:
-  - fieldPaths:
-    - metadata.annotations.cert-manager\.io/inject-ca-from
-    options:
-      delimiter: /
-    select:
-      annotationSelector: cert-manager.io/inject-ca-from
+      # ASO will provide a startupProbe starting in v2.14.0.
+      # These patches should be removed when the upstream probe is set.
+      - op: test
+        path: /spec/template/spec/containers/0/startupProbe
+        value: null
+      - op: add
+        path: /spec/template/spec/containers/0/startupProbe
+        value:
+          httpGet:
+            path: /healthz
+            port: 8081
+          periodSeconds: 10
+          failureThreshold: 12
+      - op: remove
+        path: /spec/template/spec/containers/0/livenessProbe/initialDelaySeconds
+      - op: remove
+        path: /spec/template/spec/containers/0/readinessProbe/initialDelaySeconds
+    target:
+      group: apps
+      kind: Deployment
+      name: azureserviceoperator-controller-manager
       version: v1
-  - fieldPaths:
-    - spec.dnsNames.0
-    - spec.dnsNames.1
-    options:
-      delimiter: .
-      index: 1
-    select:
+replacements:
+  - source:
+      fieldPath: metadata.namespace
       group: cert-manager.io
       kind: Certificate
       name: azureserviceoperator-serving-cert
       version: v1
+    targets:
+      - fieldPaths:
+          - metadata.annotations.cert-manager\.io/inject-ca-from
+        options:
+          delimiter: /
+        select:
+          annotationSelector: cert-manager.io/inject-ca-from
+          version: v1
+      - fieldPaths:
+          - spec.dnsNames.0
+          - spec.dnsNames.1
+        options:
+          delimiter: .
+          index: 1
+        select:
+          group: cert-manager.io
+          kind: Certificate
+          name: azureserviceoperator-serving-cert
+          version: v1


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind feature

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

The last two bumps to ASO in go.mod in #5517 and #5428 didn't also update the version of ASO that gets installed alongside CAPZ which we generally try to keep in sync (e.g. #5170). This PR adds a mechanism to derive the ASO version used for the manifest fed to kustomize from go.mod. This means dependabot PRs for ASO should now generally do the right thing and we only need to exercise the normal amount of care with those (checking changelogs, fixing compile failures, etc.).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->


**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] cherry-pick candidate

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
The version of ASO installed with CAPZ is now v2.13.0.
```
