### PR TITLE
[release-1.21] Bump Go toolchain to v1.24.8

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module sigs.k8s.io/cluster-api-provider-azure
 
 go 1.24.0
 
-toolchain go1.24.6
+toolchain go1.24.8
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.19.1

--- a/hack/ensure-go.sh
+++ b/hack/ensure-go.sh
@@ -31,7 +31,7 @@ EOF
   local go_version
   IFS=" " read -ra go_version <<< "$(go version)"
   local minimum_go_version
-  minimum_go_version=go1.22.5
+  minimum_go_version=go1.24.8
   if [[ "${minimum_go_version}" != $(echo -e "${minimum_go_version}\n${go_version[2]}" | sort -s -t. -k 1,1 -k 2,2n -k 3,3n | head -n1) && "${go_version[2]}" != "devel" ]]; then
     cat <<EOF
 Detected go version: ${go_version[*]}.

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -2,7 +2,7 @@ module sigs.k8s.io/cluster-api-provider-azure/hack/tools
 
 go 1.24.0
 
-toolchain go1.24.6
+toolchain go1.24.8
 
 require sigs.k8s.io/cluster-api/hack/tools v0.0.0-20250520093716-525566440a77
 


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Manual cherry-pick of #5898

Updates the Go compiler and tools to v1.24.8.

> go1.24.8 (released 2025-10-07) includes security fixes to the `archive/tar,` `crypto/tls`, `crypto/x509`, `encoding/asn1`, `encoding/pem`, `net/http`, `net/mail`, `net/textproto`, and `net/url` packages, as well as bug fixes to the compiler, the linker, and the `debug/pe`, `net/http`, `os`, and `sync/atomic` packages. See the [Go 1.24.8 milestone](https://github.com/golang/go/issues?q=milestone%3AGo1.24.8+label%3ACherryPickApproved) on our issue tracker for details.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->


**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] cherry-pick candidate

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
