### PR TITLE
Don't take windows capi image versions into consideration if no windows machines

### DIFF
--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -692,15 +692,27 @@ func resolveKubetestRepoListPath(version string, path string) (string, error) {
 // that has an existing capi offer image available. For example, if the version is "stable-1.22", the function will set it to the latest 1.22 version that has a published reference image.
 func resolveKubernetesVersions(config *clusterctl.E2EConfig) {
 	linuxVersions := getVersionsInCommunityGallery(context.TODO(), os.Getenv(AzureLocation), capiCommunityGallery, "capi-ubun2-2404")
-	windowsVersions := getVersionsInCommunityGallery(context.TODO(), os.Getenv(AzureLocation), capiCommunityGallery, "capi-win-2019-containerd")
 	flatcarK8sVersions := getFlatcarK8sVersions(context.TODO(), os.Getenv(AzureLocation), flatcarCAPICommunityGallery)
 
-	// find the intersection of ubuntu and windows versions available, since we need an image for both.
 	var versions semver.Versions
-	for k, v := range linuxVersions {
-		if _, ok := windowsVersions[k]; ok {
+
+	// Check if Windows testing is explicitly disabled via TEST_WINDOWS environment variable
+	testWindows := os.Getenv("TEST_WINDOWS")
+	windowsRequired := testWindows != "false"
+
+	if windowsRequired {
+		windowsVersions := getVersionsInCommunityGallery(context.TODO(), os.Getenv(AzureLocation), capiCommunityGallery, "capi-win-2019-containerd")
+		for k, v := range linuxVersions {
+			if _, ok := windowsVersions[k]; ok {
+				versions = append(versions, v)
+			}
+		}
+		Logf("Windows machines required, using intersection of Linux and Windows versions")
+	} else {
+		for _, v := range linuxVersions {
 			versions = append(versions, v)
 		}
+		Logf("No Windows machines required, using Linux versions only")
 	}
 
 	if config.HasVariable(capi_e2e.KubernetesVersion) {


### PR DESCRIPTION
<!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind cleanup

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
This PR fixes a bug where `resolveKubernetesVersion` will not find all available k8s versions for Linux as it always lists the intersection between available Linux and Windows versions even if there are no Windows machines.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->


**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] cherry-pick candidate

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
