### PR TITLE
Add release 1.22 to metadata.yaml

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -81,3 +81,6 @@ releaseSeries:
   - major: 1
     minor: 21
     contract: v1beta1
+  - major: 1
+    minor: 22
+    contract: v1beta1


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Adds the impending CAPZ v1.22 minor release series to the metadata.yaml file. This is a prerequisite to doing a release.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

See also https://github.com/kubernetes/test-infra/pull/36285

See https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#2-change-milestone-skip-for-patch-releases-maintainer


**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] cherry-pick candidate

**Release note**:

```release-note
NONE
```
