### PR TITLE
Bump Go toolchain to v1.24.13

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module sigs.k8s.io/cluster-api-provider-azure
 
 go 1.24.6
 
-toolchain go1.24.12
+toolchain go1.24.13
 
 // Workaround for prometheus/common v0.66.0+ breaking change that causes panic
 // in cluster-api test framework's TextParser usage. Pin prometheus dependencies

--- a/hack/ensure-go.sh
+++ b/hack/ensure-go.sh
@@ -31,7 +31,7 @@ EOF
   local go_version
   IFS=" " read -ra go_version <<< "$(go version)"
   local minimum_go_version
-  minimum_go_version=go1.24.12
+  minimum_go_version=go1.24.13
   if [[ "${minimum_go_version}" != $(echo -e "${minimum_go_version}\n${go_version[2]}" | sort -s -t. -k 1,1 -k 2,2n -k 3,3n | head -n1) && "${go_version[2]}" != "devel" ]]; then
     cat <<EOF
 Detected go version: ${go_version[*]}.

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -2,7 +2,7 @@ module sigs.k8s.io/cluster-api-provider-azure/hack/tools
 
 go 1.24.0
 
-toolchain go1.24.12
+toolchain go1.24.13
 
 require sigs.k8s.io/cluster-api/hack/tools v0.0.0-20251125201037-d322ff6baa2f
 


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Updates the Go compiler and tools to v1.24.13.

> go1.24.13 (released 2026-02-04) includes security fixes to the go command and the `crypto/tls` package, as well as bug fixes to the `crypto/x509` package. See the [Go 1.24.13 milestone](https://github.com/golang/go/issues?q=milestone%3AGo1.24.13+label%3ACherryPickApproved) on our issue tracker for details.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
See #6045 for prior art.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [x] cherry-pick candidate

**Release note**:

```release-note
NONE
```
