### PR TITLE
test(e2e): move capacity check to dedicated autoscale-from-zero test

### DIFF
--- a/test/e2e/azure_test.go
+++ b/test/e2e/azure_test.go
@@ -281,36 +281,6 @@ var _ = Describe("Workload cluster creation", func() {
 				})
 			})
 
-			By("Verifying AzureMachineTemplate capacity is populated for autoscaling from zero", func() {
-				azureMachineTemplateList := &infrav1.AzureMachineTemplateList{}
-				err := bootstrapClusterProxy.GetClient().List(ctx, azureMachineTemplateList, client.InNamespace(namespace.Name))
-				Expect(err).NotTo(HaveOccurred())
-				Expect(azureMachineTemplateList.Items).NotTo(BeEmpty(), "Expected at least one AzureMachineTemplate")
-
-				// Verify all templates have capacity populated with CPU and Memory
-				Expect(azureMachineTemplateList.Items).To(HaveEach(
-					HaveField("Status.Capacity", And(
-						HaveKey(corev1.ResourceCPU),
-						HaveKey(corev1.ResourceMemory),
-					)),
-				), "Expected all AzureMachineTemplate to have capacity populated")
-
-				// Verify all templates have nodeInfo populated with valid architecture and OS
-				Expect(azureMachineTemplateList.Items).To(HaveEach(
-					And(
-						HaveField("Status.NodeInfo", Not(BeNil())),
-						HaveField("Status.NodeInfo.Architecture", Or(
-							Equal(infrav1.ArchitectureAmd64),
-							Equal(infrav1.ArchitectureArm64),
-						)),
-						HaveField("Status.NodeInfo.OperatingSystem", Or(
-							Equal(infrav1.OperatingSystemLinux),
-							Equal(infrav1.OperatingSystemWindows),
-						)),
-					),
-				), "Expected all AzureMachineTemplate to have nodeInfo populated")
-			})
-
 			By("PASSED!")
 		})
 	})
@@ -1522,6 +1492,36 @@ spec:
 						WaitIntervals:         e2eConfig.GetIntervals(specName, "wait-autoscale"),
 					}
 				})
+			})
+
+			By("Verifying AzureMachineTemplate capacity is populated for autoscaling from zero", func() {
+				azureMachineTemplateList := &infrav1.AzureMachineTemplateList{}
+				err := bootstrapClusterProxy.GetClient().List(ctx, azureMachineTemplateList, client.InNamespace(namespace.Name))
+				Expect(err).NotTo(HaveOccurred())
+				Expect(azureMachineTemplateList.Items).NotTo(BeEmpty(), "Expected at least one AzureMachineTemplate")
+
+				// Verify all templates have capacity populated with CPU and Memory
+				Expect(azureMachineTemplateList.Items).To(HaveEach(
+					HaveField("Status.Capacity", And(
+						HaveKey(corev1.ResourceCPU),
+						HaveKey(corev1.ResourceMemory),
+					)),
+				), "Expected all AzureMachineTemplate to have capacity populated")
+
+				// Verify all templates have nodeInfo populated with valid architecture and OS
+				Expect(azureMachineTemplateList.Items).To(HaveEach(
+					And(
+						HaveField("Status.NodeInfo", Not(BeNil())),
+						HaveField("Status.NodeInfo.Architecture", Or(
+							Equal(infrav1.ArchitectureAmd64),
+							Equal(infrav1.ArchitectureArm64),
+						)),
+						HaveField("Status.NodeInfo.OperatingSystem", Or(
+							Equal(infrav1.OperatingSystemLinux),
+							Equal(infrav1.OperatingSystemWindows),
+						)),
+					),
+				), "Expected all AzureMachineTemplate to have nodeInfo populated")
 			})
 
 			By("PASSED!")


### PR DESCRIPTION
**What type of PR is this?**
/kind flake

**What this PR does / why we need it**:
Now that #6060 has landed a dedicated autoscaling-from-zero e2e test context, move the AzureMachineTemplate capacity and nodeInfo verification into that context where it logically belongs, rather than keeping it in the generic workload cluster creation test.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->


**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] cherry-pick candidate

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
