### PR TITLE
Add release notes for CAPZ v1.20.5

### DIFF
--- a/CHANGELOG/v1.20.5.md
+++ b/CHANGELOG/v1.20.5.md
@@ -1,0 +1,22 @@
+## Changes by Kind
+
+### Other (Cleanup or Flake)
+
+- Bump CAPI to v1.10.9 ([#6000](https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/6000), [@mboersma](https://github.com/mboersma))
+
+## Dependencies
+
+### Added
+_Nothing has changed._
+
+### Changed
+- github.com/coredns/corefile-migration: [v1.0.28 → v1.0.29](https://github.com/coredns/corefile-migration/compare/v1.0.28...v1.0.29)
+- sigs.k8s.io/cluster-api/test: v1.10.7 → v1.10.9
+- sigs.k8s.io/cluster-api: v1.10.7 → v1.10.9
+
+### Removed
+_Nothing has changed._
+
+## Details
+<!-- markdown-link-check-disable-next-line -->
+https://github.com/kubernetes-sigs/cluster-api-provider-azure/compare/v1.20.4...v1.20.5


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

Adds release notes for the impending CAPZ release v1.20.5.

**Release note**:

```release-note
NONE
```
