### PR TITLE
Update test templates to Linux community gallery images

### DIFF
--- a/templates/test/ci/cluster-template-prow-ci-version-dra.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version-dra.yaml
@@ -248,10 +248,9 @@ spec:
         nameSuffix: etcddisk
       identity: UserAssigned
       image:
-        marketplace:
-          offer: capi
-          publisher: cncf-upstream
-          sku: ubuntu-2204-gen1
+        computeGallery:
+          gallery: ClusterAPI-f72ceb4f-5159-4c26-a0fe-2ea738f0d019
+          name: capi-ubun2-2404
           version: latest
       osDisk:
         diskSizeGB: 128
@@ -302,10 +301,9 @@ spec:
     type: RollingUpdate
   template:
     image:
-      marketplace:
-        offer: capi
-        publisher: cncf-upstream
-        sku: ubuntu-2204-gen1
+      computeGallery:
+        gallery: ClusterAPI-f72ceb4f-5159-4c26-a0fe-2ea738f0d019
+        name: capi-ubun2-2404
         version: latest
     osDisk:
       diskSizeGB: 30

--- a/templates/test/ci/cluster-template-prow-ci-version-dual-stack.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version-dual-stack.yaml
@@ -255,10 +255,9 @@ spec:
       enableIPForwarding: true
       identity: UserAssigned
       image:
-        marketplace:
-          offer: capi
-          publisher: cncf-upstream
-          sku: ubuntu-2204-gen1
+        computeGallery:
+          gallery: ClusterAPI-f72ceb4f-5159-4c26-a0fe-2ea738f0d019
+          name: capi-ubun2-2404
           version: latest
       osDisk:
         diskSizeGB: 128
@@ -307,10 +306,9 @@ spec:
       enableIPForwarding: true
       identity: UserAssigned
       image:
-        marketplace:
-          offer: capi
-          publisher: cncf-upstream
-          sku: ubuntu-2204-gen1
+        computeGallery:
+          gallery: ClusterAPI-f72ceb4f-5159-4c26-a0fe-2ea738f0d019
+          name: capi-ubun2-2404
           version: latest
       osDisk:
         diskSizeGB: 128

--- a/templates/test/ci/cluster-template-prow-ci-version-ipv6.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version-ipv6.yaml
@@ -266,10 +266,9 @@ spec:
       enableIPForwarding: true
       identity: UserAssigned
       image:
-        marketplace:
-          offer: capi
-          publisher: cncf-upstream
-          sku: ubuntu-2204-gen1
+        computeGallery:
+          gallery: ClusterAPI-f72ceb4f-5159-4c26-a0fe-2ea738f0d019
+          name: capi-ubun2-2404
           version: latest
       osDisk:
         diskSizeGB: 128
@@ -318,10 +317,9 @@ spec:
       enableIPForwarding: true
       identity: UserAssigned
       image:
-        marketplace:
-          offer: capi
-          publisher: cncf-upstream
-          sku: ubuntu-2204-gen1
+        computeGallery:
+          gallery: ClusterAPI-f72ceb4f-5159-4c26-a0fe-2ea738f0d019
+          name: capi-ubun2-2404
           version: latest
       osDisk:
         diskSizeGB: 128

--- a/templates/test/ci/cluster-template-prow-ci-version-md-and-mp.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version-md-and-mp.yaml
@@ -233,10 +233,9 @@ spec:
         nameSuffix: etcddisk
       identity: UserAssigned
       image:
-        marketplace:
-          offer: capi
-          publisher: cncf-upstream
-          sku: ubuntu-2204-gen1
+        computeGallery:
+          gallery: ClusterAPI-f72ceb4f-5159-4c26-a0fe-2ea738f0d019
+          name: capi-ubun2-2404
           version: latest
       osDisk:
         diskSizeGB: 128
@@ -284,10 +283,9 @@ spec:
         monitoring: virtualmachine
       identity: UserAssigned
       image:
-        marketplace:
-          offer: capi
-          publisher: cncf-upstream
-          sku: ubuntu-2204-gen1
+        computeGallery:
+          gallery: ClusterAPI-f72ceb4f-5159-4c26-a0fe-2ea738f0d019
+          name: capi-ubun2-2404
           version: latest
       osDisk:
         diskSizeGB: 128
@@ -897,10 +895,9 @@ spec:
     type: RollingUpdate
   template:
     image:
-      marketplace:
-        offer: capi
-        publisher: cncf-upstream
-        sku: ubuntu-2204-gen1
+      computeGallery:
+        gallery: ClusterAPI-f72ceb4f-5159-4c26-a0fe-2ea738f0d019
+        name: capi-ubun2-2404
         version: latest
     osDisk:
       diskSizeGB: 30

--- a/templates/test/ci/cluster-template-prow-ci-version-windows.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version-windows.yaml
@@ -237,10 +237,9 @@ spec:
         nameSuffix: etcddisk
       identity: UserAssigned
       image:
-        marketplace:
-          offer: capi
-          publisher: cncf-upstream
-          sku: ubuntu-2204-gen1
+        computeGallery:
+          gallery: ClusterAPI-f72ceb4f-5159-4c26-a0fe-2ea738f0d019
+          name: capi-ubun2-2404
           version: latest
       osDisk:
         diskSizeGB: 128
@@ -288,10 +287,9 @@ spec:
         monitoring: virtualmachine
       identity: UserAssigned
       image:
-        marketplace:
-          offer: capi
-          publisher: cncf-upstream
-          sku: ubuntu-2204-gen1
+        computeGallery:
+          gallery: ClusterAPI-f72ceb4f-5159-4c26-a0fe-2ea738f0d019
+          name: capi-ubun2-2404
           version: latest
       osDisk:
         diskSizeGB: 128

--- a/templates/test/ci/cluster-template-prow-ci-version.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version.yaml
@@ -233,10 +233,9 @@ spec:
         nameSuffix: etcddisk
       identity: UserAssigned
       image:
-        marketplace:
-          offer: capi
-          publisher: cncf-upstream
-          sku: ubuntu-2204-gen1
+        computeGallery:
+          gallery: ClusterAPI-f72ceb4f-5159-4c26-a0fe-2ea738f0d019
+          name: capi-ubun2-2404
           version: latest
       osDisk:
         diskSizeGB: 128
@@ -284,10 +283,9 @@ spec:
         monitoring: virtualmachine
       identity: UserAssigned
       image:
-        marketplace:
-          offer: capi
-          publisher: cncf-upstream
-          sku: ubuntu-2204-gen1
+        computeGallery:
+          gallery: ClusterAPI-f72ceb4f-5159-4c26-a0fe-2ea738f0d019
+          name: capi-ubun2-2404
           version: latest
       osDisk:
         diskSizeGB: 128

--- a/templates/test/ci/cluster-template-prow-machine-pool-ci-version-windows.yaml
+++ b/templates/test/ci/cluster-template-prow-machine-pool-ci-version-windows.yaml
@@ -234,10 +234,9 @@ spec:
         nameSuffix: etcddisk
       identity: UserAssigned
       image:
-        marketplace:
-          offer: capi
-          publisher: cncf-upstream
-          sku: ubuntu-2204-gen1
+        computeGallery:
+          gallery: ClusterAPI-f72ceb4f-5159-4c26-a0fe-2ea738f0d019
+          name: capi-ubun2-2404
           version: latest
       osDisk:
         diskSizeGB: 128
@@ -288,10 +287,9 @@ spec:
     type: RollingUpdate
   template:
     image:
-      marketplace:
-        offer: capi
-        publisher: cncf-upstream
-        sku: ubuntu-2204-gen1
+      computeGallery:
+        gallery: ClusterAPI-f72ceb4f-5159-4c26-a0fe-2ea738f0d019
+        name: capi-ubun2-2404
         version: latest
     osDisk:
       diskSizeGB: 30

--- a/templates/test/ci/cluster-template-prow-machine-pool-ci-version.yaml
+++ b/templates/test/ci/cluster-template-prow-machine-pool-ci-version.yaml
@@ -230,10 +230,9 @@ spec:
         nameSuffix: etcddisk
       identity: UserAssigned
       image:
-        marketplace:
-          offer: capi
-          publisher: cncf-upstream
-          sku: ubuntu-2204-gen1
+        computeGallery:
+          gallery: ClusterAPI-f72ceb4f-5159-4c26-a0fe-2ea738f0d019
+          name: capi-ubun2-2404
           version: latest
       osDisk:
         diskSizeGB: 128
@@ -284,10 +283,9 @@ spec:
     type: RollingUpdate
   template:
     image:
-      marketplace:
-        offer: capi
-        publisher: cncf-upstream
-        sku: ubuntu-2204-gen1
+      computeGallery:
+        gallery: ClusterAPI-f72ceb4f-5159-4c26-a0fe-2ea738f0d019
+        name: capi-ubun2-2404
         version: latest
     osDisk:
       diskSizeGB: 30

--- a/templates/test/ci/patches/control-plane-image-ci-version.yaml
+++ b/templates/test/ci/patches/control-plane-image-ci-version.yaml
@@ -8,8 +8,7 @@ spec:
       image:
         # we use the latest image as a workaround there is no published marketplace image for k8s CI versions.
         # latest binaries and images will get replaced to the desired version by the script above.
-        marketplace:
-          publisher: cncf-upstream
-          offer: capi
-          sku: ubuntu-2204-gen1
+        computeGallery:
+          gallery: ClusterAPI-f72ceb4f-5159-4c26-a0fe-2ea738f0d019
+          name: capi-ubun2-2404
           version: latest

--- a/templates/test/ci/prow-ci-version-windows/patches/machine-deployment-ci-version-control-plane.yaml
+++ b/templates/test/ci/prow-ci-version-windows/patches/machine-deployment-ci-version-control-plane.yaml
@@ -12,10 +12,9 @@ spec:
         nameSuffix: etcddisk
       identity: UserAssigned
       image:
-        marketplace:
-          offer: capi
-          publisher: cncf-upstream
-          sku: ubuntu-2204-gen1
+        computeGallery:
+          gallery: ClusterAPI-f72ceb4f-5159-4c26-a0fe-2ea738f0d019
+          name: capi-ubun2-2404
           version: latest
       osDisk:
         diskSizeGB: 128

--- a/templates/test/ci/prow-ci-version-windows/patches/machine-deployment-ci-version.yaml
+++ b/templates/test/ci/prow-ci-version-windows/patches/machine-deployment-ci-version.yaml
@@ -8,8 +8,7 @@ spec:
       image:
         # we use the latest image as a workaround there is no published marketplace image for k8s CI versions.
         # latest binaries and images will get replaced to the desired version by the script in this template.
-        marketplace:
-          publisher: cncf-upstream
-          offer: capi
-          sku: ubuntu-2204-gen1
-          version: "latest"
+        computeGallery:
+          gallery: ClusterAPI-f72ceb4f-5159-4c26-a0fe-2ea738f0d019
+          name: capi-ubun2-2404
+          version: latest

--- a/templates/test/ci/prow-ci-version/patches/machine-deployment-ci-version-control-plane.yaml
+++ b/templates/test/ci/prow-ci-version/patches/machine-deployment-ci-version-control-plane.yaml
@@ -12,10 +12,9 @@ spec:
         nameSuffix: etcddisk
       identity: UserAssigned
       image:
-        marketplace:
-          offer: capi
-          publisher: cncf-upstream
-          sku: ubuntu-2204-gen1
+        computeGallery:
+          gallery: ClusterAPI-f72ceb4f-5159-4c26-a0fe-2ea738f0d019
+          name: capi-ubun2-2404
           version: latest
       osDisk:
         diskSizeGB: 128

--- a/templates/test/ci/prow-ci-version/patches/machine-deployment-ci-version.yaml
+++ b/templates/test/ci/prow-ci-version/patches/machine-deployment-ci-version.yaml
@@ -8,8 +8,7 @@ spec:
       image:
         # we use the latest image as a workaround there is no published marketplace image for k8s CI versions.
         # latest binaries and images will get replaced to the desired version by the script in this template.
-        marketplace:
-          publisher: cncf-upstream
-          offer: capi
-          sku: ubuntu-2204-gen1
-          version: "latest"
+        computeGallery:
+          gallery: ClusterAPI-f72ceb4f-5159-4c26-a0fe-2ea738f0d019
+          name: capi-ubun2-2404
+          version: latest

--- a/templates/test/ci/prow-machine-pool-ci-version-windows/patches/machine-pool-ci-version.yaml
+++ b/templates/test/ci/prow-machine-pool-ci-version-windows/patches/machine-pool-ci-version.yaml
@@ -7,8 +7,7 @@ spec:
     image:
       # we use the latest image as a workaround there is no published marketplace image for k8s CI versions.
       # latest binaries and images will get replaced to the desired version by the script above.
-      marketplace:
-        publisher: cncf-upstream
-        offer: capi
-        sku: ubuntu-2204-gen1
+      computeGallery:
+        gallery: ClusterAPI-f72ceb4f-5159-4c26-a0fe-2ea738f0d019
+        name: capi-ubun2-2404
         version: latest

--- a/templates/test/ci/prow-machine-pool-ci-version/patches/machine-pool-ci-version.yaml
+++ b/templates/test/ci/prow-machine-pool-ci-version/patches/machine-pool-ci-version.yaml
@@ -7,8 +7,7 @@ spec:
     image:
       # we use the latest image as a workaround there is no published marketplace image for k8s CI versions.
       # latest binaries and images will get replaced to the desired version by the script above.
-      marketplace:
-        publisher: cncf-upstream
-        offer: capi
-        sku: ubuntu-2204-gen1
+      computeGallery:
+        gallery: ClusterAPI-f72ceb4f-5159-4c26-a0fe-2ea738f0d019
+        name: capi-ubun2-2404
         version: latest

--- a/templates/test/dev/cluster-template-custom-builds-dra.yaml
+++ b/templates/test/dev/cluster-template-custom-builds-dra.yaml
@@ -251,10 +251,9 @@ spec:
         nameSuffix: etcddisk
       identity: UserAssigned
       image:
-        marketplace:
-          offer: capi
-          publisher: cncf-upstream
-          sku: ubuntu-2204-gen1
+        computeGallery:
+          gallery: ClusterAPI-f72ceb4f-5159-4c26-a0fe-2ea738f0d019
+          name: capi-ubun2-2404
           version: latest
       osDisk:
         diskSizeGB: 128
@@ -304,10 +303,9 @@ spec:
     type: RollingUpdate
   template:
     image:
-      marketplace:
-        offer: capi
-        publisher: cncf-upstream
-        sku: ubuntu-2204-gen1
+      computeGallery:
+        gallery: ClusterAPI-f72ceb4f-5159-4c26-a0fe-2ea738f0d019
+        name: capi-ubun2-2404
         version: latest
     osDisk:
       diskSizeGB: 30

--- a/templates/test/dev/cluster-template-custom-builds-load-dra.yaml
+++ b/templates/test/dev/cluster-template-custom-builds-load-dra.yaml
@@ -249,10 +249,9 @@ spec:
         nameSuffix: etcddisk
       identity: UserAssigned
       image:
-        marketplace:
-          offer: capi
-          publisher: cncf-upstream
-          sku: ubuntu-2204-gen1
+        computeGallery:
+          gallery: ClusterAPI-f72ceb4f-5159-4c26-a0fe-2ea738f0d019
+          name: capi-ubun2-2404
           version: latest
       osDisk:
         diskSizeGB: 128
@@ -300,10 +299,9 @@ spec:
         monitoring: dra
       identity: UserAssigned
       image:
-        marketplace:
-          offer: capi
-          publisher: cncf-upstream
-          sku: ubuntu-2204-gen1
+        computeGallery:
+          gallery: ClusterAPI-f72ceb4f-5159-4c26-a0fe-2ea738f0d019
+          name: capi-ubun2-2404
           version: latest
       osDisk:
         diskSizeGB: 128
@@ -878,10 +876,9 @@ spec:
         monitoring: dra
       identity: UserAssigned
       image:
-        marketplace:
-          offer: capi
-          publisher: cncf-upstream
-          sku: ubuntu-2204-gen1
+        computeGallery:
+          gallery: ClusterAPI-f72ceb4f-5159-4c26-a0fe-2ea738f0d019
+          name: capi-ubun2-2404
           version: latest
       osDisk:
         diskSizeGB: 128

--- a/templates/test/dev/cluster-template-custom-builds-load.yaml
+++ b/templates/test/dev/cluster-template-custom-builds-load.yaml
@@ -231,10 +231,9 @@ spec:
         nameSuffix: etcddisk
       identity: UserAssigned
       image:
-        marketplace:
-          offer: capi
-          publisher: cncf-upstream
-          sku: ubuntu-2204-gen1
+        computeGallery:
+          gallery: ClusterAPI-f72ceb4f-5159-4c26-a0fe-2ea738f0d019
+          name: capi-ubun2-2404
           version: latest
       osDisk:
         diskSizeGB: 128
@@ -282,10 +281,9 @@ spec:
         monitoring: load
       identity: UserAssigned
       image:
-        marketplace:
-          offer: capi
-          publisher: cncf-upstream
-          sku: ubuntu-2204-gen1
+        computeGallery:
+          gallery: ClusterAPI-f72ceb4f-5159-4c26-a0fe-2ea738f0d019
+          name: capi-ubun2-2404
           version: latest
       osDisk:
         diskSizeGB: 128
@@ -849,10 +847,9 @@ spec:
         monitoring: load
       identity: UserAssigned
       image:
-        marketplace:
-          offer: capi
-          publisher: cncf-upstream
-          sku: ubuntu-2204-gen1
+        computeGallery:
+          gallery: ClusterAPI-f72ceb4f-5159-4c26-a0fe-2ea738f0d019
+          name: capi-ubun2-2404
           version: latest
       osDisk:
         diskSizeGB: 128

--- a/templates/test/dev/cluster-template-custom-builds-machine-pool-load-dra.yaml
+++ b/templates/test/dev/cluster-template-custom-builds-machine-pool-load-dra.yaml
@@ -259,10 +259,9 @@ spec:
         nameSuffix: etcddisk
       identity: UserAssigned
       image:
-        marketplace:
-          offer: capi
-          publisher: cncf-upstream
-          sku: ubuntu-2204-gen1
+        computeGallery:
+          gallery: ClusterAPI-f72ceb4f-5159-4c26-a0fe-2ea738f0d019
+          name: capi-ubun2-2404
           version: latest
       osDisk:
         diskSizeGB: 128
@@ -314,10 +313,9 @@ spec:
     type: RollingUpdate
   template:
     image:
-      marketplace:
-        offer: capi
-        publisher: cncf-upstream
-        sku: ubuntu-2204-gen1
+      computeGallery:
+        gallery: ClusterAPI-f72ceb4f-5159-4c26-a0fe-2ea738f0d019
+        name: capi-ubun2-2404
         version: latest
     osDisk:
       diskSizeGB: 30
@@ -659,10 +657,9 @@ spec:
         monitoring: dra
       identity: UserAssigned
       image:
-        marketplace:
-          offer: capi
-          publisher: cncf-upstream
-          sku: ubuntu-2204-gen1
+        computeGallery:
+          gallery: ClusterAPI-f72ceb4f-5159-4c26-a0fe-2ea738f0d019
+          name: capi-ubun2-2404
           version: latest
       osDisk:
         diskSizeGB: 128

--- a/templates/test/dev/cluster-template-custom-builds-machine-pool-load.yaml
+++ b/templates/test/dev/cluster-template-custom-builds-machine-pool-load.yaml
@@ -241,10 +241,9 @@ spec:
         nameSuffix: etcddisk
       identity: UserAssigned
       image:
-        marketplace:
-          offer: capi
-          publisher: cncf-upstream
-          sku: ubuntu-2204-gen1
+        computeGallery:
+          gallery: ClusterAPI-f72ceb4f-5159-4c26-a0fe-2ea738f0d019
+          name: capi-ubun2-2404
           version: latest
       osDisk:
         diskSizeGB: 128
@@ -296,10 +295,9 @@ spec:
     type: RollingUpdate
   template:
     image:
-      marketplace:
-        offer: capi
-        publisher: cncf-upstream
-        sku: ubuntu-2204-gen1
+      computeGallery:
+        gallery: ClusterAPI-f72ceb4f-5159-4c26-a0fe-2ea738f0d019
+        name: capi-ubun2-2404
         version: latest
     osDisk:
       diskSizeGB: 30
@@ -630,10 +628,9 @@ spec:
         monitoring: load
       identity: UserAssigned
       image:
-        marketplace:
-          offer: capi
-          publisher: cncf-upstream
-          sku: ubuntu-2204-gen1
+        computeGallery:
+          gallery: ClusterAPI-f72ceb4f-5159-4c26-a0fe-2ea738f0d019
+          name: capi-ubun2-2404
           version: latest
       osDisk:
         diskSizeGB: 128

--- a/templates/test/dev/cluster-template-custom-builds-machine-pool-windows.yaml
+++ b/templates/test/dev/cluster-template-custom-builds-machine-pool-windows.yaml
@@ -237,10 +237,9 @@ spec:
         nameSuffix: etcddisk
       identity: UserAssigned
       image:
-        marketplace:
-          offer: capi
-          publisher: cncf-upstream
-          sku: ubuntu-2204-gen1
+        computeGallery:
+          gallery: ClusterAPI-f72ceb4f-5159-4c26-a0fe-2ea738f0d019
+          name: capi-ubun2-2404
           version: latest
       osDisk:
         diskSizeGB: 128
@@ -290,10 +289,9 @@ spec:
     type: RollingUpdate
   template:
     image:
-      marketplace:
-        offer: capi
-        publisher: cncf-upstream
-        sku: ubuntu-2204-gen1
+      computeGallery:
+        gallery: ClusterAPI-f72ceb4f-5159-4c26-a0fe-2ea738f0d019
+        name: capi-ubun2-2404
         version: latest
     osDisk:
       diskSizeGB: 30

--- a/templates/test/dev/cluster-template-custom-builds-machine-pool.yaml
+++ b/templates/test/dev/cluster-template-custom-builds-machine-pool.yaml
@@ -233,10 +233,9 @@ spec:
         nameSuffix: etcddisk
       identity: UserAssigned
       image:
-        marketplace:
-          offer: capi
-          publisher: cncf-upstream
-          sku: ubuntu-2204-gen1
+        computeGallery:
+          gallery: ClusterAPI-f72ceb4f-5159-4c26-a0fe-2ea738f0d019
+          name: capi-ubun2-2404
           version: latest
       osDisk:
         diskSizeGB: 128
@@ -286,10 +285,9 @@ spec:
     type: RollingUpdate
   template:
     image:
-      marketplace:
-        offer: capi
-        publisher: cncf-upstream
-        sku: ubuntu-2204-gen1
+      computeGallery:
+        gallery: ClusterAPI-f72ceb4f-5159-4c26-a0fe-2ea738f0d019
+        name: capi-ubun2-2404
         version: latest
     osDisk:
       diskSizeGB: 30

--- a/templates/test/dev/cluster-template-custom-builds-windows.yaml
+++ b/templates/test/dev/cluster-template-custom-builds-windows.yaml
@@ -229,10 +229,9 @@ spec:
         nameSuffix: etcddisk
       identity: UserAssigned
       image:
-        marketplace:
-          offer: capi
-          publisher: cncf-upstream
-          sku: ubuntu-2204-gen1
+        computeGallery:
+          gallery: ClusterAPI-f72ceb4f-5159-4c26-a0fe-2ea738f0d019
+          name: capi-ubun2-2404
           version: latest
       osDisk:
         diskSizeGB: 128
@@ -280,10 +279,9 @@ spec:
         monitoring: virtualmachine
       identity: UserAssigned
       image:
-        marketplace:
-          offer: capi
-          publisher: cncf-upstream
-          sku: ubuntu-2204-gen1
+        computeGallery:
+          gallery: ClusterAPI-f72ceb4f-5159-4c26-a0fe-2ea738f0d019
+          name: capi-ubun2-2404
           version: latest
       osDisk:
         diskSizeGB: 128

--- a/templates/test/dev/cluster-template-custom-builds.yaml
+++ b/templates/test/dev/cluster-template-custom-builds.yaml
@@ -225,10 +225,9 @@ spec:
         nameSuffix: etcddisk
       identity: UserAssigned
       image:
-        marketplace:
-          offer: capi
-          publisher: cncf-upstream
-          sku: ubuntu-2204-gen1
+        computeGallery:
+          gallery: ClusterAPI-f72ceb4f-5159-4c26-a0fe-2ea738f0d019
+          name: capi-ubun2-2404
           version: latest
       osDisk:
         diskSizeGB: 128
@@ -276,10 +275,9 @@ spec:
         monitoring: virtualmachine
       identity: UserAssigned
       image:
-        marketplace:
-          offer: capi
-          publisher: cncf-upstream
-          sku: ubuntu-2204-gen1
+        computeGallery:
+          gallery: ClusterAPI-f72ceb4f-5159-4c26-a0fe-2ea738f0d019
+          name: capi-ubun2-2404
           version: latest
       osDisk:
         diskSizeGB: 128

--- a/templates/test/dev/custom-builds-load/monitoring/patches/machine-deployment-pr-version.yaml
+++ b/templates/test/dev/custom-builds-load/monitoring/patches/machine-deployment-pr-version.yaml
@@ -11,8 +11,7 @@ spec:
       image:
         # we use the latest image as a workaround there is no published marketplace image for k8s CI versions.
         # latest binaries and images will get replaced to the desired version by the script above.
-        marketplace:
-          publisher: cncf-upstream
-          offer: capi
-          sku: ubuntu-2204-gen1
+        computeGallery:
+          gallery: ClusterAPI-f72ceb4f-5159-4c26-a0fe-2ea738f0d019
+          name: capi-ubun2-2404
           version: latest

--- a/templates/test/dev/custom-builds-machine-pool-windows/patches/custom-builds.yaml
+++ b/templates/test/dev/custom-builds-machine-pool-windows/patches/custom-builds.yaml
@@ -23,7 +23,7 @@ spec:
       set -o pipefail
       set -o errexit
       [[ $(id -u) != 0 ]] && SUDO="sudo" || SUDO=""
-      
+
       # Run the az login command with managed identity
       if az login --identity > /dev/null 2>&1; then
         echo "Logged in Azure with managed identity"
@@ -79,8 +79,7 @@ spec:
     image:
       # we use the latest image as a workaround there is no published marketplace image for k8s CI versions.
       # latest binaries and images will get replaced to the desired version by the script above.
-      marketplace:
-        publisher: cncf-upstream
-        offer: capi
-        sku: ubuntu-2204-gen1
+      computeGallery:
+        gallery: ClusterAPI-f72ceb4f-5159-4c26-a0fe-2ea738f0d019
+        name: capi-ubun2-2404
         version: latest

--- a/templates/test/dev/custom-builds-machine-pool/patches/custom-builds.yaml
+++ b/templates/test/dev/custom-builds-machine-pool/patches/custom-builds.yaml
@@ -23,7 +23,7 @@ spec:
       set -o pipefail
       set -o errexit
       [[ $(id -u) != 0 ]] && SUDO="sudo" || SUDO=""
-      
+
       # Run the az login command with managed identity
       if az login --identity > /dev/null 2>&1; then
         echo "Logged in Azure with managed identity"
@@ -79,8 +79,7 @@ spec:
     image:
       # we use the latest image as a workaround there is no published marketplace image for k8s CI versions.
       # latest binaries and images will get replaced to the desired version by the script above.
-      marketplace:
-        publisher: cncf-upstream
-        offer: capi
-        sku: ubuntu-2204-gen1
+      computeGallery:
+        gallery: ClusterAPI-f72ceb4f-5159-4c26-a0fe-2ea738f0d019
+        name: capi-ubun2-2404
         version: latest

--- a/templates/test/dev/custom-builds-windows/patches/machine-deployment-pr-version.yaml
+++ b/templates/test/dev/custom-builds-windows/patches/machine-deployment-pr-version.yaml
@@ -11,10 +11,9 @@ spec:
       image:
         # we use the latest image as a workaround there is no published marketplace image for k8s CI versions.
         # latest binaries and images will get replaced to the desired version by the script above.
-        marketplace:
-          publisher: cncf-upstream
-          offer: capi
-          sku: ubuntu-2204-gen1
+        computeGallery:
+          gallery: ClusterAPI-f72ceb4f-5159-4c26-a0fe-2ea738f0d019
+          name: capi-ubun2-2404
           version: latest
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
@@ -30,10 +29,9 @@ spec:
       image:
         # we use the latest image as a workaround there is no published marketplace image for k8s CI versions.
         # latest binaries and images will get replaced to the desired version by the script above.
-        marketplace:
-          publisher: cncf-upstream
-          offer: capi
-          sku: ubuntu-2204-gen1
+        computeGallery:
+          gallery: ClusterAPI-f72ceb4f-5159-4c26-a0fe-2ea738f0d019
+          name: capi-ubun2-2404
           version: latest
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1

--- a/templates/test/dev/custom-builds/patches/machine-deployment-pr-version.yaml
+++ b/templates/test/dev/custom-builds/patches/machine-deployment-pr-version.yaml
@@ -11,10 +11,9 @@ spec:
       image:
         # we use the latest image as a workaround there is no published marketplace image for k8s CI versions.
         # latest binaries and images will get replaced to the desired version by the script above.
-        marketplace:
-          publisher: cncf-upstream
-          offer: capi
-          sku: ubuntu-2204-gen1
+        computeGallery:
+          gallery: ClusterAPI-f72ceb4f-5159-4c26-a0fe-2ea738f0d019
+          name: capi-ubun2-2404
           version: latest
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
@@ -30,10 +29,9 @@ spec:
       image:
         # we use the latest image as a workaround there is no published marketplace image for k8s CI versions.
         # latest binaries and images will get replaced to the desired version by the script above.
-        marketplace:
-          publisher: cncf-upstream
-          offer: capi
-          sku: ubuntu-2204-gen1
+        computeGallery:
+          gallery: ClusterAPI-f72ceb4f-5159-4c26-a0fe-2ea738f0d019
+          name: capi-ubun2-2404
           version: latest
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1

--- a/templates/test/dev/patches/control-plane-custom-builds.yaml
+++ b/templates/test/dev/patches/control-plane-custom-builds.yaml
@@ -43,7 +43,7 @@ spec:
           done
         fi
         systemctl restart kubelet
-        
+
         # prepull images from gcr.io/k8s-staging-ci-images and retag it to
         # registry.k8s.io so kubeadm can fetch correct images no matter what
         declare -a IMAGES=("kube-apiserver" "kube-controller-manager" "kube-proxy" "kube-scheduler")
@@ -96,8 +96,7 @@ spec:
       image:
         # we use the latest image as a workaround there is no published marketplace image for k8s CI versions.
         # latest binaries and images will get replaced to the desired version by the script above.
-        marketplace:
-          publisher: cncf-upstream
-          offer: capi
-          sku: ubuntu-2204-gen1
+        computeGallery:
+          gallery: ClusterAPI-f72ceb4f-5159-4c26-a0fe-2ea738f0d019
+          name: capi-ubun2-2404
           version: latest


### PR DESCRIPTION

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Updates templates to use reference images from the CAPZ Community Gallery.

Some CI templates were still referencing Azure Marketplace images, which are deprecated and will no longer work for testing Kubernetes v1.35+.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->


**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [x] cherry-pick candidate

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
