### PR TITLE
[release-1.21] Eliminate unnecessary periodic VMSS updates with new bootstrap data

### DIFF
--- a/azure/const.go
+++ b/azure/const.go
@@ -46,10 +46,4 @@ const (
 	// See https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
 	// for annotation formatting rules.
 	SecurityRuleLastAppliedAnnotation = "sigs.k8s.io/cluster-api-provider-azure-last-applied-security-rules"
-
-	// CustomDataHashAnnotation is the key for the machine object annotation
-	// which tracks the hash of the custom data.
-	// See https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
-	// for annotation formatting rules.
-	CustomDataHashAnnotation = "sigs.k8s.io/cluster-api-provider-azure-vmss-custom-data-hash"
 )

--- a/azure/scope/machinepool_test.go
+++ b/azure/scope/machinepool_test.go
@@ -18,17 +18,13 @@ package scope
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/base64"
 	"fmt"
-	"io"
 	"reflect"
 	"testing"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v2"
-	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
 	azureautorest "github.com/Azure/go-autorest/autorest/azure"
 	"github.com/Azure/go-autorest/autorest/azure/auth"
 	. "github.com/onsi/gomega"
@@ -1749,149 +1745,4 @@ func TestMachinePoolScope_setProvisioningStateAndConditions(t *testing.T) {
 			tt.Verify(g, s.AzureMachinePool, s.client)
 		})
 	}
-}
-
-func TestBootstrapDataChanges(t *testing.T) {
-	ctx, cancel := context.WithCancel(t.Context())
-	defer cancel()
-	scheme := runtime.NewScheme()
-	_ = clusterv1.AddToScheme(scheme)
-	_ = infrav1.AddToScheme(scheme)
-	_ = infrav1exp.AddToScheme(scheme)
-	_ = corev1.AddToScheme(scheme)
-
-	var (
-		g        = NewWithT(t)
-		mockCtrl = gomock.NewController(t)
-		cb       = fake.NewClientBuilder().WithScheme(scheme)
-		cluster  = &clusterv1.Cluster{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "cluster1",
-				Namespace: "default",
-			},
-			Spec: clusterv1.ClusterSpec{
-				InfrastructureRef: &corev1.ObjectReference{
-					Name: "azCluster1",
-				},
-			},
-			Status: clusterv1.ClusterStatus{
-				InfrastructureReady: true,
-			},
-		}
-		azureCluster = &infrav1.AzureCluster{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "azCluster1",
-				Namespace: "default",
-			},
-			Spec: infrav1.AzureClusterSpec{
-				AzureClusterClassSpec: infrav1.AzureClusterClassSpec{
-					Location: "test",
-				},
-			},
-		}
-		mp = &expv1.MachinePool{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "mp1",
-				Namespace: "default",
-				OwnerReferences: []metav1.OwnerReference{
-					{
-						Name:       "cluster1",
-						Kind:       "Cluster",
-						APIVersion: clusterv1.GroupVersion.String(),
-					},
-				},
-			},
-			Spec: expv1.MachinePoolSpec{
-				Template: clusterv1.MachineTemplateSpec{
-					Spec: clusterv1.MachineSpec{
-						Bootstrap: clusterv1.Bootstrap{
-							DataSecretName: ptr.To("mp-secret"),
-						},
-						Version: ptr.To("v1.31.0"),
-					},
-				},
-			},
-		}
-		bootstrapData     = "test"
-		bootstrapDataHash = sha256Hash(base64.StdEncoding.EncodeToString([]byte(bootstrapData)))
-		bootstrapSecret   = corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "mp-secret",
-				Namespace: "default",
-			},
-			Data: map[string][]byte{"value": []byte(bootstrapData)},
-		}
-		amp = &infrav1exp.AzureMachinePool{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "amp1",
-				Namespace: "default",
-				OwnerReferences: []metav1.OwnerReference{
-					{
-						Name:       "mp1",
-						Kind:       "MachinePool",
-						APIVersion: expv1.GroupVersion.String(),
-					},
-				},
-				Annotations: map[string]string{
-					azure.CustomDataHashAnnotation: fmt.Sprintf("%x", bootstrapDataHash),
-				},
-			},
-			Spec: infrav1exp.AzureMachinePoolSpec{
-				Template: infrav1exp.AzureMachinePoolMachineTemplate{
-					Image: &infrav1.Image{},
-					NetworkInterfaces: []infrav1.NetworkInterface{
-						{
-							SubnetName: "test",
-						},
-					},
-					VMSize: "VM_SIZE",
-				},
-			},
-		}
-		vmssState = &azure.VMSS{}
-	)
-	defer mockCtrl.Finish()
-
-	s := &MachinePoolScope{
-		client: cb.
-			WithObjects(&bootstrapSecret).
-			Build(),
-		ClusterScoper: &ClusterScope{
-			Cluster:      cluster,
-			AzureCluster: azureCluster,
-		},
-		skuCache: resourceskus.NewStaticCache([]armcompute.ResourceSKU{
-			{
-				Name: ptr.To("VM_SIZE"),
-			},
-		}, "test"),
-		MachinePool:      mp,
-		AzureMachinePool: amp,
-		vmssState:        vmssState,
-	}
-
-	g.Expect(s.InitMachinePoolCache(ctx)).NotTo(HaveOccurred())
-
-	spec := s.ScaleSetSpec(ctx)
-	sSpec := spec.(*scalesets.ScaleSetSpec)
-	g.Expect(sSpec.ShouldPatchCustomData).To(BeFalse())
-
-	amp.Annotations[azure.CustomDataHashAnnotation] = "old"
-
-	// reset cache to be able to build up the cache again
-	s.cache = nil
-	g.Expect(s.InitMachinePoolCache(ctx)).NotTo(HaveOccurred())
-
-	spec = s.ScaleSetSpec(ctx)
-	sSpec = spec.(*scalesets.ScaleSetSpec)
-	g.Expect(sSpec.ShouldPatchCustomData).To(BeTrue())
-}
-
-func sha256Hash(text string) []byte {
-	h := sha256.New()
-	_, err := io.WriteString(h, text)
-	if err != nil {
-		panic(err)
-	}
-	return h.Sum(nil)
 }

--- a/azure/services/scalesets/scalesets_test.go
+++ b/azure/services/scalesets/scalesets_test.go
@@ -813,12 +813,14 @@ func newDefaultWindowsVMSS() armcompute.VirtualMachineScaleSet {
 
 func newDefaultVMSS(vmSize string) armcompute.VirtualMachineScaleSet {
 	dataDisk := fetchDataDiskBasedOnSize(vmSize)
+	bootstrapData := "fake-bootstrap-data"
 	return armcompute.VirtualMachineScaleSet{
 		Location: ptr.To("test-location"),
 		Tags: map[string]*string{
 			"Name": ptr.To(defaultVMSSName),
 			"sigs.k8s.io_cluster-api-provider-azure_cluster_my-cluster": ptr.To("owned"),
 			"sigs.k8s.io_cluster-api-provider-azure_role":               ptr.To("node"),
+			customDataHashTagName:                                       ptr.To(mustCalculateBootstrapDataHash(bootstrapData)),
 		},
 		SKU: &armcompute.SKU{
 			Name:     ptr.To(vmSize),
@@ -837,7 +839,7 @@ func newDefaultVMSS(vmSize string) armcompute.VirtualMachineScaleSet {
 				OSProfile: &armcompute.VirtualMachineScaleSetOSProfile{
 					ComputerNamePrefix: ptr.To(defaultVMSSName),
 					AdminUsername:      ptr.To(azure.DefaultUserName),
-					CustomData:         ptr.To("fake-bootstrap-data"),
+					CustomData:         ptr.To(bootstrapData),
 					LinuxConfiguration: &armcompute.LinuxConfiguration{
 						SSH: &armcompute.SSHConfiguration{
 							PublicKeys: []*armcompute.SSHPublicKey{

--- a/azure/services/scalesets/spec.go
+++ b/azure/services/scalesets/spec.go
@@ -18,8 +18,10 @@ package scalesets
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/base64"
 	"fmt"
+	"io"
 	"strconv"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
@@ -33,6 +35,8 @@ import (
 	"sigs.k8s.io/cluster-api-provider-azure/util/generators"
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
 )
+
+const customDataHashTagName = "capz-custom-data-hash"
 
 // ScaleSetSpec defines the specification for a Scale Set.
 type ScaleSetSpec struct {
@@ -70,7 +74,6 @@ type ScaleSetSpec struct {
 	VMSSInstances                []armcompute.VirtualMachineScaleSetVM
 	MaxSurge                     int
 	ClusterName                  string
-	ShouldPatchCustomData        bool
 	HasReplicasExternallyManaged bool
 	AdditionalTags               infrav1.Tags
 	PlatformFaultDomainCount     *int32
@@ -129,19 +132,22 @@ func (s *ScaleSetSpec) existingParameters(ctx context.Context, existing interfac
 	}
 
 	// If there are no model changes and no increase in the replica count, do not update the VMSS.
-	// Decreases in replica count is handled by deleting AzureMachinePoolMachine instances in the MachinePoolScope
-	if *vmss.SKU.Capacity <= existingInfraVMSS.Capacity && !hasModelChanges && !s.ShouldPatchCustomData {
+	// Decreases in replica count is handled by deleting AzureMachinePoolMachine instances in the MachinePoolScope.
+	// Bootstrap data is allowed to get stale here and will be updated alongside changes to the model or
+	// replica count which require fresh bootstrap data.
+	if *vmss.SKU.Capacity <= existingInfraVMSS.Capacity && !hasModelChanges {
 		// up to date, nothing to do
 		return nil, nil
 	}
 
 	// if there are no model changes and no change in custom data, remove VirtualMachineProfile to avoid unnecessary VMSS model
 	// updates.
-	if !hasModelChanges && !s.ShouldPatchCustomData {
-		log.V(4).Info("removing virtual machine profile from parameters", "hasModelChanges", hasModelChanges, "shouldPatchCustomData", s.ShouldPatchCustomData)
+	shouldPatchCustomData := ptr.Deref(existingVMSS.Tags[customDataHashTagName], "") != ptr.Deref(vmss.Tags[customDataHashTagName], "")
+	if !hasModelChanges && !shouldPatchCustomData {
+		log.V(4).Info("removing virtual machine profile from parameters", "hasModelChanges", hasModelChanges, "shouldPatchCustomData", shouldPatchCustomData)
 		vmss.Properties.VirtualMachineProfile = nil
 	} else {
-		log.V(4).Info("has changes, not removing virtual machine profile from parameters", "hasModelChanges", hasModelChanges, "shouldPatchCustomData", s.ShouldPatchCustomData)
+		log.V(4).Info("has changes, not removing virtual machine profile from parameters", "hasModelChanges", hasModelChanges, "shouldPatchCustomData", shouldPatchCustomData)
 	}
 
 	return vmss, nil
@@ -293,6 +299,15 @@ func (s *ScaleSetSpec) Parameters(ctx context.Context, existing interface{}) (pa
 	})
 
 	vmss.Tags = converters.TagsToMap(tags)
+
+	// Custom data is not returned in GET responses, so we store a hash to detect when it changes. This allows
+	// CAPZ to update the VMSS model only when necessary.
+	customDataHash, err := calculateBootstrapDataHash(s.BootstrapData)
+	if err != nil {
+		return armcompute.VirtualMachineScaleSet{}, err
+	}
+	vmss.Tags[customDataHashTagName] = ptr.To(customDataHash)
+
 	return vmss, nil
 }
 
@@ -546,4 +561,14 @@ func (s *ScaleSetSpec) getSecurityProfile() (*armcompute.SecurityProfile, error)
 	return &armcompute.SecurityProfile{
 		EncryptionAtHost: ptr.To(*s.SecurityProfile.EncryptionAtHost),
 	}, nil
+}
+
+// calculateBootstrapDataHash calculates the sha256 hash of the bootstrap data.
+func calculateBootstrapDataHash(bootstrapData string) (string, error) {
+	h := sha256.New()
+	n, err := io.WriteString(h, bootstrapData)
+	if err != nil || n == 0 {
+		return "", fmt.Errorf("unable to write custom data (bytes written: %q): %w", n, err)
+	}
+	return fmt.Sprintf("%x", h.Sum(nil)), nil
 }


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind flake
/kind cleanup

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

Manual cherry-pick of #6048:
> This PR changes how CAPZ reacts to rotated bootstrap tokens for the KubeadmConfig associated with an AzureMachinePool. It aims to solve two problems:
> 
> 1. CAPZ periodically updates a VMSS every time the bootstrap token changes whether or not that bootstrap data will be used, which consumes API quota unnecessarily.
> 2. CAPZ periodically updates the AzureMachinePool with the hash of the new bootstrap data every time it rotates. This happens to break the upgrade tests which check that objects do not change without being touched.
> 
> This change solves 1 by deferring VMSS custom data changes until some other change to the model or an increase in the replica count is required. It solves 2 by then updating the stored data hash only when the VMSS custom data is updated, which may span several rotations by the kubeadm bootstrap controller. To make that easier, the hash is now stored in a tag on the VMSS object instead of an annotation on the AzureMachinePool.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->


**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [ ] includes documentation
- [X] adds unit tests
- [ ] cherry-pick candidate

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
CAPZ no longer updates a VMSS backing an AzureMachinePool with the latest kubeadm bootstrap data until other changes to the VMSS which require fresh bootstrap data are required.
```
