### PR TITLE
fix: add missing kind field to metadata.yaml

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -4,6 +4,7 @@
 #
 # update this file only when a new major or minor version is released
 apiVersion: clusterctl.cluster.x-k8s.io/v1alpha3
+kind: Metadata
 releaseSeries:
   - major: 0
     minor: 3


### PR DESCRIPTION
The metadata.yaml file was missing the required 'kind: Metadata' field, which caused clusterctl init --infrastructure azure to fail with: 'unexpected kind "" for provider infrastructure-azure (expected "Metadata")'

This fix adds the missing kind field to resolve the clusterctl initialization error.

Fixes: clusterctl init --infrastructure azure validation error

<!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

<!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This PR fixes a critical issue where `clusterctl init --infrastructure azure` fails due to a missing `kind: Metadata` field in the metadata.yaml file. The clusterctl tool expects this field for proper provider metadata validation, and without it, users cannot initialize the Azure infrastructure provider.

The fix adds the missing `kind: Metadata` field to line 7 of metadata.yaml, following the same format used in test metadata files throughout the repository.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #5834

**Special notes for your reviewer**:

- This is a minimal fix that only adds the missing required field
- The change follows the exact format used in test metadata files (e.g., `test/e2e/data/shared/v1beta1/metadata.yaml`)
- All existing tests pass with this change
- No functional changes to the provider logic

**TODOs**:

- [x] squashed commits
- [ ] includes documentation (not needed - metadata format fix)
- [ ] adds unit tests (existing tests cover this)
- [x] cherry-pick candidate

**Release note**:
```release-note
Fix clusterctl init --infrastructure azure failure by adding missing kind field to metadata.yaml
```
```

