### PR TITLE
Update source for flatcar sysexts

### DIFF
--- a/docs/book/src/self-managed/flatcar.md
+++ b/docs/book/src/self-managed/flatcar.md
@@ -12,7 +12,7 @@ The template comes with a [systemd-sysupdate](https://www.freedesktop.org/softwa
   * Update the template to enable the `systemd-sysupdate.timer`
   * Or run the following command on the nodes: `sudo systemctl enable --now systemd-sysupdate.timer`
 
-When the Kubernetes release reaches end-of-life it will not receive updates anymore. To switch to a new major version, do a `sudo rm /etc/sysupdate.kubernetes.d/kubernetes-*.conf` and download the new update config into the folder with `cd /etc/sysupdate.kubernetes.d && sudo wget https://github.com/flatcar/sysext-bakery/releases/download/latest/kubernetes-${KUBERNETES_VERSION%.*}.conf`.
+When the Kubernetes release reaches end-of-life it will not receive updates anymore. To switch to a new major version, do a `sudo rm /etc/sysupdate.kubernetes.d/kubernetes-*.conf` and download the new update config into the folder with `cd /etc/sysupdate.kubernetes.d && sudo wget https://extensions.flatcar.org/extensions/kubernetes/kubernetes-${KUBERNETES_VERSION%.*}.conf`.
 
 To coordinate the node reboot, we recommend using [Kured](https://github.com/kubereboot/kured). Note that running `kubeadm upgrade apply` on the first controller and `kubeadm upgrade node` on all other nodes is not automated (yet): see the [docs](https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade/).
 

--- a/templates/cluster-template-flatcar-sysext.yaml
+++ b/templates/cluster-template-flatcar-sysext.yaml
@@ -28,16 +28,16 @@ spec:
                 mode: 0644
                 contents:
                   remote:
-                    url: https://github.com/flatcar/sysext-bakery/releases/download/latest/kubernetes-${KUBERNETES_VERSION%.*}.conf
+                    url: https://extensions.flatcar.org/extensions/kubernetes/kubernetes-${KUBERNETES_VERSION%.*}.conf
               - path: /etc/sysupdate.d/noop.conf
                 mode: 0644
                 contents:
                   remote:
-                    url: https://github.com/flatcar/sysext-bakery/releases/download/latest/noop.conf
+                    url: https://extensions.flatcar.org/extensions/noop.conf
               - path: /opt/extensions/kubernetes/kubernetes-${KUBERNETES_VERSION}-x86-64.raw
                 contents:
                   remote:
-                    url: https://github.com/flatcar/sysext-bakery/releases/download/latest/kubernetes-${KUBERNETES_VERSION}-x86-64.raw
+                    url: https://extensions.flatcar.org/extensions/kubernetes-${KUBERNETES_VERSION}-x86-64.raw
             systemd:
               units:
               - name: systemd-sysupdate.service
@@ -207,16 +207,16 @@ spec:
               mode: 0644
               contents:
                 remote:
-                  url: https://github.com/flatcar/sysext-bakery/releases/download/latest/kubernetes-${KUBERNETES_VERSION%.*}.conf
+                  url: https://extensions.flatcar.org/extensions/kubernetes/kubernetes-${KUBERNETES_VERSION%.*}.conf
             - path: /etc/sysupdate.d/noop.conf
               mode: 0644
               contents:
                 remote:
-                  url: https://github.com/flatcar/sysext-bakery/releases/download/latest/noop.conf
+                  url: https://extensions.flatcar.org/extensions/noop.conf
             - path: /opt/extensions/kubernetes/kubernetes-${KUBERNETES_VERSION}-x86-64.raw
               contents:
                 remote:
-                  url: https://github.com/flatcar/sysext-bakery/releases/download/latest/kubernetes-${KUBERNETES_VERSION}-x86-64.raw
+                  url: https://extensions.flatcar.org/extensions/kubernetes-${KUBERNETES_VERSION}-x86-64.raw
     initConfiguration:
       nodeRegistration:
         kubeletExtraArgs:

--- a/templates/flavors/flatcar-sysext/machine-deployment.yaml
+++ b/templates/flavors/flatcar-sysext/machine-deployment.yaml
@@ -70,16 +70,16 @@ spec:
                 mode: 0644
                 contents:
                   remote:
-                    url: https://github.com/flatcar/sysext-bakery/releases/download/latest/kubernetes-${KUBERNETES_VERSION%.*}.conf
+                    url: https://extensions.flatcar.org/extensions/kubernetes/kubernetes-${KUBERNETES_VERSION%.*}.conf
               - path: /etc/sysupdate.d/noop.conf
                 mode: 0644
                 contents:
                   remote:
-                    url: https://github.com/flatcar/sysext-bakery/releases/download/latest/noop.conf
+                    url: https://extensions.flatcar.org/extensions/noop.conf
               - path: /opt/extensions/kubernetes/kubernetes-${KUBERNETES_VERSION}-x86-64.raw
                 contents:
                   remote:
-                    url: https://github.com/flatcar/sysext-bakery/releases/download/latest/kubernetes-${KUBERNETES_VERSION}-x86-64.raw
+                    url: https://extensions.flatcar.org/extensions/kubernetes-${KUBERNETES_VERSION}-x86-64.raw
             systemd:
               units:
               - name: systemd-sysupdate.service

--- a/templates/flavors/flatcar-sysext/patches/kubeadm-controlplane.yaml
+++ b/templates/flavors/flatcar-sysext/patches/kubeadm-controlplane.yaml
@@ -64,16 +64,16 @@ spec:
               mode: 0644
               contents:
                 remote:
-                  url: https://github.com/flatcar/sysext-bakery/releases/download/latest/kubernetes-${KUBERNETES_VERSION%.*}.conf
+                  url: https://extensions.flatcar.org/extensions/kubernetes/kubernetes-${KUBERNETES_VERSION%.*}.conf
             - path: /etc/sysupdate.d/noop.conf
               mode: 0644
               contents:
                 remote:
-                  url: https://github.com/flatcar/sysext-bakery/releases/download/latest/noop.conf
+                  url: https://extensions.flatcar.org/extensions/noop.conf
             - path: /opt/extensions/kubernetes/kubernetes-${KUBERNETES_VERSION}-x86-64.raw
               contents:
                 remote:
-                  url: https://github.com/flatcar/sysext-bakery/releases/download/latest/kubernetes-${KUBERNETES_VERSION}-x86-64.raw
+                  url: https://extensions.flatcar.org/extensions/kubernetes-${KUBERNETES_VERSION}-x86-64.raw
     initConfiguration:
       nodeRegistration:
         name: '@@HOSTNAME@@'

--- a/templates/test/ci/cluster-template-prow-flatcar-sysext.yaml
+++ b/templates/test/ci/cluster-template-prow-flatcar-sysext.yaml
@@ -154,16 +154,16 @@ spec:
                 mode: 0644
                 contents:
                   remote:
-                    url: https://github.com/flatcar/sysext-bakery/releases/download/latest/kubernetes-${KUBERNETES_VERSION%.*}.conf
+                    url: https://extensions.flatcar.org/extensions/kubernetes/kubernetes-${KUBERNETES_VERSION%.*}.conf
               - path: /etc/sysupdate.d/noop.conf
                 mode: 0644
                 contents:
                   remote:
-                    url: https://github.com/flatcar/sysext-bakery/releases/download/latest/noop.conf
+                    url: https://extensions.flatcar.org/extensions/noop.conf
               - path: /opt/extensions/kubernetes/kubernetes-${KUBERNETES_VERSION}-x86-64.raw
                 contents:
                   remote:
-                    url: https://github.com/flatcar/sysext-bakery/releases/download/latest/kubernetes-${KUBERNETES_VERSION}-x86-64.raw
+                    url: https://extensions.flatcar.org/extensions/kubernetes-${KUBERNETES_VERSION}-x86-64.raw
             systemd:
               units:
               - name: systemd-sysupdate.service
@@ -337,16 +337,16 @@ spec:
               mode: 0644
               contents:
                 remote:
-                  url: https://github.com/flatcar/sysext-bakery/releases/download/latest/kubernetes-${KUBERNETES_VERSION%.*}.conf
+                  url: https://extensions.flatcar.org/extensions/kubernetes/kubernetes-${KUBERNETES_VERSION%.*}.conf
             - path: /etc/sysupdate.d/noop.conf
               mode: 0644
               contents:
                 remote:
-                  url: https://github.com/flatcar/sysext-bakery/releases/download/latest/noop.conf
+                  url: https://extensions.flatcar.org/extensions/noop.conf
             - path: /opt/extensions/kubernetes/kubernetes-${KUBERNETES_VERSION}-x86-64.raw
               contents:
                 remote:
-                  url: https://github.com/flatcar/sysext-bakery/releases/download/latest/kubernetes-${KUBERNETES_VERSION}-x86-64.raw
+                  url: https://extensions.flatcar.org/extensions/kubernetes-${KUBERNETES_VERSION}-x86-64.raw
     initConfiguration:
       nodeRegistration:
         kubeletExtraArgs:


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

/kind failing-test

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

Since #5906 (I think?) the flatcar-sysext test has been failing in the periodic job since the PR effectively bumped the Kubernetes version from v1.32.0 to v1.32.9. Bootstrap logs point to the sysext being missing:

https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/periodic-cluster-api-provider-azure-e2e-main/1981040065895206912
```
[   14.233130] ignition[1119]: INFO     : files: createFilesystemsFiles: createFiles: op(c): [started]  writing file "/sysroot/opt/extensions/kubernetes/kubernetes-v1.32.9-x86-64.raw"
[   14.239468] ignition[1119]: INFO     : files: createFilesystemsFiles: createFiles: op(c): GET https://github.com/flatcar/sysext-bakery/releases/download/latest/kubernetes-v1.32.9-x86-64.raw: attempt #1
[   14.405907] ignition[1119]: INFO     : files: createFilesystemsFiles: createFiles: op(c): GET result: Not Found
[[0;1;31mFAILED[0m] Failed to start [0;1;39mignition-f…es.service[0m - Ignition (files).
[   14.410921] ignition[1119]: CRITICAL : files: createFilesystemsFiles: createFiles: op(c): Error fetching file "/sysroot/opt/extensions/kubernetes/kubernetes-v1.32.9-x86-64.raw": resource not found
[   14.422390] ignition[1119]: CRITICAL : files: createFilesystemsFiles: createFiles: op(c): [failed]   writing file "/sysroot/opt/extensions/kubernetes/kubernetes-v1.32.9-x86-64.raw": resource not found
```

Those files come from [this release](https://github.com/flatcar/sysext-bakery/releases/tag/latest) which has a big warning to move away from it and to https://extensions.flatcar.org/. The release only has up to Kubernetes v1.32.1 but the new location has all of the latest patches.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->


**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] cherry-pick candidate

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Updated flatcar-sysext flavor template to refer to https://extensions.flatcar.org/extensions instead of https://github.com/flatcar/sysext-bakery/releases/tag/latest
```
