### PR TITLE
Bump CAAPH to v0.4.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -361,7 +361,7 @@ create-management-cluster: $(KUSTOMIZE) $(ENVSUBST) $(KUBECTL) $(KIND) ## Create
 	timeout --foreground 300 bash -c "until curl --retry $(CURL_RETRIES) -sSL https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.10.4/cluster-api-components.yaml | $(ENVSUBST) | $(KUBECTL) apply -f -; do sleep 5; done"
 
 	# Deploy CAAPH
-	timeout --foreground 300 bash -c "until curl --retry $(CURL_RETRIES) -sSL https://github.com/kubernetes-sigs/cluster-api-addon-provider-helm/releases/download/v0.4.0/addon-components.yaml | $(ENVSUBST) | $(KUBECTL) apply -f -; do sleep 5; done"
+	timeout --foreground 300 bash -c "until curl --retry $(CURL_RETRIES) -sSL https://github.com/kubernetes-sigs/cluster-api-addon-provider-helm/releases/download/v0.4.1/addon-components.yaml | $(ENVSUBST) | $(KUBECTL) apply -f -; do sleep 5; done"
 
 	# Deploy CAPZ
 	if [ "$(MGMT_CLUSTER_TYPE)" != "aks" ]; then \

--- a/Tiltfile
+++ b/Tiltfile
@@ -23,7 +23,7 @@ settings = {
     "preload_images_for_kind": True,
     "kind_cluster_name": "capz",
     "capi_version": "v1.10.4",
-    "caaph_version": "v0.4.0",
+    "caaph_version": "v0.4.1",
     "cert_manager_version": "v1.18.1",
     "kubernetes_version": "v1.32.2",
     "aks_kubernetes_version": "v1.30.2",

--- a/docs/book/src/developers/getting-started-with-capi-operator.md
+++ b/docs/book/src/developers/getting-started-with-capi-operator.md
@@ -122,7 +122,7 @@ Create a `values.yaml` file for the CAPI Operator Helm chart like so:
 ```yaml
 core: "cluster-api:v1.10.4"
 infrastructure: "azure:v1.17.2"
-addon: "helm:v0.4.0"
+addon: "helm:v0.4.1"
 manager:
   featureGates:
     core:

--- a/test/e2e/config/azure-dev.yaml
+++ b/test/e2e/config/azure-dev.yaml
@@ -9,7 +9,7 @@ images:
     loadBehavior: tryLoad
   - name: registry.k8s.io/cluster-api/kubeadm-control-plane-controller:v1.10.4
     loadBehavior: tryLoad
-  - name: registry.k8s.io/cluster-api-helm/cluster-api-helm-controller:v0.4.0
+  - name: registry.k8s.io/cluster-api-helm/cluster-api-helm-controller:v0.4.1
     loadBehavior: tryLoad
 
 providers:
@@ -205,8 +205,8 @@ providers:
       replacements:
       - old: "imagePullPolicy: Always"
         new: "imagePullPolicy: IfNotPresent"
-    - name: v0.4.0
-      value: https://github.com/kubernetes-sigs/cluster-api-addon-provider-helm/releases/download/v0.4.0/addon-components.yaml
+    - name: v0.4.1
+      value: https://github.com/kubernetes-sigs/cluster-api-addon-provider-helm/releases/download/v0.4.1/addon-components.yaml
       type: url
       contract: v1beta1
       files:
@@ -255,7 +255,7 @@ variables:
   OLD_PROVIDER_UPGRADE_VERSION: "v1.19.6"
   LATEST_PROVIDER_UPGRADE_VERSION: "v1.20.2"
   OLD_CAAPH_UPGRADE_VERSION: "v0.1.0-alpha.10"
-  LATEST_CAAPH_UPGRADE_VERSION: "v0.4.0"
+  LATEST_CAAPH_UPGRADE_VERSION: "v0.4.1"
   CI_RG: "${CI_RG:-capz-ci}"
   USER_IDENTITY: "${USER_IDENTITY:-cloud-provider-user-identity}"
   EXP_APISERVER_ILB: "true"


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

This PR bumps the version of CAAPH used in tests to [v0.4.1](https://github.com/kubernetes-sigs/cluster-api-addon-provider-helm/releases/tag/v0.4.1).

**Which issue(s) this PR fixes**:

N/A, but see #5887 for prior art.

**Special notes for your reviewer**:

**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] cherry-pick candidate

**Release note**:

```release-note
NONE
```
