### PR TITLE
Ensure no new AKS LBs are created w/ Basic SKU

### DIFF
--- a/api/v1beta1/azuremanagedcontrolplane_types.go
+++ b/api/v1beta1/azuremanagedcontrolplane_types.go
@@ -125,8 +125,6 @@ const (
 const (
 	// LoadBalancerSKUStandard is the Standard load balancer SKU.
 	LoadBalancerSKUStandard = "Standard"
-	// LoadBalancerSKUBasic is the Basic load balancer SKU.
-	LoadBalancerSKUBasic = "Basic"
 )
 
 // KeyVaultNetworkAccessTypes defines the types of network access of key vault.

--- a/api/v1beta1/azuremanagedcontrolplane_webhook.go
+++ b/api/v1beta1/azuremanagedcontrolplane_webhook.go
@@ -373,6 +373,16 @@ func validateVersion(version string, fldPath *field.Path) field.ErrorList {
 	return allErrs
 }
 
+// validateLoadBalancerSKU validates the LoadBalancerSKU.
+func validateLoadBalancerSKU(loadBalancerSKU *string, fldPath *field.Path) field.ErrorList {
+	var allErrs field.ErrorList
+	if loadBalancerSKU != nil && *loadBalancerSKU != LoadBalancerSKUStandard {
+		allErrs = append(allErrs, field.Invalid(fldPath, loadBalancerSKU, "LoadBalancerSKU must be 'Standard' if specified"))
+	}
+
+	return allErrs
+}
+
 // validateSSHKey validates an SSHKey.
 func (m *AzureManagedControlPlane) validateSSHKey(_ client.Client) field.ErrorList {
 	if sshKey := m.Spec.SSHPublicKey; sshKey != nil && *sshKey != "" {

--- a/api/v1beta1/azuremanagedcontrolplane_webhook_test.go
+++ b/api/v1beta1/azuremanagedcontrolplane_webhook_test.go
@@ -209,6 +209,37 @@ func TestValidateVersion(t *testing.T) {
 	}
 }
 
+func TestValidateLoadBalancerSKU(t *testing.T) {
+	tests := []struct {
+		name            string
+		loadBalancerSKU *string
+		expectErr       bool
+	}{
+		{
+			name:            "Valid Version",
+			loadBalancerSKU: ptr.To(LoadBalancerSKUStandard),
+			expectErr:       false,
+		},
+		{
+			name:            "Invalid Version",
+			loadBalancerSKU: ptr.To("Basic"),
+			expectErr:       true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			allErrs := validateLoadBalancerSKU(tt.loadBalancerSKU, field.NewPath("spec").Child("loadBalancerSKU"))
+			if tt.expectErr {
+				g.Expect(allErrs).NotTo(BeNil())
+			} else {
+				g.Expect(allErrs).To(BeNil())
+			}
+		})
+	}
+}
+
 func TestValidateLoadBalancerProfile(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -2235,7 +2266,7 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 				Spec: AzureManagedControlPlaneSpec{
 					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
 						DNSServiceIP:    ptr.To("192.168.0.10"),
-						LoadBalancerSKU: ptr.To("Standard"),
+						LoadBalancerSKU: ptr.To(LoadBalancerSKUStandard),
 						Version:         "v1.18.0",
 					},
 				},
@@ -2244,7 +2275,7 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 				Spec: AzureManagedControlPlaneSpec{
 					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
 						DNSServiceIP:    ptr.To("192.168.0.10"),
-						LoadBalancerSKU: ptr.To(LoadBalancerSKUBasic),
+						LoadBalancerSKU: ptr.To("foo"),
 						Version:         "v1.18.0",
 					},
 				},

--- a/api/v1beta1/azuremanagedcontrolplanetemplate_webhook.go
+++ b/api/v1beta1/azuremanagedcontrolplanetemplate_webhook.go
@@ -193,6 +193,10 @@ func (mcp *AzureManagedControlPlaneTemplate) validateManagedControlPlaneTemplate
 		mcp.Spec.Template.Spec.Version,
 		field.NewPath("spec").Child("template").Child("spec").Child("version"))...)
 
+	allErrs = append(allErrs, validateLoadBalancerSKU(
+		mcp.Spec.Template.Spec.LoadBalancerSKU,
+		field.NewPath("spec").Child("template").Child("spec").Child("loadBalancerSKU"))...)
+
 	allErrs = append(allErrs, validateLoadBalancerProfile(
 		mcp.Spec.Template.Spec.LoadBalancerProfile,
 		field.NewPath("spec").Child("template").Child("spec").Child("loadBalancerProfile"))...)

--- a/api/v1beta1/azuremanagedcontrolplanetemplate_webhook_test.go
+++ b/api/v1beta1/azuremanagedcontrolplanetemplate_webhook_test.go
@@ -33,7 +33,7 @@ func TestControlPlaneTemplateDefaultingWebhook(t *testing.T) {
 	err := mcptw.Default(t.Context(), amcpt)
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(*amcpt.Spec.Template.Spec.NetworkPlugin).To(Equal("azure"))
-	g.Expect(*amcpt.Spec.Template.Spec.LoadBalancerSKU).To(Equal("Standard"))
+	g.Expect(*amcpt.Spec.Template.Spec.LoadBalancerSKU).To(Equal(LoadBalancerSKUStandard))
 	g.Expect(amcpt.Spec.Template.Spec.Version).To(Equal("v1.17.5"))
 	g.Expect(amcpt.Spec.Template.Spec.VirtualNetwork.CIDRBlock).To(Equal(defaultAKSVnetCIDR))
 	g.Expect(amcpt.Spec.Template.Spec.VirtualNetwork.Subnet.Name).To(Equal("fooName"))
@@ -42,10 +42,9 @@ func TestControlPlaneTemplateDefaultingWebhook(t *testing.T) {
 
 	t.Logf("Testing amcp defaulting webhook with baseline")
 	netPlug := "kubenet"
-	lbSKU := "Basic"
+	lbSKU := "Standard"
 	netPol := "azure"
 	amcpt.Spec.Template.Spec.NetworkPlugin = &netPlug
-	amcpt.Spec.Template.Spec.LoadBalancerSKU = &lbSKU
 	amcpt.Spec.Template.Spec.NetworkPolicy = &netPol
 	amcpt.Spec.Template.Spec.Version = "9.99.99"
 	amcpt.Spec.Template.Spec.VirtualNetwork.Name = "fooVnetName"
@@ -131,10 +130,10 @@ func TestControlPlaneTemplateUpdateWebhook(t *testing.T) {
 		{
 			name: "azuremanagedcontrolplanetemplate LoadBalancerSKU is immutable",
 			oldControlPlaneTemplate: getAzureManagedControlPlaneTemplate(func(cpt *AzureManagedControlPlaneTemplate) {
-				cpt.Spec.Template.Spec.LoadBalancerSKU = ptr.To("foo")
+				cpt.Spec.Template.Spec.LoadBalancerSKU = ptr.To(LoadBalancerSKUStandard)
 			}),
 			controlPlaneTemplate: getAzureManagedControlPlaneTemplate(func(cpt *AzureManagedControlPlaneTemplate) {
-				cpt.Spec.Template.Spec.LoadBalancerSKU = ptr.To("bar")
+				cpt.Spec.Template.Spec.LoadBalancerSKU = ptr.To("Basic")
 			}),
 			wantErr: true,
 		},

--- a/api/v1beta1/types_class.go
+++ b/api/v1beta1/types_class.go
@@ -147,7 +147,7 @@ type AzureManagedControlPlaneClassSpec struct {
 
 	// LoadBalancerSKU is the SKU of the loadBalancer to be provisioned.
 	// Immutable.
-	// +kubebuilder:validation:Enum=Basic;Standard
+	// +kubebuilder:validation:Enum=Standard
 	// +kubebuilder:default:=Standard
 	// +optional
 	LoadBalancerSKU *string `json:"loadBalancerSKU,omitempty"`

--- a/azure/scope/managedcontrolplane.go
+++ b/azure/scope/managedcontrolplane.go
@@ -577,7 +577,6 @@ func (s *ManagedControlPlaneScope) ManagedClusterSpec() azure.ASOResourceSpecGet
 		managedClusterSpec.NetworkDataplane = s.ControlPlane.Spec.NetworkDataplane
 	}
 	if s.ControlPlane.Spec.LoadBalancerSKU != nil {
-		// CAPZ accepts Standard/Basic, Azure accepts standard/basic
 		managedClusterSpec.LoadBalancerSKU = strings.ToLower(*s.ControlPlane.Spec.LoadBalancerSKU)
 	}
 

--- a/azure/services/managedclusters/spec.go
+++ b/azure/services/managedclusters/spec.go
@@ -69,7 +69,7 @@ type ManagedClusterSpec struct {
 	// Version defines the desired Kubernetes version.
 	Version string
 
-	// LoadBalancerSKU for the managed cluster. Possible values include: 'Standard', 'Basic'. Defaults to Standard.
+	// LoadBalancerSKU for the managed cluster. 'Standard' is the only supported value. Defaults to Standard.
 	LoadBalancerSKU string
 
 	// NetworkPlugin used for building Kubernetes network. Possible values include: 'azure', 'kubenet'. Defaults to azure.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremanagedcontrolplanes.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremanagedcontrolplanes.yaml
@@ -595,7 +595,6 @@ spec:
                   LoadBalancerSKU is the SKU of the loadBalancer to be provisioned.
                   Immutable.
                 enum:
-                - Basic
                 - Standard
                 type: string
               location:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremanagedcontrolplanetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremanagedcontrolplanetemplates.yaml
@@ -575,7 +575,6 @@ spec:
                           LoadBalancerSKU is the SKU of the loadBalancer to be provisioned.
                           Immutable.
                         enum:
-                        - Basic
                         - Standard
                         type: string
                       location:


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

/kind cleanup
/kind deprecation

**What this PR does / why we need it**:

This PR removes the (non-working) LB SKU configuration of "Basic" from the v1beta1 AKS types.

A code audit suggested that the self-managed LB SKU flows already require "Standard", so I think we're O.K. there.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->


**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] cherry-pick candidate

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Ensure no new AKS LBs are created w/ Basic SKU
```
