### PR TITLE
Sysconfig fix for ci-version-azl3 template

### DIFF
--- a/templates/test/ci/cluster-template-prow-ci-version-azl3.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version-azl3.yaml
@@ -228,6 +228,21 @@ spec:
       owner: root:root
       path: /tmp/kubeadm-bootstrap.sh
       permissions: "0744"
+    - content: |
+        #!/bin/bash
+
+        set -o nounset
+        set -o pipefail
+        set -o errexit
+
+        # Fix stale kubelet sysconfig flags from gallery images
+        # (e.g. --pod-infra-container-image was removed in v1.35).
+        if [ -f "/etc/sysconfig/kubelet" ]; then
+          sed -i 's/--pod-infra-container-image[^ ]*//' /etc/sysconfig/kubelet
+        fi
+      owner: root:root
+      path: /tmp/fix-sysconfig.sh
+      permissions: "0744"
     initConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
@@ -248,6 +263,7 @@ spec:
     postKubeadmCommands: []
     preKubeadmCommands:
     - bash -c /tmp/azl3-setup.sh
+    - bash -c /tmp/fix-sysconfig.sh
     - bash -c /tmp/oot-cred-provider.sh
     - bash -c /tmp/kubeadm-bootstrap.sh
     verbosity: 5
@@ -512,6 +528,21 @@ spec:
         owner: root:root
         path: /tmp/kubeadm-bootstrap.sh
         permissions: "0744"
+      - content: |
+          #!/bin/bash
+
+          set -o nounset
+          set -o pipefail
+          set -o errexit
+
+          # Fix stale kubelet sysconfig flags from gallery images
+          # (e.g. --pod-infra-container-image was removed in v1.35).
+          if [ -f "/etc/sysconfig/kubelet" ]; then
+            sed -i 's/--pod-infra-container-image[^ ]*//' /etc/sysconfig/kubelet
+          fi
+        owner: root:root
+        path: /tmp/fix-sysconfig.sh
+        permissions: "0744"
       joinConfiguration:
         nodeRegistration:
           kubeletExtraArgs:
@@ -521,6 +552,7 @@ spec:
           name: '{{ ds.meta_data["local_hostname"] }}'
       preKubeadmCommands:
       - bash -c /tmp/azl3-setup.sh
+      - bash -c /tmp/fix-sysconfig.sh
       - bash -c /tmp/oot-cred-provider.sh
       - bash -c /tmp/kubeadm-bootstrap.sh
       verbosity: 5

--- a/templates/test/ci/prow-ci-version-azl3/kustomization.yaml
+++ b/templates/test/ci/prow-ci-version-azl3/kustomization.yaml
@@ -21,6 +21,19 @@ patches:
 - path: ../prow-azl3/patches/remove-marketplace-image.yaml
 - path: ../prow-azl3/patches/cloud-provider-azure-cacertdir.yaml
 - path: ../prow-azl3/patches/cloud-provider-azure-ci-cacertdir.yaml
+- path: patches/fix-sysconfig-control-plane.yaml
+  target:
+    group: controlplane.cluster.x-k8s.io
+    kind: KubeadmControlPlane
+    name: .*-control-plane
+    version: v1beta1
+- path: patches/fix-sysconfig.yaml
+  target:
+    group: bootstrap.cluster.x-k8s.io
+    kind: KubeadmConfigTemplate
+    name: .*-md-0
+    namespace: default
+    version: v1beta1
 
 sortOptions:
   order: fifo

--- a/templates/test/ci/prow-ci-version-azl3/patches/fix-sysconfig-control-plane.yaml
+++ b/templates/test/ci/prow-ci-version-azl3/patches/fix-sysconfig-control-plane.yaml
@@ -1,0 +1,22 @@
+- op: add
+  path: /spec/kubeadmConfigSpec/files/-
+  value:
+    content: |
+      #!/bin/bash
+
+      set -o nounset
+      set -o pipefail
+      set -o errexit
+
+      # Fix stale kubelet sysconfig flags from gallery images
+      # (e.g. --pod-infra-container-image was removed in v1.35).
+      if [ -f "/etc/sysconfig/kubelet" ]; then
+        sed -i 's/--pod-infra-container-image[^ ]*//' /etc/sysconfig/kubelet
+      fi
+    path: /tmp/fix-sysconfig.sh
+    owner: "root:root"
+    permissions: "0744"
+- op: add
+  path: /spec/kubeadmConfigSpec/preKubeadmCommands/1
+  value:
+    bash -c /tmp/fix-sysconfig.sh

--- a/templates/test/ci/prow-ci-version-azl3/patches/fix-sysconfig.yaml
+++ b/templates/test/ci/prow-ci-version-azl3/patches/fix-sysconfig.yaml
@@ -1,0 +1,22 @@
+- op: add
+  path: /spec/template/spec/files/-
+  value:
+    content: |
+      #!/bin/bash
+
+      set -o nounset
+      set -o pipefail
+      set -o errexit
+
+      # Fix stale kubelet sysconfig flags from gallery images
+      # (e.g. --pod-infra-container-image was removed in v1.35).
+      if [ -f "/etc/sysconfig/kubelet" ]; then
+        sed -i 's/--pod-infra-container-image[^ ]*//' /etc/sysconfig/kubelet
+      fi
+    path: /tmp/fix-sysconfig.sh
+    owner: "root:root"
+    permissions: "0744"
+- op: add
+  path: /spec/template/spec/preKubeadmCommands/1
+  value:
+    bash -c /tmp/fix-sysconfig.sh


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
Fix ci-version-azl3 template which started failing due to a deprecated flag introduced in k8s 1.35

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->


**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] cherry-pick candidate

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
