### PR TITLE
Add ARO HCP proposal for CAPZ support

### DIFF
--- a/docs/proposals/20250425-aro-hcp.md
+++ b/docs/proposals/20250425-aro-hcp.md
@@ -839,6 +839,33 @@ The proper dependency sequence ensures resources are created in the correct orde
 
 This dependency chain **eliminates CAPI kubeconfig errors** by ensuring the kubeconfig exists before CAPI attempts to connect.
 
+### Teardown Order
+
+Deletion follows the reverse dependency chain. When the CAPI Cluster is deleted:
+
+```
+1. CAPI Cluster deletion triggered
+   ↓
+2. AROControlPlane finalizer deletes HcpOpenShiftClustersExternalAuth first
+   - ExternalAuth depends on NodePool, so it must be removed before NodePool teardown
+   - Waits for ASO to confirm deletion from Azure
+   ↓
+3. AROMachinePool finalizer runs
+   - Deletes HcpOpenShiftClustersNodePool ASO resources
+   - Waits for ASO to confirm deletion from Azure
+   ↓
+4. AROControlPlane finalizer completes
+   - Deletes HcpOpenShiftCluster ASO resource
+   - Waits for ASO to confirm deletion from Azure
+   ↓
+5. AROCluster finalizer runs
+   - Deletes infrastructure ASO resources (Vault, NSG, Subnet, VNet, Identities)
+   - Deletes ResourceGroup last (cascades remaining Azure resources)
+   - Waits for ASO to confirm deletion from Azure
+```
+
+ASO handles the actual Azure resource deletion and respects Azure-side dependencies. CAPI `ownerReferences` ensure the correct ordering between controllers. The ExternalAuth resource is deleted early in the teardown because it depends on an operational NodePool — mirroring the creation-time dependency where ExternalAuth is deferred until NodePool is ready.
+
 ### Syncing Between Controllers
 
 - **Ownership and References**:

--- a/docs/proposals/20250425-aro-hcp.md
+++ b/docs/proposals/20250425-aro-hcp.md
@@ -8,8 +8,8 @@ reviewers:
  - "@jackfrancis"
  - "@bryan-cox"
 creation-date: 2025-04-25
-last-updated: 2026-03-11
-status: implementable
+last-updated: 2026-06-30
+status: provisional
 ---
 
 
@@ -57,6 +57,7 @@ The implementation leverages ASO resources embedded directly in Custom Resource 
 
 - Support for non-HCP Azure services not specified in the ARO HCP API.
 - Field-based provisioning mode (deprecated and removed in favor of resources mode).
+- ClusterClass / topology support. ARO HCP clusters are not integrated with ClusterClass at this stage. This may be explored as future work once the core integration stabilizes.
 
 
 ## Proposal
@@ -587,6 +588,11 @@ type AROClusterSpec struct {
 
  // ControlPlaneEndpoint represents the endpoint used to communicate with the control plane.
  // Set by the controller from AROControlPlane status.
+ //
+ // NOTE: This field is in spec (not status) because the CAPI InfrastructureCluster contract
+ // requires spec.controlPlaneEndpoint to be set. The controller mutates this field, which is
+ // unusual but matches how other CAPZ infrastructure types (e.g., AzureCluster,
+ // AzureASOManagedCluster) implement the same contract.
  ControlPlaneEndpoint clusterv1.APIEndpoint `json:"controlPlaneEndpoint"`
 
  // SubscriptionID is the Azure subscription ID for the cluster
@@ -773,7 +779,7 @@ Each controller is responsible for:
 
 Key features:
 - **Dependency Management**: Waits for AROCluster infrastructure (ResourcesReady condition) before creating HcpOpenShiftCluster
-- **ExternalAuth Deferral**: Uses resource filtering to defer ExternalAuth creation until NodePool is ready to avoid Azure API errors
+- **ExternalAuth Deferral**: The controller filters HcpOpenShiftClustersExternalAuth resources from reconciliation until at least one AROMachinePool reports `Ready=True`. This is necessary because the Azure ARO HCP API returns errors if ExternalAuth is created before the cluster has operational node pools. The controller checks AROMachinePool conditions on each reconciliation loop; once a node pool is ready, the ExternalAuth resource is included in the next reconciliation pass and created via ASO.
 - **Encryption Key Management**: Uses keyvaults service to create/retrieve encryption keys, sets version in HcpOpenShiftCluster via mutator
 - **Condition Tracking**:
   - `HcpClusterReady`: HCP cluster operational status
@@ -1210,6 +1216,15 @@ Resource Deployment
 ### Using AzureASOManagedControlPlane
 
 AzureASOManagedControlPlane is designed for AKS managed clusters using `containerservice.azure.com` resources. ARO HCP uses fundamentally different Azure resource types (`redhatopenshift.azure.com/HcpOpenShiftCluster`) with ARO-specific requirements including ETCD encryption with Key Vault integration, external authentication resources, and different node pool APIs. The architectural differences are significant enough that separate CRDs provide clearer API boundaries and simpler controller logic than trying to unify both platforms under a single type.
+
+### Typed Fields with AdditionalResources
+
+An alternative to using `[]runtime.RawExtension` for all resources would be to define dedicated typed fields for the primary resources (e.g., `HcpOpenShiftCluster`, `HcpOpenShiftClustersNodePool`) and use an `AdditionalResources` field for the rest. This would provide CRD schema validation and type safety for the core resources.
+
+We chose the all-RawExtension approach because:
+- It follows the same pattern established by `AzureASOManagedControlPlane`, `AzureASOManagedCluster`, and `AzureASOManagedMachinePool` — consistency within CAPZ is valuable.
+- The ARO HCP API is still in preview and evolving. Typed fields would require CAPZ releases for every API change, while embedded ASO resources delegate schema validation to ASO itself.
+- ASO already provides full CRD validation for each resource type. Adding typed fields in CAPZ would be a second layer of validation with no additional safety benefit.
 
 ### Pure ASO Without CAPZ Controllers
 

--- a/docs/proposals/20250425-aro-hcp.md
+++ b/docs/proposals/20250425-aro-hcp.md
@@ -2,10 +2,13 @@
 title: ARO HCP Clusters
 authors:
  - "@serngawy"
+ - "@marek-veber"
 reviewers:
- - ""
-creation-date: 2025-04-23
-last-updated: 2025-04-25
+ - "@willie-yao"
+ - "@jackfrancis"
+ - "@bryan-cox"
+creation-date: 2025-04-25
+last-updated: 2026-03-11
 status: implementable
 ---
 
@@ -22,6 +25,8 @@ status: implementable
 - [Proposal](#proposal)
 - [User Stories](#user-stories)
 - [Implementation Details](#implementation-details)
+- [Alternatives Considered](#alternatives-considered)
+- [Maintenance and Ownership](#maintenance-and-ownership)
 - [Risks and Mitigations](#risks-and-mitigations)
 - [Graduation Criteria](#graduation-criteria)
 - [Implementation History](#implementation-history)
@@ -30,58 +35,58 @@ status: implementable
 ## Introduction
 
 
-The Cluster API Provider for Azure (CAPZ) aims to extend Kubernetes Cluster API functionality to Microsoft Azure environments, facilitating the management and lifecycle of Kubernetes clusters on Azure. This proposal outlines the integration of Azure Red Hat OpenShift (ARO) Hybrid Cloud Platform (HCP) clusters within CAPZ.
+The Cluster API Provider for Azure (CAPZ) extends Kubernetes Cluster API functionality to Microsoft Azure environments, facilitating the management and lifecycle of Kubernetes clusters on Azure. This proposal outlines the integration of Azure Red Hat OpenShift (ARO) Hosted Control Plane (HCP) clusters within CAPZ using Azure Service Operator (ASO) for resource provisioning.
+
+ARO HCP is an evolution of Azure Red Hat OpenShift that uses a hosted control plane architecture. For more information about ARO HCP, see the [ARO-HCP repository](https://github.com/Azure/ARO-HCP).
+
+The implementation leverages ASO resources embedded directly in Custom Resource specifications, providing a declarative, Kubernetes-native approach to managing ARO HCP infrastructure.
 
 
 ## Goals
 
 
-- **Integration**: Enable provisioning and management of ARO HCP clusters using CAPZ.
-- **API Conformance**: Align CAPZ operations with ARO HCP API specifications.
+- **Integration**: Enable provisioning and management of ARO HCP clusters using CAPZ with ASO.
+- **API Conformance**: Align CAPZ operations with ARO HCP API specifications via ASO resources.
 - **Scalability**: Support scaling of ARO HCP clusters through CAPZ controllers.
 - **Operational Excellence**: Provide seamless cluster lifecycle management, including creation, scaling, and deletion.
+- **Declarative Infrastructure**: Use embedded ASO resources for infrastructure-as-code approach.
 
 
 ## Non-Goals
 
 
 - Support for non-HCP Azure services not specified in the ARO HCP API.
+- Field-based provisioning mode (deprecated and removed in favor of resources mode).
 
 
 ## Proposal
 
 
-CAPZ will introduce controllers and reconcilers to interact with the ARO HCP API endpoints defined in [ARO HCP OpenAPI Specification](https://github.com/Azure/ARO-HCP/blob/main/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpclusters/preview/2024-06-10-preview/openapi.json). This includes:
+CAPZ introduces controllers and reconcilers to manage ARO HCP clusters using ASO (Azure Service Operator) resources. Instead of field-based specifications, infrastructure is defined declaratively using embedded ASO resource definitions in the `spec.resources` field.
 
-
-- **Cluster Creation**: Implementing CAPZ controllers to provision ARO HCP clusters based on user-defined specifications.
-- **Lifecycle Management**: Supporting cluster scaling, updates, and deletion via CAPZ workflows.
-- **Monitoring and Metrics**: Integrating with Azure monitoring services for CAPZ-managed ARO HCP clusters.
-
-
-​CAPZ will introduce new controllers and reconcilers that manage a dedicated Custom Resource Definition (CRD) representing ARO HCP clusters. These controllers will reconcile the CRD's desired state by interacting with the ARO HCP API endpoints, as defined in the [ARO HCP OpenAPI Specification](https://github.com/Azure/ARO-HCP/blob/main/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpclusters/preview/2024-06-10-preview/openapi.json). This approach enables declarative management of ARO HCP clusters through Kubernetes-native workflows.​
+This approach:
+- Uses ASO's native resource types (HcpOpenShiftCluster, Vault, etc.)
+- Provides full control over Azure resource configuration
+- Eliminates dual-path provisioning logic
+- Follows Kubernetes-native patterns for infrastructure management
 
 
 Key capabilities include:
 
 
-- **Cluster Provisioning**: Users can define ARO HCP clusters declaratively via the CRD. CAPZ controllers will interpret these definitions and provision clusters accordingly through the ARO HCP API.​
+- **Cluster Provisioning**: Users define ARO HCP clusters declaratively via embedded ASO resources in the CRD. CAPZ controllers reconcile these resources using ASO.
 
+- **Lifecycle Management**: Controllers handle scaling, upgrades, and deletion of ARO HCP clusters by reconciling ASO resources.
 
-- **Lifecycle Management**: The controllers will handle scaling, upgrades, and deletion of ARO HCP clusters by reconciling changes in the CRD with the ARO HCP API.​
-
-
-- **Monitoring and Metrics**: Integration with Azure monitoring services will provide observability for CAPZ-managed ARO HCP clusters.​
-
-
-To control the rollout of this functionality, a new Feature Gate named ARO-HCP will be introduced. This feature gate allows users to enable or disable the ARO HCP integration within CAPZ, facilitating gradual adoption and testing.
+- **Dependency Management**: Proper sequencing ensures resources are ready before dependent resources are created (e.g., infrastructure ready before HCP cluster creation).
 
 
 ## User Stories
 
 
-- As a Kubernetes operator, I want to deploy an ARO HCP cluster using familiar Kubernetes APIs via CAPZ.
-- As a platform engineer, I need automated scaling and management capabilities for ARO HCP clusters using CAPZ controllers.
+- As a Kubernetes operator, I want to deploy an ARO HCP cluster using Kubernetes-native ASO resources via CAPZ.
+- As a platform engineer, I need declarative infrastructure management for ARO HCP clusters with full control over Azure resources.
+- As a DevOps engineer, I want infrastructure-as-code for ARO HCP clusters that can be version-controlled and reviewed.
 
 
 ## Implementation Details
@@ -90,11 +95,12 @@ To control the rollout of this functionality, a new Feature Gate named ARO-HCP w
 ### Controller Architecture:
 
 
-Develop CAPZ controllers for ARO HCP resource types specified in the API. To support ARO HCP clusters within CAPZ, Three new Custom Resource Definitions (CRDs) and their corresponding controllers will be introduced:
+CAPZ implements three Custom Resource Definitions (CRDs) and their corresponding controllers to manage ARO HCP clusters:
 
 
-- **AROControlPlane CRD (HcpOpenShiftCluster)**: Represents the desired state of an ARO Hybrid Cloud Platform cluster's control plane, based on the ARO HCP OpenAPI Specification defined as [HcpOpenShiftCluster](https://github.com/Azure/ARO-HCP/blob/main/internal/api/hcpopenshiftcluster.go#L22).
+#### AROControlPlane CRD
 
+Represents the desired state of an ARO HCP cluster's control plane. Uses embedded ASO resources for infrastructure provisioning.
 
 ```go
 // AROControlPlane is the Schema for the AROControlPlane API.
@@ -102,252 +108,363 @@ type AROControlPlane struct {
  metav1.TypeMeta   `json:",inline"`
  metav1.ObjectMeta `json:"metadata,omitempty"`
 
-
  Spec   AROControlPlaneSpec   `json:"spec,omitempty"`
  Status AROControlPlaneStatus `json:"status,omitempty"`
 }
 
-
-
-
 type AROControlPlaneSpec struct {
- // Aro Cluster name must be valid DNS-1035 label.
- AroClusterName string `json:"aroClusterName"`
+ // Resources are embedded ASO resources to be managed by this AROControlPlane.
+ // This allows you to define the full infrastructure including HcpOpenShiftCluster and
+ // HcpOpenShiftClustersExternalAuth resources directly using ASO types.
+ //
+ // Required. Must include at minimum:
+ // - HcpOpenShiftCluster resource
+ // - HcpOpenShiftClustersExternalAuth resource (if external auth is needed)
+ //
+ // Example resources (using private preview API v1api20240610preview):
+ // - redhatopenshift.azure.com/v1api20240610preview/HcpOpenShiftCluster
+ // - redhatopenshift.azure.com/v1api20240610preview/HcpOpenShiftClustersExternalAuth
+ //
+ // Note: v1api20240610preview is the private preview API. Migration to public preview
+ // API (v1api20251223preview) is planned. See API specs at:
+ // https://github.com/Azure/ARO-HCP/tree/main/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpclusters/preview
+ Resources []runtime.RawExtension `json:"resources,omitempty"`
 
-
- // PlatformProfile represents the Azure platform configuration.
- Platform PlatformProfile `json:"platform,omitempty"`
-
- // Visibility represents the visibility of an API endpoint. Allowed values are public and private default is public.
- Visibility string `json:"visibility,omitempty"`
-
- // Network config for the ARO HCP cluster.
- Network *NetworkSpec `json:"network,omitempty"`
-
- // DomainPrefix is an optional prefix added to the cluster's domain name.
- DomainPrefix string `json:"domainPrefix,omitempty"`
-
- // OpenShift semantic version, for example "4.20.0".
- Version string `json:"version"`
-
-
- // OpenShift version channel group, default is stable. Allowed values are stable, candidate and nightly default is stable
- ChannelGroup string `json:"channelGroup"`
-
- // VersionGate requires acknowledgment when upgrading ARO-HCP y-stream versions (e.g., from 4.20 to 4.21).
- // Allowed values are Acknowledge, WaitForAcknowledge and AlwaysAcknowledge default is WaitForAcknowledge.
- VersionGate string `json:"versionGate"`
-
-
- // IdentityRef is a reference to an identity to be used when reconciling the aro control plane.
- // If no identity is specified, the default identity for this controller will be used.
+ // IdentityRef is a reference to an identity to be used when reconciling the ARO control plane.
+ // This field is optional. When set, CAPZ will:
+ // - Initialize Azure SDK credentials using the specified identity
+ // - Create encryption keys in Key Vault (but NOT the vault itself!)
+ // - Propagate key versions to HcpOpenShiftCluster spec
+ //
+ // IMPORTANT: Even when identityRef is set, the Vault resource must be declared in
+ // AROCluster.spec.resources[] so ASO can create the vault. CAPZ only creates the
+ // encryption KEY inside the existing vault.
+ //
+ // When NOT set (ASO credential-based mode):
+ // - ASO handles authentication via serviceoperator.azure.com/credential-from annotations
+ // - CAPZ skips Key Vault operations
+ // - Customers must manually create the vault (in AROCluster.spec.resources[]) and encryption key
+ // - The key version must be manually specified in HcpOpenShiftCluster spec
+ //
+ // +optional
  IdentityRef *corev1.ObjectReference `json:"identityRef,omitempty"`
 
+ // SubscriptionID is the GUID of the Azure subscription that owns this cluster.
+ // Required for Azure API authentication and ARM resource ID construction.
+ SubscriptionID string `json:"subscriptionID,omitempty"`
 
- // AdditionalTags are user-defined tags to be added to the Azure resources associated with the control plane.
- AdditionalTags infrav1.Tags `json:"additionalTags,omitempty"`
-}
-
-
-// PlatformProfile represents the Azure platform configuration.
-type PlatformProfile struct {
- // Location should be valid Azure location ex; centralus
- Location string `json:"location,omitempty"`
-
-
- // Resource group name where the Aro-hcp will be attached to it.
- ResourceGroup string `json:"resourceGroup,omitempty"`
-
-
- // ResourceGroup Ref name that is used to create the ResourceGroup CR. The ResourceGroupRef must be in the same namespace as the AroControlPlane.
- ResourceGroupRef string `json:"resourceGroupRef,omitempty"`
-
-
- // Azure subnet id
- Subnet string `json:"subnet,omitempty"`
-
-
- // Subnet Ref name that is used to create the VirtualNetworksSubnet CR. The SubnetRef must be in the same namespace as the AroControlPlane and cannot be set with Subnet.
- SubnetRef string `json:"subnetRef,omitempty"`
-
-
-  // OutboundType represents a routing strategy to provide egress to the Internet. Allowed value is loadBalancer
-  OutboundType string `json:"outboundType,omitempty"`
-
-  // Azure Network Security Group ID
-  NetworkSecurityGroupID string `json:"networkSecurityGroupId,omitempty"`
-
-  // ManagedIdentities Azure managed identities for ARO HCP.
-  ManagedIdentities ManagedIdentities `json:"managedIdentities,omitempty"`
-}
-
-type ManagedIdentities struct {
-  // CreateAROHCPManagedIdentities is used to create the required ARO-HCP managed identities if not provided.
-  // It will create UserAssignedIdentity CR for each required managed identity. Default is false. 
-  CreateAROHCPManagedIdentities bool `json:"createAROHCPManagedIdentities,omitempty"`
-  
- // ControlPlaneOperators Ref to Microsoft.ManagedIdentity/userAssignedIdentities
- ControlPlaneOperators  *ControlPlaneOperators `json:"controlPlaneOperators,omitempty"`
-
- // DataPlaneOperators ref to Microsoft.ManagedIdentity/userAssignedIdentities
- DataPlaneOperators     *DataPlaneOperators `json:"dataPlaneOperators,omitempty"`
-
- // ServiceManagedIdentity ref to Microsoft.ManagedIdentity/userAssignedIdentities
- ServiceManagedIdentity string            `json:"serviceManagedIdentity,omitempty"`
-}
-
-type ControlPlaneOperators struct {
-	// ControlPlaneManagedIdentities "control-plane" Microsoft.ManagedIdentity/userAssignedIdentities
-	ControlPlaneManagedIdentities string `json:"controlPlaneOperatorsManagedIdentities,omitempty"`
-
-    // ClusterAPIAzureManagedIdentities "cluster-api-azure" Microsoft.ManagedIdentity/userAssignedIdentities
-	ClusterAPIAzureManagedIdentities string `json:"clusterAPIAzureManagedIdentities,omitempty"`
-	
-	// CloudControllerManagerManagedIdentities "cloud-controller-manager" Microsoft.ManagedIdentity/userAssignedIdentities
-	CloudControllerManagerManagedIdentities string `json:"cloudControllerManager,omitempty"`
-	
-	// IngressManagedIdentities "ingress" Microsoft.ManagedIdentity/userAssignedIdentities
-	IngressManagedIdentities string `json:"ingressManagedIdentities,omitempty"`
-
-    // DiskCsiDriverManagedIdentities "disk-csi-driver" Microsoft.ManagedIdentity/userAssignedIdentities
-	DiskCsiDriverManagedIdentities string `json:"diskCsiDriverManagedIdentities,omitempty"`
-
-    // FileCsiDriverManagedIdentities "file-csi-driver" Microsoft.ManagedIdentity/userAssignedIdentities
-	FileCsiDriverManagedIdentities string `json:"fileCsiDriverManagedIdentities,omitempty"`
-
-    // ImageRegistryManagedIdentities "image-registry" Microsoft.ManagedIdentity/userAssignedIdentities
-	ImageRegistryManagedIdentities string `json:"imageRegistryManagedIdentities,omitempty"`
-
-    // CloudNetworkConfigManagedIdentities "cloud-network-config" Microsoft.ManagedIdentity/userAssignedIdentities
-	CloudNetworkConfigManagedIdentities string `json:"cloudNetworkConfigManagedIdentities,omitempty"`
-
-    // KmsManagedIdentities "kms" Microsoft.ManagedIdentity/userAssignedIdentities
-	KmsManagedIdentities string `json:"kmsManagedIdentities,omitempty"`
-}
-
-type DataPlaneOperators struct {
-	// DiskCsiDriverManagedIdentities "disk-csi-driver" Microsoft.ManagedIdentity/userAssignedIdentities
-	DiskCsiDriverManagedIdentities string `json:"diskCsiDriverManagedIdentities,omitempty"`
-
-	// FileCsiDriverManagedIdentities "file-csi-driver" Microsoft.ManagedIdentity/userAssignedIdentities
-	FileCsiDriverManagedIdentities string `json:"fileCsiDriverManagedIdentities,omitempty"`
-
-    // ImageRegistryManagedIdentities "image-registry" Microsoft.ManagedIdentity/userAssignedIdentities
-	ImageRegistryManagedIdentities string `json:"imageRegistryManagedIdentities,omitempty"`
-}
-
-type NetworkSpec struct {
- // IP addresses block used by OpenShift while installing the cluster, for example "10.0.0.0/16".
- MachineCIDR string `json:"machineCIDR,omitempty"`
-
- // IP address block from which to assign pod IP addresses, for example `10.128.0.0/14`.
- PodCIDR string `json:"podCIDR,omitempty"`
-
- // IP address block from which to assign service IP addresses, for example `172.30.0.0/16`.
- ServiceCIDR string `json:"serviceCIDR,omitempty"`
-
- // Network host prefix which is defaulted to `23` if not specified.
- HostPrefix int `json:"hostPrefix,omitempty"`
-
- // The CNI network type default is OVNKubernetes. Allowed values are OVNKubernetes and Other.
- NetworkType string `json:"networkType,omitempty"`
+ // AzureEnvironment is the name of the AzureCloud to be used.
+ // The default value that would be used by most users is "AzurePublicCloud", other values are:
+ // - ChinaCloud: "AzureChinaCloud"
+ // - PublicCloud: "AzurePublicCloud"
+ // - USGovernmentCloud: "AzureUSGovernmentCloud"
+ //
+ // Note that values other than the default must also be accompanied by corresponding changes to the
+ // aso-controller-settings Secret to configure ASO to refer to the non-Public cloud.
+ AzureEnvironment string `json:"azureEnvironment,omitempty"`
 }
 
 type AROControlPlaneStatus struct {
- // Initialized indicates whether or not the control plane has initialized.
- Initialized bool `json:"initialized"`
+ // Initialization status
+ Initialization *AROControlPlaneInitializationStatus `json:"initialization,omitempty"`
 
  // Ready indicates that the AROControlPlane API Server is ready to receive requests.
+ // Set to true when both HcpClusterReady condition is true AND kubeconfig exists.
  Ready bool `json:"ready"`
 
  // FailureMessage will be set in the event that there is a terminal problem
  FailureMessage *string `json:"failureMessage,omitempty"`
 
  // Conditions specifies the conditions for the managed control plane
+ // Key conditions:
+ // - HcpClusterReady: HCP cluster is fully operational
+ // - EncryptionKeyReady: ETCD encryption key is ready (if encryption configured)
+ // - ExternalAuthReady: External authentication is configured (if enabled)
  Conditions clusterv1.Conditions `json:"conditions,omitempty"`
 
- // ID is the cluster ID given by ARO-HCP.
- ID string `json:"id,omitempty"`
+ // Resources status for each ASO resource managed by this control plane
+ Resources []ResourceStatus `json:"resources,omitempty"`
 
- // ConsoleURL is the url for the ARO-HCP openshift console.
- ConsoleURL string `json:"consoleURL,omitempty"`
-
- // APIURL is the url for the ARO-HCP openshift cluster api endPoint.
+ // APIURL is the url for the ARO-HCP openshift cluster api endpoint.
  APIURL string `json:"apiURL,omitempty"`
 
- // ARO-HCP OpenShift semantic version, for example "4.20.0".
- Version string `json:"version"`
+ // Version is the ARO-HCP OpenShift semantic version, for example "4.20.0".
+ Version string `json:"version,omitempty"`
+}
 
- // Available upgrades for the ARO hosted control plane.
- AvailableUpgrades []string `json:"availableUpgrades,omitempty"`
+type AROControlPlaneInitializationStatus struct {
+ // ControlPlaneInitialized indicates whether or not the control plane has the
+ // uploaded kubeconfig secret and the secret is valid.
+ ControlPlaneInitialized bool `json:"controlPlaneInitialized,omitempty"`
+}
+
+type ResourceStatus struct {
+ // Resource reference
+ Resource corev1.ObjectReference `json:"resource"`
+
+ // Ready indicates if the resource is ready
+ Ready bool `json:"ready"`
+
+ // Message provides details about the resource status
+ Message string `json:"message,omitempty"`
 }
 ```
 
-
-An example of AROControlPlane CR as below
-
+An example of AROControlPlane CR using resources mode:
 
 ```yaml
-apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 kind: AROControlPlane
 metadata:
- name: aro-control-plane
- namespace: default
+  name: my-cluster
+  namespace: default
 spec:
- aroClusterName: aro-cluster-01
- platform:
-   location: east-us
-   resourceGroup: "dev-group"
-   subnet: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-vnet-rg/providers/Microsoft.Network/virtualNetworks/aro-vnet/subnets/aro-subnet"
-   outboundType: loadBalancer
-   networkSecurityGroupId: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/aro-nsg-rg/providers/Microsoft.Network/networkSecurityGroups/aro-nsg"
-   managedIdentities:
-     controlPlaneOperators: {}
-     dataPlaneOperators: {}
-     serviceManagedIdentity: "/subscriptions/.../userAssignedIdentities/service-msi"
- visibility: public
- network:
-   machineCIDR: "10.0.0.0/16"
-   podCIDR: "10.128.0.0/14"
-   serviceCIDR: "172.30.0.0/16"
-   hostPrefix: 23
-   networkType: OVNKubernetes
- domainPrefix: aro-cluster
- version: "4.20.0"
- channelGroup: stable
- versionGate: WaitForAcknowledge
- identityRef:
-   kind: AzureClusterIdentity
-   name: aro-identity
-   namespace: default
- additionalTags:
-   environment: production
-   owner: sre-team
+  identityRef:
+    kind: AzureClusterIdentity
+    name: aro-identity
+    namespace: default
+  subscriptionID: "00000000-0000-0000-0000-000000000000"
+  azureEnvironment: "AzurePublicCloud"  # Optional, defaults to AzurePublicCloud
+  resources:
+    # HcpOpenShiftCluster - The main ARO HCP cluster resource
+    - apiVersion: redhatopenshift.azure.com/v1api20240610preview
+      kind: HcpOpenShiftCluster
+      metadata:
+        name: my-cluster
+        namespace: default
+      spec:
+        azureName: my-cluster
+        owner:
+          name: my-cluster-resgroup
+        location: eastus
+        identity:
+          type: UserAssigned
+          userAssignedIdentities:
+            - reference:
+                armId: /subscriptions/.../userAssignedIdentities/my-cluster-cp-control-plane
+        properties:
+          api:
+            visibility: Public
+          clusterImageRegistry:
+            state: Enabled
+          etcd:
+            dataEncryption:
+              customerManaged:
+                encryptionType: KMS
+                kms:
+                  activeKey:
+                    name: etcd-data-kms-encryption-key
+                    vaultName: my-cluster-kv
+              keyManagementMode: CustomerManaged
+          network:
+            hostPrefix: 23
+            machineCidr: "10.0.0.0/16"
+            networkType: OVNKubernetes
+            podCidr: "10.128.0.0/14"
+            serviceCidr: "172.30.0.0/16"
+          platform:
+            managedResourceGroup: capz_node_my-cluster_rg
+            networkSecurityGroupReference:
+              group: network.azure.com
+              kind: NetworkSecurityGroup
+              name: my-cluster-nsg
+            operatorsAuthentication:
+              userAssignedIdentities:
+                controlPlaneOperatorsReferences:
+                  control-plane:
+                    armId: /subscriptions/.../userAssignedIdentities/...
+            outboundType: LoadBalancer
+            subnetReference:
+              group: network.azure.com
+              kind: VirtualNetworksSubnet
+              name: my-cluster-vnet-subnet
+          version:
+            channelGroup: stable
+            id: "4.20"
+        operatorSpec:
+          secrets:
+            adminCredentials:
+              key: value
+              name: my-cluster-kubeconfig
+
+    # HcpOpenShiftClustersExternalAuth - Optional external authentication
+    - apiVersion: redhatopenshift.azure.com/v1api20240610preview
+      kind: HcpOpenShiftClustersExternalAuth
+      metadata:
+        name: my-cluster-ea
+        namespace: default
+      spec:
+        azureName: my-cluster-ea
+        owner:
+          name: my-cluster  # References the HcpOpenShiftCluster
+        properties:
+          claim:
+            mappings:
+              groups:
+                claim: groups
+              username:
+                claim: oid
+                prefixPolicy: NoPrefix
+          clients:
+            - clientId: "51ed0256-1d54-46d4-9479-14ac212ca10f"
+              component:
+                authClientNamespace: openshift-console
+                name: console
+              extraScopes:
+                - openid
+                - profile
+              type: Confidential
+          issuer:
+            audiences:
+              - "51ed0256-1d54-46d4-9479-14ac212ca10f"
+            url: "https://login.microsoftonline.com/<tenant-id>/v2.0"
+
 status:
- initialized: true
- ready: true
- failureMessage: ""
- conditions:
-   - type: Ready
-     status: "True"
-     reason: ClusterReady
-     message: ARO Control Plane is ready
-     lastTransitionTime: "2025-04-28T10:00:00Z"
- id: aro-hcp-123456
- consoleURL: "https://console-openshift-console.apps.aro-cluster.example.com"
- apiURL: "https://api.aro-cluster.example.com:6443"
- version: "4.20.0"
- availableUpgrades:
-   - "4.20.1"
-   - "4.21.0"
-   - "4.22.0"
+  initialization:
+    controlPlaneInitialized: true
+  ready: true
+  conditions:
+    - type: HcpClusterReady
+      status: "True"
+      reason: Succeeded
+      message: HCP cluster is fully operational
+    - type: EncryptionKeyReady
+      status: "True"
+      reason: KeyReady
+      message: Encryption key 'etcd-data-kms-encryption-key' version 'abc123' ready in vault 'my-cluster-kv'
+    - type: ExternalAuthReady
+      status: "True"
+      reason: Succeeded
+      message: External authentication configured successfully
+  resources:
+    - resource:
+        apiVersion: redhatopenshift.azure.com/v1api20240610preview
+        kind: HcpOpenShiftCluster
+        name: my-cluster
+        namespace: default
+      ready: true
+      message: Cluster is provisioned and ready
+  apiURL: "https://api.my-cluster.example.com:6443"
+  version: "4.20.0"
 ```
 
+**Example: ASO Credential-Based Mode (without identityRef)**
 
+This example shows AROControlPlane using ASO credentials instead of identityRef:
 
+```yaml
+apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+kind: AROControlPlane
+metadata:
+  name: hcp-cluster
+  namespace: default
+spec:
+  # identityRef is NOT set - using ASO credential-based authentication
+  # ASO uses serviceoperator.azure.com/credential-from annotations
+  subscriptionID: "00000000-0000-0000-0000-000000000000"
+  azureEnvironment: "AzurePublicCloud"
+  resources:
+    # HcpOpenShiftCluster - The main ARO HCP cluster resource
+    - apiVersion: redhatopenshift.azure.com/v1api20240610preview
+      kind: HcpOpenShiftCluster
+      metadata:
+        name: hcp-cluster
+        namespace: default
+        annotations:
+          # ASO credential annotation - ASO uses this for authentication
+          serviceoperator.azure.com/credential-from: aso-credential
+      spec:
+        azureName: hcp-cluster
+        owner:
+          name: hcp-cluster-resgroup
+        location: eastus
+        identity:
+          type: UserAssigned
+          userAssignedIdentities:
+            - reference:
+                armId: /subscriptions/.../userAssignedIdentities/hcp-cluster-cp-control-plane
+        properties:
+          api:
+            visibility: Public
+          clusterImageRegistry:
+            state: Enabled
+          etcd:
+            dataEncryption:
+              customerManaged:
+                encryptionType: KMS
+                kms:
+                  # IMPORTANT: When identityRef is not set, activeKey.version MUST be manually specified
+                  # CAPZ cannot auto-create or propagate the key without Azure credentials
+                  # Customer must manually create the key and specify the version here
+                  activeKey:
+                    vaultName: "my-vault"
+                    name: "etcd-data-kms-encryption-key"
+                    version: "abc123def456"  # ✅ REQUIRED when identityRef is nil
+              keyManagementMode: CustomerManaged
+          network:
+            hostPrefix: 23
+            machineCidr: "10.0.0.0/16"
+            networkType: OVNKubernetes
+            podCidr: "10.128.0.0/14"
+            serviceCidr: "172.30.0.0/16"
+          platform:
+            managedResourceGroup: capz_node_hcp-cluster_rg
+            networkSecurityGroupReference:
+              group: network.azure.com
+              kind: NetworkSecurityGroup
+              name: hcp-cluster-nsg
+            operatorsAuthentication:
+              userAssignedIdentities:
+                controlPlaneOperatorsReferences:
+                  control-plane:
+                    armId: /subscriptions/.../userAssignedIdentities/...
+            outboundType: LoadBalancer
+            subnetReference:
+              group: network.azure.com
+              kind: VirtualNetworksSubnet
+              name: hcp-cluster-vnet-subnet
+          version:
+            channelGroup: stable
+            id: "4.20"
+        operatorSpec:
+          secrets:
+            adminCredentials:
+              key: value
+              name: hcp-cluster-kubeconfig
 
-- **AROMachinePool CRD (NodePool)**: Represents the desired state of the worker nodes (compute node pools) associated with a given `AROControlPlane`. The CRD spec based on the ARO HCP OpenAPI Specification defined as [HCPOpenShiftClusterNodePool](https://github.com/Azure/ARO-HCP/blob/main/internal/api/hcpopenshiftclusternodepool.go#L23).
+status:
+  ready: true
+  conditions:
+    - type: HcpClusterReady
+      status: "True"
+      reason: Succeeded
+      message: HCP cluster is fully operational
+    - type: EncryptionKeyReady
+      status: Unknown
+      reason: ManualKeyManagement
+      message: "identityRef not set - encryption key must be manually created and specified in HcpOpenShiftCluster"
+  resources:
+    - resource:
+        apiVersion: redhatopenshift.azure.com/v1api20240610preview
+        kind: HcpOpenShiftCluster
+        name: hcp-cluster
+        namespace: default
+      ready: true
+      message: Cluster is provisioned and ready
+  apiURL: "https://api.hcp-cluster.example.com:6443"
+  version: "4.20.0"
+```
 
+**Note**: When using ASO credential-based mode:
+- ✅ No need to manage AzureClusterIdentity
+- ✅ ASO handles all authentication via credential annotations
+- ⚠️  Customer must manually create Key Vault and encryption key
+- ⚠️  Customer must manually specify `activeKey.version` in HcpOpenShiftCluster spec
+- ⚠️  Webhook validation will reject the CR if activeKey.version is missing and encryption is configured
+
+#### AROMachinePool CRD
+
+Represents the desired state of the worker nodes (compute node pools) using embedded ASO HcpOpenShiftClustersNodePool resources.
 
 ```go
 // AROMachinePool is the Schema for the AROMachinePool API.
@@ -355,191 +472,94 @@ type AROMachinePool struct {
  metav1.TypeMeta   `json:",inline"`
  metav1.ObjectMeta `json:"metadata,omitempty"`
 
-
  Spec   AROMachinePoolSpec   `json:"spec,omitempty"`
  Status AROMachinePoolStatus `json:"status,omitempty"`
 }
 
-
 // AROMachinePoolSpec defines the desired spec of AROMachinePool.
 type AROMachinePoolSpec struct {
- // nodePool name must be valid DNS-1035 label.
- NodePoolName string `json:"nodePoolName,omitempty"`
-
-
- // OpenShift semantic version, for example "4.20.0". Version specifies the OpenShift version of the nodes associated with this machine pool.
- Version string `json:"version,omitempty"`
-
-
- // PlatformProfile represents the NodePool Azure platform configuration.
- Platform PlatformProfile `json:"platform,omitempty"`
-
-
- // Labels specifies labels for the Kubernetes node objects
- Labels map[string]string `json:"labels,omitempty"`
-
-
- // Taints specifies the taints to apply to the nodes of the machine pool
- Taints []AROTaint `json:"taints,omitempty"`
-
-
- // AdditionalTags are user-defined tags to be added to the nodePool Azure resources.
- AdditionalTags infrav1.Tags `json:"additionalTags,omitempty"`
-
-
- // AutoRepair specifies whether health checks should be enabled for machines
- AutoRepair bool `json:"autoRepair,omitempty"`
-
-
- // Autoscaling specifies auto scaling behaviour for this MachinePool.
- Autoscaling *AROMachinePoolAutoScaling `json:"autoscaling,omitempty"`
+ // Resources are embedded ASO resources to be managed by this AROMachinePool.
+ // Must include HcpOpenShiftClustersNodePool resource.
+ //
+ // Example (using private preview API v1api20240610preview):
+ // - redhatopenshift.azure.com/v1api20240610preview/HcpOpenShiftClustersNodePool
+ Resources []runtime.RawExtension `json:"resources"`
 }
-
-
-// PlatformProfile represents the Azure platform configuration.
-type PlatformProfile struct {
- // Azure subnet id
- Subnet string `json:"subnet,omitempty"`
-
-
- // Subnet Ref name that is used to create the VirtualNetworksSubnet CR. The SubnetRef must be in the same namespace as the AroMachinePool and cannot be set with Subnet.
- SubnetRef string `json:"subnetRef,omitempty"`
-
-
- // VMSize sets the VM disk volume size to the node.
- VMSize string `json:"vmSize,omitempty"`
-
-
- // DiskSizeGiB sets the disk volume size for the machine pool, in Gib.
- DiskSizeGiB int32 `json:"diskSizeGiB,omitempty"`
-
-
- // DiskStorageAccountType represents supported Azure storage account types.
- // Available values are Premium_LRS, StandardSSD_LRS and Standard_LRS.
- // With kubebuilder:validation:Enum= Premium_LRS;StandardSSD_LRS;Standard_LRS
- DiskStorageAccountType string `json:"diskStorageAccountType,omitempty"`
-
-
- // AvailabilityZone specifying the availability zone where instances of this machine pool should run.
- AvailabilityZone string `json:"availabilityZone,omitempty"`
-}
-
-
-// AROTaint represents a taint to be applied to a node.
-type AROTaint struct {
- // The taint key to be applied to a node.
- Key string `json:"key"`
-
-
- // The taint value corresponding to the taint key.
- Value string `json:"value,omitempty"`
-
-
- // The effect of the taint on pods that do not tolerate the taint.
- // Valid effects values are NoSchedule, PreferNoSchedule and NoExecute.
- Effect corev1.TaintEffect `json:"effect"`
-}
-
-
-// AROMachinePoolAutoScaling specifies scaling options.
-type AROMachinePoolAutoScaling struct {
- // MinReplicas for the nodePool nodes. Cannot be bigger than max replica
- MinReplicas int `json:"minReplicas,omitempty"`
-
-
- // MaxReplicas for the nodePool nodes. Cannot be less than min replica
- MaxReplicas int `json:"maxReplicas,omitempty"`
-}
-
 
 // AROMachinePoolStatus defines the observed state of AROMachinePool.
 type AROMachinePoolStatus struct {
- // Conditions specifies the conditions for the machine Pool
+ // Conditions specifies the conditions for the machine pool
  Conditions clusterv1.Conditions `json:"conditions,omitempty"`
 
+ // Resources status for each ASO resource managed by this machine pool
+ Resources []ResourceStatus `json:"resources,omitempty"`
 
- // ID is the NodePool ID given by ARO-HCP.
- ID string `json:"id,omitempty"`
-
-
- // ProvisioningState represents the asynchronous provisioning state of an ARM resource.
- // Allowed values are; Succeeded, Failed, Canceled, Accepted, Deleting, Provisioning and Updating.
- ProvisioningState string   `json:"provisioningState,omitempty"`
-
-
- // Ready indicates that the AROMachinePool (nodePool) has joined the ARO-HCP cluster and is ready to deploy workload.
+ // Ready indicates that the AROMachinePool has joined the cluster
  Ready bool `json:"ready"`
-
 
  // FailureMessage will be set in the event that there is a terminal problem
  FailureMessage *string `json:"failureMessage,omitempty"`
 
-
- // Replicas are the most recently observed number of replicas.
+ // Replicas are the most recently observed number of replicas
  Replicas int32 `json:"replicas"`
-
-
- // ARO-HCP OpenShift semantic version, for example "4.20.0".
- Version string `json:"version"`
-
-
- // Available upgrades for the ARO MachinePool.
- AvailableUpgrades []string `json:"availableUpgrades,omitempty"`
 }
 ```
 
-
-An example of AROMachinePool CR as below
-
+An example of AROMachinePool CR:
 
 ```yaml
-apiVersion: infrastructure.openshift.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: AROMachinePool
 metadata:
- name: example-aromachinepool
- namespace: default
+  name: my-cluster-mp1
+  namespace: default
 spec:
- nodePoolName: worker-eastus
- version: "4.20.0"
- platform:
-   subnet: "subnets/worker-subnet"
-   vmSize: "Standard_D4s_v3"
-   diskSizeGiB: 128
-   diskStorageAccountType: "Premium_LRS"
-   availabilityZone: "zone-1"
- labels:
-   node-role.kubernetes.io/worker: ""
-   region: east-us
- taints:
-   - key: "example.com/special"
-     value: "true"
-     effect: "NoSchedule"
- additionalTags:
-   environment: production
-   cost-center: engineering
- autoRepair: true
- autoscaling:
-   minReplicas: 3
-   maxReplicas: 6
+  resources:
+    - apiVersion: redhatopenshift.azure.com/v1api20240610preview
+      kind: HcpOpenShiftClustersNodePool
+      metadata:
+        name: my-cluster-mp1
+        namespace: default
+      spec:
+        azureName: my-cluster-mp1
+        owner:
+          name: my-cluster  # References the HcpOpenShiftCluster
+        properties:
+          autoRepair: true
+          autoscaling:
+            max: 10
+            min: 2
+          labels:
+            node-role.kubernetes.io/worker: ""
+          platform:
+            diskSizeGiB: 120
+            diskStorageAccountType: Premium_LRS
+            subnetReference:
+              group: network.azure.com
+              kind: VirtualNetworksSubnet
+              name: my-cluster-vnet-subnet
+            vmSize: Standard_D4s_v3
+          version:
+            channelGroup: stable
+            id: "4.20"
 status:
- conditions:
-   - type: Ready
-     status: "True"
-     reason: MachinesReady
-     message: All machines in the pool are available
-     lastTransitionTime: "2025-04-28T12:00:00Z"
- id: "nodePools/worker-eastus"
- provisioningState: "Succeeded"
- ready: true
- replicas: 5
- version: "4.20.0"
- availableUpgrades:
-   - "4.20.1"
-   - "4.21.0"
-   - "4.22.0"
+  ready: true
+  replicas: 5
+  conditions:
+    - type: Ready
+      status: "True"
+      reason: NodePoolReady
+  resources:
+    - resource:
+        apiVersion: redhatopenshift.azure.com/v1api20240610preview
+        kind: HcpOpenShiftClustersNodePool
+        name: my-cluster-mp1
+      ready: true
 ```
 
-- **AROCluster CRD**: Represents the desired state of the ARO managed cluster associated with the given `AROControlPlane` and `AROMachinePool`.
+#### AROCluster CRD
+
+Represents the infrastructure cluster, managing infrastructure resources via embedded ASO resources.
 
 ```go
 // AROCluster is the Schema for the AROClusters API.
@@ -547,118 +567,729 @@ type AROCluster struct {
  metav1.TypeMeta   `json:",inline"`
  metav1.ObjectMeta `json:"metadata,omitempty"`
 
-
  Spec   AROClusterSpec   `json:"spec,omitempty"`
  Status AROClusterStatus `json:"status,omitempty"`
 }
 
-
 // AROClusterSpec defines the desired spec of AROCluster.
 type AROClusterSpec struct {
- // ControlPlaneEndpoint represents the endpoint used to communicate with the control plane.
- ControlPlaneEndpoint clusterv1.APIEndpoint `json:"controlPlaneEndpoint"`
-}
+ // Resources are embedded ASO resources to be managed by this AROCluster.
+ // Typically includes infrastructure resources like:
+ // - ResourceGroup
+ // - VirtualNetwork
+ // - Subnet
+ // - NetworkSecurityGroup
+ // - Vault (for encryption)
+ // - UserAssignedIdentity resources
+ //
+ // These resources are provisioned before the HcpOpenShiftCluster.
+ Resources []runtime.RawExtension `json:"resources,omitempty"`
 
+ // ControlPlaneEndpoint represents the endpoint used to communicate with the control plane.
+ // Set by the controller from AROControlPlane status.
+ ControlPlaneEndpoint clusterv1.APIEndpoint `json:"controlPlaneEndpoint"`
+
+ // SubscriptionID is the Azure subscription ID for the cluster
+ SubscriptionID string `json:"subscriptionID"`
+
+ // IdentityRef is a reference to an identity to be used when reconciling resources.
+ // This field is optional. When not set, ASO handles authentication via
+ // serviceoperator.azure.com/credential-from annotations.
+ // +optional
+ IdentityRef *corev1.ObjectReference `json:"identityRef,omitempty"`
+}
 
 // AROClusterStatus defines the observed state of AROCluster.
 type AROClusterStatus struct {
- // Ready is when the AROControlPlane has an API server URL.
+ // Initialization status
+ Initialization *AROClusterInitializationStatus `json:"initialization,omitempty"`
+
+ // Ready is when the infrastructure and control plane are ready.
  Ready bool `json:"ready,omitempty"`
 
-
- // FailureDomains specifies a list of failure domains associated with the ARO cluster
- FailureDomains clusterv1.FailureDomains `json:"failureDomains,omitempty"`
-
-
  // Conditions define the current service state of the AROCluster.
+ // Key conditions:
+ // - ResourcesReady: All infrastructure resources are ready
+ // - NetworkInfrastructureReady: Network infrastructure is ready
  Conditions clusterv1.Conditions `json:"conditions,omitempty"`
+
+ // Resources status for each ASO resource managed by this cluster
+ Resources []ResourceStatus `json:"resources,omitempty"`
+}
+
+type AROClusterInitializationStatus struct {
+ // Provisioned indicates whether infrastructure is provisioned.
+ // Set to true when:
+ // 1. All infrastructure resources are ready (ResourcesReady condition)
+ // 2. AROControlPlane is ready (HcpClusterReady + kubeconfig exists)
+ // This gates CAPI from attempting to connect before the cluster is actually ready.
+ Provisioned bool `json:"provisioned,omitempty"`
 }
 ```
 
-An example of AROCluster CR as below
+An example of AROCluster CR:
 
 ```yaml
-apiVersion: infrastructure.openshift.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: AROCluster
 metadata:
- name: example-arocluster
- namespace: default
- labels:
-   cluster.x-k8s.io/cluster-name: aro-cluster-01
+  name: my-cluster
+  namespace: default
 spec:
- controlPlaneEndpoint:
-   host: api.example-arocluster.example.com
-   port: 6443
+  subscriptionID: "00000000-0000-0000-0000-000000000000"
+  controlPlaneEndpoint:
+    host: api.my-cluster.example.com
+    port: 6443
+  identityRef:
+    kind: AzureClusterIdentity
+    name: aro-identity
+  resources:
+    # ResourceGroup
+    - apiVersion: resources.azure.com/v1api20200601
+      kind: ResourceGroup
+      metadata:
+        name: my-cluster-resgroup
+        namespace: default
+      spec:
+        azureName: my-cluster-resgroup
+        location: eastus
+
+    # VirtualNetwork
+    - apiVersion: network.azure.com/v1api20201101
+      kind: VirtualNetwork
+      metadata:
+        name: my-cluster-vnet
+        namespace: default
+      spec:
+        azureName: my-cluster-vnet
+        owner:
+          name: my-cluster-resgroup
+        location: eastus
+        properties:
+          addressSpace:
+            addressPrefixes:
+              - "10.0.0.0/16"
+
+    # Subnet
+    - apiVersion: network.azure.com/v1api20201101
+      kind: VirtualNetworksSubnet
+      metadata:
+        name: my-cluster-vnet-subnet
+        namespace: default
+      spec:
+        azureName: my-cluster-subnet
+        owner:
+          name: my-cluster-vnet
+        properties:
+          addressPrefix: "10.0.0.0/24"
+
+    # NetworkSecurityGroup
+    - apiVersion: network.azure.com/v1api20201101
+      kind: NetworkSecurityGroup
+      metadata:
+        name: my-cluster-nsg
+        namespace: default
+      spec:
+        azureName: my-cluster-nsg
+        owner:
+          name: my-cluster-resgroup
+        location: eastus
+
+    # KeyVault for encryption
+    # REQUIRED: Vault must be declared here even when identityRef is set
+    # ASO creates the vault, CAPZ creates the encryption key inside it
+    - apiVersion: keyvault.azure.com/v1api20230701
+      kind: Vault
+      metadata:
+        name: my-cluster-kv
+        namespace: default
+      spec:
+        azureName: my-cluster-kv  # Must match vaultName in HcpOpenShiftCluster
+        owner:
+          name: my-cluster-resgroup
+        location: eastus
+        properties:
+          sku:
+            family: A
+            name: standard
+          tenantId: "00000000-0000-0000-0000-000000000000"
+          enableRbacAuthorization: true
+          enableSoftDelete: true
+
+    # User Assigned Identities (example - multiple needed for ARO)
+    - apiVersion: managedidentity.azure.com/v1api20230131
+      kind: UserAssignedIdentity
+      metadata:
+        name: my-cluster-cp-control-plane
+        namespace: default
+      spec:
+        azureName: my-cluster-cp-control-plane
+        owner:
+          name: my-cluster-resgroup
+        location: eastus
+
 status:
- ready: true
- conditions:
-   - type: Ready
-     status: "True"
-     reason: ControlPlaneReady
-     message: ARO Cluster control plane is up and running
-     lastTransitionTime: "2025-04-28T12:00:00Z"
+  initialization:
+    provisioned: true
+  ready: true
+  conditions:
+    - type: ResourcesReady
+      status: "True"
+      reason: InfrastructureReady
+      message: "All 7 infrastructure resources are ready"
+    - type: NetworkInfrastructureReady
+      status: "True"
+      reason: Succeeded
+  resources:
+    - resource:
+        kind: ResourceGroup
+        name: my-cluster-resgroup
+      ready: true
+    - resource:
+        kind: VirtualNetwork
+        name: my-cluster-vnet
+      ready: true
+    # ... other resources
 ```
 
-Each controller will be responsible for:
+### Controller Responsibilities
 
-- **AROControlPlane Controller**:
- - Watch `AROControlPlane` resources.
- - Reconciles the desired state by calling the Azure ARO HCP API to:
-   - Create/update/delete the corresponding HCP cluster on Azure.
-   - Manage cluster-wide settings like networking, identities, ingress, and API server visibility.
- - Updates the `status` field of the `AROControlPlane` resource with real-time cluster health and endpoint information.
+Each controller is responsible for:
 
-- **AROMachinePool Controller**:
- - Watch `AROMachinePool` resources.
- - Reconciles the desired state by calling the Azure ARO HCP API to:
-   - Create/update/delete node pools (compute plane) associated with a specific `AROControlPlane` cluster.
-   - Manage node counts, VM sizes, disk settings, scaling configurations, and availability zones.
- - Updates the `status` field of the `AROMachinePool` resource with node pool health and scaling status.
+#### AROControlPlane Controller
 
-- **AROCluster Controller**:
- - Watch `AROCluster` resources.
- - Reconciles the desired state of the ARO Cluster reflecting the associated `AROControlPlane` & `AROMachinePool` status:
-   - Create/update/delete ARO cluster associated with its `AROControlPlane` and `AROMachinePools`.
- - Updates the `status` field of the `AROCluster` resource reflecting its `AROControlPlane` health and scaling status.
+- Watches `AROControlPlane` resources
+- Reconciles embedded ASO resources (HcpOpenShiftCluster, HcpOpenShiftClustersExternalAuth)
+- Manages encryption key creation via keyvaults service
+- Updates resource status based on ASO resource conditions
+- Sets `Ready` status when:
+  1. HcpClusterReady condition is True (from ASO)
+  2. Kubeconfig secret exists
+- Sets `ControlPlaneInitialized` when both conditions above are met
+- Applies mutators to:
+  - Set defaults on HcpOpenShiftCluster
+  - Inject encryption key version
+  - Set owner references
 
-#### Syncing Between Controllers
+Key features:
+- **Dependency Management**: Waits for AROCluster infrastructure (ResourcesReady condition) before creating HcpOpenShiftCluster
+- **ExternalAuth Deferral**: Uses resource filtering to defer ExternalAuth creation until NodePool is ready to avoid Azure API errors
+- **Encryption Key Management**: Uses keyvaults service to create/retrieve encryption keys, sets version in HcpOpenShiftCluster via mutator
+- **Condition Tracking**:
+  - `HcpClusterReady`: HCP cluster operational status
+  - `EncryptionKeyReady`: Encryption key status (if configured)
+  - `ExternalAuthReady`: External auth status (if configured)
+
+#### AROMachinePool Controller
+
+- Watches `AROMachinePool` resources
+- Reconciles embedded ASO HcpOpenShiftClustersNodePool resources
+- Waits for AROControlPlane to be ready before creating node pools
+- Updates resource status based on ASO resource conditions
+- Applies mutators to set defaults and owner references
+- **Populates providerIDList from workload cluster nodes** (no Azure SDK required):
+  - Uses ClusterTracker to get workload cluster client
+  - Lists nodes from workload cluster
+  - Filters nodes by node pool name pattern
+  - Extracts providerID from node.Spec.ProviderID
+  - Pattern matches ASOManagedMachinePool for consistency
+
+#### AROCluster Controller
+
+- Watches `AROCluster` resources
+- Reconciles embedded ASO infrastructure resources (ResourceGroup, VNet, Subnet, NSG, Vault, Identities)
+- Tracks infrastructure readiness via `ResourcesReady` condition
+- Mirrors AROControlPlane endpoint to spec.controlPlaneEndpoint
+- Sets `Initialization.Provisioned` when:
+  1. ResourcesReady condition is True
+  2. AROControlPlane.Ready is True
+- This gates CAPI from connecting before the cluster is truly ready
+
+### Dependency Chain
+
+The proper dependency sequence ensures resources are created in the correct order:
+
+```
+1. AROCluster infrastructure resources created
+   ↓
+2. ResourcesReady condition becomes True
+   ↓
+3. HcpOpenShiftCluster created (waits for step 2)
+   ↓
+4. HcpClusterReady condition becomes True
+   ↓
+5. Kubeconfig secret created by ASO
+   ↓
+6. AROControlPlane.Ready becomes True (checks steps 4 & 5)
+   ↓
+7. AROCluster.Ready becomes True
+   ↓
+8. AROCluster.Initialization.Provisioned becomes True
+   ↓
+9. CAPI Cluster.InfrastructureProvisioned becomes True
+   ↓
+10. CAPI connects to cluster
+```
+
+This dependency chain **eliminates CAPI kubeconfig errors** by ensuring the kubeconfig exists before CAPI attempts to connect.
+
+### Syncing Between Controllers
 
 - **Ownership and References**:
- - Each `AROMachinePool` must reference an existing `AROControlPlane` via `spec.clusterName`.
- - The `AROMachinePool` controller will ensure that the corresponding `AROControlPlane` exists and is in a "Ready" state before proceeding to manage the NodePool resource.
- - The ownership will be reflected using Kubernetes `ownerReferences` metadata for automatic cascading deletes (i.e., when an `AROControlPlane` is deleted, its associated `AROMachinePools` are automatically cleaned up).
-
+  - ASO resources use `owner` references to link resources (e.g., NodePool → HcpOpenShiftCluster)
+  - CAPI resources use `ownerReferences` for cascading deletes
+  - AROMachinePool references AROControlPlane via cluster name
 
 - **Reconciliation Ordering**:
- - The `AROControlPlane` controller must reconcile and reach a "Ready" state before `AROMachinePool` resources are reconciled.
- - The `AROMachinePool` controller will watch for events or status changes in the referenced `AROControlPlane` and only proceed when appropriate.
- - **Status Propagation**:
- - The `AROMachinePool` status will propagate partial status information (such as NodePool health) back to the parent `AROControlPlane` if needed, enabling centralized cluster health reporting.
+  - AROCluster resources must be ready before AROControlPlane creates HcpOpenShiftCluster
+  - AROControlPlane must be ready before AROMachinePool creates NodePools
+  - Controllers watch related resources and requeue when dependencies change
 
+- **Status Propagation**:
+  - Resource statuses are aggregated into CRD conditions
+  - Parent resources track child resource readiness
+  - CAPI Cluster reflects AROCluster initialization status
 
 - **Error Handling and Retries**:
- - Both controllers will be designed with proper retry mechanisms and will handle transient Azure API errors gracefully (e.g., rate limiting, network issues).
+  - Controllers use exponential backoff for transient errors
+  - ASO handles Azure API rate limiting and retries
+  - Terminal errors are surfaced in status conditions
 
-This architecture ensures a clean separation of concerns between managing the control plane and compute resources while maintaining a strong, validated linkage between the two layers.
+### Resources Mode Architecture
 
-#### ARO-HCP Feature Gate
+The implementation uses a **resources-only mode** where all infrastructure is defined using embedded ASO resources:
 
-A new [feature gate](https://github.com/serngawy/cluster-api-provider-azure/blob/aro-hcp-Proposal/feature/feature.go) `ARO-HCP` will be introduced to enable/disable the ARO-HCP controllers.
+**Benefits:**
+- **Declarative**: Full infrastructure as code
+- **Flexible**: Direct access to all ASO resource properties
+- **Version controlled**: Resources can be managed in git
+- **Type-safe**: Uses ASO's generated types
+- **Consistent**: Same pattern for all Azure resources
 
-### Azure Resource Management:
+**Implementation:**
+- ASO resources are embedded in `spec.resources` as RawExtension
+- Controllers convert RawExtension to Unstructured for processing
+- Mutators apply defaults and inject dynamic values (e.g., encryption key version)
+- ResourceReconciler manages ASO resource lifecycle
+- Status tracking reports on each resource's readiness
 
-Leverage the [ARO-HCP Azure SDKs](https://github.com/Azure/ARO-HCP/tree/main/internal/api) to securely communicate with the ARO HCP APIs, enabling the creation, updating, and deletion of ARO-HCP resources within the Azure infrastructure.
+### Authentication Modes
 
-### Validation and Testing:
+AROControlPlane supports two authentication modes for Azure API access:
 
-Validate CAPZ operations against ARO HCP API compliance and Kubernetes integration tests.
+#### 1. CAPZ Managed Authentication (with identityRef)
+
+When `identityRef` is specified:
+- CAPZ initializes Azure SDK credentials from AzureClusterIdentity
+- CAPZ performs Key Vault operations automatically:
+  - Creates encryption keys in Key Vault
+  - Retrieves key versions
+  - Propagates key versions to HcpOpenShiftCluster spec
+- **Best for**: Users who want automated key management
+- **Configuration**: Set `spec.identityRef` to reference an AzureClusterIdentity
+
+Example:
+```yaml
+spec:
+  identityRef:
+    kind: AzureClusterIdentity
+    name: aro-identity
+    namespace: default
+```
+
+#### 2. ASO Credential-Based Authentication (without identityRef)
+
+When `identityRef` is NOT specified:
+- ASO handles authentication via `serviceoperator.azure.com/credential-from` annotations
+- CAPZ skips all Key Vault operations
+- Customer responsibilities:
+  - Manually create Key Vault via ASO
+  - Manually create encryption key
+  - **Manually specify activeKey.version in HcpOpenShiftCluster spec**
+- **Best for**: Users who want full control via ASO
+- **Configuration**: Omit `spec.identityRef` and use ASO credential annotations
+
+Example:
+```yaml
+spec:
+  # identityRef: NOT SET - using ASO credentials
+  subscriptionID: "00000000-0000-0000-0000-000000000000"
+  resources:
+    - apiVersion: redhatopenshift.azure.com/v1api20240610preview
+      kind: HcpOpenShiftCluster
+      spec:
+        properties:
+          etcd:
+            dataEncryption:
+              customerManaged:
+                kms:
+                  activeKey:
+                    vaultName: "my-vault"
+                    name: "etcd-data-kms-encryption-key"
+                    version: "abc123def456"  # REQUIRED when identityRef not set
+```
+
+### KeyVault Service and Encryption Key Management
+
+While most resources are managed via ASO, the **keyvaults service** handles encryption key management when `identityRef` is set:
+
+**Why keep keyvaults service:**
+- ASO manages the Vault **resource** (the vault itself)
+- Azure SDK (via keyvaults service) manages **keys within the vault**
+- ASO doesn't support key version retrieval
+- Key version must be injected into HcpOpenShiftCluster spec
+
+**IMPORTANT: Vault resource location**
+- ⚠️ The Vault resource must be declared in **AROCluster.spec.resources[]**, NOT AROControlPlane
+- Even when `identityRef` is set, CAPZ does NOT create the vault itself
+- CAPZ only creates the encryption **KEY** inside an existing vault
+- ASO creates the vault based on the Vault resource in AROCluster.spec.resources[]
+
+**How it works (with identityRef):**
+1. **Vault resource created via ASO** (declared in **AROCluster.spec.resources[]** - REQUIRED!)
+2. keyvaults service waits for vault to be ready (checks AROCluster.Status.Resources)
+3. keyvaults service extracts vault metadata from AROCluster.spec.resources[]
+4. keyvaults service queries deployed Vault and gets resource group from status.id
+5. keyvaults service creates/retrieves encryption key using Azure SDK
+6. Key version stored in scope via SetVaultInfo()
+7. Mutator injects key version into HcpOpenShiftCluster spec
+8. HcpOpenShiftCluster references the key for ETCD encryption
+
+**How it works (without identityRef):**
+1. Customer creates Vault via ASO (in AROCluster.spec.resources[])
+2. Customer creates encryption key manually (via Azure Portal, CLI, or ASO)
+3. Customer specifies activeKey.version in HcpOpenShiftCluster spec
+4. CAPZ validates activeKey.version is present (see validation section below)
+5. HcpOpenShiftCluster uses the manually specified key
+
+**KeyVault Refactoring (2026-02-26):**
+
+The KeyVault service was refactored to properly handle `spec.azureName` and eliminate hardcoded API versions:
+
+1. **Vault metadata discovery**: `getVaultK8sInfo()` extracts K8s object name, namespace, and API version from AROCluster.spec.resources[]
+2. **Resource group extraction**: `getVaultResourceGroupFromStatus()` queries the deployed Vault and parses resource group from `status.id`
+3. **Robust ARM ID parsing**: `parseARMResourceAttribute()` uses attribute/value pair pattern instead of position-based parsing
+4. **No hardcoded versions**: API versions dynamically discovered from AROCluster.spec.resources[]
+5. **Production tested**: Successfully deployed in mv9-stage cluster with K8s name (`mv9-stage-kv`) ≠ Azure name (`mv9-stage-kv-actual`)
+
+**Error messages**:
+- Clear guidance when vault not found: "vault with azureName 'X' not found in AROCluster spec.resources - when using encryption with identityRef, the Vault resource must be declared in AROCluster.spec.resources[]"
+- Explains that CAPZ creates the key, but ASO creates the vault
+
+### Encryption Key Version Validation
+
+To prevent deployment failures, CAPZ implements **two-layer validation** for encryption key versions when `identityRef` is not set:
+
+#### Layer 1: Webhook Validation (Create/Update Time)
+
+**Purpose**: Fail fast with clear error messages before any reconciliation starts.
+
+**Implementation**: `exp/api/controlplane/v1beta2/arocontrolplane_webhook.go`
+
+**Validation Logic**:
+1. For each resource in `spec.resources`
+2. If resource is HcpOpenShiftCluster
+3. If ETCD encryption is configured (`spec.properties.etcd.dataEncryption.customerManaged.kms` exists)
+4. AND `identityRef` is NOT set
+5. THEN validate that `kms.activeKey.version` is specified
+
+**Error Message**:
+```
+activeKey.version is required when identityRef is not set -
+CAPZ cannot auto-create or propagate the encryption key without Azure credentials
+```
+
+**Example - Invalid (will be rejected by webhook)**:
+```yaml
+spec:
+  # identityRef: NOT SET
+  resources:
+    - kind: HcpOpenShiftCluster
+      spec:
+        properties:
+          etcd:
+            dataEncryption:
+              customerManaged:
+                kms:
+                  # activeKey.version: MISSING - VALIDATION ERROR
+                  # activeKey structure is completely missing
+```
+
+**Example - Valid (will be accepted)**:
+```yaml
+spec:
+  # identityRef: NOT SET
+  resources:
+    - kind: HcpOpenShiftCluster
+      spec:
+        properties:
+          etcd:
+            dataEncryption:
+              customerManaged:
+                kms:
+                  activeKey:
+                    vaultName: "my-vault"
+                    name: "etcd-data-kms-encryption-key"
+                    version: "abc123def456"  # ✅ Specified
+```
+
+#### Layer 2: Controller Runtime Validation (Reconciliation Time)
+
+**Purpose**: Safety net in case webhook is bypassed or disabled.
+
+**Implementation**: `exp/controllers/arocontrolplane_reconciler.go`
+
+**Validation Logic**:
+1. During reconciliation, detect encryption configuration
+2. If encryption configured AND `identityRef` is NOT set
+3. Validate activeKey.version is present in KMS configuration
+4. If missing:
+   - Set `EncryptionKeyReadyCondition` to `False` with reason `KeyVersionMissing`
+   - Return error to prevent HcpOpenShiftCluster deployment
+   - Log detailed error message
+
+**Error Message**:
+```
+identityRef is not set and activeKey.version is not specified in HcpOpenShiftCluster -
+CAPZ cannot auto-create or propagate the encryption key without Azure credentials.
+Please manually create the vault and key via ASO and specify the version in
+spec.properties.etcd.dataEncryption.customerManaged.kms.activeKey.version
+```
+
+**Benefits**:
+- ✅ Prevents wasted reconciliation cycles
+- ✅ Clear, actionable error messages
+- ✅ Fails before attempting Azure operations
+- ✅ Guides customers to fix the configuration
+
+### Common Issues and FAQ
+
+#### Issue: "vault with azureName 'X' not found in AROCluster spec.resources"
+
+**Cause**: The Vault resource is missing from AROCluster.spec.resources[].
+
+**Understanding**: When using `identityRef` with encryption:
+- ✅ CAPZ creates the encryption **KEY** inside the vault
+- ❌ CAPZ does NOT create the **vault itself**
+- ✅ ASO creates the vault (from AROCluster.spec.resources[])
+
+**Solution**: Add the Vault resource to **AROCluster.spec.resources[]** (not AROControlPlane):
+
+```yaml
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: AROCluster
+metadata:
+  name: my-cluster
+spec:
+  resources:
+    - apiVersion: keyvault.azure.com/v1api20230701
+      kind: Vault
+      metadata:
+        name: my-cluster-kv
+        namespace: default
+      spec:
+        azureName: my-cluster-kv  # Must match vaultName in HcpOpenShiftCluster
+        location: eastus2
+        owner:
+          name: my-resource-group
+        properties:
+          enableRbacAuthorization: true
+          sku:
+            family: A
+            name: standard
+    # ... other resources
+```
+
+**Additional requirements**:
+1. KMS identity needs `Key Vault Crypto Officer` role on the vault
+2. Add RoleAssignment in AROCluster.spec.resources[] for the KMS identity
+
+#### Issue: HcpOpenShiftCluster stuck in "Reconciling" state
+
+**Common causes**:
+1. **Missing `machineCidr`**: Required even with `networkType: "Other"`
+2. **Vault not ready**: Wait for vault to be provisioned
+3. **Missing role assignments**: KMS identity needs vault permissions
+4. **Azure provisioning time**: HCP clusters take 15-30 minutes to provision
+
+**Debugging**:
+```bash
+# Check encryption key status
+kubectl get arocontrolplane -n <namespace> <name> -o jsonpath='{.status.conditions[?(@.type=="EncryptionKeyReady")]}'
+
+# Check HCP cluster conditions
+kubectl get hcpopenshiftclusters -n <namespace> <name> -o yaml | grep -A 20 "conditions:"
+
+# Check CAPZ logs
+kubectl logs -n capz-system deploy/capz-controller-manager --tail=100
+```
+
+#### Issue: "identityRef is not set and activeKey.version is not specified"
+
+**Cause**: Using ASO credential mode without specifying the key version.
+
+**Solution**: When using ASO credentials (identityRef not set):
+1. Create vault in AROCluster.spec.resources[]
+2. Manually create the encryption key (Azure Portal/CLI)
+3. Specify the key version in HcpOpenShiftCluster:
+
+```yaml
+spec:
+  properties:
+    etcd:
+      dataEncryption:
+        customerManaged:
+          kms:
+            activeKey:
+              vaultName: my-vault
+              name: etcd-data-kms-encryption-key
+              version: "abc123def456"  # REQUIRED!
+```
+
+### Azure Resource Management
+
+- **ASO (Azure Service Operator)**: Primary method for resource provisioning
+  - HcpOpenShiftCluster
+  - HcpOpenShiftClustersNodePool
+  - HcpOpenShiftClustersExternalAuth
+  - ResourceGroup, VirtualNetwork, Subnet, NetworkSecurityGroup
+  - **Vault** (even when identityRef is set!)
+  - UserAssignedIdentity, RoleAssignment
+
+- **Azure SDK**: Used only for encryption key management (when identityRef is set)
+  - KeyVault keys (create/retrieve key versions within existing vault)
+  - **Note**: This is a temporary gap in ASO coverage. ASO supports Vault CRDs but not key management within vaults. Upstream tracking: [Azure/azure-service-operator#3188](https://github.com/Azure/azure-service-operator/issues/3188)
+  - **Future**: Once ASO adds support for key version retrieval, the keyvaults SDK service can be removed entirely
+
+### Validation and Testing
+
+#### Validation
+
+**Webhook Validation** (`exp/api/controlplane/v1beta2/arocontrolplane_webhook.go`):
+- Resources mode validation (ensures `spec.resources` is not empty)
+- Identity validation (validates `identityRef` if provided)
+- Resource structure validation (valid JSON, required fields)
+- **Encryption key version validation** (when identityRef is nil and encryption configured)
+
+**Controller Runtime Validation** (`exp/controllers/arocontrolplane_reconciler.go`):
+- Resource readiness checks before creating dependent resources
+- **Encryption key version validation** (safety net for webhook bypass)
+- Condition setting for validation failures
+- Proper error propagation with actionable messages
+
+**Validation Flow**:
+```
+Create/Update AROControlPlane
+    ↓
+Webhook Validation
+├─ Resources mode check
+├─ Identity validation
+├─ Resource structure
+└─ Encryption key version ← FAIL FAST if missing
+    ↓
+Controller Reconciliation
+├─ Runtime validation ← SAFETY NET
+├─ Resource dependency checks
+└─ Condition updates
+    ↓
+Resource Deployment
+```
+
+#### Testing
+
+- Unit tests for controller reconciliation logic
+- Unit tests for webhook validation (including encryption key validation)
+- Integration tests for ASO resource creation
+- E2E tests for full cluster lifecycle (with and without identityRef)
+- Validation of proper dependency sequencing
+- Testing of error conditions and recovery
+- Testing of both authentication modes (CAPZ managed vs ASO credential-based)
+
+## Alternatives Considered
+
+### Using AzureASOManagedControlPlane
+
+AzureASOManagedControlPlane is designed for AKS managed clusters using `containerservice.azure.com` resources. ARO HCP uses fundamentally different Azure resource types (`redhatopenshift.azure.com/HcpOpenShiftCluster`) with ARO-specific requirements including ETCD encryption with Key Vault integration, external authentication resources, and different node pool APIs. The architectural differences are significant enough that separate CRDs provide clearer API boundaries and simpler controller logic than trying to unify both platforms under a single type.
+
+### Pure ASO Without CAPZ Controllers
+
+While ASO provides Azure resource management, CAPZ controllers add Cluster API integration (lifecycle management, dependency orchestration, status aggregation) and automation features like encryption key version injection. Users who don't need CAPI integration can use ASO directly with `identityRef: nil` mode.
+
+## Maintenance and Ownership
+
+The ARO HCP integration is **owned and maintained by the Azure Red Hat OpenShift (ARO) team at Red Hat**. This includes the AROControlPlane, AROMachinePool, and AROCluster CRDs, controllers, webhooks, and ARO-specific documentation.
+
+**CAPZ core team responsibilities** are limited to maintaining shared infrastructure (ASO integration patterns, common libraries) and reviewing ARO pull requests for CAPZ architectural alignment. The CAPZ core team is **not expected to own or maintain ARO-specific logic**.
+
+### Azure SDK Usage and ASO Migration Plan
+
+The keyvaults service currently uses Azure SDK for key version retrieval because ASO doesn't yet support Key Vault key management CRDs (only Vault resources). This SDK usage is temporary and will be removed once ASO coverage is available.
+
+**ARO HCP API Versions**:
+- **2024-06-10-preview**: Private preview API version (currently used in this implementation)
+- **2025-12-23-preview**: Public preview API version (planned migration target)
+
+API specifications are maintained in the [ARO-HCP repository](https://github.com/Azure/ARO-HCP/tree/main/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpclusters/preview).
+
+**Dependency chain for full ASO migration**:
+1. ARO HCP public preview completion (pending Microsoft release formalities)
+2. ARO HCP API specification merged into Azure REST API specs repository
+3. ASO generation of ARO HCP CRDs from updated specs
+4. Backporting ASO changes to the release version used by CAPZ
+
+Once these dependencies are resolved and ASO supports key management, the keyvaults SDK service will be removed entirely. The ARO team commits to migrating to pure ASO-native implementation at that time.
 
 ## Risks and Mitigations
 
-- **API Changes**: Monitor ARO HCP API updates and adapt CAPZ controllers accordingly.
-- **Security**: Implement secure communication protocols between CAPZ and ARO HCP endpoints.
+- **ASO API Changes**: Monitor ASO releases and update resource definitions accordingly
+- **Azure API Changes**: ARO HCP API changes will require ASO updates
+- **Security**: Use managed identities and RBAC for Azure resource access
+- **Dependency Timing**: Proper condition checking prevents premature resource creation
+- **Resource Cleanup**: Owner references ensure cascading deletion of related resources
 
 ## Graduation Criteria
 
-- Successful provisioning and scaling of ARO HCP clusters using CAPZ in a test environment.
-- Validation of CAPZ-managed ARO HCP clusters against Azure and Kubernetes integration benchmarks.
+- ✅ Successful provisioning of ARO HCP clusters using resources mode
+- ✅ Proper dependency chain implementation preventing CAPI errors
+- ✅ Validation against Azure and Kubernetes integration benchmarks
+- ✅ Encryption key management working correctly
+- ✅ ExternalAuth configuration functioning properly
+- ✅ Clean code with field-based mode removed (~5,400 lines removed)
+- ✅ Maintenance ownership documented and agreed upon
+- ✅ Plan documented to remove keyvaults SDK service when ASO supports key version retrieval
+- ✅ Acknowledgment that CAPZ's long-term direction is toward pure ASO-native controllers
+
+## Implementation History
+
+- 2025-04-23: Initial proposal
+- 2025-04-25: Proposal marked as implementable
+- 2026-02-05: Implementation completed with resources mode
+- 2026-02-07: Dependency chain refactored for proper sequencing
+- 2026-02-08: Field-based provisioning code removed, proposal updated to reflect current implementation
+- 2026-02-09: AROControlPlaneSpec field cleanup - removed redundant fields (domainPrefix, version, channelGroup, versionGate, additionalTags) that duplicated ASO resource configuration. Retained only functionally required fields: Resources, IdentityRef, SubscriptionID, AzureEnvironment. This simplifies the API and enforces resources-only mode where all cluster configuration is defined in embedded ASO resources.
+- 2026-02-20: **ARO-24514 implementation** - Made `identityRef` optional to support ASO credential-based authentication. Added two-layer validation (webhook + runtime) for encryption key version when identityRef is not set. This enables customers to use ASO credentials without managing separate AzureClusterIdentity, while ensuring proper validation prevents deployment failures. Key changes:
+  - identityRef is now optional (previously required for Key Vault operations)
+  - **AROControlPlane**: CAPZ skips Key Vault operations when identityRef is not set
+  - **AROMachinePool**: CAPZ skips Azure credential initialization when identityRef is not set
+  - Webhook validates activeKey.version is specified when encryption is configured and identityRef is nil
+  - Controller performs runtime validation as safety net
+  - Clear error messages guide customers to manually specify activeKey.version
+  - Documentation updated with authentication modes and validation requirements
+- 2026-02-20: **AROMachinePool refactoring** - Removed Azure SDK dependency and replaced Azure VM API calls with workload cluster node listing (following ASOManagedMachinePool pattern). AROMachinePool is now fully ASO-native with no Azure credentials required. Key changes:
+  - Removed AzureClients and CredentialCache from AROMachinePool scope and reconciler
+  - Removed virtualMachines service and Azure SDK dependencies
+  - Added ClusterTracker to get workload cluster client (similar to ASOManagedMachinePool)
+  - Populates providerIDList from workload cluster nodes instead of Azure VMs
+  - Lists nodes from workload cluster and filters by node pool name pattern
+  - More reliable - no dependency on Azure API availability
+  - Consistent with other ASO-based machine pool implementations
+- 2026-02-26: **KeyVault service refactoring and error message improvements** - Simplified KeyVault resource group extraction and improved error messages to prevent customer confusion. Production tested with mv9-stage cluster. Key changes:
+  - Added `getVaultK8sInfo()` to extract vault metadata (name, namespace, API version) from AROCluster.spec.resources[]
+  - Added `getVaultResourceGroupFromStatus()` to query deployed Vault and extract resource group from status.id
+  - Added `parseARMResourceAttribute()` for robust ARM ID parsing using attribute/value pairs
+  - Removed hardcoded API versions - now dynamically discovered from AROCluster.spec.resources[]
+  - Simplified KeyVaultScope interface - removed 3 unused methods (ResourceGroup, SubscriptionID, AsyncStatusUpdater)
+  - Improved error message: "vault with azureName 'X' not found in AROCluster spec.resources - when using encryption with identityRef, the Vault resource must be declared in AROCluster.spec.resources[]"
+  - Updated API documentation to clarify: "Even when identityRef is set, the Vault resource must be declared in AROCluster.spec.resources[] so ASO can create the vault. CAPZ only creates the encryption KEY inside the existing vault"
+  - Added Common Issues/FAQ section to proposal with debugging guidance
+  - Successfully deployed in production (mv9-stage) with K8s name ≠ Azure name (spec.azureName)


### PR DESCRIPTION
Adds a comprehensive proposal document for implementing Azure Red Hat OpenShift Hosted Control Plane (ARO HCP) cluster provisioning using Cluster API Provider Azure (CAPZ).

The proposal covers:
- Architecture and design for ARO HCP integration with CAPZ
- ASO resource definitions and CAPI contract implementation
- KeyVault and encryption key management
- Security considerations and alternatives

This document serves as the technical foundation for ARO HCP CAPZ development and guides customers deploying ARO HCP clusters via CAPZ.


**What type of PR is this?**

/kind design

**What this PR does / why we need it**:
We want to design how to provision Azure Red Hat OpenShift Hosted Control Plane (ARO HCP) clusters using CAPZ,