### PR TITLE
Fix: GIT_MAJOR unbound variable error in hack/version.sh

### DIFF
--- a/hack/version.sh
+++ b/hack/version.sh
@@ -27,6 +27,11 @@ version::get_version_vars() {
         GIT_TREE_STATE="dirty"
     fi
 
+    # Initialize version variables with defaults
+    GIT_VERSION=""
+    GIT_MAJOR=""
+    GIT_MINOR=""
+
     # borrowed from k8s.io/hack/lib/version.sh
     # Use git describe to find the version based on tags.
     if GIT_VERSION=$(git describe --tags --abbrev=14 2>/dev/null); then
@@ -88,9 +93,9 @@ version::ldflags() {
     add_ldflag "buildDate" "$(date ${SOURCE_DATE_EPOCH:+"--date=@${SOURCE_DATE_EPOCH}"} -u +'%Y-%m-%dT%H:%M:%SZ')"
     add_ldflag "gitCommit" "${GIT_COMMIT}"
     add_ldflag "gitTreeState" "${GIT_TREE_STATE}"
-    add_ldflag "gitMajor" "${GIT_MAJOR}"
-    add_ldflag "gitMinor" "${GIT_MINOR}"
-    add_ldflag "gitVersion" "${GIT_VERSION}"
+    add_ldflag "gitMajor" "${GIT_MAJOR:-0}"
+    add_ldflag "gitMinor" "${GIT_MINOR:-0}"
+    add_ldflag "gitVersion" "${GIT_VERSION:-$(git rev-parse --short HEAD)}"
 
   # The -ldflags parameter takes a single string, so join the output.
   echo "${ldflags[*]-}"


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
Fixes the "GIT_MAJOR: unbound variable" error that occurs when `hack/version.sh` is executed in environments where git version cannot be parsed (e.g., repository without version tags or version doesn't match expected pattern).

The script has `set -o nounset` enabled, which causes it to fail when variables are referenced before being set. The variables `GIT_MAJOR` and `GIT_MINOR` are only set conditionally when the git version matches a specific regex pattern, leaving them unbound in edge cases.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #6023 

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->
- Initialize `GIT_VERSION`, `GIT_MAJOR`, and `GIT_MINOR` with default empty strings at the start of `version::get_version_vars()`
- Use parameter expansion defaults (`${VAR:-default}`) when referencing these variables to provide safe fallbacks


**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] cherry-pick candidate

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
