### PR TITLE
Pin RKE2 provider to v0.21.1

### DIFF
--- a/test/e2e/azure_test.go
+++ b/test/e2e/azure_test.go
@@ -34,6 +34,7 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	clusterctlconfig "sigs.k8s.io/cluster-api/cmd/clusterctl/client/config"
 	capi_e2e "sigs.k8s.io/cluster-api/test/e2e"
 	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
 	"sigs.k8s.io/cluster-api/util"
@@ -1147,14 +1148,15 @@ var _ = Describe("Workload cluster creation", func() {
 			clusterName = getClusterName(clusterNamePrefix, "cc")
 
 			// Init rke2 CP and bootstrap providers
+			rke2Version := "v0.21.1"
 			initInput := clusterctl.InitInput{
 				// pass reference to the management cluster hosting this test
 				KubeconfigPath: bootstrapClusterProxy.GetKubeconfigPath(),
 				// pass the clusterctl config file that points to the local provider repository created for this test
 				ClusterctlConfigPath: clusterctlConfigPath,
 				// setup the desired list of providers for a single-tenant management cluster
-				BootstrapProviders:    []string{"rke2"},
-				ControlPlaneProviders: []string{"rke2"},
+				BootstrapProviders:    []string{clusterctlconfig.RKE2BootstrapProviderName + ":" + rke2Version},
+				ControlPlaneProviders: []string{clusterctlconfig.RKE2ControlPlaneProviderName + ":" + rke2Version},
 				// setup clusterctl logs folder
 				LogFolder: filepath.Join(artifactFolder, "clusters", clusterName),
 			}


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind failing-test

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

RKE2 recently published a new version of their CAPI provider we use in e2e tests that we inherited implicitly. That appears to come with breaking API changes where our existing template becomes invalid with the new version. Pinning RKE2 to the next latest version which is known to work.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->


**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [X] cherry-pick candidate

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
