### PR TITLE
Fix pdb flake on aks mgmt cluster create and delete flow

### DIFF
--- a/e2e.mk
+++ b/e2e.mk
@@ -4,6 +4,7 @@
 # long-running E2E jobs every time that file changes
 
 ##@ E2E Testing:
+
 .PHONY: test-e2e-run
 test-e2e-run: generate-e2e-templates install-tools create-bootstrap ## Run e2e tests.
 	if [ "$(MGMT_CLUSTER_TYPE)" == "aks" ]; then \
@@ -17,32 +18,35 @@ test-e2e-run: generate-e2e-templates install-tools create-bootstrap ## Run e2e t
 		-e2e.artifacts-folder="$(ARTIFACTS)" \
 		-e2e.config="$(E2E_CONF_FILE_ENVSUBST)" \
 		-e2e.skip-log-collection="$(SKIP_LOG_COLLECTION)" \
-		-e2e.skip-resource-cleanup=$(SKIP_CLEANUP) -e2e.use-existing-cluster=$(SKIP_CREATE_MGMT_CLUSTER) $(E2E_ARGS) \
-	$(MAKE) cleanup-workload-identity
-	$(MAKE) clean-release-git
+		-e2e.skip-resource-cleanup=$(SKIP_CLEANUP) -e2e.use-existing-cluster=$(SKIP_CREATE_MGMT_CLUSTER) $(E2E_ARGS)
+
+.PHONY: test-e2e-run-cleanup
+test-e2e-run-cleanup: ## Run e2e cleanup tasks.
+	$(MAKE) cleanup-workload-identity || true
+	$(MAKE) clean-release-git || true
 	if [ "$(MGMT_CLUSTER_TYPE)" == "aks" ] && [ "$(SKIP_CLEANUP)" != "true" ]; then \
 		echo "Cleaning up AKS management cluster..."; \
-		$(MAKE) aks-delete; \
+		$(MAKE) aks-delete || true; \
 	fi
 
 .PHONY: test-e2e
 test-e2e: ## Run "docker-build" and "docker-push" rules then run e2e tests.
 	PULL_POLICY=IfNotPresent MANAGER_IMAGE=$(CONTROLLER_IMG)-$(ARCH):$(TAG) \
 	$(MAKE) docker-build docker-push \
-	test-e2e-run
+	test-e2e-run;
 
 .PHONY: test-e2e-skip-push
 test-e2e-skip-push: ## Run "docker-build" rule then run e2e tests.
 	PULL_POLICY=IfNotPresent MANAGER_IMAGE=$(CONTROLLER_IMG)-$(ARCH):$(TAG) \
 	$(MAKE) docker-build \
-	test-e2e-run
+	test-e2e-run;
 
 .PHONY: test-e2e-skip-build-and-push
 test-e2e-skip-build-and-push:
 	$(MAKE) set-manifest-image MANIFEST_IMG=$(CONTROLLER_IMG)-$(ARCH) MANIFEST_TAG=$(TAG) TARGET_RESOURCE="./config/capz/manager_image_patch.yaml"
 	$(MAKE) set-manifest-pull-policy TARGET_RESOURCE="./config/capz/manager_pull_policy.yaml" PULL_POLICY=IfNotPresent
 	MANAGER_IMAGE=$(CONTROLLER_IMG)-$(ARCH):$(TAG) \
-	$(MAKE) test-e2e-run
+	$(MAKE) test-e2e-run;
 
 .PHONY: test-e2e-custom-image
 test-e2e-custom-image: ## Run e2e tests with a custom image format (use MANAGER_IMAGE env var).
@@ -52,4 +56,4 @@ test-e2e-custom-image: ## Run e2e tests with a custom image format (use MANAGER_
 	fi
 	$(MAKE) set-manifest-image MANIFEST_IMG=$(shell echo $(MANAGER_IMAGE) | cut -d: -f1) MANIFEST_TAG=$(shell echo $(MANAGER_IMAGE) | cut -d: -f2) TARGET_RESOURCE="./config/capz/manager_image_patch.yaml"
 	$(MAKE) set-manifest-pull-policy TARGET_RESOURCE="./config/capz/manager_pull_policy.yaml" PULL_POLICY=IfNotPresent
-	$(MAKE) test-e2e-run
+	$(MAKE) test-e2e-run;

--- a/scripts/aks-as-mgmt.sh
+++ b/scripts/aks-as-mgmt.sh
@@ -186,12 +186,45 @@ create_aks_cluster() {
     export USER_IDENTITY
 
     echo "assigning user-assigned managed identity to the AKS cluster"
-    az aks update --resource-group "${AKS_RESOURCE_GROUP}" \
+    
+    # Wait for any ongoing cluster operations to complete before proceeding
+    echo "waiting for cluster to be in a ready state"
+    az aks wait --resource-group "${AKS_RESOURCE_GROUP}" --name "${MGMT_CLUSTER_NAME}" --created --timeout 600 --only-show-errors
+    
+    # Temporarily mitigate PDB issues by scaling up metrics-server before the update
+    echo "temporarily scaling up metrics-server to avoid PDB drain issues"
+    kubectl scale deployment metrics-server --replicas=3 -n kube-system || true
+    
+    # Wait a moment for the pods to be scheduled
+    sleep 15
+    
+    # Retry the managed identity assignment with exponential backoff
+    retry_count=0
+    max_retries=5
+    base_sleep=30
+    until az aks update --resource-group "${AKS_RESOURCE_GROUP}" \
     --name "${MGMT_CLUSTER_NAME}" \
     --enable-managed-identity \
     --assign-identity "${AKS_MI_RESOURCE_ID}" \
     --assign-kubelet-identity "${AKS_MI_RESOURCE_ID}" \
-    --output none --only-show-errors --yes
+    --output none --only-show-errors --yes; do
+      retry_count=$((retry_count + 1))
+      if [ $retry_count -ge $max_retries ]; then
+        echo "Failed to assign managed identity after $max_retries attempts"
+        # Restore original metrics-server replicas before failing
+        kubectl scale deployment metrics-server --replicas=2 -n kube-system || true
+        exit 1
+      fi
+      
+      # Exponential backoff with jitter: base_sleep * (2^retry_count) + random(0-10)
+      sleep_time=$((base_sleep * (1 << retry_count) + RANDOM % 11))
+      echo "Attempt $retry_count failed, retrying in $sleep_time seconds..."
+      sleep $sleep_time
+    done
+    
+    # Restore original metrics-server replica count
+    echo "restoring metrics-server to original replica count"
+    kubectl scale deployment metrics-server --replicas=2 -n kube-system || true
 
   else
     # echo "fetching Client ID for ${MGMT_CLUSTER_NAME}"

--- a/scripts/ci-conformance.sh
+++ b/scripts/ci-conformance.sh
@@ -88,6 +88,7 @@ capz::util::generate_ssh_key
 
 capz::ci-conformance::cleanup() {
     "${REPO_ROOT}/hack/log/redact.sh" || true
+    make test-e2e-run-cleanup || true
 }
 
 trap capz::ci-conformance::cleanup EXIT

--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -76,6 +76,7 @@ capz::util::generate_ssh_key
 
 capz::ci-e2e::cleanup() {
     "${REPO_ROOT}/hack/log/redact.sh" || true
+    make test-e2e-run-cleanup || true
 }
 
 trap capz::ci-e2e::cleanup EXIT


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind flake

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
This PR fixes a bug with pdb error: `Message: Cordoned nodes have used all surge nodes but there are more nodes to be upgraded. Please fix your PDBs blocking node drain and kindly retry upgrade operation.` It also fixes the delete flow where the aks management cluster wasn't being deleted when the test fails, only when it succeeds.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->


**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] cherry-pick candidate

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
