### PR TITLE
WIP: Disable vm bootstrap extension by default

### DIFF
--- a/api/v1beta1/azuremachine_default.go
+++ b/api/v1beta1/azuremachine_default.go
@@ -27,6 +27,7 @@ import (
 	"golang.org/x/crypto/ssh"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/uuid"
+	"k8s.io/utils/ptr"
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -120,6 +121,13 @@ func (s *AzureMachineSpec) SetSpotEvictionPolicyDefaults() {
 			defaultPolicy = SpotEvictionPolicyDelete
 		}
 		s.SpotVMOptions.EvictionPolicy = &defaultPolicy
+	}
+}
+
+// SetDisableVMBootstrapExtensionDefaults sets the default for DisableVMBootstrapExtension.
+func (s *AzureMachineSpec) SetDisableVMBootstrapExtensionDefaults() {
+	if s.DisableVMBootstrapExtension == nil {
+		s.DisableVMBootstrapExtension = ptr.To(true)
 	}
 }
 
@@ -243,6 +251,7 @@ func (m *AzureMachine) SetDefaults(client client.Client) error {
 	m.Spec.SetSpotEvictionPolicyDefaults()
 	m.Spec.SetDiagnosticsDefaults()
 	m.Spec.SetNetworkInterfacesDefaults()
+	m.Spec.SetDisableVMBootstrapExtensionDefaults()
 
 	return kerrors.NewAggregate(errs)
 }

--- a/api/v1beta1/azuremachine_default_test.go
+++ b/api/v1beta1/azuremachine_default_test.go
@@ -346,6 +346,30 @@ func TestAzureMachineSpec_SetDataDisksDefaults(t *testing.T) {
 	}
 }
 
+func TestAzureMachineSpec_SetDisableVMBootstrapExtensionDefaults(t *testing.T) {
+	g := NewWithT(t)
+
+	// Test that nil defaults to true
+	machineWithNil := &AzureMachine{Spec: AzureMachineSpec{}}
+	machineWithNil.Spec.SetDisableVMBootstrapExtensionDefaults()
+	g.Expect(machineWithNil.Spec.DisableVMBootstrapExtension).ToNot(BeNil())
+	g.Expect(*machineWithNil.Spec.DisableVMBootstrapExtension).To(BeTrue())
+
+	// Test that explicit true is preserved
+	machineWithTrue := &AzureMachine{Spec: AzureMachineSpec{
+		DisableVMBootstrapExtension: ptr.To(true),
+	}}
+	machineWithTrue.Spec.SetDisableVMBootstrapExtensionDefaults()
+	g.Expect(*machineWithTrue.Spec.DisableVMBootstrapExtension).To(BeTrue())
+
+	// Test that explicit false is preserved
+	machineWithFalse := &AzureMachine{Spec: AzureMachineSpec{
+		DisableVMBootstrapExtension: ptr.To(false),
+	}}
+	machineWithFalse.Spec.SetDisableVMBootstrapExtensionDefaults()
+	g.Expect(*machineWithFalse.Spec.DisableVMBootstrapExtension).To(BeFalse())
+}
+
 func TestAzureMachineSpec_SetNetworkInterfacesDefaults(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/api/v1beta1/azuremachine_webhook.go
+++ b/api/v1beta1/azuremachine_webhook.go
@@ -221,11 +221,15 @@ func (mw *azureMachineWebhook) ValidateUpdate(_ context.Context, oldObj, newObj 
 		allErrs = append(allErrs, err)
 	}
 
-	if err := webhookutils.ValidateImmutable(
-		field.NewPath("spec", "disableVMBootstrapExtension"),
-		old.Spec.DisableVMBootstrapExtension,
-		m.Spec.DisableVMBootstrapExtension); err != nil {
-		allErrs = append(allErrs, err)
+	// Only validate immutability if the old value was explicitly set.
+	// This allows the transition from nil (old default) to true (new default) during upgrades.
+	if old.Spec.DisableVMBootstrapExtension != nil {
+		if err := webhookutils.ValidateImmutable(
+			field.NewPath("spec", "disableVMBootstrapExtension"),
+			old.Spec.DisableVMBootstrapExtension,
+			m.Spec.DisableVMBootstrapExtension); err != nil {
+			allErrs = append(allErrs, err)
+		}
 	}
 
 	if len(allErrs) == 0 {

--- a/api/v1beta1/azuremachine_webhook_test.go
+++ b/api/v1beta1/azuremachine_webhook_test.go
@@ -824,6 +824,62 @@ func TestAzureMachine_ValidateUpdate(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "validTest: azuremachine.spec.disableVMBootstrapExtension transition from nil to true is allowed",
+			oldMachine: &AzureMachine{
+				Spec: AzureMachineSpec{
+					DisableVMBootstrapExtension: nil,
+				},
+			},
+			newMachine: &AzureMachine{
+				Spec: AzureMachineSpec{
+					DisableVMBootstrapExtension: ptr.To(true),
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "validTest: azuremachine.spec.disableVMBootstrapExtension transition from nil to false is allowed",
+			oldMachine: &AzureMachine{
+				Spec: AzureMachineSpec{
+					DisableVMBootstrapExtension: nil,
+				},
+			},
+			newMachine: &AzureMachine{
+				Spec: AzureMachineSpec{
+					DisableVMBootstrapExtension: ptr.To(false),
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalidTest: azuremachine.spec.disableVMBootstrapExtension is immutable when previously set",
+			oldMachine: &AzureMachine{
+				Spec: AzureMachineSpec{
+					DisableVMBootstrapExtension: ptr.To(true),
+				},
+			},
+			newMachine: &AzureMachine{
+				Spec: AzureMachineSpec{
+					DisableVMBootstrapExtension: ptr.To(false),
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "validTest: azuremachine.spec.disableVMBootstrapExtension is immutable when previously set to same value",
+			oldMachine: &AzureMachine{
+				Spec: AzureMachineSpec{
+					DisableVMBootstrapExtension: ptr.To(true),
+				},
+			},
+			newMachine: &AzureMachine{
+				Spec: AzureMachineSpec{
+					DisableVMBootstrapExtension: ptr.To(true),
+				},
+			},
+			wantErr: false,
+		},
+		{
 			name: "validTest: azuremachine.spec.networkInterfaces is immutable",
 			oldMachine: &AzureMachine{
 				Spec: AzureMachineSpec{

--- a/azure/scope/machine.go
+++ b/azure/scope/machine.go
@@ -402,7 +402,7 @@ func (m *MachineScope) VMExtensionSpecs() []azure.ResourceSpecGetter {
 		})
 	}
 
-	if !ptr.Deref(m.AzureMachine.Spec.DisableVMBootstrapExtension, false) {
+	if !ptr.Deref(m.AzureMachine.Spec.DisableVMBootstrapExtension, true) {
 		cpuArchitectureType, _ := m.cache.VMSKU.GetCapability(resourceskus.CPUArchitectureType)
 		bootstrapExtensionSpec := azure.GetBootstrappingVMExtension(m.AzureMachine.Spec.OSDisk.OSType, m.CloudEnvironment(), m.Name(), cpuArchitectureType)
 

--- a/azure/scope/machine.go
+++ b/azure/scope/machine.go
@@ -181,7 +181,7 @@ func (m *MachineScope) VMSpec() azure.ResourceSpecGetter {
 		SecurityProfile:             m.AzureMachine.Spec.SecurityProfile,
 		DiagnosticsProfile:          m.AzureMachine.Spec.Diagnostics,
 		DisableExtensionOperations:  ptr.Deref(m.AzureMachine.Spec.DisableExtensionOperations, false),
-		DisableVMBootstrapExtension: ptr.Deref(m.AzureMachine.Spec.DisableVMBootstrapExtension, false),
+		DisableVMBootstrapExtension: ptr.Deref(m.AzureMachine.Spec.DisableVMBootstrapExtension, true),
 		AdditionalTags:              m.AdditionalTags(),
 		AdditionalCapabilities:      m.AzureMachine.Spec.AdditionalCapabilities,
 		CapacityReservationGroupID:  m.GetCapacityReservationGroupID(),

--- a/azure/scope/machinepool.go
+++ b/azure/scope/machinepool.go
@@ -824,14 +824,16 @@ func (m *MachinePoolScope) VMSSExtensionSpecs() []azure.ResourceSpecGetter {
 		})
 	}
 
-	cpuArchitectureType, _ := m.cache.VMSKU.GetCapability(resourceskus.CPUArchitectureType)
-	bootstrapExtensionSpec := azure.GetBootstrappingVMExtension(m.AzureMachinePool.Spec.Template.OSDisk.OSType, m.CloudEnvironment(), m.Name(), cpuArchitectureType)
+	if !ptr.Deref(m.AzureMachinePool.Spec.Template.DisableVMBootstrapExtension, true) {
+		cpuArchitectureType, _ := m.cache.VMSKU.GetCapability(resourceskus.CPUArchitectureType)
+		bootstrapExtensionSpec := azure.GetBootstrappingVMExtension(m.AzureMachinePool.Spec.Template.OSDisk.OSType, m.CloudEnvironment(), m.Name(), cpuArchitectureType)
 
-	if bootstrapExtensionSpec != nil {
-		extensionSpecs = append(extensionSpecs, &scalesets.VMSSExtensionSpec{
-			ExtensionSpec: *bootstrapExtensionSpec,
-			ResourceGroup: m.NodeResourceGroup(),
-		})
+		if bootstrapExtensionSpec != nil {
+			extensionSpecs = append(extensionSpecs, &scalesets.VMSSExtensionSpec{
+				ExtensionSpec: *bootstrapExtensionSpec,
+				ResourceGroup: m.NodeResourceGroup(),
+			})
+		}
 	}
 
 	return extensionSpecs

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremachinepools.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azuremachinepools.yaml
@@ -369,6 +369,11 @@ spec:
                         - storageAccountType
                         type: object
                     type: object
+                  disableVMBootstrapExtension:
+                    description: |-
+                      DisableVMBootstrapExtension specifies whether the VM bootstrap extension should be disabled on the virtual machine scale set.
+                      Use this setting if you want to disable only the bootstrapping extension and not all extensions.
+                    type: boolean
                   image:
                     description: |-
                       Image is used to provide details of an image to use during VM creation.

--- a/exp/api/v1beta1/azuremachinepool_default.go
+++ b/exp/api/v1beta1/azuremachinepool_default.go
@@ -24,6 +24,7 @@ import (
 	"golang.org/x/crypto/ssh"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/uuid"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
@@ -44,6 +45,7 @@ func (amp *AzureMachinePool) SetDefaults(client client.Client) error {
 	amp.SetDiagnosticsDefaults()
 	amp.SetNetworkInterfacesDefaults()
 	amp.SetOSDiskDefaults()
+	amp.SetDisableVMBootstrapExtensionDefaults()
 
 	return kerrors.NewAggregate(errs)
 }
@@ -169,5 +171,12 @@ func (amp *AzureMachinePool) SetOSDiskDefaults() {
 	}
 	if amp.Spec.Template.OSDisk.CachingType == "" {
 		amp.Spec.Template.OSDisk.CachingType = "None"
+	}
+}
+
+// SetDisableVMBootstrapExtensionDefaults sets the default for DisableVMBootstrapExtension.
+func (amp *AzureMachinePool) SetDisableVMBootstrapExtensionDefaults() {
+	if amp.Spec.Template.DisableVMBootstrapExtension == nil {
+		amp.Spec.Template.DisableVMBootstrapExtension = ptr.To(true)
 	}
 }

--- a/exp/api/v1beta1/azuremachinepool_default_test.go
+++ b/exp/api/v1beta1/azuremachinepool_default_test.go
@@ -401,6 +401,36 @@ func TestAzureMachinePool_SetNetworkInterfacesDefaults(t *testing.T) {
 	}
 }
 
+func TestAzureMachinePool_SetDisableVMBootstrapExtensionDefaults(t *testing.T) {
+	g := NewWithT(t)
+
+	// Test that nil defaults to true
+	machinePoolWithNil := &AzureMachinePool{Spec: AzureMachinePoolSpec{
+		Template: AzureMachinePoolMachineTemplate{},
+	}}
+	machinePoolWithNil.SetDisableVMBootstrapExtensionDefaults()
+	g.Expect(machinePoolWithNil.Spec.Template.DisableVMBootstrapExtension).ToNot(BeNil())
+	g.Expect(*machinePoolWithNil.Spec.Template.DisableVMBootstrapExtension).To(BeTrue())
+
+	// Test that explicit true is preserved
+	machinePoolWithTrue := &AzureMachinePool{Spec: AzureMachinePoolSpec{
+		Template: AzureMachinePoolMachineTemplate{
+			DisableVMBootstrapExtension: ptr.To(true),
+		},
+	}}
+	machinePoolWithTrue.SetDisableVMBootstrapExtensionDefaults()
+	g.Expect(*machinePoolWithTrue.Spec.Template.DisableVMBootstrapExtension).To(BeTrue())
+
+	// Test that explicit false is preserved
+	machinePoolWithFalse := &AzureMachinePool{Spec: AzureMachinePoolSpec{
+		Template: AzureMachinePoolMachineTemplate{
+			DisableVMBootstrapExtension: ptr.To(false),
+		},
+	}}
+	machinePoolWithFalse.SetDisableVMBootstrapExtensionDefaults()
+	g.Expect(*machinePoolWithFalse.Spec.Template.DisableVMBootstrapExtension).To(BeFalse())
+}
+
 func createMachinePoolWithSSHPublicKey(sshPublicKey string) *AzureMachinePool {
 	return hardcodedAzureMachinePoolWithSSHKey(sshPublicKey)
 }

--- a/exp/api/v1beta1/azuremachinepool_types.go
+++ b/exp/api/v1beta1/azuremachinepool_types.go
@@ -101,6 +101,11 @@ type (
 		// +optional
 		VMExtensions []infrav1.VMExtension `json:"vmExtensions,omitempty"`
 
+		// DisableVMBootstrapExtension specifies whether the VM bootstrap extension should be disabled on the virtual machine scale set.
+		// Use this setting if you want to disable only the bootstrapping extension and not all extensions.
+		// +optional
+		DisableVMBootstrapExtension *bool `json:"disableVMBootstrapExtension,omitempty"`
+
 		// NetworkInterfaces specifies a list of network interface configurations.
 		// If left unspecified, the VM will get a single network interface with a
 		// single IPConfig in the subnet specified in the cluster's node subnet field.

--- a/exp/api/v1beta1/azuremachinepool_webhook_test.go
+++ b/exp/api/v1beta1/azuremachinepool_webhook_test.go
@@ -387,6 +387,94 @@ func TestAzureMachinePool_ValidateUpdate(t *testing.T) {
 			amp:     createMachinePoolWithNetworkConfig("subnet", []infrav1.NetworkInterface{{SubnetName: "testSubnet2"}}),
 			wantErr: true,
 		},
+		{
+			name: "azuremachinepool disableVMBootstrapExtension transition from nil to true is allowed",
+			oldAMP: &AzureMachinePool{
+				Spec: AzureMachinePoolSpec{
+					Template: AzureMachinePoolMachineTemplate{
+						SSHPublicKey:                validSSHPublicKey,
+						DisableVMBootstrapExtension: nil,
+						OSDisk:                      infrav1.OSDisk{CachingType: "None", OSType: "Linux"},
+					},
+				},
+			},
+			amp: &AzureMachinePool{
+				Spec: AzureMachinePoolSpec{
+					Template: AzureMachinePoolMachineTemplate{
+						SSHPublicKey:                validSSHPublicKey,
+						DisableVMBootstrapExtension: ptr.To(true),
+						OSDisk:                      infrav1.OSDisk{CachingType: "None", OSType: "Linux"},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "azuremachinepool disableVMBootstrapExtension transition from nil to false is allowed",
+			oldAMP: &AzureMachinePool{
+				Spec: AzureMachinePoolSpec{
+					Template: AzureMachinePoolMachineTemplate{
+						SSHPublicKey:                validSSHPublicKey,
+						DisableVMBootstrapExtension: nil,
+						OSDisk:                      infrav1.OSDisk{CachingType: "None", OSType: "Linux"},
+					},
+				},
+			},
+			amp: &AzureMachinePool{
+				Spec: AzureMachinePoolSpec{
+					Template: AzureMachinePoolMachineTemplate{
+						SSHPublicKey:                validSSHPublicKey,
+						DisableVMBootstrapExtension: ptr.To(false),
+						OSDisk:                      infrav1.OSDisk{CachingType: "None", OSType: "Linux"},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "azuremachinepool disableVMBootstrapExtension is immutable when previously set",
+			oldAMP: &AzureMachinePool{
+				Spec: AzureMachinePoolSpec{
+					Template: AzureMachinePoolMachineTemplate{
+						SSHPublicKey:                validSSHPublicKey,
+						DisableVMBootstrapExtension: ptr.To(true),
+						OSDisk:                      infrav1.OSDisk{CachingType: "None", OSType: "Linux"},
+					},
+				},
+			},
+			amp: &AzureMachinePool{
+				Spec: AzureMachinePoolSpec{
+					Template: AzureMachinePoolMachineTemplate{
+						SSHPublicKey:                validSSHPublicKey,
+						DisableVMBootstrapExtension: ptr.To(false),
+						OSDisk:                      infrav1.OSDisk{CachingType: "None", OSType: "Linux"},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "azuremachinepool disableVMBootstrapExtension unchanged when previously set",
+			oldAMP: &AzureMachinePool{
+				Spec: AzureMachinePoolSpec{
+					Template: AzureMachinePoolMachineTemplate{
+						SSHPublicKey:                validSSHPublicKey,
+						DisableVMBootstrapExtension: ptr.To(true),
+						OSDisk:                      infrav1.OSDisk{CachingType: "None", OSType: "Linux"},
+					},
+				},
+			},
+			amp: &AzureMachinePool{
+				Spec: AzureMachinePoolSpec{
+					Template: AzureMachinePoolMachineTemplate{
+						SSHPublicKey:                validSSHPublicKey,
+						DisableVMBootstrapExtension: ptr.To(true),
+						OSDisk:                      infrav1.OSDisk{CachingType: "None", OSType: "Linux"},
+					},
+				},
+			},
+			wantErr: false,
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/exp/api/v1beta1/zz_generated.deepcopy.go
+++ b/exp/api/v1beta1/zz_generated.deepcopy.go
@@ -301,6 +301,11 @@ func (in *AzureMachinePoolMachineTemplate) DeepCopyInto(out *AzureMachinePoolMac
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.DisableVMBootstrapExtension != nil {
+		in, out := &in.DisableVMBootstrapExtension, &out.DisableVMBootstrapExtension
+		*out = new(bool)
+		**out = **in
+	}
 	if in.NetworkInterfaces != nil {
 		in, out := &in.NetworkInterfaces, &out.NetworkInterfaces
 		*out = make([]apiv1beta1.NetworkInterface, len(*in))


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind cleanup

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
This PR disables the vm bootstrapping extension by default since it doesn't provide much value and causes confusion when cloud-init fails.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->


**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] cherry-pick candidate

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Disable VM Bootstrap Extension by default
```
