### PR TITLE
[release-1.21] Get GO_VERSION from toolchain statment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ SHELL:=/usr/bin/env bash
 
 .DEFAULT_GOAL:=help
 
-GO_VERSION ?= $(shell sed -n 's/^go //p' go.mod)
+GO_VERSION ?= $(shell sed -n 's/^toolchain go//p' go.mod)
 GOPATH  := $(shell go env GOPATH)
 GOARCH  := $(shell go env GOARCH)
 GOOS    := $(shell go env GOOS)


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Manual cherry-pick of part of #5865

Changes `make go-version` to use the `toolchain` statement in `go.mod`. The `go` statement generally represents a "base" version and lags behind `toolchain`, which is the version actually used.

The discrepency caused the weekly security scan job to report false positives based on security issues in the base version of Go, which isn't actually being used.

**Which issue(s) this PR fixes**:

Fixes [security scan failure](https://github.com/kubernetes-sigs/cluster-api-provider-azure/actions/runs/17732295129/job/50385888948)

**Special notes for your reviewer**:

**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] cherry-pick candidate

**Release note**:

```release-note
NONE
```
