### PR TITLE
Add bryan-cox to reviewers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -22,5 +22,6 @@ aliases:
     - willie-yao
     - nawazkh
   cluster-api-azure-reviewers:
+    - bryan-cox
     - jsturtevant
     - marosset


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

This PR will add @bryan-cox as a CAPZ reviewer.

According to the requirements defined here:

- https://github.com/kubernetes/community/blob/master/community-membership.md#requirements-1

- @bryan-cox has been a member of the Kubernetes org since 18 November 2024:
  - https://github.com/kubernetes/org/issues/5260
- was the author of 16 merged PRs:
  - https://github.com/kubernetes-sigs/cluster-api-provider-azure/pulls?q=is%3Apr+author%3Abryan-cox+is%3Aclosed+
- has been a primary reviewer of at least 11 PRs:
  - https://github.com/kubernetes-sigs/cluster-api-provider-azure/pulls?q=is%3Apr+is%3Aclosed+assignee%3Abryan-cox

Bryan has been continuously active in weekly Cluster API Provider Azure meetings and on Slack. Thanks Bryan!

**Special notes for your reviewer**:

**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:

```release-note
NONE
```
