### PR TITLE
Ignore HTTPProxyCIDR in join configuration dalec test

### DIFF
--- a/templates/test/ci/cluster-template-prow-dalec-custom-builds.yaml
+++ b/templates/test/ci/cluster-template-prow-dalec-custom-builds.yaml
@@ -283,6 +283,8 @@ spec:
         name: '{{ ds.meta_data["local_hostname"] }}'
     joinConfiguration:
       nodeRegistration:
+        ignorePreflightErrors:
+        - HTTPProxyCIDR
         kubeletExtraArgs:
           cloud-provider: external
         name: '{{ ds.meta_data["local_hostname"] }}'

--- a/templates/test/ci/prow-dalec-custom-builds/patches/control-plane-custom-builds.yaml
+++ b/templates/test/ci/prow-dalec-custom-builds/patches/control-plane-custom-builds.yaml
@@ -111,4 +111,8 @@
   path: /spec/kubeadmConfigSpec/initConfiguration/nodeRegistration/ignorePreflightErrors
   value:
     - HTTPProxyCIDR
-  
+# Also add ignorePreflightErrors for join operations (second/third control plane nodes)
+- op: add
+  path: /spec/kubeadmConfigSpec/joinConfiguration/nodeRegistration/ignorePreflightErrors
+  value:
+    - HTTPProxyCIDR


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind cleanup

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
This PR adds a patch to ignore HTTPProxyCIDR in join configuration as well as init as it affects other control plane nodes too

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->


**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] cherry-pick candidate

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
