### PR TITLE
Use correct ClusterProxy for e2e AKSMachinePoolSpec

### DIFF
--- a/test/e2e/aks_machinepools.go
+++ b/test/e2e/aks_machinepools.go
@@ -53,7 +53,7 @@ func AKSMachinePoolSpec(ctx context.Context, inputGetter func() AKSMachinePoolSp
 	patchMachinePoolReplicas := func(mp *clusterv1.MachinePool, replicas int32) {
 		GinkgoHelper()
 
-		patchHelper, err := patch.NewHelper(mp, bootstrapClusterProxy.GetClient())
+		patchHelper, err := patch.NewHelper(mp, input.MgmtCluster.GetClient())
 		Expect(err).NotTo(HaveOccurred())
 
 		mp.Spec.Replicas = &replicas


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind failing-test

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

This PR fixes the API version upgrade e2e tests where the smoke test we do after upgrading a management cluster reconciling AzureASOManagedMachinePools was using the wrong `ClusterProxy` and trying to patch MachinePools in the management cluster, not the workload cluster.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #6076

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->


**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] cherry-pick candidate

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
