### PR TITLE
Update kubelet restart script in Windows templates

### DIFF
--- a/templates/cluster-template-machinepool-windows.yaml
+++ b/templates/cluster-template-machinepool-windows.yaml
@@ -289,6 +289,7 @@ spec:
       criSocket: npipe:////./pipe/containerd-containerd
       kubeletExtraArgs:
         cloud-provider: external
+        register-with-taints: node.cloudprovider.kubernetes.io/uninitialized=true:NoSchedule
       name: '{{ ds.meta_data["local_hostname"] }}'
   postKubeadmCommands:
   - powershell C:/KubeletRestart_nssm_sc.ps1

--- a/templates/cluster-template-windows-apiserver-ilb.yaml
+++ b/templates/cluster-template-windows-apiserver-ilb.yaml
@@ -313,6 +313,7 @@ spec:
           criSocket: npipe:////./pipe/containerd-containerd
           kubeletExtraArgs:
             cloud-provider: external
+            register-with-taints: node.cloudprovider.kubernetes.io/uninitialized=true:NoSchedule
             v: "2"
             windows-priorityclass: ABOVE_NORMAL_PRIORITY_CLASS
           name: '{{ ds.meta_data["local_hostname"] }}'

--- a/templates/cluster-template-windows.yaml
+++ b/templates/cluster-template-windows.yaml
@@ -297,6 +297,7 @@ spec:
           criSocket: npipe:////./pipe/containerd-containerd
           kubeletExtraArgs:
             cloud-provider: external
+            register-with-taints: node.cloudprovider.kubernetes.io/uninitialized=true:NoSchedule
             v: "2"
             windows-priorityclass: ABOVE_NORMAL_PRIORITY_CLASS
           name: '{{ ds.meta_data["local_hostname"] }}'

--- a/templates/flavors/machinepool-windows/machine-pool-deployment-windows.yaml
+++ b/templates/flavors/machinepool-windows/machine-pool-deployment-windows.yaml
@@ -59,6 +59,7 @@ spec:
       criSocket: npipe:////./pipe/containerd-containerd
       kubeletExtraArgs:
         cloud-provider: external
+        register-with-taints: node.cloudprovider.kubernetes.io/uninitialized=true:NoSchedule
   files:
   - contentFrom:
       secret:

--- a/templates/flavors/windows-apiserver-ilb/machine-deployment-windows.yaml
+++ b/templates/flavors/windows-apiserver-ilb/machine-deployment-windows.yaml
@@ -67,6 +67,7 @@ spec:
           criSocket: npipe:////./pipe/containerd-containerd
           kubeletExtraArgs:
             cloud-provider: external
+            register-with-taints: node.cloudprovider.kubernetes.io/uninitialized=true:NoSchedule
             v: "2"
             windows-priorityclass: "ABOVE_NORMAL_PRIORITY_CLASS"
       files:

--- a/templates/flavors/windows/machine-deployment-windows.yaml
+++ b/templates/flavors/windows/machine-deployment-windows.yaml
@@ -67,6 +67,7 @@ spec:
           criSocket: npipe:////./pipe/containerd-containerd
           kubeletExtraArgs:
             cloud-provider: external
+            register-with-taints: node.cloudprovider.kubernetes.io/uninitialized=true:NoSchedule
             v: "2"
             windows-priorityclass: ABOVE_NORMAL_PRIORITY_CLASS
       files:

--- a/templates/test/ci/cluster-template-prow-ci-version-windows.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version-windows.yaml
@@ -611,6 +611,7 @@ spec:
             feature-gates: ${NODE_FEATURE_GATES:-""}
             image-credential-provider-bin-dir: /var/lib/kubelet/credential-provider
             image-credential-provider-config: /var/lib/kubelet/credential-provider-config.yaml
+            register-with-taints: node.cloudprovider.kubernetes.io/uninitialized=true:NoSchedule
             v: "2"
             windows-priorityclass: ABOVE_NORMAL_PRIORITY_CLASS
           name: '{{ ds.meta_data["local_hostname"] }}'

--- a/templates/test/ci/cluster-template-prow-clusterclass-ci-default.yaml
+++ b/templates/test/ci/cluster-template-prow-clusterclass-ci-default.yaml
@@ -554,6 +554,7 @@ spec:
           criSocket: npipe:////./pipe/containerd-containerd
           kubeletExtraArgs:
             cloud-provider: external
+            register-with-taints: node.cloudprovider.kubernetes.io/uninitialized=true:NoSchedule
             v: "2"
             windows-priorityclass: ABOVE_NORMAL_PRIORITY_CLASS
           name: '{{ ds.meta_data["local_hostname"] }}'

--- a/templates/test/ci/cluster-template-prow-machine-pool-ci-version-windows.yaml
+++ b/templates/test/ci/cluster-template-prow-machine-pool-ci-version-windows.yaml
@@ -577,6 +577,7 @@ spec:
         cloud-provider: external
         image-credential-provider-bin-dir: /var/lib/kubelet/credential-provider
         image-credential-provider-config: /var/lib/kubelet/credential-provider-config.yaml
+        register-with-taints: node.cloudprovider.kubernetes.io/uninitialized=true:NoSchedule
       name: '{{ ds.meta_data["local_hostname"] }}'
   postKubeadmCommands:
   - powershell C:/KubeletRestart_nssm_sc.ps1

--- a/templates/test/ci/cluster-template-prow-machine-pool-windows.yaml
+++ b/templates/test/ci/cluster-template-prow-machine-pool-windows.yaml
@@ -309,6 +309,7 @@ spec:
       criSocket: npipe:////./pipe/containerd-containerd
       kubeletExtraArgs:
         cloud-provider: external
+        register-with-taints: node.cloudprovider.kubernetes.io/uninitialized=true:NoSchedule
       name: '{{ ds.meta_data["local_hostname"] }}'
   postKubeadmCommands:
   - powershell C:/KubeletRestart_nssm_sc.ps1

--- a/templates/test/ci/cluster-template-prow-windows.yaml
+++ b/templates/test/ci/cluster-template-prow-windows.yaml
@@ -348,6 +348,7 @@ spec:
           kubeletExtraArgs:
             cloud-provider: external
             feature-gates: ${NODE_FEATURE_GATES:-""}
+            register-with-taints: node.cloudprovider.kubernetes.io/uninitialized=true:NoSchedule
             v: "2"
             windows-priorityclass: ABOVE_NORMAL_PRIORITY_CLASS
           name: '{{ ds.meta_data["local_hostname"] }}'

--- a/templates/test/ci/prow-clusterclass-ci-default/windows.yaml
+++ b/templates/test/ci/prow-clusterclass-ci-default/windows.yaml
@@ -28,6 +28,7 @@ spec:
           criSocket: npipe:////./pipe/containerd-containerd
           kubeletExtraArgs:
             cloud-provider: external
+            register-with-taints: node.cloudprovider.kubernetes.io/uninitialized=true:NoSchedule
             v: "2"
             windows-priorityclass: "ABOVE_NORMAL_PRIORITY_CLASS"
       files:

--- a/templates/test/dev/cluster-template-custom-builds-machine-pool-windows.yaml
+++ b/templates/test/dev/cluster-template-custom-builds-machine-pool-windows.yaml
@@ -531,6 +531,7 @@ spec:
         cloud-provider: external
         image-credential-provider-bin-dir: /var/lib/kubelet/credential-provider
         image-credential-provider-config: /var/lib/kubelet/credential-provider-config.yaml
+        register-with-taints: node.cloudprovider.kubernetes.io/uninitialized=true:NoSchedule
       name: '{{ ds.meta_data["local_hostname"] }}'
   postKubeadmCommands:
   - powershell C:/KubeletRestart_nssm_sc.ps1

--- a/templates/test/dev/cluster-template-custom-builds-windows.yaml
+++ b/templates/test/dev/cluster-template-custom-builds-windows.yaml
@@ -576,6 +576,7 @@ spec:
             feature-gates: ${NODE_FEATURE_GATES:-""}
             image-credential-provider-bin-dir: /var/lib/kubelet/credential-provider
             image-credential-provider-config: /var/lib/kubelet/credential-provider-config.yaml
+            register-with-taints: node.cloudprovider.kubernetes.io/uninitialized=true:NoSchedule
             v: "2"
             windows-priorityclass: ABOVE_NORMAL_PRIORITY_CLASS
           name: '{{ ds.meta_data["local_hostname"] }}'


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Updates commands in Windows templates to work with either old nssm.exe or new sc.exe for running the kubelet.exe service.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->


**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [x] cherry-pick candidate

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
