### PR TITLE
Fix image plan for image from compute gallery

### DIFF
--- a/azure/services/scalesets/spec.go
+++ b/azure/services/scalesets/spec.go
@@ -525,28 +525,7 @@ func (s *ScaleSetSpec) generateImagePlan(ctx context.Context) *armcompute.Plan {
 		log.V(2).Info("no vm image found, disabling plan")
 		return nil
 	}
-
-	if s.VMImage.SharedGallery != nil && s.VMImage.SharedGallery.Publisher != nil && s.VMImage.SharedGallery.SKU != nil && s.VMImage.SharedGallery.Offer != nil {
-		return &armcompute.Plan{
-			Publisher: s.VMImage.SharedGallery.Publisher,
-			Name:      s.VMImage.SharedGallery.SKU,
-			Product:   s.VMImage.SharedGallery.Offer,
-		}
-	}
-
-	if s.VMImage.Marketplace == nil || !s.VMImage.Marketplace.ThirdPartyImage {
-		return nil
-	}
-
-	if s.VMImage.Marketplace.Publisher == "" || s.VMImage.Marketplace.SKU == "" || s.VMImage.Marketplace.Offer == "" {
-		return nil
-	}
-
-	return &armcompute.Plan{
-		Publisher: ptr.To(s.VMImage.Marketplace.Publisher),
-		Name:      ptr.To(s.VMImage.Marketplace.SKU),
-		Product:   ptr.To(s.VMImage.Marketplace.Offer),
-	}
+	return converters.ImageToPlan(s.VMImage)
 }
 
 func (s *ScaleSetSpec) getSecurityProfile() (*armcompute.SecurityProfile, error) {


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
Currently, when VMSS (AzureMachinePool) uses an image with defined plan from compute gallery, plan is not set on VMSS. 
This impacts flatcar image built by image-builder that is then stored in compute gallery.

VMSS instances fail with following message:
```
Creating a virtual machine from Marketplace image or a custom image sourced from a Marketplace image requires Plan information in the request. VM: '/subscriptions/<ID>/resourceGroups/<RG>/providers/Microsoft.Compute/virtualMachineScaleSets/<VMSS>/virtualMachines/<VMSS>_72'.
```
AzureMachinePool manifest:
```
apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
kind: AzureMachinePool
<omitted>
  template:
    image:
      computeGallery:
        gallery: gal-name
        name: image-name
        resourceGroup: rg
        subscriptionID: id
        version: '1.35.1'
        plan:
          publisher: kinvolk
          offer: flatcar-container-linux-free
          sku: stable-gen2
<omitted>
```

The `generateImagePlan()` method in `azure/services/scalesets/spec.go:520` only handled two image types:
* `SharedGallery` images with plan fields
* Marketplace third-party images

Replaced the duplicated plan-generation logic in `ScaleSetSpec.generateImagePlan()` with a call to the shared `converters.ImageToPlan()` converter — the same one the VM path uses. This:
* Fixes the missing `ComputeGallery` plan support for VMSS
* Eliminates code duplication between VMSS and VM paths
* Ensures both paths stay in sync if new image types are added in the future

PR was tested locally and at cluster, where both MD and MP types deployed fine.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
none, I can create one if needed.

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->


**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] cherry-pick candidate

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix AzureMachinePool image plan for image from compute gallery
```
