### PR TITLE
E2E wait for webhook ca injection

### DIFF
--- a/config/certmanager/certificate.yaml
+++ b/config/certmanager/certificate.yaml
@@ -20,6 +20,4 @@ spec:
   issuerRef:
     kind: Issuer
     name: selfsigned-issuer
-  privateKey:
-    rotationPolicy: Never
   secretName: SERVICE_NAME_PLACEHOLDER-cert

--- a/config/certmanager/certificate.yaml
+++ b/config/certmanager/certificate.yaml
@@ -20,4 +20,6 @@ spec:
   issuerRef:
     kind: Issuer
     name: selfsigned-issuer
+  privateKey:
+    rotationPolicy: Never
   secretName: SERVICE_NAME_PLACEHOLDER-cert

--- a/test/e2e/config/azure-dev.yaml
+++ b/test/e2e/config/azure-dev.yaml
@@ -115,7 +115,7 @@ providers:
       - old: "imagePullPolicy: Always"
         new: "imagePullPolicy: IfNotPresent"
     - name: v1.23.99 # "vNext"; use manifests from local source files
-      value: "${PWD}/config/default"
+      value: "${PWD}/test/e2e/data/infrastructure-azure/v1beta1/provider-components"
       contract: v1beta1
       files:
       - sourcePath: "../data/shared/v1beta1_provider/metadata.yaml"

--- a/test/e2e/data/infrastructure-azure/v1beta1/provider-components/kustomization.yaml
+++ b/test/e2e/data/infrastructure-azure/v1beta1/provider-components/kustomization.yaml
@@ -1,0 +1,18 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../../../../../config/default
+patches:
+# Disable cert-manager private key rotation in e2e to reduce the window for
+# cainjector race conditions where webhook caBundle updates lag behind a
+# rotated certificate, causing "x509: certificate signed by unknown authority".
+- target:
+    group: cert-manager.io
+    version: v1
+    kind: Certificate
+    name: capz-serving-cert
+  patch: |
+    - op: add
+      path: /spec/privateKey
+      value:
+        rotationPolicy: Never

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -199,6 +199,8 @@ func initBootstrapCluster(bootstrapClusterProxy framework.ClusterProxy, config *
 		AddonProviders:          config.AddonProviders(),
 		LogFolder:               filepath.Join(artifactFolder, "clusters", bootstrapClusterProxy.GetName()),
 	}, config.GetIntervals(bootstrapClusterProxy.GetName(), "wait-controllers")...)
+
+	waitForWebhookCAInjection(ctx, bootstrapClusterProxy.GetClient())
 }
 
 func tearDown(bootstrapClusterProvider bootstrap.ClusterProvider, bootstrapClusterProxy framework.ClusterProxy) {

--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -43,6 +43,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/pkg/sftp"
 	"golang.org/x/crypto/ssh"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -816,4 +817,48 @@ func getSubscriptionID(g Gomega) string {
 	subscriptionID := os.Getenv("AZURE_SUBSCRIPTION_ID")
 	g.Expect(subscriptionID).NotTo(BeEmpty())
 	return subscriptionID
+}
+
+// waitForWebhookCAInjection waits for cert-manager's cainjector to populate
+// the caBundle field in all webhook configurations annotated with
+// cert-manager.io/inject-ca-from. This prevents a race condition where tests
+// start before the cainjector has finished injecting CA bundles, causing
+// webhook calls to fail with "x509: certificate signed by unknown authority".
+func waitForWebhookCAInjection(ctx context.Context, c client.Client) {
+	By("Waiting for webhook CA injection to complete")
+	Eventually(func() error {
+		var vwcList admissionregistrationv1.ValidatingWebhookConfigurationList
+		if err := c.List(ctx, &vwcList); err != nil {
+			return err
+		}
+		for i := range vwcList.Items {
+			vwc := &vwcList.Items[i]
+			if _, ok := vwc.Annotations["cert-manager.io/inject-ca-from"]; !ok {
+				continue
+			}
+			for _, wh := range vwc.Webhooks {
+				if len(wh.ClientConfig.CABundle) == 0 {
+					return fmt.Errorf("webhook %s in ValidatingWebhookConfiguration %s has no caBundle", wh.Name, vwc.Name)
+				}
+			}
+		}
+
+		var mwcList admissionregistrationv1.MutatingWebhookConfigurationList
+		if err := c.List(ctx, &mwcList); err != nil {
+			return err
+		}
+		for i := range mwcList.Items {
+			mwc := &mwcList.Items[i]
+			if _, ok := mwc.Annotations["cert-manager.io/inject-ca-from"]; !ok {
+				continue
+			}
+			for _, wh := range mwc.Webhooks {
+				if len(wh.ClientConfig.CABundle) == 0 {
+					return fmt.Errorf("webhook %s in MutatingWebhookConfiguration %s has no caBundle", wh.Name, mwc.Name)
+				}
+			}
+		}
+
+		return nil
+	}, 5*time.Minute, 5*time.Second).Should(Succeed(), "cert-manager cainjector did not inject CA bundles into webhook configurations in time")
 }

--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -825,40 +825,32 @@ func getSubscriptionID(g Gomega) string {
 // start before the cainjector has finished injecting CA bundles, causing
 // webhook calls to fail with "x509: certificate signed by unknown authority".
 func waitForWebhookCAInjection(ctx context.Context, c client.Client) {
+	const caInjectionAnnotation = "cert-manager.io/inject-ca-from"
+
 	By("Waiting for webhook CA injection to complete")
-	Eventually(func() error {
-		var vwcList admissionregistrationv1.ValidatingWebhookConfigurationList
-		if err := c.List(ctx, &vwcList); err != nil {
-			return err
-		}
-		for i := range vwcList.Items {
-			vwc := &vwcList.Items[i]
-			if _, ok := vwc.Annotations["cert-manager.io/inject-ca-from"]; !ok {
+	Eventually(func(g Gomega) {
+		var validatingList admissionregistrationv1.ValidatingWebhookConfigurationList
+		g.Expect(c.List(ctx, &validatingList)).To(Succeed())
+		for _, config := range validatingList.Items {
+			if _, ok := config.Annotations[caInjectionAnnotation]; !ok {
 				continue
 			}
-			for _, wh := range vwc.Webhooks {
-				if len(wh.ClientConfig.CABundle) == 0 {
-					return fmt.Errorf("webhook %s in ValidatingWebhookConfiguration %s has no caBundle", wh.Name, vwc.Name)
-				}
+			for _, wh := range config.Webhooks {
+				g.Expect(wh.ClientConfig.CABundle).ToNot(BeEmpty(),
+					"webhook %s in ValidatingWebhookConfiguration %s has no caBundle", wh.Name, config.Name)
 			}
 		}
 
-		var mwcList admissionregistrationv1.MutatingWebhookConfigurationList
-		if err := c.List(ctx, &mwcList); err != nil {
-			return err
-		}
-		for i := range mwcList.Items {
-			mwc := &mwcList.Items[i]
-			if _, ok := mwc.Annotations["cert-manager.io/inject-ca-from"]; !ok {
+		var mutatingList admissionregistrationv1.MutatingWebhookConfigurationList
+		g.Expect(c.List(ctx, &mutatingList)).To(Succeed())
+		for _, config := range mutatingList.Items {
+			if _, ok := config.Annotations[caInjectionAnnotation]; !ok {
 				continue
 			}
-			for _, wh := range mwc.Webhooks {
-				if len(wh.ClientConfig.CABundle) == 0 {
-					return fmt.Errorf("webhook %s in MutatingWebhookConfiguration %s has no caBundle", wh.Name, mwc.Name)
-				}
+			for _, wh := range config.Webhooks {
+				g.Expect(wh.ClientConfig.CABundle).ToNot(BeEmpty(),
+					"webhook %s in MutatingWebhookConfiguration %s has no caBundle", wh.Name, config.Name)
 			}
 		}
-
-		return nil
 	}, 5*time.Minute, 5*time.Second).Should(Succeed(), "cert-manager cainjector did not inject CA bundles into webhook configurations in time")
 }


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind failing-test

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
This is a PR attempting to fix webhook certificate errors

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Could affect #5690 

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->


**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [x] cherry-pick candidate

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
