### PR TITLE
[WIP] triage e2e test failures

### DIFF
--- a/api/v1beta1/azuremanagedmachinepool_webhook.go
+++ b/api/v1beta1/azuremanagedmachinepool_webhook.go
@@ -42,7 +42,7 @@ import (
 
 var validNodePublicPrefixID = regexp.MustCompile(`(?i)^/?subscriptions/[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}/resourcegroups/[^/]+/providers/microsoft\.network/publicipprefixes/[^/]+$`)
 
-// SetupAzureManagedMachinePoolWebhookWithManager sets up and registers the webhook with the manager.
+// SetupAzureManagedMachinePoolWebhookWithManager sets up and registers the webhook with the manager
 func SetupAzureManagedMachinePoolWebhookWithManager(mgr ctrl.Manager) error {
 	mw := &azureManagedMachinePoolWebhook{Client: mgr.GetClient()}
 	return ctrl.NewWebhookManagedBy(mgr).

--- a/azure/credential_cache_test.go
+++ b/azure/credential_cache_test.go
@@ -58,7 +58,7 @@ func TestGetOrStore(t *testing.T) {
 	g.Expect(cred).To(Equal(fakeTokenCredential{tenantID: "1"}))
 	g.Expect(newCredCount).To(Equal(1))
 
-	// subsequent calls for the same key should not create a new credential
+	// subsequent calls for the same key should not create a new credential.
 	cred, err = credCache.getOrStore(credentialCacheKey{tenantID: "1"}, newCredFunc(fakeTokenCredential{tenantID: "1"}, nil))
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(cred).To(Equal(fakeTokenCredential{tenantID: "1"}))


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->


**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] cherry-pick candidate

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
