### PR TITLE
fix: restore custom-builds bootstrapping foo

### DIFF
--- a/templates/test/dev/cluster-template-custom-builds-dra.yaml
+++ b/templates/test/dev/cluster-template-custom-builds-dra.yaml
@@ -101,53 +101,59 @@ spec:
         set -o nounset
         set -o pipefail
         set -o errexit
-        [[ $(id -u) != 0 ]] && SUDO="sudo" || SUDO=""
-
-        # This test installs release packages or binaries that are a result of the CI and release builds.
-        # It runs '... --version' commands to verify that the binaries are correctly installed
-        # and finally uninstalls the packages.
-        # For the release packages it tests all versions in the support skew.
-        LINE_SEPARATOR="*************************************************"
-        echo "$${LINE_SEPARATOR}"
-        CI_VERSION=${CI_VERSION}
-
-        CI_DIR=/tmp/k8s-ci
-        mkdir -p "$${CI_DIR}"
 
         systemctl stop kubelet
-        declare -a PACKAGES_TO_TEST=("kubectl" "kubelet" "kubeadm")
-        # Let's just also download the control plane images for worker nodes. It's easier then optimizing it.
-        declare -a CONTAINERS_TO_TEST=("kube-apiserver" "kube-controller-manager" "kube-proxy" "kube-scheduler")
-        CONTAINER_EXT="tar"
-        echo "* testing version $${CI_VERSION}"
-        az login --identity
-        for CI_PACKAGE in "$${PACKAGES_TO_TEST[@]}"; do
-            echo "* downloading binary: https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${CI_PACKAGE}"
-            az storage blob download --blob-url "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${CI_PACKAGE}" -f "$${CI_DIR}/$${CI_PACKAGE}" --auth-mode login
-            chmod +x "$${CI_DIR}/$${CI_PACKAGE}"
-            mv "$${CI_DIR}/$${CI_PACKAGE}" "/usr/bin/$${CI_PACKAGE}"
-        done
-
-        systemctl restart kubelet
-        IMAGE_REGISTRY_PREFIX=registry.k8s.io
-        # Kubernetes builds from 1.20 through 1.24 are tagged with k8s.gcr.io
-        if [[ "$${CI_VERSION}" =~ ^v1\.(1[0-9]|2[0-4])[\.[0-9]+ ]]; then
-            IMAGE_REGISTRY_PREFIX=k8s.gcr.io
+        declare -a BINARIES=("kubeadm" "kubectl" "kubelet")
+        # Run the az login command with managed identity
+        if az login --identity > /dev/null 2>&1; then
+          echo "Logged in Azure with managed identity"
+          for BINARY in "$${BINARIES[@]}"; do
+            echo "* installing package: $${BINARY} ${KUBE_GIT_VERSION}"
+            az storage blob download --blob-url "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${BINARY}" -f "/usr/bin/$${BINARY}" --auth-mode login
+          done
+        else
+          echo "Using curl to download the binaries"
+          for BINARY in "$${BINARIES[@]}"; do
+            echo "* installing package: $${BINARY} ${KUBE_GIT_VERSION}"
+            curl --retry 10 --retry-delay 5 -w "response status code is %{http_code}" "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${BINARY}" --output "/usr/bin/$${BINARY}"
+          done
         fi
-        for CI_CONTAINER in "$${CONTAINERS_TO_TEST[@]}"; do
-            echo "* downloading container image: ${REGISTRY}/kube-apiserver:${KUBE_IMAGE_TAG}"
-            $${SUDO} ctr -n k8s.io images pull "${REGISTRY}/$${CI_CONTAINER}:${KUBE_IMAGE_TAG}"
-            $${SUDO} ctr -n k8s.io images tag "${REGISTRY}/$${CI_CONTAINER}:${KUBE_IMAGE_TAG}" "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}:$${CI_VERSION//+/_}"
-            $${SUDO} ctr -n k8s.io images tag "${REGISTRY}/$${CI_CONTAINER}:${KUBE_IMAGE_TAG}" "gcr.io/k8s-staging-ci-images/$${CI_CONTAINER}:$${CI_VERSION//+/_}"
+        systemctl restart kubelet
+        # prepull images from gcr.io/k8s-staging-ci-images and retag it to
+        # registry.k8s.io so kubeadm can fetch correct images no matter what
+        declare -a IMAGES=("kube-apiserver" "kube-controller-manager" "kube-proxy" "kube-scheduler")
+        [[ $(id -u) != 0 ]] && SUDO="sudo" || SUDO=""
+        IMAGE_REGISTRY_PREFIX=registry.k8s.io
+        for IMAGE in "$${IMAGES[@]}"; do
+          $${SUDO} ctr -n k8s.io images tag $$IMAGE_REGISTRY_PREFIX/$$IMAGE-amd64:"${CI_VERSION//+/_}" $$IMAGE_REGISTRY_PREFIX/$$IMAGE:"${CI_VERSION//+/_}"
+          $${SUDO} ctr -n k8s.io images tag $$IMAGE_REGISTRY_PREFIX/$$IMAGE-amd64:"${CI_VERSION//+/_}" gcr.io/k8s-staging-ci-images/$$IMAGE:"${CI_VERSION//+/_}"
         done
-        echo "* checking binary versions"
-        echo "ctr version: " "$(ctr version)"
-        echo "kubeadm version: " "$(kubeadm version -o=short)"
-        echo "kubectl version: " "$(kubectl version --client=true)"
-        echo "kubelet version: " "$(kubelet --version)"
-        echo "$${LINE_SEPARATOR}"
+        echo "kubeadm version: $(kubeadm version -o=short)"
+        echo "kubectl version: $(kubectl version --client=true)"
+        echo "kubelet version: $(kubelet --version)"
       owner: root:root
       path: /tmp/replace-k8s-binaries.sh
+      permissions: "0744"
+    - content: |
+        #!/bin/bash
+
+        set -o nounset
+        set -o pipefail
+        set -o errexit
+
+        curl -L --retry 10 --retry-delay 5 https://github.com/mikefarah/yq/releases/download/v4.6.1/yq_linux_amd64.tar.gz --output /tmp/yq_linux_amd64.tar.gz
+        tar -xzvf /tmp/yq_linux_amd64.tar.gz -C /tmp && mv /tmp/yq_linux_amd64 /usr/bin/yq
+        rm /tmp/yq_linux_amd64.tar.gz
+
+        export KUBECONFIG=/etc/kubernetes/admin.conf
+        kubectl -n kube-system set image daemonset/kube-proxy kube-proxy="${REGISTRY}/kube-proxy:${KUBE_IMAGE_TAG}"
+        systemctl stop kubelet
+        yq e '.spec.containers[0].image = "${REGISTRY}/kube-apiserver:${KUBE_IMAGE_TAG}"' -i /etc/kubernetes/manifests/kube-apiserver.yaml
+        yq e '.spec.containers[0].image = "${REGISTRY}/kube-controller-manager:${KUBE_IMAGE_TAG}"' -i /etc/kubernetes/manifests/kube-controller-manager.yaml
+        yq e '.spec.containers[0].image = "${REGISTRY}/kube-scheduler:${KUBE_IMAGE_TAG}"' -i /etc/kubernetes/manifests/kube-scheduler.yaml
+        systemctl restart kubelet
+      owner: root:root
+      path: /tmp/replace-k8s-components.sh
       permissions: "0744"
     - contentFrom:
         secret:
@@ -212,7 +218,8 @@ spec:
     mounts:
     - - LABEL=etcd_disk
       - /var/lib/etcddisk
-    postKubeadmCommands: []
+    postKubeadmCommands:
+    - bash -c /tmp/replace-k8s-components.sh
     preKubeadmCommands:
     - bash -c /tmp/containerd-config.sh
     - bash -c /tmp/replace-k8s-binaries.sh

--- a/templates/test/dev/cluster-template-custom-builds-load-dra.yaml
+++ b/templates/test/dev/cluster-template-custom-builds-load-dra.yaml
@@ -145,63 +145,48 @@ spec:
         set -o errexit
         [[ $(id -u) != 0 ]] && SUDO="sudo" || SUDO=""
 
-        # This test installs release packages or binaries that are a result of the CI and release builds.
-        # It runs '... --version' commands to verify that the binaries are correctly installed
-        # and finally uninstalls the packages.
-        # For the release packages it tests all versions in the support skew.
-        LINE_SEPARATOR="*************************************************"
-        echo "$${LINE_SEPARATOR}"
-        CI_VERSION=${CI_VERSION}
+        systemctl stop kubelet
+        declare -a BINARIES=("kubeadm" "kubectl" "kubelet")
+        az login --identity
+        for BINARY in "$${BINARIES[@]}"; do
+          echo "* installing package: $${BINARY} ${KUBE_GIT_VERSION}"
+          az storage blob download --blob-url "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${BINARY}" -f "/usr/bin/$${BINARY}" --auth-mode login
+        done
+        systemctl restart kubelet
 
-        # Note: We assume if kubectl has the right version, everything else has as well
-        if [[ $(kubectl version --client=true -o json | jq '.clientVersion.gitVersion' -r) = "$${CI_VERSION}" ]]; then
-            echo "Detected Kubernetes $${CI_VERSION} via kubectl version, nothing to do"
-            exit 0
-        fi
-        if [[ "$${CI_VERSION}" != "" ]]; then
-            CI_DIR=/tmp/k8s-ci
-            mkdir -p "$${CI_DIR}"
-            declare -a PACKAGES_TO_TEST=("kubectl" "kubelet" "kubeadm")
-            # Let's just also download the control plane images for worker nodes. It's easier then optimizing it.
-            declare -a CONTAINERS_TO_TEST=("kube-apiserver" "kube-controller-manager" "kube-proxy" "kube-scheduler")
-            CONTAINER_EXT="tar"
-            echo "* testing version $${CI_VERSION}"
-            CI_URL="https://dl.k8s.io/ci/$${CI_VERSION}/bin/linux/amd64"
-            # Set CI_URL to the released binaries for actually released versions.
-            if [[ "$${CI_VERSION}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || [[ "$${CI_VERSION}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+-(beta|rc).[0-9]+$ ]]; then
-                CI_URL="https://dl.k8s.io/release/$${CI_VERSION}/bin/linux/amd64"
-            fi
-            for CI_PACKAGE in "$${PACKAGES_TO_TEST[@]}"; do
-                # Browser: https://console.cloud.google.com/storage/browser/k8s-release-dev?project=k8s-release-dev
-                # e.g.: https://storage.googleapis.com/k8s-release-dev/ci/v1.21.0-beta.1.378+cf3374e43491c5/bin/linux/amd64/kubectl
-                echo "* downloading binary: $${CI_URL}/$${CI_PACKAGE}"
-                wget --inet4-only "$${CI_URL}/$${CI_PACKAGE}" -O "$${CI_DIR}/$${CI_PACKAGE}"
-                chmod +x "$${CI_DIR}/$${CI_PACKAGE}"
-                mv "$${CI_DIR}/$${CI_PACKAGE}" "/usr/bin/$${CI_PACKAGE}"
-            done
+        # prepull images from gcr.io/k8s-staging-ci-images and retag it to
+        # registry.k8s.io so kubeadm can fetch correct images no matter what
+        declare -a IMAGES=("kube-apiserver" "kube-controller-manager" "kube-proxy" "kube-scheduler")
+        [[ $(id -u) != 0 ]] && SUDO="sudo" || SUDO=""
+        IMAGE_REGISTRY_PREFIX=registry.k8s.io
+        for IMAGE in "$${IMAGES[@]}"; do
+          $${SUDO} ctr -n k8s.io images tag $$IMAGE_REGISTRY_PREFIX/$$IMAGE-amd64:"${CI_VERSION//+/_}" $$IMAGE_REGISTRY_PREFIX/$$IMAGE:"${CI_VERSION//+/_}"
+          $${SUDO} ctr -n k8s.io images tag $$IMAGE_REGISTRY_PREFIX/$$IMAGE-amd64:"${CI_VERSION//+/_}" gcr.io/k8s-staging-ci-images/$$IMAGE:"${CI_VERSION//+/_}"
+        done
 
-            systemctl restart kubelet
-            IMAGE_REGISTRY_PREFIX=registry.k8s.io
-            # Kubernetes builds from 1.20 through 1.24 are tagged with k8s.gcr.io
-            if [[ "$${CI_VERSION}" =~ ^v1\.(1[0-9]|2[0-4])[\.[0-9]+ ]]; then
-                IMAGE_REGISTRY_PREFIX=k8s.gcr.io
-            fi
-            for CI_CONTAINER in "$${CONTAINERS_TO_TEST[@]}"; do
-                echo "* downloading package: $${CI_URL}/$${CI_CONTAINER}.$${CONTAINER_EXT}"
-                wget --inet4-only "$${CI_URL}/$${CI_CONTAINER}.$${CONTAINER_EXT}" -O "$${CI_DIR}/$${CI_CONTAINER}.$${CONTAINER_EXT}"
-                $${SUDO} ctr -n k8s.io images import "$${CI_DIR}/$${CI_CONTAINER}.$${CONTAINER_EXT}" || echo "* ignoring expected 'ctr images import' result"
-                $${SUDO} ctr -n k8s.io images tag "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}-amd64:$${CI_VERSION//+/_}" "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}:$${CI_VERSION//+/_}"
-                $${SUDO} ctr -n k8s.io images tag "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}-amd64:$${CI_VERSION//+/_}" "gcr.io/k8s-staging-ci-images/$${CI_CONTAINER}:$${CI_VERSION//+/_}"
-            done
-        fi
-        echo "* checking binary versions"
-        echo "ctr version: " "$(ctr version)"
-        echo "kubeadm version: " "$(kubeadm version -o=short)"
-        echo "kubectl version: " "$(kubectl version --client=true)"
-        echo "kubelet version: " "$(kubelet --version)"
-        echo "$${LINE_SEPARATOR}"
+        echo "kubeadm version: $(kubeadm version -o=short)"
+        echo "kubectl version: $(kubectl version --client=true)"
+        echo "kubelet version: $(kubelet --version)"
       owner: root:root
       path: /tmp/replace-k8s-binaries.sh
+      permissions: "0744"
+    - content: |
+        #!/bin/bash
+        set -o nounset
+        set -o pipefail
+        set -o errexit
+        curl -L --retry 10 --retry-delay 5 https://github.com/mikefarah/yq/releases/download/v4.6.1/yq_linux_amd64.tar.gz --output /tmp/yq_linux_amd64.tar.gz
+        tar -xzvf /tmp/yq_linux_amd64.tar.gz -C /tmp && mv /tmp/yq_linux_amd64 /usr/bin/yq
+        rm /tmp/yq_linux_amd64.tar.gz
+        export KUBECONFIG=/etc/kubernetes/admin.conf
+        kubectl -n kube-system set image daemonset/kube-proxy kube-proxy="${REGISTRY}/kube-proxy:${KUBE_IMAGE_TAG}"
+        systemctl stop kubelet
+        yq e '.spec.containers[0].image = "${REGISTRY}/kube-apiserver:${KUBE_IMAGE_TAG}"' -i /etc/kubernetes/manifests/kube-apiserver.yaml
+        yq e '.spec.containers[0].image = "${REGISTRY}/kube-controller-manager:${KUBE_IMAGE_TAG}"' -i /etc/kubernetes/manifests/kube-controller-manager.yaml
+        yq e '.spec.containers[0].image = "${REGISTRY}/kube-scheduler:${KUBE_IMAGE_TAG}"' -i /etc/kubernetes/manifests/kube-scheduler.yaml
+        systemctl restart kubelet
+      owner: root:root
+      path: /tmp/replace-k8s-components.sh
       permissions: "0744"
     - content: |
         #!/bin/bash
@@ -231,7 +216,8 @@ spec:
     mounts:
     - - LABEL=etcd_disk
       - /var/lib/etcddisk
-    postKubeadmCommands: []
+    postKubeadmCommands:
+    - bash -c /tmp/replace-k8s-components.sh
     preKubeadmCommands:
     - bash -c /tmp/containerd-config.sh
     - bash -c /tmp/oot-cred-provider.sh
@@ -382,31 +368,13 @@ spec:
           set -o nounset
           set -o pipefail
           set -o errexit
-          [[ $(id -u) != 0 ]] && SUDO="sudo" || SUDO=""
-
-          # This test installs release packages or binaries that are a result of the CI and release builds.
-          # It runs '... --version' commands to verify that the binaries are correctly installed
-          # and finally uninstalls the packages.
-          # For the release packages it tests all versions in the support skew.
-          LINE_SEPARATOR="*************************************************"
-          echo "$${LINE_SEPARATOR}"
-          CI_VERSION=${CI_VERSION}
-
-          CI_DIR=/tmp/k8s-ci
-          mkdir -p "$${CI_DIR}"
 
           systemctl stop kubelet
-          declare -a PACKAGES_TO_TEST=("kubectl" "kubelet" "kubeadm")
-          # Let's just also download the control plane images for worker nodes. It's easier then optimizing it.
-          declare -a CONTAINERS_TO_TEST=("kube-apiserver" "kube-controller-manager" "kube-proxy" "kube-scheduler")
-          CONTAINER_EXT="tar"
-          echo "* testing version $${CI_VERSION}"
+          declare -a BINARIES=("kubeadm" "kubectl" "kubelet")
           az login --identity
-          for CI_PACKAGE in "$${PACKAGES_TO_TEST[@]}"; do
-              echo "* downloading binary: https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${CI_PACKAGE}"
-              az storage blob download --blob-url "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${CI_PACKAGE}" -f "$${CI_DIR}/$${CI_PACKAGE}" --auth-mode login
-              chmod +x "$${CI_DIR}/$${CI_PACKAGE}"
-              mv "$${CI_DIR}/$${CI_PACKAGE}" "/usr/bin/$${CI_PACKAGE}"
+          for BINARY in "$${BINARIES[@]}"; do
+            echo "* installing package: $${BINARY} ${KUBE_GIT_VERSION}"
+            az storage blob download --blob-url "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${BINARY}" -f "/usr/bin/$${BINARY}" --auth-mode login
           done
 
           systemctl restart kubelet
@@ -421,12 +389,9 @@ spec:
               $${SUDO} ctr -n k8s.io images tag "${REGISTRY}/$${CI_CONTAINER}:${KUBE_IMAGE_TAG}" "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}:$${CI_VERSION//+/_}"
               $${SUDO} ctr -n k8s.io images tag "${REGISTRY}/$${CI_CONTAINER}:${KUBE_IMAGE_TAG}" "gcr.io/k8s-staging-ci-images/$${CI_CONTAINER}:$${CI_VERSION//+/_}"
           done
-          echo "* checking binary versions"
-          echo "ctr version: " "$(ctr version)"
-          echo "kubeadm version: " "$(kubeadm version -o=short)"
-          echo "kubectl version: " "$(kubectl version --client=true)"
-          echo "kubelet version: " "$(kubelet --version)"
-          echo "$${LINE_SEPARATOR}"
+          echo "kubeadm version: $(kubeadm version -o=short)"
+          echo "kubectl version: $(kubectl version --client=true)"
+          echo "kubelet version: $(kubelet --version)"
         owner: root:root
         path: /tmp/replace-k8s-binaries.sh
         permissions: "0744"
@@ -982,31 +947,13 @@ spec:
           set -o nounset
           set -o pipefail
           set -o errexit
-          [[ $(id -u) != 0 ]] && SUDO="sudo" || SUDO=""
-
-          # This test installs release packages or binaries that are a result of the CI and release builds.
-          # It runs '... --version' commands to verify that the binaries are correctly installed
-          # and finally uninstalls the packages.
-          # For the release packages it tests all versions in the support skew.
-          LINE_SEPARATOR="*************************************************"
-          echo "$${LINE_SEPARATOR}"
-          CI_VERSION=${CI_VERSION}
-
-          CI_DIR=/tmp/k8s-ci
-          mkdir -p "$${CI_DIR}"
 
           systemctl stop kubelet
-          declare -a PACKAGES_TO_TEST=("kubectl" "kubelet" "kubeadm")
-          # Let's just also download the control plane images for worker nodes. It's easier then optimizing it.
-          declare -a CONTAINERS_TO_TEST=("kube-apiserver" "kube-controller-manager" "kube-proxy" "kube-scheduler")
-          CONTAINER_EXT="tar"
-          echo "* testing version $${CI_VERSION}"
+          declare -a BINARIES=("kubeadm" "kubectl" "kubelet")
           az login --identity
-          for CI_PACKAGE in "$${PACKAGES_TO_TEST[@]}"; do
-              echo "* downloading binary: https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${CI_PACKAGE}"
-              az storage blob download --blob-url "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${CI_PACKAGE}" -f "$${CI_DIR}/$${CI_PACKAGE}" --auth-mode login
-              chmod +x "$${CI_DIR}/$${CI_PACKAGE}"
-              mv "$${CI_DIR}/$${CI_PACKAGE}" "/usr/bin/$${CI_PACKAGE}"
+          for BINARY in "$${BINARIES[@]}"; do
+            echo "* installing package: $${BINARY} ${KUBE_GIT_VERSION}"
+            az storage blob download --blob-url "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${BINARY}" -f "/usr/bin/$${BINARY}" --auth-mode login
           done
 
           systemctl restart kubelet
@@ -1021,12 +968,9 @@ spec:
               $${SUDO} ctr -n k8s.io images tag "${REGISTRY}/$${CI_CONTAINER}:${KUBE_IMAGE_TAG}" "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}:$${CI_VERSION//+/_}"
               $${SUDO} ctr -n k8s.io images tag "${REGISTRY}/$${CI_CONTAINER}:${KUBE_IMAGE_TAG}" "gcr.io/k8s-staging-ci-images/$${CI_CONTAINER}:$${CI_VERSION//+/_}"
           done
-          echo "* checking binary versions"
-          echo "ctr version: " "$(ctr version)"
-          echo "kubeadm version: " "$(kubeadm version -o=short)"
-          echo "kubectl version: " "$(kubectl version --client=true)"
-          echo "kubelet version: " "$(kubelet --version)"
-          echo "$${LINE_SEPARATOR}"
+          echo "kubeadm version: $(kubeadm version -o=short)"
+          echo "kubectl version: $(kubectl version --client=true)"
+          echo "kubelet version: $(kubelet --version)"
         owner: root:root
         path: /tmp/replace-k8s-binaries.sh
         permissions: "0744"

--- a/templates/test/dev/cluster-template-custom-builds-load.yaml
+++ b/templates/test/dev/cluster-template-custom-builds-load.yaml
@@ -139,63 +139,48 @@ spec:
         set -o errexit
         [[ $(id -u) != 0 ]] && SUDO="sudo" || SUDO=""
 
-        # This test installs release packages or binaries that are a result of the CI and release builds.
-        # It runs '... --version' commands to verify that the binaries are correctly installed
-        # and finally uninstalls the packages.
-        # For the release packages it tests all versions in the support skew.
-        LINE_SEPARATOR="*************************************************"
-        echo "$${LINE_SEPARATOR}"
-        CI_VERSION=${CI_VERSION}
+        systemctl stop kubelet
+        declare -a BINARIES=("kubeadm" "kubectl" "kubelet")
+        az login --identity
+        for BINARY in "$${BINARIES[@]}"; do
+          echo "* installing package: $${BINARY} ${KUBE_GIT_VERSION}"
+          az storage blob download --blob-url "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${BINARY}" -f "/usr/bin/$${BINARY}" --auth-mode login
+        done
+        systemctl restart kubelet
 
-        # Note: We assume if kubectl has the right version, everything else has as well
-        if [[ $(kubectl version --client=true -o json | jq '.clientVersion.gitVersion' -r) = "$${CI_VERSION}" ]]; then
-            echo "Detected Kubernetes $${CI_VERSION} via kubectl version, nothing to do"
-            exit 0
-        fi
-        if [[ "$${CI_VERSION}" != "" ]]; then
-            CI_DIR=/tmp/k8s-ci
-            mkdir -p "$${CI_DIR}"
-            declare -a PACKAGES_TO_TEST=("kubectl" "kubelet" "kubeadm")
-            # Let's just also download the control plane images for worker nodes. It's easier then optimizing it.
-            declare -a CONTAINERS_TO_TEST=("kube-apiserver" "kube-controller-manager" "kube-proxy" "kube-scheduler")
-            CONTAINER_EXT="tar"
-            echo "* testing version $${CI_VERSION}"
-            CI_URL="https://dl.k8s.io/ci/$${CI_VERSION}/bin/linux/amd64"
-            # Set CI_URL to the released binaries for actually released versions.
-            if [[ "$${CI_VERSION}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || [[ "$${CI_VERSION}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+-(beta|rc).[0-9]+$ ]]; then
-                CI_URL="https://dl.k8s.io/release/$${CI_VERSION}/bin/linux/amd64"
-            fi
-            for CI_PACKAGE in "$${PACKAGES_TO_TEST[@]}"; do
-                # Browser: https://console.cloud.google.com/storage/browser/k8s-release-dev?project=k8s-release-dev
-                # e.g.: https://storage.googleapis.com/k8s-release-dev/ci/v1.21.0-beta.1.378+cf3374e43491c5/bin/linux/amd64/kubectl
-                echo "* downloading binary: $${CI_URL}/$${CI_PACKAGE}"
-                wget --inet4-only "$${CI_URL}/$${CI_PACKAGE}" -O "$${CI_DIR}/$${CI_PACKAGE}"
-                chmod +x "$${CI_DIR}/$${CI_PACKAGE}"
-                mv "$${CI_DIR}/$${CI_PACKAGE}" "/usr/bin/$${CI_PACKAGE}"
-            done
+        # prepull images from gcr.io/k8s-staging-ci-images and retag it to
+        # registry.k8s.io so kubeadm can fetch correct images no matter what
+        declare -a IMAGES=("kube-apiserver" "kube-controller-manager" "kube-proxy" "kube-scheduler")
+        [[ $(id -u) != 0 ]] && SUDO="sudo" || SUDO=""
+        IMAGE_REGISTRY_PREFIX=registry.k8s.io
+        for IMAGE in "$${IMAGES[@]}"; do
+          $${SUDO} ctr -n k8s.io images tag $$IMAGE_REGISTRY_PREFIX/$$IMAGE-amd64:"${CI_VERSION//+/_}" $$IMAGE_REGISTRY_PREFIX/$$IMAGE:"${CI_VERSION//+/_}"
+          $${SUDO} ctr -n k8s.io images tag $$IMAGE_REGISTRY_PREFIX/$$IMAGE-amd64:"${CI_VERSION//+/_}" gcr.io/k8s-staging-ci-images/$$IMAGE:"${CI_VERSION//+/_}"
+        done
 
-            systemctl restart kubelet
-            IMAGE_REGISTRY_PREFIX=registry.k8s.io
-            # Kubernetes builds from 1.20 through 1.24 are tagged with k8s.gcr.io
-            if [[ "$${CI_VERSION}" =~ ^v1\.(1[0-9]|2[0-4])[\.[0-9]+ ]]; then
-                IMAGE_REGISTRY_PREFIX=k8s.gcr.io
-            fi
-            for CI_CONTAINER in "$${CONTAINERS_TO_TEST[@]}"; do
-                echo "* downloading package: $${CI_URL}/$${CI_CONTAINER}.$${CONTAINER_EXT}"
-                wget --inet4-only "$${CI_URL}/$${CI_CONTAINER}.$${CONTAINER_EXT}" -O "$${CI_DIR}/$${CI_CONTAINER}.$${CONTAINER_EXT}"
-                $${SUDO} ctr -n k8s.io images import "$${CI_DIR}/$${CI_CONTAINER}.$${CONTAINER_EXT}" || echo "* ignoring expected 'ctr images import' result"
-                $${SUDO} ctr -n k8s.io images tag "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}-amd64:$${CI_VERSION//+/_}" "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}:$${CI_VERSION//+/_}"
-                $${SUDO} ctr -n k8s.io images tag "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}-amd64:$${CI_VERSION//+/_}" "gcr.io/k8s-staging-ci-images/$${CI_CONTAINER}:$${CI_VERSION//+/_}"
-            done
-        fi
-        echo "* checking binary versions"
-        echo "ctr version: " "$(ctr version)"
-        echo "kubeadm version: " "$(kubeadm version -o=short)"
-        echo "kubectl version: " "$(kubectl version --client=true)"
-        echo "kubelet version: " "$(kubelet --version)"
-        echo "$${LINE_SEPARATOR}"
+        echo "kubeadm version: $(kubeadm version -o=short)"
+        echo "kubectl version: $(kubectl version --client=true)"
+        echo "kubelet version: $(kubelet --version)"
       owner: root:root
       path: /tmp/replace-k8s-binaries.sh
+      permissions: "0744"
+    - content: |
+        #!/bin/bash
+        set -o nounset
+        set -o pipefail
+        set -o errexit
+        curl -L --retry 10 --retry-delay 5 https://github.com/mikefarah/yq/releases/download/v4.6.1/yq_linux_amd64.tar.gz --output /tmp/yq_linux_amd64.tar.gz
+        tar -xzvf /tmp/yq_linux_amd64.tar.gz -C /tmp && mv /tmp/yq_linux_amd64 /usr/bin/yq
+        rm /tmp/yq_linux_amd64.tar.gz
+        export KUBECONFIG=/etc/kubernetes/admin.conf
+        kubectl -n kube-system set image daemonset/kube-proxy kube-proxy="${REGISTRY}/kube-proxy:${KUBE_IMAGE_TAG}"
+        systemctl stop kubelet
+        yq e '.spec.containers[0].image = "${REGISTRY}/kube-apiserver:${KUBE_IMAGE_TAG}"' -i /etc/kubernetes/manifests/kube-apiserver.yaml
+        yq e '.spec.containers[0].image = "${REGISTRY}/kube-controller-manager:${KUBE_IMAGE_TAG}"' -i /etc/kubernetes/manifests/kube-controller-manager.yaml
+        yq e '.spec.containers[0].image = "${REGISTRY}/kube-scheduler:${KUBE_IMAGE_TAG}"' -i /etc/kubernetes/manifests/kube-scheduler.yaml
+        systemctl restart kubelet
+      owner: root:root
+      path: /tmp/replace-k8s-components.sh
       permissions: "0744"
     initConfiguration:
       nodeRegistration:
@@ -214,7 +199,8 @@ spec:
     mounts:
     - - LABEL=etcd_disk
       - /var/lib/etcddisk
-    postKubeadmCommands: []
+    postKubeadmCommands:
+    - bash -c /tmp/replace-k8s-components.sh
     preKubeadmCommands:
     - bash -c /tmp/oot-cred-provider.sh
     - bash -c /tmp/replace-k8s-binaries.sh
@@ -364,31 +350,13 @@ spec:
           set -o nounset
           set -o pipefail
           set -o errexit
-          [[ $(id -u) != 0 ]] && SUDO="sudo" || SUDO=""
-
-          # This test installs release packages or binaries that are a result of the CI and release builds.
-          # It runs '... --version' commands to verify that the binaries are correctly installed
-          # and finally uninstalls the packages.
-          # For the release packages it tests all versions in the support skew.
-          LINE_SEPARATOR="*************************************************"
-          echo "$${LINE_SEPARATOR}"
-          CI_VERSION=${CI_VERSION}
-
-          CI_DIR=/tmp/k8s-ci
-          mkdir -p "$${CI_DIR}"
 
           systemctl stop kubelet
-          declare -a PACKAGES_TO_TEST=("kubectl" "kubelet" "kubeadm")
-          # Let's just also download the control plane images for worker nodes. It's easier then optimizing it.
-          declare -a CONTAINERS_TO_TEST=("kube-apiserver" "kube-controller-manager" "kube-proxy" "kube-scheduler")
-          CONTAINER_EXT="tar"
-          echo "* testing version $${CI_VERSION}"
+          declare -a BINARIES=("kubeadm" "kubectl" "kubelet")
           az login --identity
-          for CI_PACKAGE in "$${PACKAGES_TO_TEST[@]}"; do
-              echo "* downloading binary: https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${CI_PACKAGE}"
-              az storage blob download --blob-url "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${CI_PACKAGE}" -f "$${CI_DIR}/$${CI_PACKAGE}" --auth-mode login
-              chmod +x "$${CI_DIR}/$${CI_PACKAGE}"
-              mv "$${CI_DIR}/$${CI_PACKAGE}" "/usr/bin/$${CI_PACKAGE}"
+          for BINARY in "$${BINARIES[@]}"; do
+            echo "* installing package: $${BINARY} ${KUBE_GIT_VERSION}"
+            az storage blob download --blob-url "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${BINARY}" -f "/usr/bin/$${BINARY}" --auth-mode login
           done
 
           systemctl restart kubelet
@@ -403,12 +371,9 @@ spec:
               $${SUDO} ctr -n k8s.io images tag "${REGISTRY}/$${CI_CONTAINER}:${KUBE_IMAGE_TAG}" "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}:$${CI_VERSION//+/_}"
               $${SUDO} ctr -n k8s.io images tag "${REGISTRY}/$${CI_CONTAINER}:${KUBE_IMAGE_TAG}" "gcr.io/k8s-staging-ci-images/$${CI_CONTAINER}:$${CI_VERSION//+/_}"
           done
-          echo "* checking binary versions"
-          echo "ctr version: " "$(ctr version)"
-          echo "kubeadm version: " "$(kubeadm version -o=short)"
-          echo "kubectl version: " "$(kubectl version --client=true)"
-          echo "kubelet version: " "$(kubelet --version)"
-          echo "$${LINE_SEPARATOR}"
+          echo "kubeadm version: $(kubeadm version -o=short)"
+          echo "kubectl version: $(kubectl version --client=true)"
+          echo "kubelet version: $(kubelet --version)"
         owner: root:root
         path: /tmp/replace-k8s-binaries.sh
         permissions: "0744"
@@ -953,31 +918,13 @@ spec:
           set -o nounset
           set -o pipefail
           set -o errexit
-          [[ $(id -u) != 0 ]] && SUDO="sudo" || SUDO=""
-
-          # This test installs release packages or binaries that are a result of the CI and release builds.
-          # It runs '... --version' commands to verify that the binaries are correctly installed
-          # and finally uninstalls the packages.
-          # For the release packages it tests all versions in the support skew.
-          LINE_SEPARATOR="*************************************************"
-          echo "$${LINE_SEPARATOR}"
-          CI_VERSION=${CI_VERSION}
-
-          CI_DIR=/tmp/k8s-ci
-          mkdir -p "$${CI_DIR}"
 
           systemctl stop kubelet
-          declare -a PACKAGES_TO_TEST=("kubectl" "kubelet" "kubeadm")
-          # Let's just also download the control plane images for worker nodes. It's easier then optimizing it.
-          declare -a CONTAINERS_TO_TEST=("kube-apiserver" "kube-controller-manager" "kube-proxy" "kube-scheduler")
-          CONTAINER_EXT="tar"
-          echo "* testing version $${CI_VERSION}"
+          declare -a BINARIES=("kubeadm" "kubectl" "kubelet")
           az login --identity
-          for CI_PACKAGE in "$${PACKAGES_TO_TEST[@]}"; do
-              echo "* downloading binary: https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${CI_PACKAGE}"
-              az storage blob download --blob-url "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${CI_PACKAGE}" -f "$${CI_DIR}/$${CI_PACKAGE}" --auth-mode login
-              chmod +x "$${CI_DIR}/$${CI_PACKAGE}"
-              mv "$${CI_DIR}/$${CI_PACKAGE}" "/usr/bin/$${CI_PACKAGE}"
+          for BINARY in "$${BINARIES[@]}"; do
+            echo "* installing package: $${BINARY} ${KUBE_GIT_VERSION}"
+            az storage blob download --blob-url "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${BINARY}" -f "/usr/bin/$${BINARY}" --auth-mode login
           done
 
           systemctl restart kubelet
@@ -992,12 +939,9 @@ spec:
               $${SUDO} ctr -n k8s.io images tag "${REGISTRY}/$${CI_CONTAINER}:${KUBE_IMAGE_TAG}" "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}:$${CI_VERSION//+/_}"
               $${SUDO} ctr -n k8s.io images tag "${REGISTRY}/$${CI_CONTAINER}:${KUBE_IMAGE_TAG}" "gcr.io/k8s-staging-ci-images/$${CI_CONTAINER}:$${CI_VERSION//+/_}"
           done
-          echo "* checking binary versions"
-          echo "ctr version: " "$(ctr version)"
-          echo "kubeadm version: " "$(kubeadm version -o=short)"
-          echo "kubectl version: " "$(kubectl version --client=true)"
-          echo "kubelet version: " "$(kubelet --version)"
-          echo "$${LINE_SEPARATOR}"
+          echo "kubeadm version: $(kubeadm version -o=short)"
+          echo "kubectl version: $(kubectl version --client=true)"
+          echo "kubelet version: $(kubelet --version)"
         owner: root:root
         path: /tmp/replace-k8s-binaries.sh
         permissions: "0744"

--- a/templates/test/dev/cluster-template-custom-builds-machine-pool-load-dra.yaml
+++ b/templates/test/dev/cluster-template-custom-builds-machine-pool-load-dra.yaml
@@ -107,53 +107,59 @@ spec:
         set -o nounset
         set -o pipefail
         set -o errexit
-        [[ $(id -u) != 0 ]] && SUDO="sudo" || SUDO=""
-
-        # This test installs release packages or binaries that are a result of the CI and release builds.
-        # It runs '... --version' commands to verify that the binaries are correctly installed
-        # and finally uninstalls the packages.
-        # For the release packages it tests all versions in the support skew.
-        LINE_SEPARATOR="*************************************************"
-        echo "$${LINE_SEPARATOR}"
-        CI_VERSION=${CI_VERSION}
-
-        CI_DIR=/tmp/k8s-ci
-        mkdir -p "$${CI_DIR}"
 
         systemctl stop kubelet
-        declare -a PACKAGES_TO_TEST=("kubectl" "kubelet" "kubeadm")
-        # Let's just also download the control plane images for worker nodes. It's easier then optimizing it.
-        declare -a CONTAINERS_TO_TEST=("kube-apiserver" "kube-controller-manager" "kube-proxy" "kube-scheduler")
-        CONTAINER_EXT="tar"
-        echo "* testing version $${CI_VERSION}"
-        az login --identity
-        for CI_PACKAGE in "$${PACKAGES_TO_TEST[@]}"; do
-            echo "* downloading binary: https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${CI_PACKAGE}"
-            az storage blob download --blob-url "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${CI_PACKAGE}" -f "$${CI_DIR}/$${CI_PACKAGE}" --auth-mode login
-            chmod +x "$${CI_DIR}/$${CI_PACKAGE}"
-            mv "$${CI_DIR}/$${CI_PACKAGE}" "/usr/bin/$${CI_PACKAGE}"
-        done
-
-        systemctl restart kubelet
-        IMAGE_REGISTRY_PREFIX=registry.k8s.io
-        # Kubernetes builds from 1.20 through 1.24 are tagged with k8s.gcr.io
-        if [[ "$${CI_VERSION}" =~ ^v1\.(1[0-9]|2[0-4])[\.[0-9]+ ]]; then
-            IMAGE_REGISTRY_PREFIX=k8s.gcr.io
+        declare -a BINARIES=("kubeadm" "kubectl" "kubelet")
+        # Run the az login command with managed identity
+        if az login --identity > /dev/null 2>&1; then
+          echo "Logged in Azure with managed identity"
+          for BINARY in "$${BINARIES[@]}"; do
+            echo "* installing package: $${BINARY} ${KUBE_GIT_VERSION}"
+            az storage blob download --blob-url "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${BINARY}" -f "/usr/bin/$${BINARY}" --auth-mode login
+          done
+        else
+          echo "Using curl to download the binaries"
+          for BINARY in "$${BINARIES[@]}"; do
+            echo "* installing package: $${BINARY} ${KUBE_GIT_VERSION}"
+            curl --retry 10 --retry-delay 5 -w "response status code is %{http_code}" "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${BINARY}" --output "/usr/bin/$${BINARY}"
+          done
         fi
-        for CI_CONTAINER in "$${CONTAINERS_TO_TEST[@]}"; do
-            echo "* downloading container image: ${REGISTRY}/kube-apiserver:${KUBE_IMAGE_TAG}"
-            $${SUDO} ctr -n k8s.io images pull "${REGISTRY}/$${CI_CONTAINER}:${KUBE_IMAGE_TAG}"
-            $${SUDO} ctr -n k8s.io images tag "${REGISTRY}/$${CI_CONTAINER}:${KUBE_IMAGE_TAG}" "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}:$${CI_VERSION//+/_}"
-            $${SUDO} ctr -n k8s.io images tag "${REGISTRY}/$${CI_CONTAINER}:${KUBE_IMAGE_TAG}" "gcr.io/k8s-staging-ci-images/$${CI_CONTAINER}:$${CI_VERSION//+/_}"
+        systemctl restart kubelet
+        # prepull images from gcr.io/k8s-staging-ci-images and retag it to
+        # registry.k8s.io so kubeadm can fetch correct images no matter what
+        declare -a IMAGES=("kube-apiserver" "kube-controller-manager" "kube-proxy" "kube-scheduler")
+        [[ $(id -u) != 0 ]] && SUDO="sudo" || SUDO=""
+        IMAGE_REGISTRY_PREFIX=registry.k8s.io
+        for IMAGE in "$${IMAGES[@]}"; do
+          $${SUDO} ctr -n k8s.io images tag $$IMAGE_REGISTRY_PREFIX/$$IMAGE-amd64:"${CI_VERSION//+/_}" $$IMAGE_REGISTRY_PREFIX/$$IMAGE:"${CI_VERSION//+/_}"
+          $${SUDO} ctr -n k8s.io images tag $$IMAGE_REGISTRY_PREFIX/$$IMAGE-amd64:"${CI_VERSION//+/_}" gcr.io/k8s-staging-ci-images/$$IMAGE:"${CI_VERSION//+/_}"
         done
-        echo "* checking binary versions"
-        echo "ctr version: " "$(ctr version)"
-        echo "kubeadm version: " "$(kubeadm version -o=short)"
-        echo "kubectl version: " "$(kubectl version --client=true)"
-        echo "kubelet version: " "$(kubelet --version)"
-        echo "$${LINE_SEPARATOR}"
+        echo "kubeadm version: $(kubeadm version -o=short)"
+        echo "kubectl version: $(kubectl version --client=true)"
+        echo "kubelet version: $(kubelet --version)"
       owner: root:root
       path: /tmp/replace-k8s-binaries.sh
+      permissions: "0744"
+    - content: |
+        #!/bin/bash
+
+        set -o nounset
+        set -o pipefail
+        set -o errexit
+
+        curl -L --retry 10 --retry-delay 5 https://github.com/mikefarah/yq/releases/download/v4.6.1/yq_linux_amd64.tar.gz --output /tmp/yq_linux_amd64.tar.gz
+        tar -xzvf /tmp/yq_linux_amd64.tar.gz -C /tmp && mv /tmp/yq_linux_amd64 /usr/bin/yq
+        rm /tmp/yq_linux_amd64.tar.gz
+
+        export KUBECONFIG=/etc/kubernetes/admin.conf
+        kubectl -n kube-system set image daemonset/kube-proxy kube-proxy="${REGISTRY}/kube-proxy:${KUBE_IMAGE_TAG}"
+        systemctl stop kubelet
+        yq e '.spec.containers[0].image = "${REGISTRY}/kube-apiserver:${KUBE_IMAGE_TAG}"' -i /etc/kubernetes/manifests/kube-apiserver.yaml
+        yq e '.spec.containers[0].image = "${REGISTRY}/kube-controller-manager:${KUBE_IMAGE_TAG}"' -i /etc/kubernetes/manifests/kube-controller-manager.yaml
+        yq e '.spec.containers[0].image = "${REGISTRY}/kube-scheduler:${KUBE_IMAGE_TAG}"' -i /etc/kubernetes/manifests/kube-scheduler.yaml
+        systemctl restart kubelet
+      owner: root:root
+      path: /tmp/replace-k8s-components.sh
       permissions: "0744"
     - contentFrom:
         secret:
@@ -218,7 +224,8 @@ spec:
     mounts:
     - - LABEL=etcd_disk
       - /var/lib/etcddisk
-    postKubeadmCommands: []
+    postKubeadmCommands:
+    - bash -c /tmp/replace-k8s-components.sh
     preKubeadmCommands:
     - bash -c /tmp/containerd-config.sh
     - bash -c /tmp/replace-k8s-binaries.sh
@@ -708,31 +715,13 @@ spec:
           set -o nounset
           set -o pipefail
           set -o errexit
-          [[ $(id -u) != 0 ]] && SUDO="sudo" || SUDO=""
-
-          # This test installs release packages or binaries that are a result of the CI and release builds.
-          # It runs '... --version' commands to verify that the binaries are correctly installed
-          # and finally uninstalls the packages.
-          # For the release packages it tests all versions in the support skew.
-          LINE_SEPARATOR="*************************************************"
-          echo "$${LINE_SEPARATOR}"
-          CI_VERSION=${CI_VERSION}
-
-          CI_DIR=/tmp/k8s-ci
-          mkdir -p "$${CI_DIR}"
 
           systemctl stop kubelet
-          declare -a PACKAGES_TO_TEST=("kubectl" "kubelet" "kubeadm")
-          # Let's just also download the control plane images for worker nodes. It's easier then optimizing it.
-          declare -a CONTAINERS_TO_TEST=("kube-apiserver" "kube-controller-manager" "kube-proxy" "kube-scheduler")
-          CONTAINER_EXT="tar"
-          echo "* testing version $${CI_VERSION}"
+          declare -a BINARIES=("kubeadm" "kubectl" "kubelet")
           az login --identity
-          for CI_PACKAGE in "$${PACKAGES_TO_TEST[@]}"; do
-              echo "* downloading binary: https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${CI_PACKAGE}"
-              az storage blob download --blob-url "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${CI_PACKAGE}" -f "$${CI_DIR}/$${CI_PACKAGE}" --auth-mode login
-              chmod +x "$${CI_DIR}/$${CI_PACKAGE}"
-              mv "$${CI_DIR}/$${CI_PACKAGE}" "/usr/bin/$${CI_PACKAGE}"
+          for BINARY in "$${BINARIES[@]}"; do
+            echo "* installing package: $${BINARY} ${KUBE_GIT_VERSION}"
+            az storage blob download --blob-url "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${BINARY}" -f "/usr/bin/$${BINARY}" --auth-mode login
           done
 
           systemctl restart kubelet
@@ -747,12 +736,9 @@ spec:
               $${SUDO} ctr -n k8s.io images tag "${REGISTRY}/$${CI_CONTAINER}:${KUBE_IMAGE_TAG}" "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}:$${CI_VERSION//+/_}"
               $${SUDO} ctr -n k8s.io images tag "${REGISTRY}/$${CI_CONTAINER}:${KUBE_IMAGE_TAG}" "gcr.io/k8s-staging-ci-images/$${CI_CONTAINER}:$${CI_VERSION//+/_}"
           done
-          echo "* checking binary versions"
-          echo "ctr version: " "$(ctr version)"
-          echo "kubeadm version: " "$(kubeadm version -o=short)"
-          echo "kubectl version: " "$(kubectl version --client=true)"
-          echo "kubelet version: " "$(kubelet --version)"
-          echo "$${LINE_SEPARATOR}"
+          echo "kubeadm version: $(kubeadm version -o=short)"
+          echo "kubectl version: $(kubectl version --client=true)"
+          echo "kubelet version: $(kubelet --version)"
         owner: root:root
         path: /tmp/replace-k8s-binaries.sh
         permissions: "0744"

--- a/templates/test/dev/cluster-template-custom-builds-machine-pool-load.yaml
+++ b/templates/test/dev/cluster-template-custom-builds-machine-pool-load.yaml
@@ -101,53 +101,59 @@ spec:
         set -o nounset
         set -o pipefail
         set -o errexit
-        [[ $(id -u) != 0 ]] && SUDO="sudo" || SUDO=""
-
-        # This test installs release packages or binaries that are a result of the CI and release builds.
-        # It runs '... --version' commands to verify that the binaries are correctly installed
-        # and finally uninstalls the packages.
-        # For the release packages it tests all versions in the support skew.
-        LINE_SEPARATOR="*************************************************"
-        echo "$${LINE_SEPARATOR}"
-        CI_VERSION=${CI_VERSION}
-
-        CI_DIR=/tmp/k8s-ci
-        mkdir -p "$${CI_DIR}"
 
         systemctl stop kubelet
-        declare -a PACKAGES_TO_TEST=("kubectl" "kubelet" "kubeadm")
-        # Let's just also download the control plane images for worker nodes. It's easier then optimizing it.
-        declare -a CONTAINERS_TO_TEST=("kube-apiserver" "kube-controller-manager" "kube-proxy" "kube-scheduler")
-        CONTAINER_EXT="tar"
-        echo "* testing version $${CI_VERSION}"
-        az login --identity
-        for CI_PACKAGE in "$${PACKAGES_TO_TEST[@]}"; do
-            echo "* downloading binary: https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${CI_PACKAGE}"
-            az storage blob download --blob-url "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${CI_PACKAGE}" -f "$${CI_DIR}/$${CI_PACKAGE}" --auth-mode login
-            chmod +x "$${CI_DIR}/$${CI_PACKAGE}"
-            mv "$${CI_DIR}/$${CI_PACKAGE}" "/usr/bin/$${CI_PACKAGE}"
-        done
-
-        systemctl restart kubelet
-        IMAGE_REGISTRY_PREFIX=registry.k8s.io
-        # Kubernetes builds from 1.20 through 1.24 are tagged with k8s.gcr.io
-        if [[ "$${CI_VERSION}" =~ ^v1\.(1[0-9]|2[0-4])[\.[0-9]+ ]]; then
-            IMAGE_REGISTRY_PREFIX=k8s.gcr.io
+        declare -a BINARIES=("kubeadm" "kubectl" "kubelet")
+        # Run the az login command with managed identity
+        if az login --identity > /dev/null 2>&1; then
+          echo "Logged in Azure with managed identity"
+          for BINARY in "$${BINARIES[@]}"; do
+            echo "* installing package: $${BINARY} ${KUBE_GIT_VERSION}"
+            az storage blob download --blob-url "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${BINARY}" -f "/usr/bin/$${BINARY}" --auth-mode login
+          done
+        else
+          echo "Using curl to download the binaries"
+          for BINARY in "$${BINARIES[@]}"; do
+            echo "* installing package: $${BINARY} ${KUBE_GIT_VERSION}"
+            curl --retry 10 --retry-delay 5 -w "response status code is %{http_code}" "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${BINARY}" --output "/usr/bin/$${BINARY}"
+          done
         fi
-        for CI_CONTAINER in "$${CONTAINERS_TO_TEST[@]}"; do
-            echo "* downloading container image: ${REGISTRY}/kube-apiserver:${KUBE_IMAGE_TAG}"
-            $${SUDO} ctr -n k8s.io images pull "${REGISTRY}/$${CI_CONTAINER}:${KUBE_IMAGE_TAG}"
-            $${SUDO} ctr -n k8s.io images tag "${REGISTRY}/$${CI_CONTAINER}:${KUBE_IMAGE_TAG}" "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}:$${CI_VERSION//+/_}"
-            $${SUDO} ctr -n k8s.io images tag "${REGISTRY}/$${CI_CONTAINER}:${KUBE_IMAGE_TAG}" "gcr.io/k8s-staging-ci-images/$${CI_CONTAINER}:$${CI_VERSION//+/_}"
+        systemctl restart kubelet
+        # prepull images from gcr.io/k8s-staging-ci-images and retag it to
+        # registry.k8s.io so kubeadm can fetch correct images no matter what
+        declare -a IMAGES=("kube-apiserver" "kube-controller-manager" "kube-proxy" "kube-scheduler")
+        [[ $(id -u) != 0 ]] && SUDO="sudo" || SUDO=""
+        IMAGE_REGISTRY_PREFIX=registry.k8s.io
+        for IMAGE in "$${IMAGES[@]}"; do
+          $${SUDO} ctr -n k8s.io images tag $$IMAGE_REGISTRY_PREFIX/$$IMAGE-amd64:"${CI_VERSION//+/_}" $$IMAGE_REGISTRY_PREFIX/$$IMAGE:"${CI_VERSION//+/_}"
+          $${SUDO} ctr -n k8s.io images tag $$IMAGE_REGISTRY_PREFIX/$$IMAGE-amd64:"${CI_VERSION//+/_}" gcr.io/k8s-staging-ci-images/$$IMAGE:"${CI_VERSION//+/_}"
         done
-        echo "* checking binary versions"
-        echo "ctr version: " "$(ctr version)"
-        echo "kubeadm version: " "$(kubeadm version -o=short)"
-        echo "kubectl version: " "$(kubectl version --client=true)"
-        echo "kubelet version: " "$(kubelet --version)"
-        echo "$${LINE_SEPARATOR}"
+        echo "kubeadm version: $(kubeadm version -o=short)"
+        echo "kubectl version: $(kubectl version --client=true)"
+        echo "kubelet version: $(kubelet --version)"
       owner: root:root
       path: /tmp/replace-k8s-binaries.sh
+      permissions: "0744"
+    - content: |
+        #!/bin/bash
+
+        set -o nounset
+        set -o pipefail
+        set -o errexit
+
+        curl -L --retry 10 --retry-delay 5 https://github.com/mikefarah/yq/releases/download/v4.6.1/yq_linux_amd64.tar.gz --output /tmp/yq_linux_amd64.tar.gz
+        tar -xzvf /tmp/yq_linux_amd64.tar.gz -C /tmp && mv /tmp/yq_linux_amd64 /usr/bin/yq
+        rm /tmp/yq_linux_amd64.tar.gz
+
+        export KUBECONFIG=/etc/kubernetes/admin.conf
+        kubectl -n kube-system set image daemonset/kube-proxy kube-proxy="${REGISTRY}/kube-proxy:${KUBE_IMAGE_TAG}"
+        systemctl stop kubelet
+        yq e '.spec.containers[0].image = "${REGISTRY}/kube-apiserver:${KUBE_IMAGE_TAG}"' -i /etc/kubernetes/manifests/kube-apiserver.yaml
+        yq e '.spec.containers[0].image = "${REGISTRY}/kube-controller-manager:${KUBE_IMAGE_TAG}"' -i /etc/kubernetes/manifests/kube-controller-manager.yaml
+        yq e '.spec.containers[0].image = "${REGISTRY}/kube-scheduler:${KUBE_IMAGE_TAG}"' -i /etc/kubernetes/manifests/kube-scheduler.yaml
+        systemctl restart kubelet
+      owner: root:root
+      path: /tmp/replace-k8s-components.sh
       permissions: "0744"
     - contentFrom:
         secret:
@@ -201,7 +207,8 @@ spec:
     mounts:
     - - LABEL=etcd_disk
       - /var/lib/etcddisk
-    postKubeadmCommands: []
+    postKubeadmCommands:
+    - bash -c /tmp/replace-k8s-components.sh
     preKubeadmCommands:
     - bash -c /tmp/replace-k8s-binaries.sh
     - bash -c /tmp/oot-cred-provider.sh
@@ -679,31 +686,13 @@ spec:
           set -o nounset
           set -o pipefail
           set -o errexit
-          [[ $(id -u) != 0 ]] && SUDO="sudo" || SUDO=""
-
-          # This test installs release packages or binaries that are a result of the CI and release builds.
-          # It runs '... --version' commands to verify that the binaries are correctly installed
-          # and finally uninstalls the packages.
-          # For the release packages it tests all versions in the support skew.
-          LINE_SEPARATOR="*************************************************"
-          echo "$${LINE_SEPARATOR}"
-          CI_VERSION=${CI_VERSION}
-
-          CI_DIR=/tmp/k8s-ci
-          mkdir -p "$${CI_DIR}"
 
           systemctl stop kubelet
-          declare -a PACKAGES_TO_TEST=("kubectl" "kubelet" "kubeadm")
-          # Let's just also download the control plane images for worker nodes. It's easier then optimizing it.
-          declare -a CONTAINERS_TO_TEST=("kube-apiserver" "kube-controller-manager" "kube-proxy" "kube-scheduler")
-          CONTAINER_EXT="tar"
-          echo "* testing version $${CI_VERSION}"
+          declare -a BINARIES=("kubeadm" "kubectl" "kubelet")
           az login --identity
-          for CI_PACKAGE in "$${PACKAGES_TO_TEST[@]}"; do
-              echo "* downloading binary: https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${CI_PACKAGE}"
-              az storage blob download --blob-url "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${CI_PACKAGE}" -f "$${CI_DIR}/$${CI_PACKAGE}" --auth-mode login
-              chmod +x "$${CI_DIR}/$${CI_PACKAGE}"
-              mv "$${CI_DIR}/$${CI_PACKAGE}" "/usr/bin/$${CI_PACKAGE}"
+          for BINARY in "$${BINARIES[@]}"; do
+            echo "* installing package: $${BINARY} ${KUBE_GIT_VERSION}"
+            az storage blob download --blob-url "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${BINARY}" -f "/usr/bin/$${BINARY}" --auth-mode login
           done
 
           systemctl restart kubelet
@@ -718,12 +707,9 @@ spec:
               $${SUDO} ctr -n k8s.io images tag "${REGISTRY}/$${CI_CONTAINER}:${KUBE_IMAGE_TAG}" "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}:$${CI_VERSION//+/_}"
               $${SUDO} ctr -n k8s.io images tag "${REGISTRY}/$${CI_CONTAINER}:${KUBE_IMAGE_TAG}" "gcr.io/k8s-staging-ci-images/$${CI_CONTAINER}:$${CI_VERSION//+/_}"
           done
-          echo "* checking binary versions"
-          echo "ctr version: " "$(ctr version)"
-          echo "kubeadm version: " "$(kubeadm version -o=short)"
-          echo "kubectl version: " "$(kubectl version --client=true)"
-          echo "kubelet version: " "$(kubelet --version)"
-          echo "$${LINE_SEPARATOR}"
+          echo "kubeadm version: $(kubeadm version -o=short)"
+          echo "kubectl version: $(kubectl version --client=true)"
+          echo "kubelet version: $(kubelet --version)"
         owner: root:root
         path: /tmp/replace-k8s-binaries.sh
         permissions: "0744"

--- a/templates/test/dev/cluster-template-custom-builds-machine-pool-windows.yaml
+++ b/templates/test/dev/cluster-template-custom-builds-machine-pool-windows.yaml
@@ -99,53 +99,59 @@ spec:
         set -o nounset
         set -o pipefail
         set -o errexit
-        [[ $(id -u) != 0 ]] && SUDO="sudo" || SUDO=""
-
-        # This test installs release packages or binaries that are a result of the CI and release builds.
-        # It runs '... --version' commands to verify that the binaries are correctly installed
-        # and finally uninstalls the packages.
-        # For the release packages it tests all versions in the support skew.
-        LINE_SEPARATOR="*************************************************"
-        echo "$${LINE_SEPARATOR}"
-        CI_VERSION=${CI_VERSION}
-
-        CI_DIR=/tmp/k8s-ci
-        mkdir -p "$${CI_DIR}"
 
         systemctl stop kubelet
-        declare -a PACKAGES_TO_TEST=("kubectl" "kubelet" "kubeadm")
-        # Let's just also download the control plane images for worker nodes. It's easier then optimizing it.
-        declare -a CONTAINERS_TO_TEST=("kube-apiserver" "kube-controller-manager" "kube-proxy" "kube-scheduler")
-        CONTAINER_EXT="tar"
-        echo "* testing version $${CI_VERSION}"
-        az login --identity
-        for CI_PACKAGE in "$${PACKAGES_TO_TEST[@]}"; do
-            echo "* downloading binary: https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${CI_PACKAGE}"
-            az storage blob download --blob-url "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${CI_PACKAGE}" -f "$${CI_DIR}/$${CI_PACKAGE}" --auth-mode login
-            chmod +x "$${CI_DIR}/$${CI_PACKAGE}"
-            mv "$${CI_DIR}/$${CI_PACKAGE}" "/usr/bin/$${CI_PACKAGE}"
-        done
-
-        systemctl restart kubelet
-        IMAGE_REGISTRY_PREFIX=registry.k8s.io
-        # Kubernetes builds from 1.20 through 1.24 are tagged with k8s.gcr.io
-        if [[ "$${CI_VERSION}" =~ ^v1\.(1[0-9]|2[0-4])[\.[0-9]+ ]]; then
-            IMAGE_REGISTRY_PREFIX=k8s.gcr.io
+        declare -a BINARIES=("kubeadm" "kubectl" "kubelet")
+        # Run the az login command with managed identity
+        if az login --identity > /dev/null 2>&1; then
+          echo "Logged in Azure with managed identity"
+          for BINARY in "$${BINARIES[@]}"; do
+            echo "* installing package: $${BINARY} ${KUBE_GIT_VERSION}"
+            az storage blob download --blob-url "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${BINARY}" -f "/usr/bin/$${BINARY}" --auth-mode login
+          done
+        else
+          echo "Using curl to download the binaries"
+          for BINARY in "$${BINARIES[@]}"; do
+            echo "* installing package: $${BINARY} ${KUBE_GIT_VERSION}"
+            curl --retry 10 --retry-delay 5 -w "response status code is %{http_code}" "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${BINARY}" --output "/usr/bin/$${BINARY}"
+          done
         fi
-        for CI_CONTAINER in "$${CONTAINERS_TO_TEST[@]}"; do
-            echo "* downloading container image: ${REGISTRY}/kube-apiserver:${KUBE_IMAGE_TAG}"
-            $${SUDO} ctr -n k8s.io images pull "${REGISTRY}/$${CI_CONTAINER}:${KUBE_IMAGE_TAG}"
-            $${SUDO} ctr -n k8s.io images tag "${REGISTRY}/$${CI_CONTAINER}:${KUBE_IMAGE_TAG}" "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}:$${CI_VERSION//+/_}"
-            $${SUDO} ctr -n k8s.io images tag "${REGISTRY}/$${CI_CONTAINER}:${KUBE_IMAGE_TAG}" "gcr.io/k8s-staging-ci-images/$${CI_CONTAINER}:$${CI_VERSION//+/_}"
+        systemctl restart kubelet
+        # prepull images from gcr.io/k8s-staging-ci-images and retag it to
+        # registry.k8s.io so kubeadm can fetch correct images no matter what
+        declare -a IMAGES=("kube-apiserver" "kube-controller-manager" "kube-proxy" "kube-scheduler")
+        [[ $(id -u) != 0 ]] && SUDO="sudo" || SUDO=""
+        IMAGE_REGISTRY_PREFIX=registry.k8s.io
+        for IMAGE in "$${IMAGES[@]}"; do
+          $${SUDO} ctr -n k8s.io images tag $$IMAGE_REGISTRY_PREFIX/$$IMAGE-amd64:"${CI_VERSION//+/_}" $$IMAGE_REGISTRY_PREFIX/$$IMAGE:"${CI_VERSION//+/_}"
+          $${SUDO} ctr -n k8s.io images tag $$IMAGE_REGISTRY_PREFIX/$$IMAGE-amd64:"${CI_VERSION//+/_}" gcr.io/k8s-staging-ci-images/$$IMAGE:"${CI_VERSION//+/_}"
         done
-        echo "* checking binary versions"
-        echo "ctr version: " "$(ctr version)"
-        echo "kubeadm version: " "$(kubeadm version -o=short)"
-        echo "kubectl version: " "$(kubectl version --client=true)"
-        echo "kubelet version: " "$(kubelet --version)"
-        echo "$${LINE_SEPARATOR}"
+        echo "kubeadm version: $(kubeadm version -o=short)"
+        echo "kubectl version: $(kubectl version --client=true)"
+        echo "kubelet version: $(kubelet --version)"
       owner: root:root
       path: /tmp/replace-k8s-binaries.sh
+      permissions: "0744"
+    - content: |
+        #!/bin/bash
+
+        set -o nounset
+        set -o pipefail
+        set -o errexit
+
+        curl -L --retry 10 --retry-delay 5 https://github.com/mikefarah/yq/releases/download/v4.6.1/yq_linux_amd64.tar.gz --output /tmp/yq_linux_amd64.tar.gz
+        tar -xzvf /tmp/yq_linux_amd64.tar.gz -C /tmp && mv /tmp/yq_linux_amd64 /usr/bin/yq
+        rm /tmp/yq_linux_amd64.tar.gz
+
+        export KUBECONFIG=/etc/kubernetes/admin.conf
+        kubectl -n kube-system set image daemonset/kube-proxy kube-proxy="${REGISTRY}/kube-proxy:${KUBE_IMAGE_TAG}"
+        systemctl stop kubelet
+        yq e '.spec.containers[0].image = "${REGISTRY}/kube-apiserver:${KUBE_IMAGE_TAG}"' -i /etc/kubernetes/manifests/kube-apiserver.yaml
+        yq e '.spec.containers[0].image = "${REGISTRY}/kube-controller-manager:${KUBE_IMAGE_TAG}"' -i /etc/kubernetes/manifests/kube-controller-manager.yaml
+        yq e '.spec.containers[0].image = "${REGISTRY}/kube-scheduler:${KUBE_IMAGE_TAG}"' -i /etc/kubernetes/manifests/kube-scheduler.yaml
+        systemctl restart kubelet
+      owner: root:root
+      path: /tmp/replace-k8s-components.sh
       permissions: "0744"
     - contentFrom:
         secret:
@@ -199,7 +205,8 @@ spec:
     mounts:
     - - LABEL=etcd_disk
       - /var/lib/etcddisk
-    postKubeadmCommands: []
+    postKubeadmCommands:
+    - bash -c /tmp/replace-k8s-components.sh
     preKubeadmCommands:
     - bash -c /tmp/replace-k8s-binaries.sh
     - bash -c /tmp/oot-cred-provider.sh

--- a/templates/test/dev/cluster-template-custom-builds-machine-pool.yaml
+++ b/templates/test/dev/cluster-template-custom-builds-machine-pool.yaml
@@ -95,53 +95,59 @@ spec:
         set -o nounset
         set -o pipefail
         set -o errexit
-        [[ $(id -u) != 0 ]] && SUDO="sudo" || SUDO=""
-
-        # This test installs release packages or binaries that are a result of the CI and release builds.
-        # It runs '... --version' commands to verify that the binaries are correctly installed
-        # and finally uninstalls the packages.
-        # For the release packages it tests all versions in the support skew.
-        LINE_SEPARATOR="*************************************************"
-        echo "$${LINE_SEPARATOR}"
-        CI_VERSION=${CI_VERSION}
-
-        CI_DIR=/tmp/k8s-ci
-        mkdir -p "$${CI_DIR}"
 
         systemctl stop kubelet
-        declare -a PACKAGES_TO_TEST=("kubectl" "kubelet" "kubeadm")
-        # Let's just also download the control plane images for worker nodes. It's easier then optimizing it.
-        declare -a CONTAINERS_TO_TEST=("kube-apiserver" "kube-controller-manager" "kube-proxy" "kube-scheduler")
-        CONTAINER_EXT="tar"
-        echo "* testing version $${CI_VERSION}"
-        az login --identity
-        for CI_PACKAGE in "$${PACKAGES_TO_TEST[@]}"; do
-            echo "* downloading binary: https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${CI_PACKAGE}"
-            az storage blob download --blob-url "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${CI_PACKAGE}" -f "$${CI_DIR}/$${CI_PACKAGE}" --auth-mode login
-            chmod +x "$${CI_DIR}/$${CI_PACKAGE}"
-            mv "$${CI_DIR}/$${CI_PACKAGE}" "/usr/bin/$${CI_PACKAGE}"
-        done
-
-        systemctl restart kubelet
-        IMAGE_REGISTRY_PREFIX=registry.k8s.io
-        # Kubernetes builds from 1.20 through 1.24 are tagged with k8s.gcr.io
-        if [[ "$${CI_VERSION}" =~ ^v1\.(1[0-9]|2[0-4])[\.[0-9]+ ]]; then
-            IMAGE_REGISTRY_PREFIX=k8s.gcr.io
+        declare -a BINARIES=("kubeadm" "kubectl" "kubelet")
+        # Run the az login command with managed identity
+        if az login --identity > /dev/null 2>&1; then
+          echo "Logged in Azure with managed identity"
+          for BINARY in "$${BINARIES[@]}"; do
+            echo "* installing package: $${BINARY} ${KUBE_GIT_VERSION}"
+            az storage blob download --blob-url "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${BINARY}" -f "/usr/bin/$${BINARY}" --auth-mode login
+          done
+        else
+          echo "Using curl to download the binaries"
+          for BINARY in "$${BINARIES[@]}"; do
+            echo "* installing package: $${BINARY} ${KUBE_GIT_VERSION}"
+            curl --retry 10 --retry-delay 5 -w "response status code is %{http_code}" "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${BINARY}" --output "/usr/bin/$${BINARY}"
+          done
         fi
-        for CI_CONTAINER in "$${CONTAINERS_TO_TEST[@]}"; do
-            echo "* downloading container image: ${REGISTRY}/kube-apiserver:${KUBE_IMAGE_TAG}"
-            $${SUDO} ctr -n k8s.io images pull "${REGISTRY}/$${CI_CONTAINER}:${KUBE_IMAGE_TAG}"
-            $${SUDO} ctr -n k8s.io images tag "${REGISTRY}/$${CI_CONTAINER}:${KUBE_IMAGE_TAG}" "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}:$${CI_VERSION//+/_}"
-            $${SUDO} ctr -n k8s.io images tag "${REGISTRY}/$${CI_CONTAINER}:${KUBE_IMAGE_TAG}" "gcr.io/k8s-staging-ci-images/$${CI_CONTAINER}:$${CI_VERSION//+/_}"
+        systemctl restart kubelet
+        # prepull images from gcr.io/k8s-staging-ci-images and retag it to
+        # registry.k8s.io so kubeadm can fetch correct images no matter what
+        declare -a IMAGES=("kube-apiserver" "kube-controller-manager" "kube-proxy" "kube-scheduler")
+        [[ $(id -u) != 0 ]] && SUDO="sudo" || SUDO=""
+        IMAGE_REGISTRY_PREFIX=registry.k8s.io
+        for IMAGE in "$${IMAGES[@]}"; do
+          $${SUDO} ctr -n k8s.io images tag $$IMAGE_REGISTRY_PREFIX/$$IMAGE-amd64:"${CI_VERSION//+/_}" $$IMAGE_REGISTRY_PREFIX/$$IMAGE:"${CI_VERSION//+/_}"
+          $${SUDO} ctr -n k8s.io images tag $$IMAGE_REGISTRY_PREFIX/$$IMAGE-amd64:"${CI_VERSION//+/_}" gcr.io/k8s-staging-ci-images/$$IMAGE:"${CI_VERSION//+/_}"
         done
-        echo "* checking binary versions"
-        echo "ctr version: " "$(ctr version)"
-        echo "kubeadm version: " "$(kubeadm version -o=short)"
-        echo "kubectl version: " "$(kubectl version --client=true)"
-        echo "kubelet version: " "$(kubelet --version)"
-        echo "$${LINE_SEPARATOR}"
+        echo "kubeadm version: $(kubeadm version -o=short)"
+        echo "kubectl version: $(kubectl version --client=true)"
+        echo "kubelet version: $(kubelet --version)"
       owner: root:root
       path: /tmp/replace-k8s-binaries.sh
+      permissions: "0744"
+    - content: |
+        #!/bin/bash
+
+        set -o nounset
+        set -o pipefail
+        set -o errexit
+
+        curl -L --retry 10 --retry-delay 5 https://github.com/mikefarah/yq/releases/download/v4.6.1/yq_linux_amd64.tar.gz --output /tmp/yq_linux_amd64.tar.gz
+        tar -xzvf /tmp/yq_linux_amd64.tar.gz -C /tmp && mv /tmp/yq_linux_amd64 /usr/bin/yq
+        rm /tmp/yq_linux_amd64.tar.gz
+
+        export KUBECONFIG=/etc/kubernetes/admin.conf
+        kubectl -n kube-system set image daemonset/kube-proxy kube-proxy="${REGISTRY}/kube-proxy:${KUBE_IMAGE_TAG}"
+        systemctl stop kubelet
+        yq e '.spec.containers[0].image = "${REGISTRY}/kube-apiserver:${KUBE_IMAGE_TAG}"' -i /etc/kubernetes/manifests/kube-apiserver.yaml
+        yq e '.spec.containers[0].image = "${REGISTRY}/kube-controller-manager:${KUBE_IMAGE_TAG}"' -i /etc/kubernetes/manifests/kube-controller-manager.yaml
+        yq e '.spec.containers[0].image = "${REGISTRY}/kube-scheduler:${KUBE_IMAGE_TAG}"' -i /etc/kubernetes/manifests/kube-scheduler.yaml
+        systemctl restart kubelet
+      owner: root:root
+      path: /tmp/replace-k8s-components.sh
       permissions: "0744"
     - contentFrom:
         secret:
@@ -195,7 +201,8 @@ spec:
     mounts:
     - - LABEL=etcd_disk
       - /var/lib/etcddisk
-    postKubeadmCommands: []
+    postKubeadmCommands:
+    - bash -c /tmp/replace-k8s-components.sh
     preKubeadmCommands:
     - bash -c /tmp/replace-k8s-binaries.sh
     - bash -c /tmp/oot-cred-provider.sh

--- a/templates/test/dev/cluster-template-custom-builds-windows.yaml
+++ b/templates/test/dev/cluster-template-custom-builds-windows.yaml
@@ -135,53 +135,50 @@ spec:
         set -o nounset
         set -o pipefail
         set -o errexit
-        [[ $(id -u) != 0 ]] && SUDO="sudo" || SUDO=""
-
-        # This test installs release packages or binaries that are a result of the CI and release builds.
-        # It runs '... --version' commands to verify that the binaries are correctly installed
-        # and finally uninstalls the packages.
-        # For the release packages it tests all versions in the support skew.
-        LINE_SEPARATOR="*************************************************"
-        echo "$${LINE_SEPARATOR}"
-        CI_VERSION=${CI_VERSION}
-
-        CI_DIR=/tmp/k8s-ci
-        mkdir -p "$${CI_DIR}"
 
         systemctl stop kubelet
-        declare -a PACKAGES_TO_TEST=("kubectl" "kubelet" "kubeadm")
-        # Let's just also download the control plane images for worker nodes. It's easier then optimizing it.
-        declare -a CONTAINERS_TO_TEST=("kube-apiserver" "kube-controller-manager" "kube-proxy" "kube-scheduler")
-        CONTAINER_EXT="tar"
-        echo "* testing version $${CI_VERSION}"
+        declare -a BINARIES=("kubeadm" "kubectl" "kubelet")
         az login --identity
-        for CI_PACKAGE in "$${PACKAGES_TO_TEST[@]}"; do
-            echo "* downloading binary: https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${CI_PACKAGE}"
-            az storage blob download --blob-url "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${CI_PACKAGE}" -f "$${CI_DIR}/$${CI_PACKAGE}" --auth-mode login
-            chmod +x "$${CI_DIR}/$${CI_PACKAGE}"
-            mv "$${CI_DIR}/$${CI_PACKAGE}" "/usr/bin/$${CI_PACKAGE}"
+        for BINARY in "$${BINARIES[@]}"; do
+          echo "* installing package: $${BINARY} ${KUBE_GIT_VERSION}"
+          az storage blob download --blob-url "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${BINARY}" -f "/usr/bin/$${BINARY}" --auth-mode login
+        done
+        systemctl restart kubelet
+
+        # prepull images from gcr.io/k8s-staging-ci-images and retag it to
+        # registry.k8s.io so kubeadm can fetch correct images no matter what
+        declare -a IMAGES=("kube-apiserver" "kube-controller-manager" "kube-proxy" "kube-scheduler")
+        [[ $(id -u) != 0 ]] && SUDO="sudo" || SUDO=""
+        IMAGE_REGISTRY_PREFIX=registry.k8s.io
+        for IMAGE in "$${IMAGES[@]}"; do
+          $${SUDO} ctr -n k8s.io images tag $$IMAGE_REGISTRY_PREFIX/$$IMAGE-amd64:"${CI_VERSION//+/_}" $$IMAGE_REGISTRY_PREFIX/$$IMAGE:"${CI_VERSION//+/_}"
+          $${SUDO} ctr -n k8s.io images tag $$IMAGE_REGISTRY_PREFIX/$$IMAGE-amd64:"${CI_VERSION//+/_}" gcr.io/k8s-staging-ci-images/$$IMAGE:"${CI_VERSION//+/_}"
         done
 
-        systemctl restart kubelet
-        IMAGE_REGISTRY_PREFIX=registry.k8s.io
-        # Kubernetes builds from 1.20 through 1.24 are tagged with k8s.gcr.io
-        if [[ "$${CI_VERSION}" =~ ^v1\.(1[0-9]|2[0-4])[\.[0-9]+ ]]; then
-            IMAGE_REGISTRY_PREFIX=k8s.gcr.io
-        fi
-        for CI_CONTAINER in "$${CONTAINERS_TO_TEST[@]}"; do
-            echo "* downloading container image: ${REGISTRY}/kube-apiserver:${KUBE_IMAGE_TAG}"
-            $${SUDO} ctr -n k8s.io images pull "${REGISTRY}/$${CI_CONTAINER}:${KUBE_IMAGE_TAG}"
-            $${SUDO} ctr -n k8s.io images tag "${REGISTRY}/$${CI_CONTAINER}:${KUBE_IMAGE_TAG}" "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}:$${CI_VERSION//+/_}"
-            $${SUDO} ctr -n k8s.io images tag "${REGISTRY}/$${CI_CONTAINER}:${KUBE_IMAGE_TAG}" "gcr.io/k8s-staging-ci-images/$${CI_CONTAINER}:$${CI_VERSION//+/_}"
-        done
-        echo "* checking binary versions"
-        echo "ctr version: " "$(ctr version)"
-        echo "kubeadm version: " "$(kubeadm version -o=short)"
-        echo "kubectl version: " "$(kubectl version --client=true)"
-        echo "kubelet version: " "$(kubelet --version)"
-        echo "$${LINE_SEPARATOR}"
+        echo "kubeadm version: $(kubeadm version -o=short)"
+        echo "kubectl version: $(kubectl version --client=true)"
+        echo "kubelet version: $(kubelet --version)"
       owner: root:root
       path: /tmp/replace-k8s-binaries.sh
+      permissions: "0744"
+    - content: |
+        #!/bin/bash
+        set -o nounset
+        set -o pipefail
+        set -o errexit
+        curl -L --retry 10 --retry-delay 5 https://github.com/mikefarah/yq/releases/download/v4.6.1/yq_linux_amd64.tar.gz --output /tmp/yq_linux_amd64.tar.gz
+        tar -xzvf /tmp/yq_linux_amd64.tar.gz -C /tmp && mv /tmp/yq_linux_amd64 /usr/bin/yq
+        rm /tmp/yq_linux_amd64.tar.gz
+
+        export KUBECONFIG=/etc/kubernetes/admin.conf
+        kubectl -n kube-system set image daemonset/kube-proxy kube-proxy="${REGISTRY}/kube-proxy:${KUBE_IMAGE_TAG}"
+        systemctl stop kubelet
+        yq e '.spec.containers[0].image = "${REGISTRY}/kube-apiserver:${KUBE_IMAGE_TAG}"' -i /etc/kubernetes/manifests/kube-apiserver.yaml
+        yq e '.spec.containers[0].image = "${REGISTRY}/kube-controller-manager:${KUBE_IMAGE_TAG}"' -i /etc/kubernetes/manifests/kube-controller-manager.yaml
+        yq e '.spec.containers[0].image = "${REGISTRY}/kube-scheduler:${KUBE_IMAGE_TAG}"' -i /etc/kubernetes/manifests/kube-scheduler.yaml
+        systemctl restart kubelet
+      owner: root:root
+      path: /tmp/replace-k8s-components.sh
       permissions: "0744"
     initConfiguration:
       nodeRegistration:
@@ -200,7 +197,8 @@ spec:
     mounts:
     - - LABEL=etcd_disk
       - /var/lib/etcddisk
-    postKubeadmCommands: []
+    postKubeadmCommands:
+    - bash -c /tmp/replace-k8s-components.sh
     preKubeadmCommands:
     - bash -c /tmp/oot-cred-provider.sh
     - bash -c /tmp/replace-k8s-binaries.sh
@@ -350,41 +348,20 @@ spec:
           set -o nounset
           set -o pipefail
           set -o errexit
-          [[ $(id -u) != 0 ]] && SUDO="sudo" || SUDO=""
-
-          # This test installs release packages or binaries that are a result of the CI and release builds.
-          # It runs '... --version' commands to verify that the binaries are correctly installed
-          # and finally uninstalls the packages.
-          # For the release packages it tests all versions in the support skew.
-          LINE_SEPARATOR="*************************************************"
-          echo "$${LINE_SEPARATOR}"
-          CI_VERSION=${CI_VERSION}
-
-          CI_DIR=/tmp/k8s-ci
-          mkdir -p "$${CI_DIR}"
 
           systemctl stop kubelet
-          declare -a PACKAGES_TO_TEST=("kubectl" "kubelet" "kubeadm")
-          # Let's just also download the control plane images for worker nodes. It's easier then optimizing it.
-          declare -a CONTAINERS_TO_TEST=("kube-apiserver" "kube-controller-manager" "kube-proxy" "kube-scheduler")
-          CONTAINER_EXT="tar"
-          echo "* testing version $${CI_VERSION}"
+          declare -a BINARIES=("kubeadm" "kubectl" "kubelet")
           az login --identity
-          for CI_PACKAGE in "$${PACKAGES_TO_TEST[@]}"; do
-              echo "* downloading binary: https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${CI_PACKAGE}"
-              az storage blob download --blob-url "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${CI_PACKAGE}" -f "$${CI_DIR}/$${CI_PACKAGE}" --auth-mode login
-              chmod +x "$${CI_DIR}/$${CI_PACKAGE}"
-              mv "$${CI_DIR}/$${CI_PACKAGE}" "/usr/bin/$${CI_PACKAGE}"
+          for BINARY in "$${BINARIES[@]}"; do
+            echo "* installing package: $${BINARY} ${KUBE_GIT_VERSION}"
+            az storage blob download --blob-url "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${BINARY}" -f "/usr/bin/$${BINARY}" --auth-mode login
           done
 
           systemctl restart kubelet
 
-          echo "* checking binary versions"
-          echo "ctr version: " "$(ctr version)"
-          echo "kubeadm version: " "$(kubeadm version -o=short)"
-          echo "kubectl version: " "$(kubectl version --client=true)"
-          echo "kubelet version: " "$(kubelet --version)"
-          echo "$${LINE_SEPARATOR}"
+          echo "kubeadm version: $(kubeadm version -o=short)"
+          echo "kubectl version: $(kubectl version --client=true)"
+          echo "kubelet version: $(kubelet --version)"
         owner: root:root
         path: /tmp/replace-k8s-binaries.sh
         permissions: "0744"

--- a/templates/test/dev/cluster-template-custom-builds.yaml
+++ b/templates/test/dev/cluster-template-custom-builds.yaml
@@ -133,63 +133,48 @@ spec:
         set -o errexit
         [[ $(id -u) != 0 ]] && SUDO="sudo" || SUDO=""
 
-        # This test installs release packages or binaries that are a result of the CI and release builds.
-        # It runs '... --version' commands to verify that the binaries are correctly installed
-        # and finally uninstalls the packages.
-        # For the release packages it tests all versions in the support skew.
-        LINE_SEPARATOR="*************************************************"
-        echo "$${LINE_SEPARATOR}"
-        CI_VERSION=${CI_VERSION}
+        systemctl stop kubelet
+        declare -a BINARIES=("kubeadm" "kubectl" "kubelet")
+        az login --identity
+        for BINARY in "$${BINARIES[@]}"; do
+          echo "* installing package: $${BINARY} ${KUBE_GIT_VERSION}"
+          az storage blob download --blob-url "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${BINARY}" -f "/usr/bin/$${BINARY}" --auth-mode login
+        done
+        systemctl restart kubelet
 
-        # Note: We assume if kubectl has the right version, everything else has as well
-        if [[ $(kubectl version --client=true -o json | jq '.clientVersion.gitVersion' -r) = "$${CI_VERSION}" ]]; then
-            echo "Detected Kubernetes $${CI_VERSION} via kubectl version, nothing to do"
-            exit 0
-        fi
-        if [[ "$${CI_VERSION}" != "" ]]; then
-            CI_DIR=/tmp/k8s-ci
-            mkdir -p "$${CI_DIR}"
-            declare -a PACKAGES_TO_TEST=("kubectl" "kubelet" "kubeadm")
-            # Let's just also download the control plane images for worker nodes. It's easier then optimizing it.
-            declare -a CONTAINERS_TO_TEST=("kube-apiserver" "kube-controller-manager" "kube-proxy" "kube-scheduler")
-            CONTAINER_EXT="tar"
-            echo "* testing version $${CI_VERSION}"
-            CI_URL="https://dl.k8s.io/ci/$${CI_VERSION}/bin/linux/amd64"
-            # Set CI_URL to the released binaries for actually released versions.
-            if [[ "$${CI_VERSION}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || [[ "$${CI_VERSION}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+-(beta|rc).[0-9]+$ ]]; then
-                CI_URL="https://dl.k8s.io/release/$${CI_VERSION}/bin/linux/amd64"
-            fi
-            for CI_PACKAGE in "$${PACKAGES_TO_TEST[@]}"; do
-                # Browser: https://console.cloud.google.com/storage/browser/k8s-release-dev?project=k8s-release-dev
-                # e.g.: https://storage.googleapis.com/k8s-release-dev/ci/v1.21.0-beta.1.378+cf3374e43491c5/bin/linux/amd64/kubectl
-                echo "* downloading binary: $${CI_URL}/$${CI_PACKAGE}"
-                wget --inet4-only "$${CI_URL}/$${CI_PACKAGE}" -O "$${CI_DIR}/$${CI_PACKAGE}"
-                chmod +x "$${CI_DIR}/$${CI_PACKAGE}"
-                mv "$${CI_DIR}/$${CI_PACKAGE}" "/usr/bin/$${CI_PACKAGE}"
-            done
+        # prepull images from gcr.io/k8s-staging-ci-images and retag it to
+        # registry.k8s.io so kubeadm can fetch correct images no matter what
+        declare -a IMAGES=("kube-apiserver" "kube-controller-manager" "kube-proxy" "kube-scheduler")
+        [[ $(id -u) != 0 ]] && SUDO="sudo" || SUDO=""
+        IMAGE_REGISTRY_PREFIX=registry.k8s.io
+        for IMAGE in "$${IMAGES[@]}"; do
+          $${SUDO} ctr -n k8s.io images tag $$IMAGE_REGISTRY_PREFIX/$$IMAGE-amd64:"${CI_VERSION//+/_}" $$IMAGE_REGISTRY_PREFIX/$$IMAGE:"${CI_VERSION//+/_}"
+          $${SUDO} ctr -n k8s.io images tag $$IMAGE_REGISTRY_PREFIX/$$IMAGE-amd64:"${CI_VERSION//+/_}" gcr.io/k8s-staging-ci-images/$$IMAGE:"${CI_VERSION//+/_}"
+        done
 
-            systemctl restart kubelet
-            IMAGE_REGISTRY_PREFIX=registry.k8s.io
-            # Kubernetes builds from 1.20 through 1.24 are tagged with k8s.gcr.io
-            if [[ "$${CI_VERSION}" =~ ^v1\.(1[0-9]|2[0-4])[\.[0-9]+ ]]; then
-                IMAGE_REGISTRY_PREFIX=k8s.gcr.io
-            fi
-            for CI_CONTAINER in "$${CONTAINERS_TO_TEST[@]}"; do
-                echo "* downloading package: $${CI_URL}/$${CI_CONTAINER}.$${CONTAINER_EXT}"
-                wget --inet4-only "$${CI_URL}/$${CI_CONTAINER}.$${CONTAINER_EXT}" -O "$${CI_DIR}/$${CI_CONTAINER}.$${CONTAINER_EXT}"
-                $${SUDO} ctr -n k8s.io images import "$${CI_DIR}/$${CI_CONTAINER}.$${CONTAINER_EXT}" || echo "* ignoring expected 'ctr images import' result"
-                $${SUDO} ctr -n k8s.io images tag "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}-amd64:$${CI_VERSION//+/_}" "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}:$${CI_VERSION//+/_}"
-                $${SUDO} ctr -n k8s.io images tag "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}-amd64:$${CI_VERSION//+/_}" "gcr.io/k8s-staging-ci-images/$${CI_CONTAINER}:$${CI_VERSION//+/_}"
-            done
-        fi
-        echo "* checking binary versions"
-        echo "ctr version: " "$(ctr version)"
-        echo "kubeadm version: " "$(kubeadm version -o=short)"
-        echo "kubectl version: " "$(kubectl version --client=true)"
-        echo "kubelet version: " "$(kubelet --version)"
-        echo "$${LINE_SEPARATOR}"
+        echo "kubeadm version: $(kubeadm version -o=short)"
+        echo "kubectl version: $(kubectl version --client=true)"
+        echo "kubelet version: $(kubelet --version)"
       owner: root:root
       path: /tmp/replace-k8s-binaries.sh
+      permissions: "0744"
+    - content: |
+        #!/bin/bash
+        set -o nounset
+        set -o pipefail
+        set -o errexit
+        curl -L --retry 10 --retry-delay 5 https://github.com/mikefarah/yq/releases/download/v4.6.1/yq_linux_amd64.tar.gz --output /tmp/yq_linux_amd64.tar.gz
+        tar -xzvf /tmp/yq_linux_amd64.tar.gz -C /tmp && mv /tmp/yq_linux_amd64 /usr/bin/yq
+        rm /tmp/yq_linux_amd64.tar.gz
+        export KUBECONFIG=/etc/kubernetes/admin.conf
+        kubectl -n kube-system set image daemonset/kube-proxy kube-proxy="${REGISTRY}/kube-proxy:${KUBE_IMAGE_TAG}"
+        systemctl stop kubelet
+        yq e '.spec.containers[0].image = "${REGISTRY}/kube-apiserver:${KUBE_IMAGE_TAG}"' -i /etc/kubernetes/manifests/kube-apiserver.yaml
+        yq e '.spec.containers[0].image = "${REGISTRY}/kube-controller-manager:${KUBE_IMAGE_TAG}"' -i /etc/kubernetes/manifests/kube-controller-manager.yaml
+        yq e '.spec.containers[0].image = "${REGISTRY}/kube-scheduler:${KUBE_IMAGE_TAG}"' -i /etc/kubernetes/manifests/kube-scheduler.yaml
+        systemctl restart kubelet
+      owner: root:root
+      path: /tmp/replace-k8s-components.sh
       permissions: "0744"
     initConfiguration:
       nodeRegistration:
@@ -208,7 +193,8 @@ spec:
     mounts:
     - - LABEL=etcd_disk
       - /var/lib/etcddisk
-    postKubeadmCommands: []
+    postKubeadmCommands:
+    - bash -c /tmp/replace-k8s-components.sh
     preKubeadmCommands:
     - bash -c /tmp/oot-cred-provider.sh
     - bash -c /tmp/replace-k8s-binaries.sh
@@ -358,31 +344,13 @@ spec:
           set -o nounset
           set -o pipefail
           set -o errexit
-          [[ $(id -u) != 0 ]] && SUDO="sudo" || SUDO=""
-
-          # This test installs release packages or binaries that are a result of the CI and release builds.
-          # It runs '... --version' commands to verify that the binaries are correctly installed
-          # and finally uninstalls the packages.
-          # For the release packages it tests all versions in the support skew.
-          LINE_SEPARATOR="*************************************************"
-          echo "$${LINE_SEPARATOR}"
-          CI_VERSION=${CI_VERSION}
-
-          CI_DIR=/tmp/k8s-ci
-          mkdir -p "$${CI_DIR}"
 
           systemctl stop kubelet
-          declare -a PACKAGES_TO_TEST=("kubectl" "kubelet" "kubeadm")
-          # Let's just also download the control plane images for worker nodes. It's easier then optimizing it.
-          declare -a CONTAINERS_TO_TEST=("kube-apiserver" "kube-controller-manager" "kube-proxy" "kube-scheduler")
-          CONTAINER_EXT="tar"
-          echo "* testing version $${CI_VERSION}"
+          declare -a BINARIES=("kubeadm" "kubectl" "kubelet")
           az login --identity
-          for CI_PACKAGE in "$${PACKAGES_TO_TEST[@]}"; do
-              echo "* downloading binary: https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${CI_PACKAGE}"
-              az storage blob download --blob-url "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${CI_PACKAGE}" -f "$${CI_DIR}/$${CI_PACKAGE}" --auth-mode login
-              chmod +x "$${CI_DIR}/$${CI_PACKAGE}"
-              mv "$${CI_DIR}/$${CI_PACKAGE}" "/usr/bin/$${CI_PACKAGE}"
+          for BINARY in "$${BINARIES[@]}"; do
+            echo "* installing package: $${BINARY} ${KUBE_GIT_VERSION}"
+            az storage blob download --blob-url "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${BINARY}" -f "/usr/bin/$${BINARY}" --auth-mode login
           done
 
           systemctl restart kubelet
@@ -397,12 +365,9 @@ spec:
               $${SUDO} ctr -n k8s.io images tag "${REGISTRY}/$${CI_CONTAINER}:${KUBE_IMAGE_TAG}" "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}:$${CI_VERSION//+/_}"
               $${SUDO} ctr -n k8s.io images tag "${REGISTRY}/$${CI_CONTAINER}:${KUBE_IMAGE_TAG}" "gcr.io/k8s-staging-ci-images/$${CI_CONTAINER}:$${CI_VERSION//+/_}"
           done
-          echo "* checking binary versions"
-          echo "ctr version: " "$(ctr version)"
-          echo "kubeadm version: " "$(kubeadm version -o=short)"
-          echo "kubectl version: " "$(kubectl version --client=true)"
-          echo "kubelet version: " "$(kubelet --version)"
-          echo "$${LINE_SEPARATOR}"
+          echo "kubeadm version: $(kubeadm version -o=short)"
+          echo "kubectl version: $(kubectl version --client=true)"
+          echo "kubelet version: $(kubelet --version)"
         owner: root:root
         path: /tmp/replace-k8s-binaries.sh
         permissions: "0744"

--- a/templates/test/dev/custom-builds-windows/patches/kubeadm-bootstrap.yaml
+++ b/templates/test/dev/custom-builds-windows/patches/kubeadm-bootstrap.yaml
@@ -7,41 +7,20 @@
       set -o nounset
       set -o pipefail
       set -o errexit
-      [[ $(id -u) != 0 ]] && SUDO="sudo" || SUDO=""
-
-      # This test installs release packages or binaries that are a result of the CI and release builds.
-      # It runs '... --version' commands to verify that the binaries are correctly installed
-      # and finally uninstalls the packages.
-      # For the release packages it tests all versions in the support skew.
-      LINE_SEPARATOR="*************************************************"
-      echo "$${LINE_SEPARATOR}"
-      CI_VERSION=${CI_VERSION}
-
-      CI_DIR=/tmp/k8s-ci
-      mkdir -p "$${CI_DIR}"
 
       systemctl stop kubelet
-      declare -a PACKAGES_TO_TEST=("kubectl" "kubelet" "kubeadm")
-      # Let's just also download the control plane images for worker nodes. It's easier then optimizing it.
-      declare -a CONTAINERS_TO_TEST=("kube-apiserver" "kube-controller-manager" "kube-proxy" "kube-scheduler")
-      CONTAINER_EXT="tar"
-      echo "* testing version $${CI_VERSION}"
+      declare -a BINARIES=("kubeadm" "kubectl" "kubelet")
       az login --identity
-      for CI_PACKAGE in "$${PACKAGES_TO_TEST[@]}"; do
-          echo "* downloading binary: https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${CI_PACKAGE}"
-          az storage blob download --blob-url "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${CI_PACKAGE}" -f "$${CI_DIR}/$${CI_PACKAGE}" --auth-mode login
-          chmod +x "$${CI_DIR}/$${CI_PACKAGE}"
-          mv "$${CI_DIR}/$${CI_PACKAGE}" "/usr/bin/$${CI_PACKAGE}"
+      for BINARY in "$${BINARIES[@]}"; do
+        echo "* installing package: $${BINARY} ${KUBE_GIT_VERSION}"
+        az storage blob download --blob-url "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${BINARY}" -f "/usr/bin/$${BINARY}" --auth-mode login
       done
 
       systemctl restart kubelet
 
-      echo "* checking binary versions"
-      echo "ctr version: " "$(ctr version)"
-      echo "kubeadm version: " "$(kubeadm version -o=short)"
-      echo "kubectl version: " "$(kubectl version --client=true)"
-      echo "kubelet version: " "$(kubelet --version)"
-      echo "$${LINE_SEPARATOR}"
+      echo "kubeadm version: $(kubeadm version -o=short)"
+      echo "kubectl version: $(kubectl version --client=true)"
+      echo "kubelet version: $(kubelet --version)"
     path: /tmp/replace-k8s-binaries.sh
     owner: "root:root"
     permissions: "0744"

--- a/templates/test/dev/custom-builds-windows/patches/kubeadm-controlplane-bootstrap.yaml
+++ b/templates/test/dev/custom-builds-windows/patches/kubeadm-controlplane-bootstrap.yaml
@@ -7,55 +7,59 @@
       set -o nounset
       set -o pipefail
       set -o errexit
-      [[ $(id -u) != 0 ]] && SUDO="sudo" || SUDO=""
-
-      # This test installs release packages or binaries that are a result of the CI and release builds.
-      # It runs '... --version' commands to verify that the binaries are correctly installed
-      # and finally uninstalls the packages.
-      # For the release packages it tests all versions in the support skew.
-      LINE_SEPARATOR="*************************************************"
-      echo "$${LINE_SEPARATOR}"
-      CI_VERSION=${CI_VERSION}
-
-      CI_DIR=/tmp/k8s-ci
-      mkdir -p "$${CI_DIR}"
 
       systemctl stop kubelet
-      declare -a PACKAGES_TO_TEST=("kubectl" "kubelet" "kubeadm")
-      # Let's just also download the control plane images for worker nodes. It's easier then optimizing it.
-      declare -a CONTAINERS_TO_TEST=("kube-apiserver" "kube-controller-manager" "kube-proxy" "kube-scheduler")
-      CONTAINER_EXT="tar"
-      echo "* testing version $${CI_VERSION}"
+      declare -a BINARIES=("kubeadm" "kubectl" "kubelet")
       az login --identity
-      for CI_PACKAGE in "$${PACKAGES_TO_TEST[@]}"; do
-          echo "* downloading binary: https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${CI_PACKAGE}"
-          az storage blob download --blob-url "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${CI_PACKAGE}" -f "$${CI_DIR}/$${CI_PACKAGE}" --auth-mode login
-          chmod +x "$${CI_DIR}/$${CI_PACKAGE}"
-          mv "$${CI_DIR}/$${CI_PACKAGE}" "/usr/bin/$${CI_PACKAGE}"
+      for BINARY in "$${BINARIES[@]}"; do
+        echo "* installing package: $${BINARY} ${KUBE_GIT_VERSION}"
+        az storage blob download --blob-url "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${BINARY}" -f "/usr/bin/$${BINARY}" --auth-mode login
+      done
+      systemctl restart kubelet
+
+      # prepull images from gcr.io/k8s-staging-ci-images and retag it to
+      # registry.k8s.io so kubeadm can fetch correct images no matter what
+      declare -a IMAGES=("kube-apiserver" "kube-controller-manager" "kube-proxy" "kube-scheduler")
+      [[ $(id -u) != 0 ]] && SUDO="sudo" || SUDO=""
+      IMAGE_REGISTRY_PREFIX=registry.k8s.io
+      for IMAGE in "$${IMAGES[@]}"; do
+        $${SUDO} ctr -n k8s.io images tag $$IMAGE_REGISTRY_PREFIX/$$IMAGE-amd64:"${CI_VERSION//+/_}" $$IMAGE_REGISTRY_PREFIX/$$IMAGE:"${CI_VERSION//+/_}"
+        $${SUDO} ctr -n k8s.io images tag $$IMAGE_REGISTRY_PREFIX/$$IMAGE-amd64:"${CI_VERSION//+/_}" gcr.io/k8s-staging-ci-images/$$IMAGE:"${CI_VERSION//+/_}"
       done
 
-      systemctl restart kubelet
-      IMAGE_REGISTRY_PREFIX=registry.k8s.io
-      # Kubernetes builds from 1.20 through 1.24 are tagged with k8s.gcr.io
-      if [[ "$${CI_VERSION}" =~ ^v1\.(1[0-9]|2[0-4])[\.[0-9]+ ]]; then
-          IMAGE_REGISTRY_PREFIX=k8s.gcr.io
-      fi
-      for CI_CONTAINER in "$${CONTAINERS_TO_TEST[@]}"; do
-          echo "* downloading container image: ${REGISTRY}/kube-apiserver:${KUBE_IMAGE_TAG}"
-          $${SUDO} ctr -n k8s.io images pull "${REGISTRY}/$${CI_CONTAINER}:${KUBE_IMAGE_TAG}"
-          $${SUDO} ctr -n k8s.io images tag "${REGISTRY}/$${CI_CONTAINER}:${KUBE_IMAGE_TAG}" "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}:$${CI_VERSION//+/_}"
-          $${SUDO} ctr -n k8s.io images tag "${REGISTRY}/$${CI_CONTAINER}:${KUBE_IMAGE_TAG}" "gcr.io/k8s-staging-ci-images/$${CI_CONTAINER}:$${CI_VERSION//+/_}"
-      done
-      echo "* checking binary versions"
-      echo "ctr version: " "$(ctr version)"
-      echo "kubeadm version: " "$(kubeadm version -o=short)"
-      echo "kubectl version: " "$(kubectl version --client=true)"
-      echo "kubelet version: " "$(kubelet --version)"
-      echo "$${LINE_SEPARATOR}"
+      echo "kubeadm version: $(kubeadm version -o=short)"
+      echo "kubectl version: $(kubectl version --client=true)"
+      echo "kubelet version: $(kubelet --version)"
     path: /tmp/replace-k8s-binaries.sh
+    owner: "root:root"
+    permissions: "0744"
+- op: add
+  path: /spec/kubeadmConfigSpec/files/-
+  value:
+    content: |
+      #!/bin/bash
+      set -o nounset
+      set -o pipefail
+      set -o errexit
+      curl -L --retry 10 --retry-delay 5 https://github.com/mikefarah/yq/releases/download/v4.6.1/yq_linux_amd64.tar.gz --output /tmp/yq_linux_amd64.tar.gz
+      tar -xzvf /tmp/yq_linux_amd64.tar.gz -C /tmp && mv /tmp/yq_linux_amd64 /usr/bin/yq
+      rm /tmp/yq_linux_amd64.tar.gz
+
+      export KUBECONFIG=/etc/kubernetes/admin.conf
+      kubectl -n kube-system set image daemonset/kube-proxy kube-proxy="${REGISTRY}/kube-proxy:${KUBE_IMAGE_TAG}"
+      systemctl stop kubelet
+      yq e '.spec.containers[0].image = "${REGISTRY}/kube-apiserver:${KUBE_IMAGE_TAG}"' -i /etc/kubernetes/manifests/kube-apiserver.yaml
+      yq e '.spec.containers[0].image = "${REGISTRY}/kube-controller-manager:${KUBE_IMAGE_TAG}"' -i /etc/kubernetes/manifests/kube-controller-manager.yaml
+      yq e '.spec.containers[0].image = "${REGISTRY}/kube-scheduler:${KUBE_IMAGE_TAG}"' -i /etc/kubernetes/manifests/kube-scheduler.yaml
+      systemctl restart kubelet
+    path: /tmp/replace-k8s-components.sh
     owner: "root:root"
     permissions: "0744"
 - op: add
   path: /spec/kubeadmConfigSpec/preKubeadmCommands/-
   value:
     bash -c /tmp/replace-k8s-binaries.sh
+- op: add
+  path: /spec/kubeadmConfigSpec/postKubeadmCommands/-
+  value:
+    bash -c /tmp/replace-k8s-components.sh

--- a/templates/test/dev/custom-builds/patches/kubeadm-bootstrap.yaml
+++ b/templates/test/dev/custom-builds/patches/kubeadm-bootstrap.yaml
@@ -7,31 +7,13 @@
       set -o nounset
       set -o pipefail
       set -o errexit
-      [[ $(id -u) != 0 ]] && SUDO="sudo" || SUDO=""
-
-      # This test installs release packages or binaries that are a result of the CI and release builds.
-      # It runs '... --version' commands to verify that the binaries are correctly installed
-      # and finally uninstalls the packages.
-      # For the release packages it tests all versions in the support skew.
-      LINE_SEPARATOR="*************************************************"
-      echo "$${LINE_SEPARATOR}"
-      CI_VERSION=${CI_VERSION}
-
-      CI_DIR=/tmp/k8s-ci
-      mkdir -p "$${CI_DIR}"
 
       systemctl stop kubelet
-      declare -a PACKAGES_TO_TEST=("kubectl" "kubelet" "kubeadm")
-      # Let's just also download the control plane images for worker nodes. It's easier then optimizing it.
-      declare -a CONTAINERS_TO_TEST=("kube-apiserver" "kube-controller-manager" "kube-proxy" "kube-scheduler")
-      CONTAINER_EXT="tar"
-      echo "* testing version $${CI_VERSION}"
+      declare -a BINARIES=("kubeadm" "kubectl" "kubelet")
       az login --identity
-      for CI_PACKAGE in "$${PACKAGES_TO_TEST[@]}"; do
-          echo "* downloading binary: https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${CI_PACKAGE}"
-          az storage blob download --blob-url "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${CI_PACKAGE}" -f "$${CI_DIR}/$${CI_PACKAGE}" --auth-mode login
-          chmod +x "$${CI_DIR}/$${CI_PACKAGE}"
-          mv "$${CI_DIR}/$${CI_PACKAGE}" "/usr/bin/$${CI_PACKAGE}"
+      for BINARY in "$${BINARIES[@]}"; do
+        echo "* installing package: $${BINARY} ${KUBE_GIT_VERSION}"
+        az storage blob download --blob-url "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${BINARY}" -f "/usr/bin/$${BINARY}" --auth-mode login
       done
 
       systemctl restart kubelet
@@ -46,12 +28,9 @@
           $${SUDO} ctr -n k8s.io images tag "${REGISTRY}/$${CI_CONTAINER}:${KUBE_IMAGE_TAG}" "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}:$${CI_VERSION//+/_}"
           $${SUDO} ctr -n k8s.io images tag "${REGISTRY}/$${CI_CONTAINER}:${KUBE_IMAGE_TAG}" "gcr.io/k8s-staging-ci-images/$${CI_CONTAINER}:$${CI_VERSION//+/_}"
       done
-      echo "* checking binary versions"
-      echo "ctr version: " "$(ctr version)"
-      echo "kubeadm version: " "$(kubeadm version -o=short)"
-      echo "kubectl version: " "$(kubectl version --client=true)"
-      echo "kubelet version: " "$(kubelet --version)"
-      echo "$${LINE_SEPARATOR}"
+      echo "kubeadm version: $(kubeadm version -o=short)"
+      echo "kubectl version: $(kubectl version --client=true)"
+      echo "kubelet version: $(kubelet --version)"
     path: /tmp/replace-k8s-binaries.sh
     owner: "root:root"
     permissions: "0744"

--- a/templates/test/dev/custom-builds/patches/kubeadm-controlplane-bootstrap.yaml
+++ b/templates/test/dev/custom-builds/patches/kubeadm-controlplane-bootstrap.yaml
@@ -9,65 +9,57 @@
       set -o errexit
       [[ $(id -u) != 0 ]] && SUDO="sudo" || SUDO=""
 
-      # This test installs release packages or binaries that are a result of the CI and release builds.
-      # It runs '... --version' commands to verify that the binaries are correctly installed
-      # and finally uninstalls the packages.
-      # For the release packages it tests all versions in the support skew.
-      LINE_SEPARATOR="*************************************************"
-      echo "$${LINE_SEPARATOR}"
-      CI_VERSION=${CI_VERSION}
+      systemctl stop kubelet
+      declare -a BINARIES=("kubeadm" "kubectl" "kubelet")
+      az login --identity
+      for BINARY in "$${BINARIES[@]}"; do
+        echo "* installing package: $${BINARY} ${KUBE_GIT_VERSION}"
+        az storage blob download --blob-url "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${BINARY}" -f "/usr/bin/$${BINARY}" --auth-mode login
+      done
+      systemctl restart kubelet
 
-      # Note: We assume if kubectl has the right version, everything else has as well
-      if [[ $(kubectl version --client=true -o json | jq '.clientVersion.gitVersion' -r) = "$${CI_VERSION}" ]]; then
-          echo "Detected Kubernetes $${CI_VERSION} via kubectl version, nothing to do"
-          exit 0
-      fi
-      if [[ "$${CI_VERSION}" != "" ]]; then
-          CI_DIR=/tmp/k8s-ci
-          mkdir -p "$${CI_DIR}"
-          declare -a PACKAGES_TO_TEST=("kubectl" "kubelet" "kubeadm")
-          # Let's just also download the control plane images for worker nodes. It's easier then optimizing it.
-          declare -a CONTAINERS_TO_TEST=("kube-apiserver" "kube-controller-manager" "kube-proxy" "kube-scheduler")
-          CONTAINER_EXT="tar"
-          echo "* testing version $${CI_VERSION}"
-          CI_URL="https://dl.k8s.io/ci/$${CI_VERSION}/bin/linux/amd64"
-          # Set CI_URL to the released binaries for actually released versions.
-          if [[ "$${CI_VERSION}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || [[ "$${CI_VERSION}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+-(beta|rc).[0-9]+$ ]]; then
-              CI_URL="https://dl.k8s.io/release/$${CI_VERSION}/bin/linux/amd64"
-          fi
-          for CI_PACKAGE in "$${PACKAGES_TO_TEST[@]}"; do
-              # Browser: https://console.cloud.google.com/storage/browser/k8s-release-dev?project=k8s-release-dev
-              # e.g.: https://storage.googleapis.com/k8s-release-dev/ci/v1.21.0-beta.1.378+cf3374e43491c5/bin/linux/amd64/kubectl
-              echo "* downloading binary: $${CI_URL}/$${CI_PACKAGE}"
-              wget --inet4-only "$${CI_URL}/$${CI_PACKAGE}" -O "$${CI_DIR}/$${CI_PACKAGE}"
-              chmod +x "$${CI_DIR}/$${CI_PACKAGE}"
-              mv "$${CI_DIR}/$${CI_PACKAGE}" "/usr/bin/$${CI_PACKAGE}"
-          done
+      # prepull images from gcr.io/k8s-staging-ci-images and retag it to
+      # registry.k8s.io so kubeadm can fetch correct images no matter what
+      declare -a IMAGES=("kube-apiserver" "kube-controller-manager" "kube-proxy" "kube-scheduler")
+      [[ $(id -u) != 0 ]] && SUDO="sudo" || SUDO=""
+      IMAGE_REGISTRY_PREFIX=registry.k8s.io
+      for IMAGE in "$${IMAGES[@]}"; do
+        $${SUDO} ctr -n k8s.io images tag $$IMAGE_REGISTRY_PREFIX/$$IMAGE-amd64:"${CI_VERSION//+/_}" $$IMAGE_REGISTRY_PREFIX/$$IMAGE:"${CI_VERSION//+/_}"
+        $${SUDO} ctr -n k8s.io images tag $$IMAGE_REGISTRY_PREFIX/$$IMAGE-amd64:"${CI_VERSION//+/_}" gcr.io/k8s-staging-ci-images/$$IMAGE:"${CI_VERSION//+/_}"
+      done
 
-          systemctl restart kubelet
-          IMAGE_REGISTRY_PREFIX=registry.k8s.io
-          # Kubernetes builds from 1.20 through 1.24 are tagged with k8s.gcr.io
-          if [[ "$${CI_VERSION}" =~ ^v1\.(1[0-9]|2[0-4])[\.[0-9]+ ]]; then
-              IMAGE_REGISTRY_PREFIX=k8s.gcr.io
-          fi
-          for CI_CONTAINER in "$${CONTAINERS_TO_TEST[@]}"; do
-              echo "* downloading package: $${CI_URL}/$${CI_CONTAINER}.$${CONTAINER_EXT}"
-              wget --inet4-only "$${CI_URL}/$${CI_CONTAINER}.$${CONTAINER_EXT}" -O "$${CI_DIR}/$${CI_CONTAINER}.$${CONTAINER_EXT}"
-              $${SUDO} ctr -n k8s.io images import "$${CI_DIR}/$${CI_CONTAINER}.$${CONTAINER_EXT}" || echo "* ignoring expected 'ctr images import' result"
-              $${SUDO} ctr -n k8s.io images tag "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}-amd64:$${CI_VERSION//+/_}" "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}:$${CI_VERSION//+/_}"
-              $${SUDO} ctr -n k8s.io images tag "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}-amd64:$${CI_VERSION//+/_}" "gcr.io/k8s-staging-ci-images/$${CI_CONTAINER}:$${CI_VERSION//+/_}"
-          done
-      fi
-      echo "* checking binary versions"
-      echo "ctr version: " "$(ctr version)"
-      echo "kubeadm version: " "$(kubeadm version -o=short)"
-      echo "kubectl version: " "$(kubectl version --client=true)"
-      echo "kubelet version: " "$(kubelet --version)"
-      echo "$${LINE_SEPARATOR}"
+      echo "kubeadm version: $(kubeadm version -o=short)"
+      echo "kubectl version: $(kubectl version --client=true)"
+      echo "kubelet version: $(kubelet --version)"
     path: /tmp/replace-k8s-binaries.sh
+    owner: "root:root"
+    permissions: "0744"
+- op: add
+  path: /spec/kubeadmConfigSpec/files/-
+  value:
+    content: |
+        #!/bin/bash
+        set -o nounset
+        set -o pipefail
+        set -o errexit
+        curl -L --retry 10 --retry-delay 5 https://github.com/mikefarah/yq/releases/download/v4.6.1/yq_linux_amd64.tar.gz --output /tmp/yq_linux_amd64.tar.gz
+        tar -xzvf /tmp/yq_linux_amd64.tar.gz -C /tmp && mv /tmp/yq_linux_amd64 /usr/bin/yq
+        rm /tmp/yq_linux_amd64.tar.gz
+        export KUBECONFIG=/etc/kubernetes/admin.conf
+        kubectl -n kube-system set image daemonset/kube-proxy kube-proxy="${REGISTRY}/kube-proxy:${KUBE_IMAGE_TAG}"
+        systemctl stop kubelet
+        yq e '.spec.containers[0].image = "${REGISTRY}/kube-apiserver:${KUBE_IMAGE_TAG}"' -i /etc/kubernetes/manifests/kube-apiserver.yaml
+        yq e '.spec.containers[0].image = "${REGISTRY}/kube-controller-manager:${KUBE_IMAGE_TAG}"' -i /etc/kubernetes/manifests/kube-controller-manager.yaml
+        yq e '.spec.containers[0].image = "${REGISTRY}/kube-scheduler:${KUBE_IMAGE_TAG}"' -i /etc/kubernetes/manifests/kube-scheduler.yaml
+        systemctl restart kubelet
+    path: /tmp/replace-k8s-components.sh
     owner: "root:root"
     permissions: "0744"
 - op: add
   path: /spec/kubeadmConfigSpec/preKubeadmCommands/-
   value:
     bash -c /tmp/replace-k8s-binaries.sh
+- op: add
+  path: /spec/kubeadmConfigSpec/postKubeadmCommands/-
+  value:
+    bash -c /tmp/replace-k8s-components.sh

--- a/templates/test/dev/patches/control-plane-custom-builds.yaml
+++ b/templates/test/dev/patches/control-plane-custom-builds.yaml
@@ -11,6 +11,8 @@ spec:
       kubernetesVersion: "ci/${CI_VERSION}"
     preKubeadmCommands:
     - bash -c /tmp/replace-k8s-binaries.sh
+    postKubeadmCommands:
+    - bash -c /tmp/replace-k8s-components.sh
     files:
     - path: /tmp/replace-k8s-binaries.sh
       owner: "root:root"
@@ -21,51 +23,57 @@ spec:
         set -o nounset
         set -o pipefail
         set -o errexit
-        [[ $(id -u) != 0 ]] && SUDO="sudo" || SUDO=""
-
-        # This test installs release packages or binaries that are a result of the CI and release builds.
-        # It runs '... --version' commands to verify that the binaries are correctly installed
-        # and finally uninstalls the packages.
-        # For the release packages it tests all versions in the support skew.
-        LINE_SEPARATOR="*************************************************"
-        echo "$${LINE_SEPARATOR}"
-        CI_VERSION=${CI_VERSION}
-
-        CI_DIR=/tmp/k8s-ci
-        mkdir -p "$${CI_DIR}"
 
         systemctl stop kubelet
-        declare -a PACKAGES_TO_TEST=("kubectl" "kubelet" "kubeadm")
-        # Let's just also download the control plane images for worker nodes. It's easier then optimizing it.
-        declare -a CONTAINERS_TO_TEST=("kube-apiserver" "kube-controller-manager" "kube-proxy" "kube-scheduler")
-        CONTAINER_EXT="tar"
-        echo "* testing version $${CI_VERSION}"
-        az login --identity
-        for CI_PACKAGE in "$${PACKAGES_TO_TEST[@]}"; do
-            echo "* downloading binary: https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${CI_PACKAGE}"
-            az storage blob download --blob-url "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${CI_PACKAGE}" -f "$${CI_DIR}/$${CI_PACKAGE}" --auth-mode login
-            chmod +x "$${CI_DIR}/$${CI_PACKAGE}"
-            mv "$${CI_DIR}/$${CI_PACKAGE}" "/usr/bin/$${CI_PACKAGE}"
-        done
-
-        systemctl restart kubelet
-        IMAGE_REGISTRY_PREFIX=registry.k8s.io
-        # Kubernetes builds from 1.20 through 1.24 are tagged with k8s.gcr.io
-        if [[ "$${CI_VERSION}" =~ ^v1\.(1[0-9]|2[0-4])[\.[0-9]+ ]]; then
-            IMAGE_REGISTRY_PREFIX=k8s.gcr.io
+        declare -a BINARIES=("kubeadm" "kubectl" "kubelet")
+        # Run the az login command with managed identity
+        if az login --identity > /dev/null 2>&1; then
+          echo "Logged in Azure with managed identity"
+          for BINARY in "$${BINARIES[@]}"; do
+            echo "* installing package: $${BINARY} ${KUBE_GIT_VERSION}"
+            az storage blob download --blob-url "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${BINARY}" -f "/usr/bin/$${BINARY}" --auth-mode login
+          done
+        else
+          echo "Using curl to download the binaries"
+          for BINARY in "$${BINARIES[@]}"; do
+            echo "* installing package: $${BINARY} ${KUBE_GIT_VERSION}"
+            curl --retry 10 --retry-delay 5 -w "response status code is %{http_code}" "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${BINARY}" --output "/usr/bin/$${BINARY}"
+          done
         fi
-        for CI_CONTAINER in "$${CONTAINERS_TO_TEST[@]}"; do
-            echo "* downloading container image: ${REGISTRY}/kube-apiserver:${KUBE_IMAGE_TAG}"
-            $${SUDO} ctr -n k8s.io images pull "${REGISTRY}/$${CI_CONTAINER}:${KUBE_IMAGE_TAG}"
-            $${SUDO} ctr -n k8s.io images tag "${REGISTRY}/$${CI_CONTAINER}:${KUBE_IMAGE_TAG}" "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}:$${CI_VERSION//+/_}"
-            $${SUDO} ctr -n k8s.io images tag "${REGISTRY}/$${CI_CONTAINER}:${KUBE_IMAGE_TAG}" "gcr.io/k8s-staging-ci-images/$${CI_CONTAINER}:$${CI_VERSION//+/_}"
+        systemctl restart kubelet
+        # prepull images from gcr.io/k8s-staging-ci-images and retag it to
+        # registry.k8s.io so kubeadm can fetch correct images no matter what
+        declare -a IMAGES=("kube-apiserver" "kube-controller-manager" "kube-proxy" "kube-scheduler")
+        [[ $(id -u) != 0 ]] && SUDO="sudo" || SUDO=""
+        IMAGE_REGISTRY_PREFIX=registry.k8s.io
+        for IMAGE in "$${IMAGES[@]}"; do
+          $${SUDO} ctr -n k8s.io images tag $$IMAGE_REGISTRY_PREFIX/$$IMAGE-amd64:"${CI_VERSION//+/_}" $$IMAGE_REGISTRY_PREFIX/$$IMAGE:"${CI_VERSION//+/_}"
+          $${SUDO} ctr -n k8s.io images tag $$IMAGE_REGISTRY_PREFIX/$$IMAGE-amd64:"${CI_VERSION//+/_}" gcr.io/k8s-staging-ci-images/$$IMAGE:"${CI_VERSION//+/_}"
         done
-        echo "* checking binary versions"
-        echo "ctr version: " "$(ctr version)"
-        echo "kubeadm version: " "$(kubeadm version -o=short)"
-        echo "kubectl version: " "$(kubectl version --client=true)"
-        echo "kubelet version: " "$(kubelet --version)"
-        echo "$${LINE_SEPARATOR}"
+        echo "kubeadm version: $(kubeadm version -o=short)"
+        echo "kubectl version: $(kubectl version --client=true)"
+        echo "kubelet version: $(kubelet --version)"
+    - path: /tmp/replace-k8s-components.sh
+      owner: "root:root"
+      permissions: "0744"
+      content: |
+        #!/bin/bash
+
+        set -o nounset
+        set -o pipefail
+        set -o errexit
+
+        curl -L --retry 10 --retry-delay 5 https://github.com/mikefarah/yq/releases/download/v4.6.1/yq_linux_amd64.tar.gz --output /tmp/yq_linux_amd64.tar.gz
+        tar -xzvf /tmp/yq_linux_amd64.tar.gz -C /tmp && mv /tmp/yq_linux_amd64 /usr/bin/yq
+        rm /tmp/yq_linux_amd64.tar.gz
+
+        export KUBECONFIG=/etc/kubernetes/admin.conf
+        kubectl -n kube-system set image daemonset/kube-proxy kube-proxy="${REGISTRY}/kube-proxy:${KUBE_IMAGE_TAG}"
+        systemctl stop kubelet
+        yq e '.spec.containers[0].image = "${REGISTRY}/kube-apiserver:${KUBE_IMAGE_TAG}"' -i /etc/kubernetes/manifests/kube-apiserver.yaml
+        yq e '.spec.containers[0].image = "${REGISTRY}/kube-controller-manager:${KUBE_IMAGE_TAG}"' -i /etc/kubernetes/manifests/kube-controller-manager.yaml
+        yq e '.spec.containers[0].image = "${REGISTRY}/kube-scheduler:${KUBE_IMAGE_TAG}"' -i /etc/kubernetes/manifests/kube-scheduler.yaml
+        systemctl restart kubelet
     - path: /etc/kubernetes/azure.json
       owner: "root:root"
       permissions: "0644"


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

/kind failing-test

**What this PR does / why we need it**:

This PR restores the original implementation of running custom builds of k/k components before https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/5979.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->


**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] cherry-pick candidate

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
