### PR TITLE
Bump Go toolchain to v1.24.7

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module sigs.k8s.io/cluster-api-provider-azure
 
 go 1.24.0
 
-toolchain go1.24.6
+toolchain go1.24.7
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.19.0

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -2,7 +2,7 @@ module sigs.k8s.io/cluster-api-provider-azure/hack/tools
 
 go 1.24.0
 
-toolchain go1.24.6
+toolchain go1.24.7
 
 require sigs.k8s.io/cluster-api/hack/tools v0.0.0-20250520093716-525566440a77
 


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Updates the Go compiler and tools to v1.24.7.

> go1.24.7 (released 2025-09-03) includes fixes to the `go` command, and the `net` and `os/exec` packages. See the [Go 1.24.7 milestone](https://github.com/golang/go/issues?q=milestone%3AGo1.24.7+label%3ACherryPickApproved) on our issue tracker for details.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:


**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] cherry-pick candidate

**Release note**:

```release-note
NONE
```
