### PR TITLE
Bump CAPI to v1.11.5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -358,7 +358,7 @@ create-management-cluster: $(KUSTOMIZE) $(ENVSUBST) $(KUBECTL) $(KIND) ## Create
 	./hack/create-custom-cloud-provider-config.sh
 
 	# Deploy CAPI
-	timeout --foreground 300 bash -c "until curl --retry $(CURL_RETRIES) -sSL https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.11.4/cluster-api-components.yaml | $(ENVSUBST) | $(KUBECTL) apply -f -; do sleep 5; done"
+	timeout --foreground 300 bash -c "until curl --retry $(CURL_RETRIES) -sSL https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.11.5/cluster-api-components.yaml | $(ENVSUBST) | $(KUBECTL) apply -f -; do sleep 5; done"
 
 	# Deploy CAAPH
 	timeout --foreground 300 bash -c "until curl --retry $(CURL_RETRIES) -sSL https://github.com/kubernetes-sigs/cluster-api-addon-provider-helm/releases/download/v0.5.2/addon-components.yaml | $(ENVSUBST) | $(KUBECTL) apply -f -; do sleep 5; done"
@@ -387,7 +387,7 @@ create-management-cluster: $(KUSTOMIZE) $(ENVSUBST) $(KUBECTL) $(KIND) ## Create
 	# Wait for CAPZ deployments
 	$(KUBECTL) wait --for=condition=Available --timeout=5m -n capz-system deployment --all
 
-	# This is a temporary fix to apply https://github.com/kubernetes-sigs/cluster-api/pull/13177 which stops setting 
+	# This is a temporary fix to apply https://github.com/kubernetes-sigs/cluster-api/pull/13177 which stops setting
 	# ControlPlaneKubeletLocalMode for K8s v1.36+ clusters.
 	# Override kubeadm control plane controller image on the management cluster (temporary fix)
 	# Remove this when CAPI_VERSION above is update to v1.12.2 OR GREATER

--- a/Tiltfile
+++ b/Tiltfile
@@ -22,7 +22,7 @@ settings = {
     "deploy_cert_manager": True,
     "preload_images_for_kind": True,
     "kind_cluster_name": "capz",
-    "capi_version": "v1.11.4",
+    "capi_version": "v1.11.5",
     "caaph_version": "v0.5.2",
     "cert_manager_version": "v1.19.1",
     "kubernetes_version": "v1.33.6",

--- a/docs/book/src/developers/getting-started-with-capi-operator.md
+++ b/docs/book/src/developers/getting-started-with-capi-operator.md
@@ -120,7 +120,7 @@ helm install cert-manager jetstack/cert-manager --namespace cert-manager --creat
 Create a `values.yaml` file for the CAPI Operator Helm chart like so:
 
 ```yaml
-core: "cluster-api:v1.11.4"
+core: "cluster-api:v1.11.5"
 infrastructure: "azure:v1.17.2"
 addon: "helm:v0.5.2"
 manager:

--- a/go.mod
+++ b/go.mod
@@ -63,8 +63,8 @@ require (
 	k8s.io/kubectl v0.33.6
 	k8s.io/utils v0.0.0-20250321185631-1f6e0b77f77e
 	sigs.k8s.io/cloud-provider-azure v1.33.6
-	sigs.k8s.io/cluster-api v1.11.4
-	sigs.k8s.io/cluster-api/test v1.11.4
+	sigs.k8s.io/cluster-api v1.11.5
+	sigs.k8s.io/cluster-api/test v1.11.5
 	sigs.k8s.io/controller-runtime v0.21.0
 	sigs.k8s.io/kind v0.31.0
 )

--- a/go.sum
+++ b/go.sum
@@ -621,10 +621,10 @@ sigs.k8s.io/cloud-provider-azure/pkg/azclient v0.9.1 h1:9N7Pdu3zOyO0W1iE44MYK9Bt
 sigs.k8s.io/cloud-provider-azure/pkg/azclient v0.9.1/go.mod h1:93tr4zarMRObuc6/KEspD+22ZTg7JOC7IDq0IJwhpv4=
 sigs.k8s.io/cloud-provider-azure/pkg/azclient/configloader v0.8.2 h1:rxDNMKj2Y1XVMMaAw4vl1IKZHiHTkYqJnXvF4HroSrI=
 sigs.k8s.io/cloud-provider-azure/pkg/azclient/configloader v0.8.2/go.mod h1:WFyNunzycMEJll1O4dZVe0u0lqV5Ls/hqiJ4x5QWjpU=
-sigs.k8s.io/cluster-api v1.11.4 h1:N83BOMdqHO11m+RluQ5/15NaWZhQkVhtWDr5NecdfxY=
-sigs.k8s.io/cluster-api v1.11.4/go.mod h1:n0d6BAo8s9+KRap8Wv/IllfmwnSN5XFTWNJuq2gKNlg=
-sigs.k8s.io/cluster-api/test v1.11.4 h1:xy9ezFC7hPcRKaXuwKbQyODOosTGu1oOK8aXdTRtWCs=
-sigs.k8s.io/cluster-api/test v1.11.4/go.mod h1:7Zfdj42bJUrgZC5cuE6Q3zer18XoZLfH+8Sv3Yf7kO0=
+sigs.k8s.io/cluster-api v1.11.5 h1:mKQAfB8+6l2uxtEvQ6Z5EIcTObdPNs3TL4DcJScchGo=
+sigs.k8s.io/cluster-api v1.11.5/go.mod h1:n0d6BAo8s9+KRap8Wv/IllfmwnSN5XFTWNJuq2gKNlg=
+sigs.k8s.io/cluster-api/test v1.11.5 h1:sL/CqxD5vRMVrwkmoi2ewNfdJq5BFHDE8Pv+7zfdjMA=
+sigs.k8s.io/cluster-api/test v1.11.5/go.mod h1:7Zfdj42bJUrgZC5cuE6Q3zer18XoZLfH+8Sv3Yf7kO0=
 sigs.k8s.io/controller-runtime v0.21.0 h1:CYfjpEuicjUecRk+KAeyYh+ouUBn4llGyDYytIGcJS8=
 sigs.k8s.io/controller-runtime v0.21.0/go.mod h1:OSg14+F65eWqIu4DceX7k/+QRAbTTvxeQSNSOQpukWM=
 sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8 h1:gBQPwqORJ8d8/YNZWEjoZs7npUVDpVXUUOFfW6CgAqE=

--- a/test/e2e/config/azure-dev.yaml
+++ b/test/e2e/config/azure-dev.yaml
@@ -3,11 +3,11 @@ managementClusterName: capz-e2e
 images:
   - name: ${MANAGER_IMAGE}
     loadBehavior: mustLoad
-  - name: registry.k8s.io/cluster-api/cluster-api-controller:v1.11.4
+  - name: registry.k8s.io/cluster-api/cluster-api-controller:v1.11.5
     loadBehavior: tryLoad
-  - name: registry.k8s.io/cluster-api/kubeadm-bootstrap-controller:v1.11.4
+  - name: registry.k8s.io/cluster-api/kubeadm-bootstrap-controller:v1.11.5
     loadBehavior: tryLoad
-  - name: registry.k8s.io/cluster-api/kubeadm-control-plane-controller:v1.11.4
+  - name: registry.k8s.io/cluster-api/kubeadm-control-plane-controller:v1.11.5
     loadBehavior: tryLoad
   - name: registry.k8s.io/cluster-api-helm/cluster-api-helm-controller:v0.5.2
     loadBehavior: tryLoad
@@ -25,8 +25,8 @@ providers:
           new: --metrics-addr=:8080
       files:
         - sourcePath: "../data/shared/v1beta1/metadata.yaml"
-    - name: v1.11.4
-      value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.11.4/core-components.yaml
+    - name: v1.11.5
+      value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.11.5/core-components.yaml
       type: url
       contract: v1beta2
       files:
@@ -47,8 +47,8 @@ providers:
           new: --metrics-addr=:8080
       files:
         - sourcePath: "../data/shared/v1beta1/metadata.yaml"
-    - name: v1.11.4
-      value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.11.4/bootstrap-components.yaml
+    - name: v1.11.5
+      value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.11.5/bootstrap-components.yaml
       type: url
       contract: v1beta2
       files:
@@ -69,8 +69,8 @@ providers:
           new: --metrics-addr=:8080
       files:
         - sourcePath: "../data/shared/v1beta1/metadata.yaml"
-    - name: v1.11.4
-      value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.11.4/control-plane-components.yaml
+    - name: v1.11.5
+      value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.11.5/control-plane-components.yaml
       type: url
       contract: v1beta2
       files:
@@ -252,7 +252,7 @@ variables:
   WINDOWS_CONTAINERD_URL: "${WINDOWS_CONTAINERD_URL:-}"
   AZURE_CNI_V1_MANIFEST_PATH: "${PWD}/templates/addons/azure-cni-v1.yaml"
   OLD_CAPI_UPGRADE_VERSION: "v1.10.9"
-  LATEST_CAPI_UPGRADE_VERSION: "v1.11.4"
+  LATEST_CAPI_UPGRADE_VERSION: "v1.11.5"
   OLD_PROVIDER_UPGRADE_VERSION: "v1.20.4"
   LATEST_PROVIDER_UPGRADE_VERSION: "v1.21.1"
   OLD_CAAPH_UPGRADE_VERSION: "v0.1.0-alpha.10"


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Updates the Cluster API dependency to [v1.11.5](https://github.com/kubernetes-sigs/cluster-api/releases/tag/v1.11.5).

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:


**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] cherry-pick candidate

**Release note**:

```release-note
Bump CAPI to v1.11.5
```
