### PR TITLE
Remove e2e log redaction in between tests

### DIFF
--- a/test/e2e/capi_test.go
+++ b/test/e2e/capi_test.go
@@ -63,7 +63,6 @@ var _ = Describe("Running the Cluster API E2E tests", func() {
 
 	AfterEach(func() {
 		CheckTestBeforeCleanup()
-		redactLogs()
 
 		Expect(os.Unsetenv(AzureResourceGroup)).To(Succeed())
 		Expect(os.Unsetenv(AzureVNetName)).To(Succeed())

--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -23,7 +23,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"os/exec"
 	"path"
 	"path/filepath"
 	"strings"
@@ -158,7 +157,6 @@ type cleanupInput struct {
 func dumpSpecResourcesAndCleanup(ctx context.Context, input cleanupInput) {
 	defer func() {
 		input.CancelWatches()
-		redactLogs()
 	}()
 
 	Logf("Dumping all the Cluster API resources in the %q namespace", input.Namespace.Name)
@@ -228,16 +226,6 @@ func ExpectResourceGroupToBe404(ctx context.Context) {
 	Expect(err).NotTo(HaveOccurred())
 	_, err = groupsClient.Get(ctx, resourceGroup, nil)
 	Expect(azure.ResourceNotFound(err)).To(BeTrue(), "The resource group in Azure still exists. After deleting the cluster all of the Azure resources should also be deleted.")
-}
-
-func redactLogs() {
-	By("Redacting sensitive information from logs")
-	Expect(e2eConfig.Variables).To(HaveKey(RedactLogScriptPath))
-	//nolint:gosec // Ignore warning about running a command constructed from user input
-	cmd := exec.Command(e2eConfig.MustGetVariable(RedactLogScriptPath))
-	if err := cmd.Run(); err != nil {
-		LogWarningf("Redact logs command failed: %v", err)
-	}
 }
 
 func createRestConfig(ctx context.Context, tmpdir, namespace, clusterName string) *rest.Config {


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind cleanup

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

This PR removes the calls to the log redaction script in between individual e2e tests which seems to have been causing the logs for all CAPI provider controllers to be cut off early. Redaction invoked by ci-e2e.sh after all tests have completed is still engaged.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->


**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] cherry-pick candidate

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
