### PR TITLE
docs: fix prerequisites link in development guide

### DIFF
--- a/docs/book/src/developers/development.md
+++ b/docs/book/src/developers/development.md
@@ -124,7 +124,7 @@ Makefile targets and scripts are offered to work with go modules:
 
 ### Setting up the environment
 
-You must have the Azure credentials as outlined in the [getting started prerequisites](../getting-started.md#Prerequisites) section.
+You must have the Azure credentials as outlined in the [getting started prerequisites](../getting-started-with-aks.md#Prerequisites) section.
 
 ### Tilt Requirements
 
@@ -172,7 +172,7 @@ kustomize_substitutions:
   AZURE_CLIENT_ID: <client-id>
 ```
 
-You should have these values saved from the [getting started prerequisites](../getting-started.md#Prerequisites) section.
+You should have these values saved from the [getting started prerequisites](../getting-started-with-aks.md#Prerequisites) section.
 
 To build a kind cluster and start Tilt, just run:
 
@@ -230,7 +230,7 @@ kustomize_substitutions:
 EOF
 ```
 
-Make sure to replace the credentials with the values from the [getting started prerequisites](../getting-started.md#Prerequisites) section.
+Make sure to replace the credentials with the values from the [getting started prerequisites](../getting-started-with-aks.md#Prerequisites) section.
 
 > `$REGISTRY` should be in the format `docker.io/<dockerhub-username>`
 


### PR DESCRIPTION
Update references from getting-started.md to getting-started-with-aks.md in the development documentation to point to the correct prerequisites section.

 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

/kind documentation

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

Updates references from `getting-started.md` to `getting-started-with-aks.md` in the development documentation to point to the correct prerequisites section. This fixes broken links that were pointing to a non-existent file.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #6019

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->


**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [X] includes documentation
- [ ] adds unit tests
- [ ] cherry-pick candidate

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
