### PR TITLE
wip: Change bootstrap extension to RunCommandLinux

### DIFF
--- a/azure/defaults.go
+++ b/azure/defaults.go
@@ -25,7 +25,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
-	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
 	"github.com/Azure/azure-sdk-for-go/sdk/tracing/azotel"
 	"go.opentelemetry.io/otel"
 
@@ -66,7 +65,7 @@ const (
 
 const (
 	// BootstrappingExtensionLinux is the name of the Linux CAPZ bootstrapping VM extension.
-	BootstrappingExtensionLinux = "CAPZ.Linux.Bootstrapping"
+	BootstrappingExtensionLinux = "RunCommandLinux"
 	// BootstrappingExtensionWindows is the name of the Windows CAPZ bootstrapping VM extension.
 	BootstrappingExtensionWindows = "CAPZ.Windows.Bootstrapping"
 )
@@ -319,21 +318,13 @@ func GetBootstrappingVMExtension(osType string, cloud string, vmName string, cpu
 	// currently, the bootstrap extension is only available in AzurePublicCloud.
 	if osType == LinuxOS && cloud == PublicCloudName {
 		// The command checks for the existence of the bootstrapSentinelFile on the machine, with retries and sleep between retries.
-		// We set the version to 1.1 (will target 1.1.1) for arm64 machines and 1.0 for x64. This is due to a known issue with newer versions of
-		// Go on Ubuntu 20.04. The issue is being tracked here: https://github.com/golang/go/issues/58550
-		// TODO: Remove this once the issue is fixed, or when Ubuntu 20.04 is no longer supported.
-		// We are using 1.1 instead of 1.1.1 for Arm64 as AzureAPI do not allow us to specify the full version.
-		extensionVersion := "1.0"
-		if cpuArchitectureType == string(armcompute.ArchitectureTypesArm64) {
-			extensionVersion = "1.1"
-		}
 		return &ExtensionSpec{
 			Name:      BootstrappingExtensionLinux,
 			VMName:    vmName,
-			Publisher: "Microsoft.Azure.ContainerUpstream",
-			Version:   extensionVersion,
+			Publisher: "Microsoft.CPlat.Core",
+			Version:   "1.0",
 			ProtectedSettings: map[string]string{
-				"commandToExecute": LinuxBootstrapExtensionCommand,
+				"script": LinuxBootstrapExtensionCommand,
 			},
 		}
 	} else if osType == WindowsOS && cloud == PublicCloudName {

--- a/azure/defaults.go
+++ b/azure/defaults.go
@@ -64,10 +64,10 @@ const (
 )
 
 const (
-	// BootstrappingExtensionLinux is the name of the Linux CAPZ bootstrapping VM extension.
+	// BootstrappingExtensionLinux is the name of the Linux bootstrapping VM extension.
 	BootstrappingExtensionLinux = "RunCommandLinux"
-	// BootstrappingExtensionWindows is the name of the Windows CAPZ bootstrapping VM extension.
-	BootstrappingExtensionWindows = "CAPZ.Windows.Bootstrapping"
+	// BootstrappingExtensionWindows is the name of the Windows bootstrapping VM extension.
+	BootstrappingExtensionWindows = "RunCommandWindows"
 )
 
 const (
@@ -309,12 +309,10 @@ func FleetID(subscriptionID, resourceGroup, fleetName string) string {
 	return fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.ContainerService/fleets/%s", subscriptionID, resourceGroup, fleetName)
 }
 
-// GetBootstrappingVMExtension returns the CAPZ Bootstrapping VM extension.
-// The CAPZ Bootstrapping extension is a simple clone of https://github.com/Azure/custom-script-extension-linux for Linux or
-// https://learn.microsoft.com/azure/virtual-machines/extensions/custom-script-windows for Windows.
-// This extension allows running arbitrary scripts on the VM.
-// Its role is to detect and report Kubernetes bootstrap failure or success.
-func GetBootstrappingVMExtension(osType string, cloud string, vmName string, cpuArchitectureType string) *ExtensionSpec {
+// GetBootstrappingVMExtension returns the bootstrapping VM extension.
+// It uses the RunCommand extension (Microsoft.CPlat.Core) to run a script that
+// detects and reports Kubernetes bootstrap failure or success.
+func GetBootstrappingVMExtension(osType string, cloud string, vmName string) *ExtensionSpec {
 	// currently, the bootstrap extension is only available in AzurePublicCloud.
 	if osType == LinuxOS && cloud == PublicCloudName {
 		// The command checks for the existence of the bootstrapSentinelFile on the machine, with retries and sleep between retries.
@@ -333,10 +331,10 @@ func GetBootstrappingVMExtension(osType string, cloud string, vmName string, cpu
 		return &ExtensionSpec{
 			Name:      BootstrappingExtensionWindows,
 			VMName:    vmName,
-			Publisher: "Microsoft.Azure.ContainerUpstream",
-			Version:   "1.0",
+			Publisher: "Microsoft.CPlat.Core",
+			Version:   "1.1",
 			ProtectedSettings: map[string]string{
-				"commandToExecute": WindowsBootstrapExtensionCommand,
+				"script": WindowsBootstrapExtensionCommand,
 			},
 		}
 	}

--- a/azure/defaults_test.go
+++ b/azure/defaults_test.go
@@ -216,40 +216,28 @@ func TestGetBootstrappingVMExtension(t *testing.T) {
 		osType          string
 		cloud           string
 		vmName          string
-		cpuArchitecture string
 		expectedVersion string
 		expectNil       bool
 	}{
 		{
-			name:            "Linux OS, Public Cloud, x64 CPU Architecture",
+			name:            "Linux OS, Public Cloud",
 			osType:          LinuxOS,
 			cloud:           PublicCloudName,
 			vmName:          "test-vm",
-			cpuArchitecture: "x64",
 			expectedVersion: "1.0",
-		},
-		{
-			name:            "Linux OS, Public Cloud, ARM64 CPU Architecture",
-			osType:          LinuxOS,
-			cloud:           PublicCloudName,
-			vmName:          "test-vm",
-			cpuArchitecture: "Arm64",
-			expectedVersion: "1.1",
 		},
 		{
 			name:            "Windows OS, Public Cloud",
 			osType:          WindowsOS,
 			cloud:           PublicCloudName,
 			vmName:          "test-vm",
-			cpuArchitecture: "x64",
-			expectedVersion: "1.0",
+			expectedVersion: "1.1",
 		},
 		{
 			name:            "Invalid OS Type",
 			osType:          "invalid",
 			cloud:           PublicCloudName,
 			vmName:          "test-vm",
-			cpuArchitecture: "x64",
 			expectedVersion: "1.0",
 			expectNil:       true,
 		},
@@ -258,7 +246,6 @@ func TestGetBootstrappingVMExtension(t *testing.T) {
 			osType:          LinuxOS,
 			cloud:           "invalid",
 			vmName:          "test-vm",
-			cpuArchitecture: "x64",
 			expectedVersion: "1.0",
 			expectNil:       true,
 		},
@@ -267,7 +254,7 @@ func TestGetBootstrappingVMExtension(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			g := NewWithT(t)
-			actualExtension := GetBootstrappingVMExtension(tc.osType, tc.cloud, tc.vmName, tc.cpuArchitecture)
+			actualExtension := GetBootstrappingVMExtension(tc.osType, tc.cloud, tc.vmName)
 			if tc.expectNil {
 				g.Expect(actualExtension).To(BeNil())
 			} else {

--- a/azure/scope/machine.go
+++ b/azure/scope/machine.go
@@ -403,8 +403,7 @@ func (m *MachineScope) VMExtensionSpecs() []azure.ResourceSpecGetter {
 	}
 
 	if !ptr.Deref(m.AzureMachine.Spec.DisableVMBootstrapExtension, false) {
-		cpuArchitectureType, _ := m.cache.VMSKU.GetCapability(resourceskus.CPUArchitectureType)
-		bootstrapExtensionSpec := azure.GetBootstrappingVMExtension(m.AzureMachine.Spec.OSDisk.OSType, m.CloudEnvironment(), m.Name(), cpuArchitectureType)
+		bootstrapExtensionSpec := azure.GetBootstrappingVMExtension(m.AzureMachine.Spec.OSDisk.OSType, m.CloudEnvironment(), m.Name())
 
 		if bootstrapExtensionSpec != nil {
 			extensionSpecs = append(extensionSpecs, &vmextensions.VMExtensionSpec{

--- a/azure/scope/machine_test.go
+++ b/azure/scope/machine_test.go
@@ -569,12 +569,12 @@ func TestMachineScope_VMExtensionSpecs(t *testing.T) {
 			want: []azure.ResourceSpecGetter{
 				&vmextensions.VMExtensionSpec{
 					ExtensionSpec: azure.ExtensionSpec{
-						Name:      "CAPZ.Linux.Bootstrapping",
+						Name:      "RunCommandLinux",
 						VMName:    "machine-name",
-						Publisher: "Microsoft.Azure.ContainerUpstream",
+						Publisher: "Microsoft.CPlat.Core",
 						Version:   "1.0",
 						ProtectedSettings: map[string]string{
-							"commandToExecute": azure.LinuxBootstrapExtensionCommand,
+							"script": azure.LinuxBootstrapExtensionCommand,
 						},
 					},
 					ResourceGroup: "my-rg",
@@ -683,12 +683,12 @@ func TestMachineScope_VMExtensionSpecs(t *testing.T) {
 			want: []azure.ResourceSpecGetter{
 				&vmextensions.VMExtensionSpec{
 					ExtensionSpec: azure.ExtensionSpec{
-						Name:      "CAPZ.Windows.Bootstrapping",
+						Name:      "RunCommandWindows",
 						VMName:    "machine-name",
-						Publisher: "Microsoft.Azure.ContainerUpstream",
-						Version:   "1.0",
+						Publisher: "Microsoft.CPlat.Core",
+						Version:   "1.1",
 						ProtectedSettings: map[string]string{
-							"commandToExecute": azure.WindowsBootstrapExtensionCommand,
+							"script": azure.WindowsBootstrapExtensionCommand,
 						},
 					},
 					ResourceGroup: "my-rg",
@@ -858,12 +858,12 @@ func TestMachineScope_VMExtensionSpecs(t *testing.T) {
 				},
 				&vmextensions.VMExtensionSpec{
 					ExtensionSpec: azure.ExtensionSpec{
-						Name:      "CAPZ.Linux.Bootstrapping",
+						Name:      "RunCommandLinux",
 						VMName:    "machine-name",
-						Publisher: "Microsoft.Azure.ContainerUpstream",
+						Publisher: "Microsoft.CPlat.Core",
 						Version:   "1.0",
 						ProtectedSettings: map[string]string{
-							"commandToExecute": azure.LinuxBootstrapExtensionCommand,
+							"script": azure.LinuxBootstrapExtensionCommand,
 						},
 					},
 					ResourceGroup: "my-rg",

--- a/azure/scope/machinepool.go
+++ b/azure/scope/machinepool.go
@@ -867,8 +867,7 @@ func (m *MachinePoolScope) VMSSExtensionSpecs() []azure.ResourceSpecGetter {
 		})
 	}
 
-	cpuArchitectureType, _ := m.cache.VMSKU.GetCapability(resourceskus.CPUArchitectureType)
-	bootstrapExtensionSpec := azure.GetBootstrappingVMExtension(m.AzureMachinePool.Spec.Template.OSDisk.OSType, m.CloudEnvironment(), m.Name(), cpuArchitectureType)
+	bootstrapExtensionSpec := azure.GetBootstrappingVMExtension(m.AzureMachinePool.Spec.Template.OSDisk.OSType, m.CloudEnvironment(), m.Name())
 
 	if bootstrapExtensionSpec != nil {
 		extensionSpecs = append(extensionSpecs, &scalesets.VMSSExtensionSpec{

--- a/azure/scope/machinepool_test.go
+++ b/azure/scope/machinepool_test.go
@@ -897,12 +897,12 @@ func TestMachinePoolScope_VMSSExtensionSpecs(t *testing.T) {
 			want: []azure.ResourceSpecGetter{
 				&scalesets.VMSSExtensionSpec{
 					ExtensionSpec: azure.ExtensionSpec{
-						Name:      "CAPZ.Linux.Bootstrapping",
+						Name:      "RunCommandLinux",
 						VMName:    "machinepool-name",
-						Publisher: "Microsoft.Azure.ContainerUpstream",
+						Publisher: "Microsoft.CPlat.Core",
 						Version:   "1.0",
 						ProtectedSettings: map[string]string{
-							"commandToExecute": azure.LinuxBootstrapExtensionCommand,
+							"script": azure.LinuxBootstrapExtensionCommand,
 						},
 					},
 					ResourceGroup: "my-rg",
@@ -975,13 +975,13 @@ func TestMachinePoolScope_VMSSExtensionSpecs(t *testing.T) {
 			want: []azure.ResourceSpecGetter{
 				&scalesets.VMSSExtensionSpec{
 					ExtensionSpec: azure.ExtensionSpec{
-						Name: "CAPZ.Windows.Bootstrapping",
+						Name: "RunCommandWindows",
 						// Note: machine pool names longer than 9 characters get truncated. See MachinePoolScope::Name() for more details.
 						VMName:    "winpool",
-						Publisher: "Microsoft.Azure.ContainerUpstream",
-						Version:   "1.0",
+						Publisher: "Microsoft.CPlat.Core",
+						Version:   "1.1",
 						ProtectedSettings: map[string]string{
-							"commandToExecute": azure.WindowsBootstrapExtensionCommand,
+							"script": azure.WindowsBootstrapExtensionCommand,
 						},
 					},
 					ResourceGroup: "my-rg",
@@ -1148,12 +1148,12 @@ func TestMachinePoolScope_VMSSExtensionSpecs(t *testing.T) {
 				},
 				&scalesets.VMSSExtensionSpec{
 					ExtensionSpec: azure.ExtensionSpec{
-						Name:      "CAPZ.Linux.Bootstrapping",
+						Name:      "RunCommandLinux",
 						VMName:    "machinepool-name",
-						Publisher: "Microsoft.Azure.ContainerUpstream",
+						Publisher: "Microsoft.CPlat.Core",
 						Version:   "1.0",
 						ProtectedSettings: map[string]string{
-							"commandToExecute": azure.LinuxBootstrapExtensionCommand,
+							"script": azure.LinuxBootstrapExtensionCommand,
 						},
 					},
 					ResourceGroup: "my-rg",

--- a/config/capz/manager_image_patch.yaml
+++ b/config/capz/manager_image_patch.yaml
@@ -8,5 +8,5 @@ spec:
     spec:
       containers:
       # Change the value of image field below to your controller image URL
-      - image: gcr.io/k8s-staging-cluster-api-azure/cluster-api-azure-controller:main
+      - image: docker.io/quillie/cluster-api-azure-controller:dev
         name: manager

--- a/test/e2e/azure_vmextensions.go
+++ b/test/e2e/azure_vmextensions.go
@@ -115,7 +115,7 @@ func AzureVMExtensionsSpec(ctx context.Context, inputGetter func() AzureVMExtens
 				vmExtensionNames = append(vmExtensionNames, *vmExtension.Name)
 			}
 			osName := string(*machine.Properties.StorageProfile.OSDisk.OSType)
-			Expect(vmExtensionNames).To(ContainElements("CAPZ." + osName + ".Bootstrapping"))
+			Expect(vmExtensionNames).To(ContainElements("RunCommand" + osName))
 			Expect(vmExtensionNames).To(ContainElements(expectedVMExtensionMap[*machine.ID]))
 		}
 	}
@@ -174,7 +174,7 @@ func AzureVMExtensionsSpec(ctx context.Context, inputGetter func() AzureVMExtens
 				vmssExtensionNames = append(vmssExtensionNames, *vmssExtension.Name)
 			}
 			osName := string(*machinePool.Properties.VirtualMachineProfile.StorageProfile.OSDisk.OSType)
-			Expect(vmssExtensionNames).To(ContainElements("CAPZ." + osName + ".Bootstrapping"))
+			Expect(vmssExtensionNames).To(ContainElements("RunCommand" + osName))
 			Expect(vmssExtensionNames).To(ContainElements(expectedVMSSExtensionMap[*machinePool.ID]))
 		}
 	}


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind cleanup

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
This PR replaces the CAPZ Linux bootstrapping extension with RunCommandLinux as the CAPZ Linux bootstrapping extension is being deprecated

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->


**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] cherry-pick candidate

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Replace CAPZ bootstrap extension with RunCommandLinux
```
