### PR TITLE
Add missing `required` for RKE2 ClusterClass variable

### DIFF
--- a/templates/test/ci/cluster-template-prow-clusterclass-ci-rke2.yaml
+++ b/templates/test/ci/cluster-template-prow-clusterclass-ci-rke2.yaml
@@ -256,6 +256,7 @@ spec:
         default: ClusterAPI-f72ceb4f-5159-4c26-a0fe-2ea738f0d019
         type: string
   - name: resourceGroup
+    required: false
     schema:
       openAPIV3Schema:
         description: The Azure Resource Group where the Cluster will be created.

--- a/templates/test/ci/prow-clusterclass-ci-rke2/variables.yaml
+++ b/templates/test/ci/prow-clusterclass-ci-rke2/variables.yaml
@@ -75,6 +75,7 @@ spec:
           type: string
           default: ClusterAPI-f72ceb4f-5159-4c26-a0fe-2ea738f0d019
     - name: resourceGroup
+      required: false
       schema:
         openAPIV3Schema:
           description: "The Azure Resource Group where the Cluster will be created."


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind failing-test

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

This PR adds a missing required field to the RKE2 ClusterClass template. https://github.com/kubernetes-sigs/cluster-api/pull/12501 seems like the likely cause of this since this error started happening when we bumped to CAPI v1.11.

https://storage.googleapis.com/k8s-triage/index.html?date=2025-12-18&text=Failed%20to%20apply%20the%20cluster%20template&job=periodic-cluster-api-provider-azure-e2e-main&test=RKE2

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->


**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] cherry-pick candidate

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
