### PR TITLE
docs: fix typo in custom-vnet.md from groupIds to groupIDs

### DIFF
--- a/docs/book/src/self-managed/custom-vnet.md
+++ b/docs/book/src/self-managed/custom-vnet.md
@@ -338,7 +338,7 @@ spec:
         privateLinkServiceConnections:
         - name: my-pls # optional
           privateLinkServiceID: /subscriptions/<Subscription ID>/resourceGroups/<Remote Resource Group Name>/providers/Microsoft.Storage/storageAccounts/<Name>
-          groupIds:
+          groupIDs:
           - "blob"
 ```
 


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
type specifies `groupIDs` and not `groupIds` and will fail to reconcile when specifying `groupIds`.

https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/fdbf48b98e940d295e2ff89fffb6e957b86f3e29/api/v1beta1/types.go#L815

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [x] includes documentation
- [ ] adds unit tests
- [ ] cherry-pick candidate

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
