### PR TITLE
Prevent KubeadmConfig bootstrap token rotation during upgrade tests

### DIFF
--- a/test/e2e/capi_test.go
+++ b/test/e2e/capi_test.go
@@ -181,6 +181,30 @@ var _ = Describe("Running the Cluster API E2E tests", func() {
 	// })
 
 	if os.Getenv("USE_LOCAL_KIND_REGISTRY") != "true" {
+		// CAPI refreshes the bootstrap token for MachinePools' KubeadmConfigs
+		// every ~10m by default. Each update causes CAPZ to update its
+		// AzureMachinePool with the new bootstrap data. This fails when the
+		// test checks that the resourceVersion of AzureMachinePools remains
+		// constant. Here we set a longer TTL to prevent the token from being
+		// rotated during the test.
+		setBootstrapTTLForUpgrade := func() (preUpgrade func(), postUpgrade func()) {
+			bootstrapTTLVarKey := "KUBEADM_BOOTSTRAP_TOKEN_TTL"
+			var oldValue *string
+			return func() {
+					ttl, found := os.LookupEnv(bootstrapTTLVarKey)
+					if found {
+						oldValue = ptr.To(ttl)
+					}
+					os.Setenv(bootstrapTTLVarKey, "1h") // sets --bootstrap-token-ttl for capi-kubeadm-bootstrap-controller-manager
+				}, func() {
+					if oldValue != nil {
+						os.Setenv(bootstrapTTLVarKey, *oldValue)
+					} else {
+						os.Unsetenv(bootstrapTTLVarKey)
+					}
+				}
+		}
+
 		Context("API Version Upgrade", func() {
 			var aksKubernetesVersion string
 
@@ -209,6 +233,7 @@ var _ = Describe("Running the Cluster API E2E tests", func() {
 
 			Context("upgrade from an old version of v1beta1 to current, and scale workload clusters created in the old version", func() {
 				capi_e2e.ClusterctlUpgradeSpec(ctx, func() capi_e2e.ClusterctlUpgradeSpecInput {
+					setBootstrapTTL, resetBootstrapTTL := setBootstrapTTLForUpgrade()
 					return capi_e2e.ClusterctlUpgradeSpecInput{
 						E2EConfig:                 e2eConfig,
 						ClusterctlConfigPath:      clusterctlConfigPath,
@@ -228,12 +253,19 @@ var _ = Describe("Running the Cluster API E2E tests", func() {
 						InitWithControlPlaneProviders:   []string{"kubeadm:" + e2eConfig.MustGetVariable(OldCAPIUpgradeVersion)},
 						InitWithInfrastructureProviders: []string{"azure:" + e2eConfig.MustGetVariable(OldProviderUpgradeVersion)},
 						InitWithAddonProviders:          []string{"helm:" + e2eConfig.MustGetVariable(OldAddonProviderUpgradeVersion)},
+						PreUpgrade: func(_ framework.ClusterProxy) {
+							setBootstrapTTL()
+						},
+						PostUpgrade: func(_ framework.ClusterProxy, _, _ string) {
+							resetBootstrapTTL()
+						},
 					}
 				})
 			})
 
 			Context("upgrade from the latest version of v1beta1 to current, and scale workload clusters created in the old version", func() {
 				capi_e2e.ClusterctlUpgradeSpec(ctx, func() capi_e2e.ClusterctlUpgradeSpecInput {
+					setBootstrapTTL, resetBootstrapTTL := setBootstrapTTLForUpgrade()
 					return capi_e2e.ClusterctlUpgradeSpecInput{
 						E2EConfig:                 e2eConfig,
 						ClusterctlConfigPath:      clusterctlConfigPath,
@@ -253,6 +285,12 @@ var _ = Describe("Running the Cluster API E2E tests", func() {
 						InitWithControlPlaneProviders:   []string{"kubeadm:" + e2eConfig.MustGetVariable(LatestCAPIUpgradeVersion)},
 						InitWithInfrastructureProviders: []string{"azure:" + e2eConfig.MustGetVariable(LatestProviderUpgradeVersion)},
 						InitWithAddonProviders:          []string{"helm:" + e2eConfig.MustGetVariable(LatestAddonProviderUpgradeVersion)},
+						PreUpgrade: func(_ framework.ClusterProxy) {
+							setBootstrapTTL()
+						},
+						PostUpgrade: func(_ framework.ClusterProxy, _, _ string) {
+							resetBootstrapTTL()
+						},
 					}
 				})
 			})


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind flake

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

This PR addresses recent flakes in the e2e tests that upgrade CAPZ: https://storage.googleapis.com/k8s-triage/index.html?date=2026-01-09&pr=1&text=resourceVersions%20never%20became%20stable&job=cluster-api-provider-azure

Since #5979, the test has additionally checked that after the upgrade, the `metadata.resourceVersion` of relevant resources stays constant. CAPZ updates an annotation on AzureMachinePools when its bootstrap data is updated which sometimes occurred during the 2m interval where the resourceVersions are expected not to change. This PR configures the CAPI kubeadm provider with a long enough TTL for bootstrap tokens that it shouldn't have to rotate the bootstrap token during the test.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->


**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] cherry-pick candidate

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
