### PR TITLE
Add release notes for CAPZ v1.21.2

### DIFF
--- a/CHANGELOG/v1.21.2.md
+++ b/CHANGELOG/v1.21.2.md
@@ -1,0 +1,36 @@
+## Changes by Kind
+
+### Other (Cleanup or Flake)
+
+- Bump CAPI to v1.10.9 ([#5999](https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/5999), [@mboersma](https://github.com/mboersma))
+- CAPZ no longer updates a VMSS backing an AzureMachinePool with the latest kubeadm bootstrap data until other changes to the VMSS which require fresh bootstrap data are required. ([#6059](https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/6059), [@nojnhuh](https://github.com/nojnhuh))
+
+### Uncategorized
+
+- Updated flatcar-sysext flavor template to refer to https://extensions.flatcar.org/extensions instead of https://github.com/flatcar/sysext-bakery/releases/tag/latest ([#5951](https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/5951), [@nojnhuh](https://github.com/nojnhuh))
+
+## Dependencies
+
+### Added
+_Nothing has changed._
+
+### Changed
+- github.com/coredns/corefile-migration: [v1.0.28 → v1.0.29](https://github.com/coredns/corefile-migration/compare/v1.0.28...v1.0.29)
+- golang.org/x/crypto: v0.41.0 → v0.45.0
+- golang.org/x/mod: v0.27.0 → v0.29.0
+- golang.org/x/net: v0.43.0 → v0.47.0
+- golang.org/x/sync: v0.16.0 → v0.18.0
+- golang.org/x/sys: v0.35.0 → v0.38.0
+- golang.org/x/telemetry: 8d8967a → 078029d
+- golang.org/x/term: v0.34.0 → v0.37.0
+- golang.org/x/text: v0.28.0 → v0.31.0
+- golang.org/x/tools: v0.35.0 → v0.38.0
+- sigs.k8s.io/cluster-api/test: v1.10.7 → v1.10.9
+- sigs.k8s.io/cluster-api: v1.10.7 → v1.10.9
+
+### Removed
+_Nothing has changed._
+
+## Details
+<!-- markdown-link-check-disable-next-line -->
+https://github.com/kubernetes-sigs/cluster-api-provider-azure/compare/v1.21.1...v1.21.2


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

Adds release notes for the impending CAPZ release v1.21.2.

**Release note**:

```release-note
NONE
```
