### PR TITLE
Replace dot imports after webhook refactor

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -233,13 +233,6 @@ linters:
           - revive
         path: _test\.go
         text: should not use dot imports
-      # Dot imports are used intentionally in internal/api and internal/webhooks
-      # to avoid verbose type prefixes when working with the v1beta1 API types.
-      - linters:
-          - revive
-          - staticcheck
-        path: internal/(api|webhooks|test)/
-        text: should not use dot imports
       # Exclude some packages or code to require comments, for example test code, or fake clients.
       - linters:
           - revive

--- a/internal/api/v1beta1/azurecluster_default.go
+++ b/internal/api/v1beta1/azurecluster_default.go
@@ -21,7 +21,7 @@ import (
 
 	"k8s.io/utils/ptr"
 
-	. "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
+	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/feature"
 )
 
@@ -41,7 +41,7 @@ const (
 	// DefaultAzureBastionSubnetName is the default Subnet Name for AzureBastion.
 	DefaultAzureBastionSubnetName = "AzureBastionSubnet"
 	// DefaultAzureBastionSubnetRole is the default Subnet role for AzureBastion.
-	DefaultAzureBastionSubnetRole = SubnetBastion
+	DefaultAzureBastionSubnetRole = infrav1.SubnetBastion
 	// DefaultInternalLBIPAddress is the default internal load balancer ip address.
 	DefaultInternalLBIPAddress = "10.0.0.100"
 	// DefaultOutboundRuleIdleTimeoutInMinutes is the default for IdleTimeoutInMinutes for the load balancer.
@@ -51,14 +51,14 @@ const (
 )
 
 // SetDefaultsAzureCluster sets default values for an AzureCluster.
-func SetDefaultsAzureCluster(c *AzureCluster) {
+func SetDefaultsAzureCluster(c *infrav1.AzureCluster) {
 	AzureClusterClassSpecSetDefaults(&c.Spec.AzureClusterClassSpec)
 	setDefaultAzureClusterResourceGroup(c)
 	setDefaultAzureClusterNetworkSpec(c)
 }
 
 // setDefaultAzureClusterNetworkSpec sets default values for an AzureCluster's NetworkSpec.
-func setDefaultAzureClusterNetworkSpec(c *AzureCluster) {
+func setDefaultAzureClusterNetworkSpec(c *infrav1.AzureCluster) {
 	setDefaultAzureClusterVnet(c)
 	setDefaultAzureClusterBastion(c)
 	setDefaultAzureClusterSubnets(c)
@@ -76,21 +76,21 @@ func setDefaultAzureClusterNetworkSpec(c *AzureCluster) {
 }
 
 // setDefaultAzureClusterResourceGroup sets the default resource group for an AzureCluster.
-func setDefaultAzureClusterResourceGroup(c *AzureCluster) {
+func setDefaultAzureClusterResourceGroup(c *infrav1.AzureCluster) {
 	if c.Spec.ResourceGroup == "" {
 		c.Spec.ResourceGroup = c.Name
 	}
 }
 
 // SetDefaultAzureClusterAzureEnvironment sets the default Azure environment for an AzureCluster.
-func SetDefaultAzureClusterAzureEnvironment(c *AzureCluster) {
+func SetDefaultAzureClusterAzureEnvironment(c *infrav1.AzureCluster) {
 	if c.Spec.AzureEnvironment == "" {
 		c.Spec.AzureEnvironment = DefaultAzureCloud
 	}
 }
 
 // setDefaultAzureClusterVnet sets default values for an AzureCluster's VNet.
-func setDefaultAzureClusterVnet(c *AzureCluster) {
+func setDefaultAzureClusterVnet(c *infrav1.AzureCluster) {
 	if c.Spec.NetworkSpec.Vnet.ResourceGroup == "" {
 		c.Spec.NetworkSpec.Vnet.ResourceGroup = c.Spec.ResourceGroup
 	}
@@ -102,27 +102,27 @@ func setDefaultAzureClusterVnet(c *AzureCluster) {
 
 // setDefaultAzureClusterSubnets ensures a fully populated, default subnet configuration
 // and in certain scenarios creates new, default subnet configurations.
-func setDefaultAzureClusterSubnets(c *AzureCluster) {
-	clusterSubnet, err := c.Spec.NetworkSpec.GetSubnet(SubnetCluster)
+func setDefaultAzureClusterSubnets(c *infrav1.AzureCluster) {
+	clusterSubnet, err := c.Spec.NetworkSpec.GetSubnet(infrav1.SubnetCluster)
 	clusterSubnetExists := err == nil
 	// If we already have a cluster subnet defined, ensure it has sensible defaults
 	// for all properties.
 	if clusterSubnetExists {
 		setDefaultSubnetSpecClusterSubnet(&clusterSubnet, c.ObjectMeta.Name)
-		c.Spec.NetworkSpec.UpdateSubnet(clusterSubnet, SubnetCluster)
+		c.Spec.NetworkSpec.UpdateSubnet(clusterSubnet, infrav1.SubnetCluster)
 	}
 
 	if c.Spec.ControlPlaneEnabled {
-		cpSubnet, errcp := c.Spec.NetworkSpec.GetSubnet(SubnetControlPlane)
+		cpSubnet, errcp := c.Spec.NetworkSpec.GetSubnet(infrav1.SubnetControlPlane)
 		// If we already have a control plane subnet defined, ensure it has sensible defaults
 		// for all properties.
 		if errcp == nil {
 			setDefaultSubnetSpecControlPlaneSubnet(&cpSubnet, c.ObjectMeta.Name)
-			c.Spec.NetworkSpec.UpdateSubnet(cpSubnet, SubnetControlPlane)
+			c.Spec.NetworkSpec.UpdateSubnet(cpSubnet, infrav1.SubnetControlPlane)
 			// If we don't have either a control plane subnet or a cluster subnet,
 			// create a new control plane subnet from scratch and populate with sensible defaults.
 		} else if !clusterSubnetExists {
-			cpSubnet = SubnetSpec{SubnetClassSpec: SubnetClassSpec{Role: SubnetControlPlane}}
+			cpSubnet = infrav1.SubnetSpec{SubnetClassSpec: infrav1.SubnetClassSpec{Role: infrav1.SubnetControlPlane}}
 			setDefaultSubnetSpecControlPlaneSubnet(&cpSubnet, c.ObjectMeta.Name)
 			c.Spec.NetworkSpec.Subnets = append(c.Spec.NetworkSpec.Subnets, cpSubnet)
 		}
@@ -134,7 +134,7 @@ func setDefaultAzureClusterSubnets(c *AzureCluster) {
 	var nodeSubnetCounter int
 	for i, subnet := range c.Spec.NetworkSpec.Subnets {
 		// Skip all non-node subnets
-		if subnet.Role != SubnetNode {
+		if subnet.Role != infrav1.SubnetNode {
 			continue
 		}
 		nodeSubnetCounter++
@@ -150,20 +150,20 @@ func setDefaultAzureClusterSubnets(c *AzureCluster) {
 	// If no node subnets are defined, and there is no cluster subnet defined,
 	// create a default 10.1.0.0/16 node subnet.
 	if !anyNodeSubnetFound && !clusterSubnetExists {
-		nodeSubnet := SubnetSpec{
-			SubnetClassSpec: SubnetClassSpec{
-				Role:       SubnetNode,
+		nodeSubnet := infrav1.SubnetSpec{
+			SubnetClassSpec: infrav1.SubnetClassSpec{
+				Role:       infrav1.SubnetNode,
 				CIDRBlocks: []string{DefaultNodeSubnetCIDR},
 				Name:       generateNodeSubnetName(c.ObjectMeta.Name),
 			},
-			SecurityGroup: SecurityGroup{
+			SecurityGroup: infrav1.SecurityGroup{
 				Name: generateNodeSecurityGroupName(c.ObjectMeta.Name),
 			},
-			RouteTable: RouteTable{
+			RouteTable: infrav1.RouteTable{
 				Name: generateNodeRouteTableName(c.ObjectMeta.Name),
 			},
-			NatGateway: NatGateway{
-				NatGatewayClassSpec: NatGatewayClassSpec{
+			NatGateway: infrav1.NatGateway{
+				NatGatewayClassSpec: infrav1.NatGatewayClassSpec{
 					Name: generateNatGatewayName(c.ObjectMeta.Name),
 				},
 			},
@@ -173,7 +173,7 @@ func setDefaultAzureClusterSubnets(c *AzureCluster) {
 }
 
 // setDefaultSubnetSpecNodeSubnet sets default values for a node SubnetSpec.
-func setDefaultSubnetSpecNodeSubnet(s *SubnetSpec, clusterName string, index int) {
+func setDefaultSubnetSpecNodeSubnet(s *infrav1.SubnetSpec, clusterName string, index int) {
 	if s.Name == "" {
 		s.Name = withIndex(generateNodeSubnetName(clusterName), index)
 	}
@@ -202,7 +202,7 @@ func setDefaultSubnetSpecNodeSubnet(s *SubnetSpec, clusterName string, index int
 }
 
 // setDefaultSubnetSpecControlPlaneSubnet sets default values for a control plane SubnetSpec.
-func setDefaultSubnetSpecControlPlaneSubnet(s *SubnetSpec, clusterName string) {
+func setDefaultSubnetSpecControlPlaneSubnet(s *infrav1.SubnetSpec, clusterName string) {
 	if s.Name == "" {
 		s.Name = generateControlPlaneSubnetName(clusterName)
 	}
@@ -216,7 +216,7 @@ func setDefaultSubnetSpecControlPlaneSubnet(s *SubnetSpec, clusterName string) {
 }
 
 // setDefaultSubnetSpecClusterSubnet sets default values for a cluster SubnetSpec.
-func setDefaultSubnetSpecClusterSubnet(s *SubnetSpec, clusterName string) {
+func setDefaultSubnetSpecClusterSubnet(s *infrav1.SubnetSpec, clusterName string) {
 	if s.Name == "" {
 		s.Name = generateClusterSubnetSubnetName(clusterName)
 	}
@@ -239,7 +239,7 @@ func setDefaultSubnetSpecClusterSubnet(s *SubnetSpec, clusterName string) {
 }
 
 // setDefaultAzureClusterVnetPeering sets default values for an AzureCluster's VNet peerings.
-func setDefaultAzureClusterVnetPeering(c *AzureCluster) {
+func setDefaultAzureClusterVnetPeering(c *infrav1.AzureCluster) {
 	for i, peering := range c.Spec.NetworkSpec.Vnet.Peerings {
 		if peering.ResourceGroup == "" {
 			c.Spec.NetworkSpec.Vnet.Peerings[i].ResourceGroup = c.Spec.ResourceGroup
@@ -248,10 +248,10 @@ func setDefaultAzureClusterVnetPeering(c *AzureCluster) {
 }
 
 // setDefaultAzureClusterAPIServerLB sets default values for an AzureCluster's API server load balancer.
-func setDefaultAzureClusterAPIServerLB(c *AzureCluster) {
+func setDefaultAzureClusterAPIServerLB(c *infrav1.AzureCluster) {
 	if c.Spec.NetworkSpec.APIServerLB == nil {
-		lbSpec := LoadBalancerSpec{
-			LoadBalancerClassSpec: LoadBalancerClassSpec{
+		lbSpec := infrav1.LoadBalancerSpec{
+			LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{
 				Type: "Public",
 			},
 		}
@@ -261,15 +261,15 @@ func setDefaultAzureClusterAPIServerLB(c *AzureCluster) {
 
 	setDefaultLoadBalancerClassSpecAPIServerLB(&lb.LoadBalancerClassSpec)
 
-	if lb.Type == Public {
+	if lb.Type == infrav1.Public {
 		if lb.Name == "" {
 			lb.Name = generatePublicLBName(c.ObjectMeta.Name)
 		}
 		if len(lb.FrontendIPs) == 0 {
-			lb.FrontendIPs = []FrontendIP{
+			lb.FrontendIPs = []infrav1.FrontendIP{
 				{
 					Name: generateFrontendIPConfigName(lb.Name),
-					PublicIP: &PublicIPSpec{
+					PublicIP: &infrav1.PublicIPSpec{
 						Name: generatePublicIPName(c.ObjectMeta.Name),
 					},
 				},
@@ -289,24 +289,24 @@ func setDefaultAzureClusterAPIServerLB(c *AzureCluster) {
 			}
 			// if no private IP is found, we should create a default internal LB IP
 			if !privateIPFound {
-				privateIP := FrontendIP{
+				privateIP := infrav1.FrontendIP{
 					Name: generatePrivateIPConfigName(lb.Name),
-					FrontendIPClass: FrontendIPClass{
+					FrontendIPClass: infrav1.FrontendIPClass{
 						PrivateIPAddress: DefaultInternalLBIPAddress,
 					},
 				}
 				lb.FrontendIPs = append(lb.FrontendIPs, privateIP)
 			}
 		}
-	} else if lb.Type == Internal {
+	} else if lb.Type == infrav1.Internal {
 		if lb.Name == "" {
 			lb.Name = generateInternalLBName(c.ObjectMeta.Name)
 		}
 		if len(lb.FrontendIPs) == 0 {
-			lb.FrontendIPs = []FrontendIP{
+			lb.FrontendIPs = []infrav1.FrontendIP{
 				{
 					Name: generateFrontendIPConfigName(lb.Name),
-					FrontendIPClass: FrontendIPClass{
+					FrontendIPClass: infrav1.FrontendIPClass{
 						PrivateIPAddress: DefaultInternalLBIPAddress,
 					},
 				},
@@ -317,15 +317,15 @@ func setDefaultAzureClusterAPIServerLB(c *AzureCluster) {
 }
 
 // setDefaultAzureClusterNodeOutboundLB sets the default values for the NodeOutboundLB.
-func setDefaultAzureClusterNodeOutboundLB(c *AzureCluster) {
+func setDefaultAzureClusterNodeOutboundLB(c *infrav1.AzureCluster) {
 	if c.Spec.NetworkSpec.NodeOutboundLB == nil {
-		if !c.Spec.ControlPlaneEnabled || c.Spec.NetworkSpec.APIServerLB.Type == Internal {
+		if !c.Spec.ControlPlaneEnabled || c.Spec.NetworkSpec.APIServerLB.Type == infrav1.Internal {
 			return
 		}
 
 		var needsOutboundLB bool
 		for _, subnet := range c.Spec.NetworkSpec.Subnets {
-			if (subnet.Role == SubnetNode || subnet.Role == SubnetCluster) && subnet.IsIPv6Enabled() {
+			if (subnet.Role == infrav1.SubnetNode || subnet.Role == infrav1.SubnetCluster) && subnet.IsIPv6Enabled() {
 				needsOutboundLB = true
 				break
 			}
@@ -338,7 +338,7 @@ func setDefaultAzureClusterNodeOutboundLB(c *AzureCluster) {
 			return
 		}
 
-		c.Spec.NetworkSpec.NodeOutboundLB = &LoadBalancerSpec{}
+		c.Spec.NetworkSpec.NodeOutboundLB = &infrav1.LoadBalancerSpec{}
 	}
 
 	lb := c.Spec.NetworkSpec.NodeOutboundLB
@@ -357,7 +357,7 @@ func setDefaultAzureClusterNodeOutboundLB(c *AzureCluster) {
 }
 
 // setDefaultAzureClusterControlPlaneOutboundLB sets the default values for the control plane's outbound LB.
-func setDefaultAzureClusterControlPlaneOutboundLB(c *AzureCluster) {
+func setDefaultAzureClusterControlPlaneOutboundLB(c *infrav1.AzureCluster) {
 	lb := c.Spec.NetworkSpec.ControlPlaneOutboundLB
 
 	if lb == nil {
@@ -376,14 +376,14 @@ func setDefaultAzureClusterControlPlaneOutboundLB(c *AzureCluster) {
 }
 
 // SetDefaultAzureClusterBackendPoolName defaults the backend pool name of the LBs.
-func SetDefaultAzureClusterBackendPoolName(c *AzureCluster) {
+func SetDefaultAzureClusterBackendPoolName(c *infrav1.AzureCluster) {
 	setDefaultAzureClusterAPIServerLBBackendPoolName(c)
 	setDefaultAzureClusterNodeOutboundLBBackendPoolName(c)
 	setDefaultAzureClusterControlPlaneOutboundLBBackendPoolName(c)
 }
 
 // setDefaultAzureClusterAPIServerLBBackendPoolName defaults the name of the backend pool for apiserver LB.
-func setDefaultAzureClusterAPIServerLBBackendPoolName(c *AzureCluster) {
+func setDefaultAzureClusterAPIServerLBBackendPoolName(c *infrav1.AzureCluster) {
 	apiServerLB := c.Spec.NetworkSpec.APIServerLB
 	if apiServerLB.BackendPool.Name == "" {
 		apiServerLB.BackendPool.Name = generateBackendAddressPoolName(apiServerLB.Name)
@@ -391,7 +391,7 @@ func setDefaultAzureClusterAPIServerLBBackendPoolName(c *AzureCluster) {
 }
 
 // setDefaultAzureClusterNodeOutboundLBBackendPoolName defaults the name of the backend pool for node outbound LB.
-func setDefaultAzureClusterNodeOutboundLBBackendPoolName(c *AzureCluster) {
+func setDefaultAzureClusterNodeOutboundLBBackendPoolName(c *infrav1.AzureCluster) {
 	nodeOutboundLB := c.Spec.NetworkSpec.NodeOutboundLB
 	if nodeOutboundLB != nil && nodeOutboundLB.BackendPool.Name == "" {
 		nodeOutboundLB.BackendPool.Name = generateOutboundBackendAddressPoolName(nodeOutboundLB.Name)
@@ -399,7 +399,7 @@ func setDefaultAzureClusterNodeOutboundLBBackendPoolName(c *AzureCluster) {
 }
 
 // setDefaultAzureClusterControlPlaneOutboundLBBackendPoolName defaults the name of the backend pool for control plane outbound LB.
-func setDefaultAzureClusterControlPlaneOutboundLBBackendPoolName(c *AzureCluster) {
+func setDefaultAzureClusterControlPlaneOutboundLBBackendPoolName(c *infrav1.AzureCluster) {
 	controlPlaneOutboundLB := c.Spec.NetworkSpec.ControlPlaneOutboundLB
 	if controlPlaneOutboundLB != nil && controlPlaneOutboundLB.BackendPool.Name == "" {
 		controlPlaneOutboundLB.BackendPool.Name = generateOutboundBackendAddressPoolName(generateControlPlaneOutboundLBName(c.ObjectMeta.Name))
@@ -408,25 +408,25 @@ func setDefaultAzureClusterControlPlaneOutboundLBBackendPoolName(c *AzureCluster
 
 // setDefaultAzureClusterOutboundLBFrontendIPs sets the frontend IPs for the given load balancer.
 // The name of the frontend IP is generated using generatePublicIPName function.
-func setDefaultAzureClusterOutboundLBFrontendIPs(c *AzureCluster, lb *LoadBalancerSpec, generatePublicIPName func(string) string) {
+func setDefaultAzureClusterOutboundLBFrontendIPs(c *infrav1.AzureCluster, lb *infrav1.LoadBalancerSpec, generatePublicIPName func(string) string) {
 	switch *lb.FrontendIPsCount {
 	case 0:
-		lb.FrontendIPs = []FrontendIP{}
+		lb.FrontendIPs = []infrav1.FrontendIP{}
 	case 1:
-		lb.FrontendIPs = []FrontendIP{
+		lb.FrontendIPs = []infrav1.FrontendIP{
 			{
 				Name: generateFrontendIPConfigName(lb.Name),
-				PublicIP: &PublicIPSpec{
+				PublicIP: &infrav1.PublicIPSpec{
 					Name: generatePublicIPName(c.ObjectMeta.Name),
 				},
 			},
 		}
 	default:
-		lb.FrontendIPs = make([]FrontendIP, *lb.FrontendIPsCount)
+		lb.FrontendIPs = make([]infrav1.FrontendIP, *lb.FrontendIPsCount)
 		for i := 0; i < int(*lb.FrontendIPsCount); i++ {
-			lb.FrontendIPs[i] = FrontendIP{
+			lb.FrontendIPs[i] = infrav1.FrontendIP{
 				Name: withIndex(generateFrontendIPConfigName(lb.Name), i+1),
-				PublicIP: &PublicIPSpec{
+				PublicIP: &infrav1.PublicIPSpec{
 					Name: withIndex(generatePublicIPName(c.ObjectMeta.Name), i+1),
 				},
 			}
@@ -435,7 +435,7 @@ func setDefaultAzureClusterOutboundLBFrontendIPs(c *AzureCluster, lb *LoadBalanc
 }
 
 // setDefaultAzureClusterBastion sets default values for an AzureCluster's bastion configuration.
-func setDefaultAzureClusterBastion(c *AzureCluster) {
+func setDefaultAzureClusterBastion(c *infrav1.AzureCluster) {
 	if c.Spec.BastionSpec.AzureBastion != nil {
 		if c.Spec.BastionSpec.AzureBastion.Name == "" {
 			c.Spec.BastionSpec.AzureBastion.Name = generateAzureBastionName(c.ObjectMeta.Name)
@@ -458,12 +458,12 @@ func setDefaultAzureClusterBastion(c *AzureCluster) {
 }
 
 // setDefaultLoadBalancerClassSpecAPIServerLB sets default values for an API server LoadBalancerClassSpec.
-func setDefaultLoadBalancerClassSpecAPIServerLB(lb *LoadBalancerClassSpec) {
+func setDefaultLoadBalancerClassSpecAPIServerLB(lb *infrav1.LoadBalancerClassSpec) {
 	if lb.Type == "" {
-		lb.Type = Public
+		lb.Type = infrav1.Public
 	}
 	if lb.SKU == "" {
-		lb.SKU = SKUStandard
+		lb.SKU = infrav1.SKUStandard
 	}
 	if lb.IdleTimeoutInMinutes == nil {
 		lb.IdleTimeoutInMinutes = ptr.To[int32](DefaultOutboundRuleIdleTimeoutInMinutes)
@@ -471,19 +471,19 @@ func setDefaultLoadBalancerClassSpecAPIServerLB(lb *LoadBalancerClassSpec) {
 }
 
 // setDefaultLoadBalancerClassSpecNodeOutboundLB sets default values for a node outbound LoadBalancerClassSpec.
-func setDefaultLoadBalancerClassSpecNodeOutboundLB(lb *LoadBalancerClassSpec) {
+func setDefaultLoadBalancerClassSpecNodeOutboundLB(lb *infrav1.LoadBalancerClassSpec) {
 	setDefaultLoadBalancerClassSpecOutboundLB(lb)
 }
 
 // setDefaultLoadBalancerClassSpecControlPlaneOutboundLB sets default values for a control plane outbound LoadBalancerClassSpec.
-func setDefaultLoadBalancerClassSpecControlPlaneOutboundLB(lb *LoadBalancerClassSpec) {
+func setDefaultLoadBalancerClassSpecControlPlaneOutboundLB(lb *infrav1.LoadBalancerClassSpec) {
 	setDefaultLoadBalancerClassSpecOutboundLB(lb)
 }
 
 // setDefaultLoadBalancerClassSpecOutboundLB sets default values for an outbound LoadBalancerClassSpec.
-func setDefaultLoadBalancerClassSpecOutboundLB(lb *LoadBalancerClassSpec) {
-	lb.Type = Public
-	lb.SKU = SKUStandard
+func setDefaultLoadBalancerClassSpecOutboundLB(lb *infrav1.LoadBalancerClassSpec) {
+	lb.Type = infrav1.Public
+	lb.SKU = infrav1.SKUStandard
 	if lb.IdleTimeoutInMinutes == nil {
 		lb.IdleTimeoutInMinutes = ptr.To[int32](DefaultOutboundRuleIdleTimeoutInMinutes)
 	}

--- a/internal/api/v1beta1/azurecluster_default_test.go
+++ b/internal/api/v1beta1/azurecluster_default_test.go
@@ -27,46 +27,46 @@ import (
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/utils/ptr"
 
-	. "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
+	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/feature"
 	apifixtures "sigs.k8s.io/cluster-api-provider-azure/internal/test/apifixtures"
 )
 
 func TestResourceGroupDefault(t *testing.T) {
 	cases := map[string]struct {
-		cluster *AzureCluster
-		output  *AzureCluster
+		cluster *infrav1.AzureCluster
+		output  *infrav1.AzureCluster
 	}{
 		"default empty rg": {
-			cluster: &AzureCluster{
+			cluster: &infrav1.AzureCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "foo",
 				},
-				Spec: AzureClusterSpec{},
+				Spec: infrav1.AzureClusterSpec{},
 			},
-			output: &AzureCluster{
+			output: &infrav1.AzureCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "foo",
 				},
-				Spec: AzureClusterSpec{
+				Spec: infrav1.AzureClusterSpec{
 					ResourceGroup: "foo",
 				},
 			},
 		},
 		"don't change if mismatched": {
-			cluster: &AzureCluster{
+			cluster: &infrav1.AzureCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "foo",
 				},
-				Spec: AzureClusterSpec{
+				Spec: infrav1.AzureClusterSpec{
 					ResourceGroup: "bar",
 				},
 			},
-			output: &AzureCluster{
+			output: &infrav1.AzureCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "foo",
 				},
-				Spec: AzureClusterSpec{
+				Spec: infrav1.AzureClusterSpec{
 					ResourceGroup: "bar",
 				},
 			},
@@ -90,69 +90,69 @@ func TestResourceGroupDefault(t *testing.T) {
 func TestVnetDefaults(t *testing.T) {
 	cases := []struct {
 		name    string
-		cluster *AzureCluster
-		output  *AzureCluster
+		cluster *infrav1.AzureCluster
+		output  *infrav1.AzureCluster
 	}{
 		{
 			name:    "resource group vnet specified",
 			cluster: apifixtures.CreateValidCluster(),
-			output: &AzureCluster{
+			output: &infrav1.AzureCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster",
 				},
-				Spec: AzureClusterSpec{
+				Spec: infrav1.AzureClusterSpec{
 					ControlPlaneEnabled: true,
-					NetworkSpec: NetworkSpec{
-						Vnet: VnetSpec{
+					NetworkSpec: infrav1.NetworkSpec{
+						Vnet: infrav1.VnetSpec{
 							ResourceGroup: "custom-vnet",
 							Name:          "my-vnet",
-							VnetClassSpec: VnetClassSpec{
+							VnetClassSpec: infrav1.VnetClassSpec{
 								CIDRBlocks: []string{DefaultVnetCIDR},
 							},
 						},
-						Subnets: Subnets{
+						Subnets: infrav1.Subnets{
 							{
-								SubnetClassSpec: SubnetClassSpec{
-									Role: SubnetControlPlane,
+								SubnetClassSpec: infrav1.SubnetClassSpec{
+									Role: infrav1.SubnetControlPlane,
 									Name: "control-plane-subnet",
 								},
 
-								SecurityGroup: SecurityGroup{},
-								RouteTable:    RouteTable{},
+								SecurityGroup: infrav1.SecurityGroup{},
+								RouteTable:    infrav1.RouteTable{},
 							},
 							{
-								SubnetClassSpec: SubnetClassSpec{
-									Role: SubnetNode,
+								SubnetClassSpec: infrav1.SubnetClassSpec{
+									Role: infrav1.SubnetNode,
 									Name: "node-subnet",
 								},
-								SecurityGroup: SecurityGroup{},
-								RouteTable:    RouteTable{},
+								SecurityGroup: infrav1.SecurityGroup{},
+								RouteTable:    infrav1.RouteTable{},
 							},
 						},
-						APIServerLB: &LoadBalancerSpec{
+						APIServerLB: &infrav1.LoadBalancerSpec{
 							Name: "my-lb",
-							FrontendIPs: []FrontendIP{
+							FrontendIPs: []infrav1.FrontendIP{
 								{
 									Name: "ip-config",
-									PublicIP: &PublicIPSpec{
+									PublicIP: &infrav1.PublicIPSpec{
 										Name:    "public-ip",
 										DNSName: "myfqdn.azure.com",
 									},
 								},
 							},
-							LoadBalancerClassSpec: LoadBalancerClassSpec{
-								SKU: SKUStandard,
+							LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{
+								SKU: infrav1.SKUStandard,
 
-								Type: Public,
+								Type: infrav1.Public,
 							},
 						},
-						NodeOutboundLB: &LoadBalancerSpec{
+						NodeOutboundLB: &infrav1.LoadBalancerSpec{
 							FrontendIPsCount: ptr.To[int32](1),
 						},
 					},
-					AzureClusterClassSpec: AzureClusterClassSpec{
+					AzureClusterClassSpec: infrav1.AzureClusterClassSpec{
 						IdentityRef: &corev1.ObjectReference{
-							Kind: AzureClusterIdentityKind,
+							Kind: infrav1.AzureClusterIdentityKind,
 						},
 					},
 				},
@@ -160,39 +160,39 @@ func TestVnetDefaults(t *testing.T) {
 		},
 		{
 			name: "vnet not specified",
-			cluster: &AzureCluster{
+			cluster: &infrav1.AzureCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
-				Spec: AzureClusterSpec{
+				Spec: infrav1.AzureClusterSpec{
 					ControlPlaneEnabled: true,
 					ResourceGroup:       "cluster-test",
-					AzureClusterClassSpec: AzureClusterClassSpec{
+					AzureClusterClassSpec: infrav1.AzureClusterClassSpec{
 						IdentityRef: &corev1.ObjectReference{
-							Kind: AzureClusterIdentityKind,
+							Kind: infrav1.AzureClusterIdentityKind,
 						},
 					},
 				},
 			},
-			output: &AzureCluster{
+			output: &infrav1.AzureCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
-				Spec: AzureClusterSpec{
+				Spec: infrav1.AzureClusterSpec{
 					ControlPlaneEnabled: true,
 					ResourceGroup:       "cluster-test",
-					NetworkSpec: NetworkSpec{
-						Vnet: VnetSpec{
+					NetworkSpec: infrav1.NetworkSpec{
+						Vnet: infrav1.VnetSpec{
 							ResourceGroup: "cluster-test",
 							Name:          "cluster-test-vnet",
-							VnetClassSpec: VnetClassSpec{
+							VnetClassSpec: infrav1.VnetClassSpec{
 								CIDRBlocks: []string{DefaultVnetCIDR},
 							},
 						},
 					},
-					AzureClusterClassSpec: AzureClusterClassSpec{
+					AzureClusterClassSpec: infrav1.AzureClusterClassSpec{
 						IdentityRef: &corev1.ObjectReference{
-							Kind: AzureClusterIdentityKind,
+							Kind: infrav1.AzureClusterIdentityKind,
 						},
 					},
 				},
@@ -200,46 +200,46 @@ func TestVnetDefaults(t *testing.T) {
 		},
 		{
 			name: "custom CIDR",
-			cluster: &AzureCluster{
+			cluster: &infrav1.AzureCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
-				Spec: AzureClusterSpec{
+				Spec: infrav1.AzureClusterSpec{
 					ControlPlaneEnabled: true,
 					ResourceGroup:       "cluster-test",
-					NetworkSpec: NetworkSpec{
-						Vnet: VnetSpec{
-							VnetClassSpec: VnetClassSpec{
+					NetworkSpec: infrav1.NetworkSpec{
+						Vnet: infrav1.VnetSpec{
+							VnetClassSpec: infrav1.VnetClassSpec{
 								CIDRBlocks: []string{"10.0.0.0/16"},
 							},
 						},
 					},
-					AzureClusterClassSpec: AzureClusterClassSpec{
+					AzureClusterClassSpec: infrav1.AzureClusterClassSpec{
 						IdentityRef: &corev1.ObjectReference{
-							Kind: AzureClusterIdentityKind,
+							Kind: infrav1.AzureClusterIdentityKind,
 						},
 					},
 				},
 			},
-			output: &AzureCluster{
+			output: &infrav1.AzureCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
-				Spec: AzureClusterSpec{
+				Spec: infrav1.AzureClusterSpec{
 					ControlPlaneEnabled: true,
 					ResourceGroup:       "cluster-test",
-					NetworkSpec: NetworkSpec{
-						Vnet: VnetSpec{
+					NetworkSpec: infrav1.NetworkSpec{
+						Vnet: infrav1.VnetSpec{
 							ResourceGroup: "cluster-test",
 							Name:          "cluster-test-vnet",
-							VnetClassSpec: VnetClassSpec{
+							VnetClassSpec: infrav1.VnetClassSpec{
 								CIDRBlocks: []string{"10.0.0.0/16"},
 							},
 						},
 					},
-					AzureClusterClassSpec: AzureClusterClassSpec{
+					AzureClusterClassSpec: infrav1.AzureClusterClassSpec{
 						IdentityRef: &corev1.ObjectReference{
-							Kind: AzureClusterIdentityKind,
+							Kind: infrav1.AzureClusterIdentityKind,
 						},
 					},
 				},
@@ -247,46 +247,46 @@ func TestVnetDefaults(t *testing.T) {
 		},
 		{
 			name: "IPv6 enabled",
-			cluster: &AzureCluster{
+			cluster: &infrav1.AzureCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
-				Spec: AzureClusterSpec{
+				Spec: infrav1.AzureClusterSpec{
 					ControlPlaneEnabled: true,
 					ResourceGroup:       "cluster-test",
-					NetworkSpec: NetworkSpec{
-						Vnet: VnetSpec{
-							VnetClassSpec: VnetClassSpec{
+					NetworkSpec: infrav1.NetworkSpec{
+						Vnet: infrav1.VnetSpec{
+							VnetClassSpec: infrav1.VnetClassSpec{
 								CIDRBlocks: []string{DefaultVnetCIDR, "2001:1234:5678:9a00::/56"},
 							},
 						},
 					},
-					AzureClusterClassSpec: AzureClusterClassSpec{
+					AzureClusterClassSpec: infrav1.AzureClusterClassSpec{
 						IdentityRef: &corev1.ObjectReference{
-							Kind: AzureClusterIdentityKind,
+							Kind: infrav1.AzureClusterIdentityKind,
 						},
 					},
 				},
 			},
-			output: &AzureCluster{
+			output: &infrav1.AzureCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
-				Spec: AzureClusterSpec{
+				Spec: infrav1.AzureClusterSpec{
 					ControlPlaneEnabled: true,
 					ResourceGroup:       "cluster-test",
-					NetworkSpec: NetworkSpec{
-						Vnet: VnetSpec{
+					NetworkSpec: infrav1.NetworkSpec{
+						Vnet: infrav1.VnetSpec{
 							ResourceGroup: "cluster-test",
 							Name:          "cluster-test-vnet",
-							VnetClassSpec: VnetClassSpec{
+							VnetClassSpec: infrav1.VnetClassSpec{
 								CIDRBlocks: []string{DefaultVnetCIDR, "2001:1234:5678:9a00::/56"},
 							},
 						},
 					},
-					AzureClusterClassSpec: AzureClusterClassSpec{
+					AzureClusterClassSpec: infrav1.AzureClusterClassSpec{
 						IdentityRef: &corev1.ObjectReference{
-							Kind: AzureClusterIdentityKind,
+							Kind: infrav1.AzureClusterIdentityKind,
 						},
 					},
 				},
@@ -311,47 +311,47 @@ func TestVnetDefaults(t *testing.T) {
 func TestSubnetDefaults(t *testing.T) {
 	cases := []struct {
 		name    string
-		cluster *AzureCluster
-		output  *AzureCluster
+		cluster *infrav1.AzureCluster
+		output  *infrav1.AzureCluster
 	}{
 		{
 			name: "no subnets",
-			cluster: &AzureCluster{
+			cluster: &infrav1.AzureCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
-				Spec: AzureClusterSpec{
+				Spec: infrav1.AzureClusterSpec{
 					ControlPlaneEnabled: true,
-					NetworkSpec:         NetworkSpec{},
+					NetworkSpec:         infrav1.NetworkSpec{},
 				},
 			},
-			output: &AzureCluster{
+			output: &infrav1.AzureCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
-				Spec: AzureClusterSpec{
+				Spec: infrav1.AzureClusterSpec{
 					ControlPlaneEnabled: true,
-					NetworkSpec: NetworkSpec{
-						Subnets: Subnets{
+					NetworkSpec: infrav1.NetworkSpec{
+						Subnets: infrav1.Subnets{
 							{
-								SubnetClassSpec: SubnetClassSpec{
-									Role:       SubnetControlPlane,
+								SubnetClassSpec: infrav1.SubnetClassSpec{
+									Role:       infrav1.SubnetControlPlane,
 									CIDRBlocks: []string{DefaultControlPlaneSubnetCIDR},
 									Name:       "cluster-test-controlplane-subnet",
 								},
 
-								SecurityGroup: SecurityGroup{Name: "cluster-test-controlplane-nsg"},
-								RouteTable:    RouteTable{},
+								SecurityGroup: infrav1.SecurityGroup{Name: "cluster-test-controlplane-nsg"},
+								RouteTable:    infrav1.RouteTable{},
 							},
 							{
-								SubnetClassSpec: SubnetClassSpec{
-									Role:       SubnetNode,
+								SubnetClassSpec: infrav1.SubnetClassSpec{
+									Role:       infrav1.SubnetNode,
 									CIDRBlocks: []string{DefaultNodeSubnetCIDR},
 									Name:       "cluster-test-node-subnet",
 								},
-								SecurityGroup: SecurityGroup{Name: "cluster-test-node-nsg"},
-								RouteTable:    RouteTable{Name: "cluster-test-node-routetable"},
-								NatGateway: NatGateway{NatGatewayClassSpec: NatGatewayClassSpec{
+								SecurityGroup: infrav1.SecurityGroup{Name: "cluster-test-node-nsg"},
+								RouteTable:    infrav1.RouteTable{Name: "cluster-test-node-routetable"},
+								NatGateway: infrav1.NatGateway{NatGatewayClassSpec: infrav1.NatGatewayClassSpec{
 									Name: "cluster-test-node-natgw",
 								}},
 							},
@@ -362,29 +362,29 @@ func TestSubnetDefaults(t *testing.T) {
 		},
 		{
 			name: "subnets with custom attributes",
-			cluster: &AzureCluster{
+			cluster: &infrav1.AzureCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
-				Spec: AzureClusterSpec{
+				Spec: infrav1.AzureClusterSpec{
 					ControlPlaneEnabled: true,
-					NetworkSpec: NetworkSpec{
-						Subnets: Subnets{
+					NetworkSpec: infrav1.NetworkSpec{
+						Subnets: infrav1.Subnets{
 							{
-								SubnetClassSpec: SubnetClassSpec{
-									Role:       SubnetControlPlane,
+								SubnetClassSpec: infrav1.SubnetClassSpec{
+									Role:       infrav1.SubnetControlPlane,
 									CIDRBlocks: []string{"10.0.0.16/24"},
 									Name:       "my-controlplane-subnet",
 								},
 							},
 							{
-								SubnetClassSpec: SubnetClassSpec{
-									Role:       SubnetNode,
+								SubnetClassSpec: infrav1.SubnetClassSpec{
+									Role:       infrav1.SubnetNode,
 									CIDRBlocks: []string{"10.1.0.16/24"},
 									Name:       "my-node-subnet",
 								},
-								NatGateway: NatGateway{
-									NatGatewayClassSpec: NatGatewayClassSpec{
+								NatGateway: infrav1.NatGateway{
+									NatGatewayClassSpec: infrav1.NatGatewayClassSpec{
 										Name: "foo-natgw",
 									},
 								},
@@ -393,36 +393,36 @@ func TestSubnetDefaults(t *testing.T) {
 					},
 				},
 			},
-			output: &AzureCluster{
+			output: &infrav1.AzureCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
-				Spec: AzureClusterSpec{
+				Spec: infrav1.AzureClusterSpec{
 					ControlPlaneEnabled: true,
-					NetworkSpec: NetworkSpec{
-						Subnets: Subnets{
+					NetworkSpec: infrav1.NetworkSpec{
+						Subnets: infrav1.Subnets{
 							{
-								SubnetClassSpec: SubnetClassSpec{
-									Role:       SubnetControlPlane,
+								SubnetClassSpec: infrav1.SubnetClassSpec{
+									Role:       infrav1.SubnetControlPlane,
 									CIDRBlocks: []string{"10.0.0.16/24"},
 									Name:       "my-controlplane-subnet",
 								},
-								SecurityGroup: SecurityGroup{Name: "cluster-test-controlplane-nsg"},
-								RouteTable:    RouteTable{},
+								SecurityGroup: infrav1.SecurityGroup{Name: "cluster-test-controlplane-nsg"},
+								RouteTable:    infrav1.RouteTable{},
 							},
 							{
-								SubnetClassSpec: SubnetClassSpec{
-									Role:       SubnetNode,
+								SubnetClassSpec: infrav1.SubnetClassSpec{
+									Role:       infrav1.SubnetNode,
 									CIDRBlocks: []string{"10.1.0.16/24"},
 									Name:       "my-node-subnet",
 								},
-								SecurityGroup: SecurityGroup{Name: "cluster-test-node-nsg"},
-								RouteTable:    RouteTable{Name: "cluster-test-node-routetable"},
-								NatGateway: NatGateway{
-									NatGatewayClassSpec: NatGatewayClassSpec{
+								SecurityGroup: infrav1.SecurityGroup{Name: "cluster-test-node-nsg"},
+								RouteTable:    infrav1.RouteTable{Name: "cluster-test-node-routetable"},
+								NatGateway: infrav1.NatGateway{
+									NatGatewayClassSpec: infrav1.NatGatewayClassSpec{
 										Name: "foo-natgw",
 									},
-									NatGatewayIP: PublicIPSpec{
+									NatGatewayIP: infrav1.PublicIPSpec{
 										Name: "pip-foo-natgw",
 									},
 								},
@@ -434,23 +434,23 @@ func TestSubnetDefaults(t *testing.T) {
 		},
 		{
 			name: "subnets specified",
-			cluster: &AzureCluster{
+			cluster: &infrav1.AzureCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
-				Spec: AzureClusterSpec{
+				Spec: infrav1.AzureClusterSpec{
 					ControlPlaneEnabled: true,
-					NetworkSpec: NetworkSpec{
-						Subnets: Subnets{
+					NetworkSpec: infrav1.NetworkSpec{
+						Subnets: infrav1.Subnets{
 							{
-								SubnetClassSpec: SubnetClassSpec{
-									Role: SubnetControlPlane,
+								SubnetClassSpec: infrav1.SubnetClassSpec{
+									Role: infrav1.SubnetControlPlane,
 									Name: "cluster-test-controlplane-subnet",
 								},
 							},
 							{
-								SubnetClassSpec: SubnetClassSpec{
-									Role: SubnetNode,
+								SubnetClassSpec: infrav1.SubnetClassSpec{
+									Role: infrav1.SubnetNode,
 									Name: "cluster-test-node-subnet",
 								},
 							},
@@ -458,37 +458,37 @@ func TestSubnetDefaults(t *testing.T) {
 					},
 				},
 			},
-			output: &AzureCluster{
+			output: &infrav1.AzureCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
-				Spec: AzureClusterSpec{
+				Spec: infrav1.AzureClusterSpec{
 					ControlPlaneEnabled: true,
-					NetworkSpec: NetworkSpec{
-						Subnets: Subnets{
+					NetworkSpec: infrav1.NetworkSpec{
+						Subnets: infrav1.Subnets{
 							{
-								SubnetClassSpec: SubnetClassSpec{
-									Role:       SubnetControlPlane,
+								SubnetClassSpec: infrav1.SubnetClassSpec{
+									Role:       infrav1.SubnetControlPlane,
 									CIDRBlocks: []string{DefaultControlPlaneSubnetCIDR},
 									Name:       "cluster-test-controlplane-subnet",
 								},
 
-								SecurityGroup: SecurityGroup{Name: "cluster-test-controlplane-nsg"},
-								RouteTable:    RouteTable{},
+								SecurityGroup: infrav1.SecurityGroup{Name: "cluster-test-controlplane-nsg"},
+								RouteTable:    infrav1.RouteTable{},
 							},
 							{
-								SubnetClassSpec: SubnetClassSpec{
-									Role:       SubnetNode,
+								SubnetClassSpec: infrav1.SubnetClassSpec{
+									Role:       infrav1.SubnetNode,
 									CIDRBlocks: []string{DefaultNodeSubnetCIDR},
 									Name:       "cluster-test-node-subnet",
 								},
-								SecurityGroup: SecurityGroup{Name: "cluster-test-node-nsg"},
-								RouteTable:    RouteTable{Name: "cluster-test-node-routetable"},
-								NatGateway: NatGateway{
-									NatGatewayClassSpec: NatGatewayClassSpec{
+								SecurityGroup: infrav1.SecurityGroup{Name: "cluster-test-node-nsg"},
+								RouteTable:    infrav1.RouteTable{Name: "cluster-test-node-routetable"},
+								NatGateway: infrav1.NatGateway{
+									NatGatewayClassSpec: infrav1.NatGatewayClassSpec{
 										Name: "cluster-test-node-natgw-1",
 									},
-									NatGatewayIP: PublicIPSpec{
+									NatGatewayIP: infrav1.PublicIPSpec{
 										Name: "pip-cluster-test-node-natgw-1",
 									},
 								},
@@ -500,22 +500,22 @@ func TestSubnetDefaults(t *testing.T) {
 		},
 		{
 			name: "cluster subnet with custom attributes",
-			cluster: &AzureCluster{
+			cluster: &infrav1.AzureCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
-				Spec: AzureClusterSpec{
+				Spec: infrav1.AzureClusterSpec{
 					ControlPlaneEnabled: true,
-					NetworkSpec: NetworkSpec{
-						Subnets: Subnets{
+					NetworkSpec: infrav1.NetworkSpec{
+						Subnets: infrav1.Subnets{
 							{
-								SubnetClassSpec: SubnetClassSpec{
-									Role:       SubnetCluster,
+								SubnetClassSpec: infrav1.SubnetClassSpec{
+									Role:       infrav1.SubnetCluster,
 									CIDRBlocks: []string{"10.0.0.16/24"},
 									Name:       "my-subnet",
 								},
-								NatGateway: NatGateway{
-									NatGatewayClassSpec: NatGatewayClassSpec{
+								NatGateway: infrav1.NatGateway{
+									NatGatewayClassSpec: infrav1.NatGatewayClassSpec{
 										Name: "foo-natgw",
 									},
 								},
@@ -524,27 +524,27 @@ func TestSubnetDefaults(t *testing.T) {
 					},
 				},
 			},
-			output: &AzureCluster{
+			output: &infrav1.AzureCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
-				Spec: AzureClusterSpec{
+				Spec: infrav1.AzureClusterSpec{
 					ControlPlaneEnabled: true,
-					NetworkSpec: NetworkSpec{
-						Subnets: Subnets{
+					NetworkSpec: infrav1.NetworkSpec{
+						Subnets: infrav1.Subnets{
 							{
-								SubnetClassSpec: SubnetClassSpec{
-									Role:       SubnetCluster,
+								SubnetClassSpec: infrav1.SubnetClassSpec{
+									Role:       infrav1.SubnetCluster,
 									CIDRBlocks: []string{"10.0.0.16/24"},
 									Name:       "my-subnet",
 								},
-								SecurityGroup: SecurityGroup{Name: "cluster-test-nsg"},
-								RouteTable:    RouteTable{Name: "cluster-test-routetable"},
-								NatGateway: NatGateway{
-									NatGatewayClassSpec: NatGatewayClassSpec{
+								SecurityGroup: infrav1.SecurityGroup{Name: "cluster-test-nsg"},
+								RouteTable:    infrav1.RouteTable{Name: "cluster-test-routetable"},
+								NatGateway: infrav1.NatGateway{
+									NatGatewayClassSpec: infrav1.NatGatewayClassSpec{
 										Name: "foo-natgw",
 									},
-									NatGatewayIP: PublicIPSpec{
+									NatGatewayIP: infrav1.PublicIPSpec{
 										Name: "pip-foo-natgw",
 									},
 								},
@@ -556,17 +556,17 @@ func TestSubnetDefaults(t *testing.T) {
 		},
 		{
 			name: "cluster subnet with subnets specified",
-			cluster: &AzureCluster{
+			cluster: &infrav1.AzureCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
-				Spec: AzureClusterSpec{
+				Spec: infrav1.AzureClusterSpec{
 					ControlPlaneEnabled: true,
-					NetworkSpec: NetworkSpec{
-						Subnets: Subnets{
+					NetworkSpec: infrav1.NetworkSpec{
+						Subnets: infrav1.Subnets{
 							{
-								SubnetClassSpec: SubnetClassSpec{
-									Role: SubnetCluster,
+								SubnetClassSpec: infrav1.SubnetClassSpec{
+									Role: infrav1.SubnetCluster,
 									Name: "cluster-test-subnet",
 								},
 							},
@@ -574,27 +574,27 @@ func TestSubnetDefaults(t *testing.T) {
 					},
 				},
 			},
-			output: &AzureCluster{
+			output: &infrav1.AzureCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
-				Spec: AzureClusterSpec{
+				Spec: infrav1.AzureClusterSpec{
 					ControlPlaneEnabled: true,
-					NetworkSpec: NetworkSpec{
-						Subnets: Subnets{
+					NetworkSpec: infrav1.NetworkSpec{
+						Subnets: infrav1.Subnets{
 							{
-								SubnetClassSpec: SubnetClassSpec{
-									Role:       SubnetCluster,
+								SubnetClassSpec: infrav1.SubnetClassSpec{
+									Role:       infrav1.SubnetCluster,
 									CIDRBlocks: []string{DefaultClusterSubnetCIDR},
 									Name:       "cluster-test-subnet",
 								},
-								SecurityGroup: SecurityGroup{Name: "cluster-test-nsg"},
-								RouteTable:    RouteTable{Name: "cluster-test-routetable"},
-								NatGateway: NatGateway{
-									NatGatewayClassSpec: NatGatewayClassSpec{
+								SecurityGroup: infrav1.SecurityGroup{Name: "cluster-test-nsg"},
+								RouteTable:    infrav1.RouteTable{Name: "cluster-test-routetable"},
+								NatGateway: infrav1.NatGateway{
+									NatGatewayClassSpec: infrav1.NatGatewayClassSpec{
 										Name: "cluster-test-natgw",
 									},
-									NatGatewayIP: PublicIPSpec{
+									NatGatewayIP: infrav1.PublicIPSpec{
 										Name: "pip-cluster-test-natgw",
 									},
 								},
@@ -606,26 +606,26 @@ func TestSubnetDefaults(t *testing.T) {
 		},
 		{
 			name: "subnets route tables specified",
-			cluster: &AzureCluster{
+			cluster: &infrav1.AzureCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
-				Spec: AzureClusterSpec{
+				Spec: infrav1.AzureClusterSpec{
 					ControlPlaneEnabled: true,
-					NetworkSpec: NetworkSpec{
-						Subnets: Subnets{
+					NetworkSpec: infrav1.NetworkSpec{
+						Subnets: infrav1.Subnets{
 							{
-								SubnetClassSpec: SubnetClassSpec{
-									Role: SubnetControlPlane,
+								SubnetClassSpec: infrav1.SubnetClassSpec{
+									Role: infrav1.SubnetControlPlane,
 									Name: "cluster-test-controlplane-subnet",
 								},
-								RouteTable: RouteTable{
+								RouteTable: infrav1.RouteTable{
 									Name: "control-plane-custom-route-table",
 								},
 							},
 							{
-								SubnetClassSpec: SubnetClassSpec{
-									Role: SubnetNode,
+								SubnetClassSpec: infrav1.SubnetClassSpec{
+									Role: infrav1.SubnetNode,
 									Name: "cluster-test-node-subnet",
 								},
 							},
@@ -633,36 +633,36 @@ func TestSubnetDefaults(t *testing.T) {
 					},
 				},
 			},
-			output: &AzureCluster{
+			output: &infrav1.AzureCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
-				Spec: AzureClusterSpec{
+				Spec: infrav1.AzureClusterSpec{
 					ControlPlaneEnabled: true,
-					NetworkSpec: NetworkSpec{
-						Subnets: Subnets{
+					NetworkSpec: infrav1.NetworkSpec{
+						Subnets: infrav1.Subnets{
 							{
-								SubnetClassSpec: SubnetClassSpec{
-									Role:       SubnetControlPlane,
+								SubnetClassSpec: infrav1.SubnetClassSpec{
+									Role:       infrav1.SubnetControlPlane,
 									CIDRBlocks: []string{DefaultControlPlaneSubnetCIDR},
 									Name:       "cluster-test-controlplane-subnet",
 								},
-								SecurityGroup: SecurityGroup{Name: "cluster-test-controlplane-nsg"},
-								RouteTable:    RouteTable{Name: "control-plane-custom-route-table"},
+								SecurityGroup: infrav1.SecurityGroup{Name: "cluster-test-controlplane-nsg"},
+								RouteTable:    infrav1.RouteTable{Name: "control-plane-custom-route-table"},
 							},
 							{
-								SubnetClassSpec: SubnetClassSpec{
-									Role:       SubnetNode,
+								SubnetClassSpec: infrav1.SubnetClassSpec{
+									Role:       infrav1.SubnetNode,
 									CIDRBlocks: []string{DefaultNodeSubnetCIDR},
 									Name:       "cluster-test-node-subnet",
 								},
-								SecurityGroup: SecurityGroup{Name: "cluster-test-node-nsg"},
-								RouteTable:    RouteTable{Name: "cluster-test-node-routetable"},
-								NatGateway: NatGateway{
-									NatGatewayClassSpec: NatGatewayClassSpec{
+								SecurityGroup: infrav1.SecurityGroup{Name: "cluster-test-node-nsg"},
+								RouteTable:    infrav1.RouteTable{Name: "cluster-test-node-routetable"},
+								NatGateway: infrav1.NatGateway{
+									NatGatewayClassSpec: infrav1.NatGatewayClassSpec{
 										Name: "cluster-test-node-natgw-1",
 									},
-									NatGatewayIP: PublicIPSpec{
+									NatGatewayIP: infrav1.PublicIPSpec{
 										Name: "pip-cluster-test-node-natgw-1",
 									},
 								},
@@ -674,17 +674,17 @@ func TestSubnetDefaults(t *testing.T) {
 		},
 		{
 			name: "only node subnet specified",
-			cluster: &AzureCluster{
+			cluster: &infrav1.AzureCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
-				Spec: AzureClusterSpec{
+				Spec: infrav1.AzureClusterSpec{
 					ControlPlaneEnabled: true,
-					NetworkSpec: NetworkSpec{
-						Subnets: Subnets{
+					NetworkSpec: infrav1.NetworkSpec{
+						Subnets: infrav1.Subnets{
 							{
-								SubnetClassSpec: SubnetClassSpec{
-									Role: SubnetNode,
+								SubnetClassSpec: infrav1.SubnetClassSpec{
+									Role: infrav1.SubnetNode,
 									Name: "my-node-subnet",
 								},
 							},
@@ -692,40 +692,40 @@ func TestSubnetDefaults(t *testing.T) {
 					},
 				},
 			},
-			output: &AzureCluster{
+			output: &infrav1.AzureCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
-				Spec: AzureClusterSpec{
+				Spec: infrav1.AzureClusterSpec{
 					ControlPlaneEnabled: true,
-					NetworkSpec: NetworkSpec{
-						Subnets: Subnets{
+					NetworkSpec: infrav1.NetworkSpec{
+						Subnets: infrav1.Subnets{
 							{
-								SubnetClassSpec: SubnetClassSpec{
-									Role:       SubnetNode,
+								SubnetClassSpec: infrav1.SubnetClassSpec{
+									Role:       infrav1.SubnetNode,
 									CIDRBlocks: []string{DefaultNodeSubnetCIDR},
 									Name:       "my-node-subnet",
 								},
 
-								SecurityGroup: SecurityGroup{Name: "cluster-test-node-nsg"},
-								RouteTable:    RouteTable{Name: "cluster-test-node-routetable"},
-								NatGateway: NatGateway{
-									NatGatewayClassSpec: NatGatewayClassSpec{
+								SecurityGroup: infrav1.SecurityGroup{Name: "cluster-test-node-nsg"},
+								RouteTable:    infrav1.RouteTable{Name: "cluster-test-node-routetable"},
+								NatGateway: infrav1.NatGateway{
+									NatGatewayClassSpec: infrav1.NatGatewayClassSpec{
 										Name: "cluster-test-node-natgw-1",
 									},
-									NatGatewayIP: PublicIPSpec{
+									NatGatewayIP: infrav1.PublicIPSpec{
 										Name: "pip-cluster-test-node-natgw-1",
 									},
 								},
 							},
 							{
-								SubnetClassSpec: SubnetClassSpec{
-									Role:       SubnetControlPlane,
+								SubnetClassSpec: infrav1.SubnetClassSpec{
+									Role:       infrav1.SubnetControlPlane,
 									CIDRBlocks: []string{DefaultControlPlaneSubnetCIDR},
 									Name:       "cluster-test-controlplane-subnet",
 								},
-								SecurityGroup: SecurityGroup{Name: "cluster-test-controlplane-nsg"},
-								RouteTable:    RouteTable{},
+								SecurityGroup: infrav1.SecurityGroup{Name: "cluster-test-controlplane-nsg"},
+								RouteTable:    infrav1.RouteTable{},
 							},
 						},
 					},
@@ -734,28 +734,28 @@ func TestSubnetDefaults(t *testing.T) {
 		},
 		{
 			name: "subnets specified with IPv6 enabled",
-			cluster: &AzureCluster{
+			cluster: &infrav1.AzureCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
-				Spec: AzureClusterSpec{
+				Spec: infrav1.AzureClusterSpec{
 					ControlPlaneEnabled: true,
-					NetworkSpec: NetworkSpec{
-						Vnet: VnetSpec{
-							VnetClassSpec: VnetClassSpec{
+					NetworkSpec: infrav1.NetworkSpec{
+						Vnet: infrav1.VnetSpec{
+							VnetClassSpec: infrav1.VnetClassSpec{
 								CIDRBlocks: []string{"2001:be00::1/56"},
 							},
 						},
-						Subnets: Subnets{
+						Subnets: infrav1.Subnets{
 							{
-								SubnetClassSpec: SubnetClassSpec{
+								SubnetClassSpec: infrav1.SubnetClassSpec{
 									Role:       "control-plane",
 									CIDRBlocks: []string{"2001:beef::1/64"},
 									Name:       "cluster-test-controlplane-subnet",
 								},
 							},
 							{
-								SubnetClassSpec: SubnetClassSpec{
+								SubnetClassSpec: infrav1.SubnetClassSpec{
 									Role:       "node",
 									CIDRBlocks: []string{"2001:beea::1/64"},
 									Name:       "cluster-test-node-subnet",
@@ -765,36 +765,36 @@ func TestSubnetDefaults(t *testing.T) {
 					},
 				},
 			},
-			output: &AzureCluster{
+			output: &infrav1.AzureCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
-				Spec: AzureClusterSpec{
+				Spec: infrav1.AzureClusterSpec{
 					ControlPlaneEnabled: true,
-					NetworkSpec: NetworkSpec{
-						Vnet: VnetSpec{
-							VnetClassSpec: VnetClassSpec{
+					NetworkSpec: infrav1.NetworkSpec{
+						Vnet: infrav1.VnetSpec{
+							VnetClassSpec: infrav1.VnetClassSpec{
 								CIDRBlocks: []string{"2001:be00::1/56"},
 							},
 						},
-						Subnets: Subnets{
+						Subnets: infrav1.Subnets{
 							{
-								SubnetClassSpec: SubnetClassSpec{
-									Role:       SubnetControlPlane,
+								SubnetClassSpec: infrav1.SubnetClassSpec{
+									Role:       infrav1.SubnetControlPlane,
 									CIDRBlocks: []string{"2001:beef::1/64"},
 									Name:       "cluster-test-controlplane-subnet",
 								},
-								SecurityGroup: SecurityGroup{Name: "cluster-test-controlplane-nsg"},
-								RouteTable:    RouteTable{},
+								SecurityGroup: infrav1.SecurityGroup{Name: "cluster-test-controlplane-nsg"},
+								RouteTable:    infrav1.RouteTable{},
 							},
 							{
-								SubnetClassSpec: SubnetClassSpec{
-									Role:       SubnetNode,
+								SubnetClassSpec: infrav1.SubnetClassSpec{
+									Role:       infrav1.SubnetNode,
 									CIDRBlocks: []string{"2001:beea::1/64"},
 									Name:       "cluster-test-node-subnet",
 								},
-								SecurityGroup: SecurityGroup{Name: "cluster-test-node-nsg"},
-								RouteTable:    RouteTable{Name: "cluster-test-node-routetable"},
+								SecurityGroup: infrav1.SecurityGroup{Name: "cluster-test-node-nsg"},
+								RouteTable:    infrav1.RouteTable{Name: "cluster-test-node-routetable"},
 							},
 						},
 					},
@@ -803,22 +803,22 @@ func TestSubnetDefaults(t *testing.T) {
 		},
 		{
 			name: "subnets with custom security group",
-			cluster: &AzureCluster{
+			cluster: &infrav1.AzureCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
-				Spec: AzureClusterSpec{
+				Spec: infrav1.AzureClusterSpec{
 					ControlPlaneEnabled: true,
-					NetworkSpec: NetworkSpec{
-						Subnets: Subnets{
+					NetworkSpec: infrav1.NetworkSpec{
+						Subnets: infrav1.Subnets{
 							{
-								SubnetClassSpec: SubnetClassSpec{
+								SubnetClassSpec: infrav1.SubnetClassSpec{
 									Role: "control-plane",
 									Name: "cluster-test-controlplane-subnet",
 								},
-								SecurityGroup: SecurityGroup{
-									SecurityGroupClass: SecurityGroupClass{
-										SecurityRules: []SecurityRule{
+								SecurityGroup: infrav1.SecurityGroup{
+									SecurityGroupClass: infrav1.SecurityGroupClass{
+										SecurityRules: []infrav1.SecurityRule{
 											{
 												Name:             "allow_port_50000",
 												Description:      "allow port 50000",
@@ -828,7 +828,7 @@ func TestSubnetDefaults(t *testing.T) {
 												DestinationPorts: ptr.To("*"),
 												Source:           ptr.To("*"),
 												Destination:      ptr.To("*"),
-												Action:           SecurityRuleActionAllow,
+												Action:           infrav1.SecurityRuleActionAllow,
 											},
 										},
 									},
@@ -836,13 +836,13 @@ func TestSubnetDefaults(t *testing.T) {
 								},
 							},
 							{
-								SubnetClassSpec: SubnetClassSpec{
+								SubnetClassSpec: infrav1.SubnetClassSpec{
 									Role: "node",
 									Name: "cluster-test-node-subnet",
 								},
-								SecurityGroup: SecurityGroup{
-									SecurityGroupClass: SecurityGroupClass{
-										SecurityRules: []SecurityRule{
+								SecurityGroup: infrav1.SecurityGroup{
+									SecurityGroupClass: infrav1.SecurityGroupClass{
+										SecurityRules: []infrav1.SecurityRule{
 											{
 												Name:             "allow_port_50000",
 												Description:      "allow port 50000",
@@ -852,7 +852,7 @@ func TestSubnetDefaults(t *testing.T) {
 												DestinationPorts: ptr.To("*"),
 												Source:           ptr.To("*"),
 												Destination:      ptr.To("*"),
-												Action:           SecurityRuleActionAllow,
+												Action:           infrav1.SecurityRuleActionAllow,
 											},
 										},
 									},
@@ -863,23 +863,23 @@ func TestSubnetDefaults(t *testing.T) {
 					},
 				},
 			},
-			output: &AzureCluster{
+			output: &infrav1.AzureCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
-				Spec: AzureClusterSpec{
+				Spec: infrav1.AzureClusterSpec{
 					ControlPlaneEnabled: true,
-					NetworkSpec: NetworkSpec{
-						Subnets: Subnets{
+					NetworkSpec: infrav1.NetworkSpec{
+						Subnets: infrav1.Subnets{
 							{
-								SubnetClassSpec: SubnetClassSpec{
+								SubnetClassSpec: infrav1.SubnetClassSpec{
 									Role:       "control-plane",
 									CIDRBlocks: []string{DefaultControlPlaneSubnetCIDR},
 									Name:       "cluster-test-controlplane-subnet",
 								},
-								SecurityGroup: SecurityGroup{
-									SecurityGroupClass: SecurityGroupClass{
-										SecurityRules: []SecurityRule{
+								SecurityGroup: infrav1.SecurityGroup{
+									SecurityGroupClass: infrav1.SecurityGroupClass{
+										SecurityRules: []infrav1.SecurityRule{
 											{
 												Name:             "allow_port_50000",
 												Description:      "allow port 50000",
@@ -889,8 +889,8 @@ func TestSubnetDefaults(t *testing.T) {
 												DestinationPorts: ptr.To("*"),
 												Source:           ptr.To("*"),
 												Destination:      ptr.To("*"),
-												Direction:        SecurityRuleDirectionInbound,
-												Action:           SecurityRuleActionAllow,
+												Direction:        infrav1.SecurityRuleDirectionInbound,
+												Action:           infrav1.SecurityRuleActionAllow,
 											},
 										},
 									},
@@ -898,15 +898,15 @@ func TestSubnetDefaults(t *testing.T) {
 								},
 							},
 							{
-								SubnetClassSpec: SubnetClassSpec{
-									Role:       SubnetNode,
+								SubnetClassSpec: infrav1.SubnetClassSpec{
+									Role:       infrav1.SubnetNode,
 									CIDRBlocks: []string{DefaultNodeSubnetCIDR},
 									Name:       "cluster-test-node-subnet",
 								},
-								SecurityGroup: SecurityGroup{
+								SecurityGroup: infrav1.SecurityGroup{
 									Name: "my-custom-node-sg",
-									SecurityGroupClass: SecurityGroupClass{
-										SecurityRules: []SecurityRule{
+									SecurityGroupClass: infrav1.SecurityGroupClass{
+										SecurityRules: []infrav1.SecurityRule{
 											{
 												Name:             "allow_port_50000",
 												Description:      "allow port 50000",
@@ -916,18 +916,18 @@ func TestSubnetDefaults(t *testing.T) {
 												DestinationPorts: ptr.To("*"),
 												Source:           ptr.To("*"),
 												Destination:      ptr.To("*"),
-												Direction:        SecurityRuleDirectionInbound,
-												Action:           SecurityRuleActionAllow,
+												Direction:        infrav1.SecurityRuleDirectionInbound,
+												Action:           infrav1.SecurityRuleActionAllow,
 											},
 										},
 									},
 								},
-								RouteTable: RouteTable{Name: "cluster-test-node-routetable"},
-								NatGateway: NatGateway{
-									NatGatewayIP: PublicIPSpec{
+								RouteTable: infrav1.RouteTable{Name: "cluster-test-node-routetable"},
+								NatGateway: infrav1.NatGateway{
+									NatGatewayIP: infrav1.PublicIPSpec{
 										Name: "pip-cluster-test-node-natgw-1",
 									},
-									NatGatewayClassSpec: NatGatewayClassSpec{
+									NatGatewayClassSpec: infrav1.NatGatewayClassSpec{
 										Name: "cluster-test-node-natgw-1",
 									},
 								},
@@ -939,22 +939,22 @@ func TestSubnetDefaults(t *testing.T) {
 		},
 		{
 			name: "subnets with custom security group to deny port 49999",
-			cluster: &AzureCluster{
+			cluster: &infrav1.AzureCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
-				Spec: AzureClusterSpec{
+				Spec: infrav1.AzureClusterSpec{
 					ControlPlaneEnabled: true,
-					NetworkSpec: NetworkSpec{
-						Subnets: Subnets{
+					NetworkSpec: infrav1.NetworkSpec{
+						Subnets: infrav1.Subnets{
 							{
-								SubnetClassSpec: SubnetClassSpec{
+								SubnetClassSpec: infrav1.SubnetClassSpec{
 									Role: "control-plane",
 									Name: "cluster-test-controlplane-subnet",
 								},
-								SecurityGroup: SecurityGroup{
-									SecurityGroupClass: SecurityGroupClass{
-										SecurityRules: []SecurityRule{
+								SecurityGroup: infrav1.SecurityGroup{
+									SecurityGroupClass: infrav1.SecurityGroupClass{
+										SecurityRules: []infrav1.SecurityRule{
 											{
 												Name:             "deny_port_49999",
 												Description:      "deny port 49999",
@@ -964,7 +964,7 @@ func TestSubnetDefaults(t *testing.T) {
 												DestinationPorts: ptr.To("*"),
 												Source:           ptr.To("*"),
 												Destination:      ptr.To("*"),
-												Action:           SecurityRuleActionDeny,
+												Action:           infrav1.SecurityRuleActionDeny,
 											},
 										},
 									},
@@ -975,23 +975,23 @@ func TestSubnetDefaults(t *testing.T) {
 					},
 				},
 			},
-			output: &AzureCluster{
+			output: &infrav1.AzureCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
-				Spec: AzureClusterSpec{
+				Spec: infrav1.AzureClusterSpec{
 					ControlPlaneEnabled: true,
-					NetworkSpec: NetworkSpec{
-						Subnets: Subnets{
+					NetworkSpec: infrav1.NetworkSpec{
+						Subnets: infrav1.Subnets{
 							{
-								SubnetClassSpec: SubnetClassSpec{
+								SubnetClassSpec: infrav1.SubnetClassSpec{
 									Role:       "control-plane",
 									CIDRBlocks: []string{DefaultControlPlaneSubnetCIDR},
 									Name:       "cluster-test-controlplane-subnet",
 								},
-								SecurityGroup: SecurityGroup{
-									SecurityGroupClass: SecurityGroupClass{
-										SecurityRules: []SecurityRule{
+								SecurityGroup: infrav1.SecurityGroup{
+									SecurityGroupClass: infrav1.SecurityGroupClass{
+										SecurityRules: []infrav1.SecurityRule{
 											{
 												Name:             "deny_port_49999",
 												Description:      "deny port 49999",
@@ -1001,8 +1001,8 @@ func TestSubnetDefaults(t *testing.T) {
 												DestinationPorts: ptr.To("*"),
 												Source:           ptr.To("*"),
 												Destination:      ptr.To("*"),
-												Direction:        SecurityRuleDirectionInbound,
-												Action:           SecurityRuleActionDeny,
+												Direction:        infrav1.SecurityRuleDirectionInbound,
+												Action:           infrav1.SecurityRuleActionDeny,
 											},
 										},
 									},
@@ -1010,18 +1010,18 @@ func TestSubnetDefaults(t *testing.T) {
 								},
 							},
 							{
-								SubnetClassSpec: SubnetClassSpec{
-									Role:       SubnetNode,
+								SubnetClassSpec: infrav1.SubnetClassSpec{
+									Role:       infrav1.SubnetNode,
 									CIDRBlocks: []string{DefaultNodeSubnetCIDR},
 									Name:       "cluster-test-node-subnet",
 								},
-								SecurityGroup: SecurityGroup{Name: "cluster-test-node-nsg"},
-								RouteTable:    RouteTable{Name: "cluster-test-node-routetable"},
-								NatGateway: NatGateway{
-									NatGatewayIP: PublicIPSpec{
+								SecurityGroup: infrav1.SecurityGroup{Name: "cluster-test-node-nsg"},
+								RouteTable:    infrav1.RouteTable{Name: "cluster-test-node-routetable"},
+								NatGateway: infrav1.NatGateway{
+									NatGatewayIP: infrav1.PublicIPSpec{
 										Name: "",
 									},
-									NatGatewayClassSpec: NatGatewayClassSpec{
+									NatGatewayClassSpec: infrav1.NatGatewayClassSpec{
 										Name: "cluster-test-node-natgw",
 									},
 								},
@@ -1033,24 +1033,24 @@ func TestSubnetDefaults(t *testing.T) {
 		},
 		{
 			name: "don't default NAT Gateway if subnet already exists",
-			cluster: &AzureCluster{
+			cluster: &infrav1.AzureCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
-				Spec: AzureClusterSpec{
+				Spec: infrav1.AzureClusterSpec{
 					ControlPlaneEnabled: true,
-					NetworkSpec: NetworkSpec{
-						Subnets: Subnets{
+					NetworkSpec: infrav1.NetworkSpec{
+						Subnets: infrav1.Subnets{
 							{
-								SubnetClassSpec: SubnetClassSpec{
-									Role: SubnetControlPlane,
+								SubnetClassSpec: infrav1.SubnetClassSpec{
+									Role: infrav1.SubnetControlPlane,
 									Name: "cluster-test-controlplane-subnet",
 								},
 								ID: "my-subnet-id",
 							},
 							{
-								SubnetClassSpec: SubnetClassSpec{
-									Role: SubnetNode,
+								SubnetClassSpec: infrav1.SubnetClassSpec{
+									Role: infrav1.SubnetNode,
 									Name: "cluster-test-node-subnet",
 								},
 								ID: "my-subnet-id-2",
@@ -1059,38 +1059,38 @@ func TestSubnetDefaults(t *testing.T) {
 					},
 				},
 			},
-			output: &AzureCluster{
+			output: &infrav1.AzureCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
-				Spec: AzureClusterSpec{
+				Spec: infrav1.AzureClusterSpec{
 					ControlPlaneEnabled: true,
-					NetworkSpec: NetworkSpec{
-						Subnets: Subnets{
+					NetworkSpec: infrav1.NetworkSpec{
+						Subnets: infrav1.Subnets{
 							{
-								SubnetClassSpec: SubnetClassSpec{
-									Role:       SubnetControlPlane,
+								SubnetClassSpec: infrav1.SubnetClassSpec{
+									Role:       infrav1.SubnetControlPlane,
 									CIDRBlocks: []string{DefaultControlPlaneSubnetCIDR},
 									Name:       "cluster-test-controlplane-subnet",
 								},
 								ID:            "my-subnet-id",
-								SecurityGroup: SecurityGroup{Name: "cluster-test-controlplane-nsg"},
-								RouteTable:    RouteTable{},
+								SecurityGroup: infrav1.SecurityGroup{Name: "cluster-test-controlplane-nsg"},
+								RouteTable:    infrav1.RouteTable{},
 							},
 							{
-								SubnetClassSpec: SubnetClassSpec{
-									Role:       SubnetNode,
+								SubnetClassSpec: infrav1.SubnetClassSpec{
+									Role:       infrav1.SubnetNode,
 									CIDRBlocks: []string{DefaultNodeSubnetCIDR},
 									Name:       "cluster-test-node-subnet",
 								},
 								ID:            "my-subnet-id-2",
-								SecurityGroup: SecurityGroup{Name: "cluster-test-node-nsg"},
-								RouteTable:    RouteTable{Name: "cluster-test-node-routetable"},
-								NatGateway: NatGateway{
-									NatGatewayClassSpec: NatGatewayClassSpec{
+								SecurityGroup: infrav1.SecurityGroup{Name: "cluster-test-node-nsg"},
+								RouteTable:    infrav1.RouteTable{Name: "cluster-test-node-routetable"},
+								NatGateway: infrav1.NatGateway{
+									NatGatewayClassSpec: infrav1.NatGatewayClassSpec{
 										Name: "",
 									},
-									NatGatewayIP: PublicIPSpec{
+									NatGatewayIP: infrav1.PublicIPSpec{
 										Name: "",
 									},
 								},
@@ -1102,17 +1102,17 @@ func TestSubnetDefaults(t *testing.T) {
 		},
 		{
 			name: "don't default NAT Gateway for cluster subnet if subnet already exists",
-			cluster: &AzureCluster{
+			cluster: &infrav1.AzureCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
-				Spec: AzureClusterSpec{
+				Spec: infrav1.AzureClusterSpec{
 					ControlPlaneEnabled: true,
-					NetworkSpec: NetworkSpec{
-						Subnets: Subnets{
+					NetworkSpec: infrav1.NetworkSpec{
+						Subnets: infrav1.Subnets{
 							{
-								SubnetClassSpec: SubnetClassSpec{
-									Role: SubnetCluster,
+								SubnetClassSpec: infrav1.SubnetClassSpec{
+									Role: infrav1.SubnetCluster,
 									Name: "cluster-test-cluster-subnet",
 								},
 								ID: "my-subnet-id",
@@ -1121,23 +1121,23 @@ func TestSubnetDefaults(t *testing.T) {
 					},
 				},
 			},
-			output: &AzureCluster{
+			output: &infrav1.AzureCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
-				Spec: AzureClusterSpec{
+				Spec: infrav1.AzureClusterSpec{
 					ControlPlaneEnabled: true,
-					NetworkSpec: NetworkSpec{
-						Subnets: Subnets{
+					NetworkSpec: infrav1.NetworkSpec{
+						Subnets: infrav1.Subnets{
 							{
-								SubnetClassSpec: SubnetClassSpec{
-									Role:       SubnetCluster,
+								SubnetClassSpec: infrav1.SubnetClassSpec{
+									Role:       infrav1.SubnetCluster,
 									CIDRBlocks: []string{DefaultClusterSubnetCIDR},
 									Name:       "cluster-test-cluster-subnet",
 								},
 								ID:            "my-subnet-id",
-								SecurityGroup: SecurityGroup{Name: "cluster-test-nsg"},
-								RouteTable:    RouteTable{Name: "cluster-test-routetable"},
+								SecurityGroup: infrav1.SecurityGroup{Name: "cluster-test-nsg"},
+								RouteTable:    infrav1.RouteTable{Name: "cluster-test-routetable"},
 							},
 						},
 					},
@@ -1163,41 +1163,41 @@ func TestSubnetDefaults(t *testing.T) {
 func TestVnetPeeringDefaults(t *testing.T) {
 	cases := []struct {
 		name    string
-		cluster *AzureCluster
-		output  *AzureCluster
+		cluster *infrav1.AzureCluster
+		output  *infrav1.AzureCluster
 	}{
 		{
 			name: "no peering",
-			cluster: &AzureCluster{
+			cluster: &infrav1.AzureCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
-				Spec: AzureClusterSpec{
-					NetworkSpec: NetworkSpec{},
+				Spec: infrav1.AzureClusterSpec{
+					NetworkSpec: infrav1.NetworkSpec{},
 				},
 			},
-			output: &AzureCluster{
+			output: &infrav1.AzureCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
-				Spec: AzureClusterSpec{
-					NetworkSpec: NetworkSpec{},
+				Spec: infrav1.AzureClusterSpec{
+					NetworkSpec: infrav1.NetworkSpec{},
 				},
 			},
 		},
 		{
 			name: "peering with resource group",
-			cluster: &AzureCluster{
+			cluster: &infrav1.AzureCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
-				Spec: AzureClusterSpec{
+				Spec: infrav1.AzureClusterSpec{
 					ResourceGroup: "cluster-test",
-					NetworkSpec: NetworkSpec{
-						Vnet: VnetSpec{
-							Peerings: VnetPeerings{
+					NetworkSpec: infrav1.NetworkSpec{
+						Vnet: infrav1.VnetSpec{
+							Peerings: infrav1.VnetPeerings{
 								{
-									VnetPeeringClassSpec: VnetPeeringClassSpec{
+									VnetPeeringClassSpec: infrav1.VnetPeeringClassSpec{
 										RemoteVnetName: "my-vnet",
 										ResourceGroup:  "cluster-test",
 									},
@@ -1207,17 +1207,17 @@ func TestVnetPeeringDefaults(t *testing.T) {
 					},
 				},
 			},
-			output: &AzureCluster{
+			output: &infrav1.AzureCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
-				Spec: AzureClusterSpec{
+				Spec: infrav1.AzureClusterSpec{
 					ResourceGroup: "cluster-test",
-					NetworkSpec: NetworkSpec{
-						Vnet: VnetSpec{
-							Peerings: VnetPeerings{
+					NetworkSpec: infrav1.NetworkSpec{
+						Vnet: infrav1.VnetSpec{
+							Peerings: infrav1.VnetPeerings{
 								{
-									VnetPeeringClassSpec: VnetPeeringClassSpec{
+									VnetPeeringClassSpec: infrav1.VnetPeeringClassSpec{
 										RemoteVnetName: "my-vnet",
 										ResourceGroup:  "cluster-test",
 									},
@@ -1230,34 +1230,34 @@ func TestVnetPeeringDefaults(t *testing.T) {
 		},
 		{
 			name: "peering without resource group",
-			cluster: &AzureCluster{
+			cluster: &infrav1.AzureCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
-				Spec: AzureClusterSpec{
+				Spec: infrav1.AzureClusterSpec{
 					ResourceGroup: "cluster-test",
-					NetworkSpec: NetworkSpec{
-						Vnet: VnetSpec{
-							Peerings: VnetPeerings{
+					NetworkSpec: infrav1.NetworkSpec{
+						Vnet: infrav1.VnetSpec{
+							Peerings: infrav1.VnetPeerings{
 								{
-									VnetPeeringClassSpec: VnetPeeringClassSpec{RemoteVnetName: "my-vnet"},
+									VnetPeeringClassSpec: infrav1.VnetPeeringClassSpec{RemoteVnetName: "my-vnet"},
 								},
 							},
 						},
 					},
 				},
 			},
-			output: &AzureCluster{
+			output: &infrav1.AzureCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
-				Spec: AzureClusterSpec{
+				Spec: infrav1.AzureClusterSpec{
 					ResourceGroup: "cluster-test",
-					NetworkSpec: NetworkSpec{
-						Vnet: VnetSpec{
-							Peerings: VnetPeerings{
+					NetworkSpec: infrav1.NetworkSpec{
+						Vnet: infrav1.VnetSpec{
+							Peerings: infrav1.VnetPeerings{
 								{
-									VnetPeeringClassSpec: VnetPeeringClassSpec{
+									VnetPeeringClassSpec: infrav1.VnetPeeringClassSpec{
 										RemoteVnetName: "my-vnet",
 										ResourceGroup:  "cluster-test",
 									},
@@ -1288,44 +1288,44 @@ func TestAPIServerLBDefaults(t *testing.T) {
 	cases := []struct {
 		name        string
 		featureGate featuregate.Feature
-		cluster     *AzureCluster
-		output      *AzureCluster
+		cluster     *infrav1.AzureCluster
+		output      *infrav1.AzureCluster
 	}{
 		{
 			name: "no lb",
-			cluster: &AzureCluster{
+			cluster: &infrav1.AzureCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
-				Spec: AzureClusterSpec{
+				Spec: infrav1.AzureClusterSpec{
 					ControlPlaneEnabled: true,
-					NetworkSpec:         NetworkSpec{},
+					NetworkSpec:         infrav1.NetworkSpec{},
 				},
 			},
-			output: &AzureCluster{
+			output: &infrav1.AzureCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
-				Spec: AzureClusterSpec{
+				Spec: infrav1.AzureClusterSpec{
 					ControlPlaneEnabled: true,
-					NetworkSpec: NetworkSpec{
-						APIServerLB: &LoadBalancerSpec{
+					NetworkSpec: infrav1.NetworkSpec{
+						APIServerLB: &infrav1.LoadBalancerSpec{
 							Name: "cluster-test-public-lb",
-							FrontendIPs: []FrontendIP{
+							FrontendIPs: []infrav1.FrontendIP{
 								{
 									Name: "cluster-test-public-lb-frontEnd",
-									PublicIP: &PublicIPSpec{
+									PublicIP: &infrav1.PublicIPSpec{
 										Name:    "pip-cluster-test-apiserver",
 										DNSName: "",
 									},
 								},
 							},
-							BackendPool: BackendPool{
+							BackendPool: infrav1.BackendPool{
 								Name: "cluster-test-public-lb-backendPool",
 							},
-							LoadBalancerClassSpec: LoadBalancerClassSpec{
-								SKU:                  SKUStandard,
-								Type:                 Public,
+							LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{
+								SKU:                  infrav1.SKUStandard,
+								Type:                 infrav1.Public,
 								IdleTimeoutInMinutes: ptr.To[int32](DefaultOutboundRuleIdleTimeoutInMinutes),
 							},
 						},
@@ -1336,45 +1336,45 @@ func TestAPIServerLBDefaults(t *testing.T) {
 		{
 			name:        "no lb with APIServerILB feature gate enabled",
 			featureGate: feature.APIServerILB,
-			cluster: &AzureCluster{
+			cluster: &infrav1.AzureCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
-				Spec: AzureClusterSpec{
+				Spec: infrav1.AzureClusterSpec{
 					ControlPlaneEnabled: true,
-					NetworkSpec:         NetworkSpec{},
+					NetworkSpec:         infrav1.NetworkSpec{},
 				},
 			},
-			output: &AzureCluster{
+			output: &infrav1.AzureCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
-				Spec: AzureClusterSpec{
+				Spec: infrav1.AzureClusterSpec{
 					ControlPlaneEnabled: true,
-					NetworkSpec: NetworkSpec{
-						APIServerLB: &LoadBalancerSpec{
+					NetworkSpec: infrav1.NetworkSpec{
+						APIServerLB: &infrav1.LoadBalancerSpec{
 							Name: "cluster-test-public-lb",
-							FrontendIPs: []FrontendIP{
+							FrontendIPs: []infrav1.FrontendIP{
 								{
 									Name: "cluster-test-public-lb-frontEnd",
-									PublicIP: &PublicIPSpec{
+									PublicIP: &infrav1.PublicIPSpec{
 										Name:    "pip-cluster-test-apiserver",
 										DNSName: "",
 									},
 								},
 								{
 									Name: "cluster-test-public-lb-frontEnd-internal-ip",
-									FrontendIPClass: FrontendIPClass{
+									FrontendIPClass: infrav1.FrontendIPClass{
 										PrivateIPAddress: DefaultInternalLBIPAddress,
 									},
 								},
 							},
-							BackendPool: BackendPool{
+							BackendPool: infrav1.BackendPool{
 								Name: "cluster-test-public-lb-backendPool",
 							},
-							LoadBalancerClassSpec: LoadBalancerClassSpec{
-								SKU:                  SKUStandard,
-								Type:                 Public,
+							LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{
+								SKU:                  infrav1.SKUStandard,
+								Type:                 infrav1.Public,
 								IdleTimeoutInMinutes: ptr.To[int32](DefaultOutboundRuleIdleTimeoutInMinutes),
 							},
 						},
@@ -1384,41 +1384,41 @@ func TestAPIServerLBDefaults(t *testing.T) {
 		},
 		{
 			name: "internal lb",
-			cluster: &AzureCluster{
+			cluster: &infrav1.AzureCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
-				Spec: AzureClusterSpec{
-					NetworkSpec: NetworkSpec{
-						APIServerLB: &LoadBalancerSpec{
-							LoadBalancerClassSpec: LoadBalancerClassSpec{
-								Type: Internal,
+				Spec: infrav1.AzureClusterSpec{
+					NetworkSpec: infrav1.NetworkSpec{
+						APIServerLB: &infrav1.LoadBalancerSpec{
+							LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{
+								Type: infrav1.Internal,
 							},
 						},
 					},
 				},
 			},
-			output: &AzureCluster{
+			output: &infrav1.AzureCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
-				Spec: AzureClusterSpec{
-					NetworkSpec: NetworkSpec{
-						APIServerLB: &LoadBalancerSpec{
-							FrontendIPs: []FrontendIP{
+				Spec: infrav1.AzureClusterSpec{
+					NetworkSpec: infrav1.NetworkSpec{
+						APIServerLB: &infrav1.LoadBalancerSpec{
+							FrontendIPs: []infrav1.FrontendIP{
 								{
 									Name: "cluster-test-internal-lb-frontEnd",
-									FrontendIPClass: FrontendIPClass{
+									FrontendIPClass: infrav1.FrontendIPClass{
 										PrivateIPAddress: DefaultInternalLBIPAddress,
 									},
 								},
 							},
-							BackendPool: BackendPool{
+							BackendPool: infrav1.BackendPool{
 								Name: "cluster-test-internal-lb-backendPool",
 							},
-							LoadBalancerClassSpec: LoadBalancerClassSpec{
-								SKU:                  SKUStandard,
-								Type:                 Internal,
+							LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{
+								SKU:                  infrav1.SKUStandard,
+								Type:                 infrav1.Internal,
 								IdleTimeoutInMinutes: ptr.To[int32](DefaultOutboundRuleIdleTimeoutInMinutes),
 							},
 							Name: "cluster-test-internal-lb",
@@ -1430,41 +1430,41 @@ func TestAPIServerLBDefaults(t *testing.T) {
 		{
 			name:        "internal lb with feature gate API Server ILB enabled",
 			featureGate: feature.APIServerILB,
-			cluster: &AzureCluster{
+			cluster: &infrav1.AzureCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
-				Spec: AzureClusterSpec{
-					NetworkSpec: NetworkSpec{
-						APIServerLB: &LoadBalancerSpec{
-							LoadBalancerClassSpec: LoadBalancerClassSpec{
-								Type: Internal,
+				Spec: infrav1.AzureClusterSpec{
+					NetworkSpec: infrav1.NetworkSpec{
+						APIServerLB: &infrav1.LoadBalancerSpec{
+							LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{
+								Type: infrav1.Internal,
 							},
 						},
 					},
 				},
 			},
-			output: &AzureCluster{
+			output: &infrav1.AzureCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
-				Spec: AzureClusterSpec{
-					NetworkSpec: NetworkSpec{
-						APIServerLB: &LoadBalancerSpec{
-							FrontendIPs: []FrontendIP{
+				Spec: infrav1.AzureClusterSpec{
+					NetworkSpec: infrav1.NetworkSpec{
+						APIServerLB: &infrav1.LoadBalancerSpec{
+							FrontendIPs: []infrav1.FrontendIP{
 								{
 									Name: "cluster-test-internal-lb-frontEnd",
-									FrontendIPClass: FrontendIPClass{
+									FrontendIPClass: infrav1.FrontendIPClass{
 										PrivateIPAddress: DefaultInternalLBIPAddress,
 									},
 								},
 							},
-							BackendPool: BackendPool{
+							BackendPool: infrav1.BackendPool{
 								Name: "cluster-test-internal-lb-backendPool",
 							},
-							LoadBalancerClassSpec: LoadBalancerClassSpec{
-								SKU:                  SKUStandard,
-								Type:                 Internal,
+							LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{
+								SKU:                  infrav1.SKUStandard,
+								Type:                 infrav1.Internal,
 								IdleTimeoutInMinutes: ptr.To[int32](DefaultOutboundRuleIdleTimeoutInMinutes),
 							},
 							Name: "cluster-test-internal-lb",
@@ -1475,44 +1475,44 @@ func TestAPIServerLBDefaults(t *testing.T) {
 		},
 		{
 			name: "with custom backend pool name",
-			cluster: &AzureCluster{
+			cluster: &infrav1.AzureCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
-				Spec: AzureClusterSpec{
-					NetworkSpec: NetworkSpec{
-						APIServerLB: &LoadBalancerSpec{
-							LoadBalancerClassSpec: LoadBalancerClassSpec{
-								Type: Internal,
+				Spec: infrav1.AzureClusterSpec{
+					NetworkSpec: infrav1.NetworkSpec{
+						APIServerLB: &infrav1.LoadBalancerSpec{
+							LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{
+								Type: infrav1.Internal,
 							},
-							BackendPool: BackendPool{
+							BackendPool: infrav1.BackendPool{
 								Name: "custom-backend-pool",
 							},
 						},
 					},
 				},
 			},
-			output: &AzureCluster{
+			output: &infrav1.AzureCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
-				Spec: AzureClusterSpec{
-					NetworkSpec: NetworkSpec{
-						APIServerLB: &LoadBalancerSpec{
-							FrontendIPs: []FrontendIP{
+				Spec: infrav1.AzureClusterSpec{
+					NetworkSpec: infrav1.NetworkSpec{
+						APIServerLB: &infrav1.LoadBalancerSpec{
+							FrontendIPs: []infrav1.FrontendIP{
 								{
 									Name: "cluster-test-internal-lb-frontEnd",
-									FrontendIPClass: FrontendIPClass{
+									FrontendIPClass: infrav1.FrontendIPClass{
 										PrivateIPAddress: DefaultInternalLBIPAddress,
 									},
 								},
 							},
-							BackendPool: BackendPool{
+							BackendPool: infrav1.BackendPool{
 								Name: "custom-backend-pool",
 							},
-							LoadBalancerClassSpec: LoadBalancerClassSpec{
-								SKU:                  SKUStandard,
-								Type:                 Internal,
+							LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{
+								SKU:                  infrav1.SKUStandard,
+								Type:                 infrav1.Internal,
 								IdleTimeoutInMinutes: ptr.To[int32](DefaultOutboundRuleIdleTimeoutInMinutes),
 							},
 							Name: "cluster-test-internal-lb",
@@ -1524,44 +1524,44 @@ func TestAPIServerLBDefaults(t *testing.T) {
 		{
 			name:        "with custom backend pool name with feature gate API Server ILB enabled",
 			featureGate: feature.APIServerILB,
-			cluster: &AzureCluster{
+			cluster: &infrav1.AzureCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
-				Spec: AzureClusterSpec{
-					NetworkSpec: NetworkSpec{
-						APIServerLB: &LoadBalancerSpec{
-							LoadBalancerClassSpec: LoadBalancerClassSpec{
-								Type: Internal,
+				Spec: infrav1.AzureClusterSpec{
+					NetworkSpec: infrav1.NetworkSpec{
+						APIServerLB: &infrav1.LoadBalancerSpec{
+							LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{
+								Type: infrav1.Internal,
 							},
-							BackendPool: BackendPool{
+							BackendPool: infrav1.BackendPool{
 								Name: "custom-backend-pool",
 							},
 						},
 					},
 				},
 			},
-			output: &AzureCluster{
+			output: &infrav1.AzureCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
-				Spec: AzureClusterSpec{
-					NetworkSpec: NetworkSpec{
-						APIServerLB: &LoadBalancerSpec{
-							FrontendIPs: []FrontendIP{
+				Spec: infrav1.AzureClusterSpec{
+					NetworkSpec: infrav1.NetworkSpec{
+						APIServerLB: &infrav1.LoadBalancerSpec{
+							FrontendIPs: []infrav1.FrontendIP{
 								{
 									Name: "cluster-test-internal-lb-frontEnd",
-									FrontendIPClass: FrontendIPClass{
+									FrontendIPClass: infrav1.FrontendIPClass{
 										PrivateIPAddress: DefaultInternalLBIPAddress,
 									},
 								},
 							},
-							BackendPool: BackendPool{
+							BackendPool: infrav1.BackendPool{
 								Name: "custom-backend-pool",
 							},
-							LoadBalancerClassSpec: LoadBalancerClassSpec{
-								SKU:                  SKUStandard,
-								Type:                 Internal,
+							LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{
+								SKU:                  infrav1.SKUStandard,
+								Type:                 infrav1.Internal,
 								IdleTimeoutInMinutes: ptr.To[int32](DefaultOutboundRuleIdleTimeoutInMinutes),
 							},
 							Name: "cluster-test-internal-lb",
@@ -1573,68 +1573,68 @@ func TestAPIServerLBDefaults(t *testing.T) {
 		{
 			name:        "public lb with APIServerILB feature gate enabled and custom private IP belonging to default control plane CIDR",
 			featureGate: feature.APIServerILB,
-			cluster: &AzureCluster{
+			cluster: &infrav1.AzureCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
-				Spec: AzureClusterSpec{
+				Spec: infrav1.AzureClusterSpec{
 					ControlPlaneEnabled: true,
-					NetworkSpec: NetworkSpec{
-						APIServerLB: &LoadBalancerSpec{
+					NetworkSpec: infrav1.NetworkSpec{
+						APIServerLB: &infrav1.LoadBalancerSpec{
 							Name: "cluster-test-public-lb",
-							FrontendIPs: []FrontendIP{
+							FrontendIPs: []infrav1.FrontendIP{
 								{
 									Name: "cluster-test-public-lb-frontEnd",
-									PublicIP: &PublicIPSpec{
+									PublicIP: &infrav1.PublicIPSpec{
 										Name:    "pip-cluster-test-apiserver",
 										DNSName: "",
 									},
 								},
 								{
 									Name: "my-internal-ip",
-									FrontendIPClass: FrontendIPClass{
+									FrontendIPClass: infrav1.FrontendIPClass{
 										PrivateIPAddress: "10.0.0.111",
 									},
 								},
 							},
-							LoadBalancerClassSpec: LoadBalancerClassSpec{
-								Type: Public,
-								SKU:  SKUStandard,
+							LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{
+								Type: infrav1.Public,
+								SKU:  infrav1.SKUStandard,
 							},
 						},
 					},
 				},
 			},
-			output: &AzureCluster{
+			output: &infrav1.AzureCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
-				Spec: AzureClusterSpec{
+				Spec: infrav1.AzureClusterSpec{
 					ControlPlaneEnabled: true,
-					NetworkSpec: NetworkSpec{
-						APIServerLB: &LoadBalancerSpec{
+					NetworkSpec: infrav1.NetworkSpec{
+						APIServerLB: &infrav1.LoadBalancerSpec{
 							Name: "cluster-test-public-lb",
-							FrontendIPs: []FrontendIP{
+							FrontendIPs: []infrav1.FrontendIP{
 								{
 									Name: "cluster-test-public-lb-frontEnd",
-									PublicIP: &PublicIPSpec{
+									PublicIP: &infrav1.PublicIPSpec{
 										Name:    "pip-cluster-test-apiserver",
 										DNSName: "",
 									},
 								},
 								{
 									Name: "my-internal-ip",
-									FrontendIPClass: FrontendIPClass{
+									FrontendIPClass: infrav1.FrontendIPClass{
 										PrivateIPAddress: "10.0.0.111",
 									},
 								},
 							},
-							BackendPool: BackendPool{
+							BackendPool: infrav1.BackendPool{
 								Name: "cluster-test-public-lb-backendPool",
 							},
-							LoadBalancerClassSpec: LoadBalancerClassSpec{
-								SKU:                  SKUStandard,
-								Type:                 Public,
+							LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{
+								SKU:                  infrav1.SKUStandard,
+								Type:                 infrav1.Public,
 								IdleTimeoutInMinutes: ptr.To[int32](DefaultOutboundRuleIdleTimeoutInMinutes),
 							},
 						},
@@ -1662,66 +1662,66 @@ func TestAPIServerLBDefaults(t *testing.T) {
 
 func TestAzureEnviromentDefault(t *testing.T) {
 	cases := map[string]struct {
-		cluster *AzureCluster
-		output  *AzureCluster
+		cluster *infrav1.AzureCluster
+		output  *infrav1.AzureCluster
 	}{
 		"default empty azure env": {
-			cluster: &AzureCluster{
+			cluster: &infrav1.AzureCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "foo",
 				},
-				Spec: AzureClusterSpec{},
+				Spec: infrav1.AzureClusterSpec{},
 			},
-			output: &AzureCluster{
+			output: &infrav1.AzureCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "foo",
 				},
-				Spec: AzureClusterSpec{
-					AzureClusterClassSpec: AzureClusterClassSpec{
+				Spec: infrav1.AzureClusterSpec{
+					AzureClusterClassSpec: infrav1.AzureClusterClassSpec{
 						AzureEnvironment: DefaultAzureCloud,
 					},
 				},
 			},
 		},
 		"azure env set to AzurePublicCloud": {
-			cluster: &AzureCluster{
+			cluster: &infrav1.AzureCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "foo",
 				},
-				Spec: AzureClusterSpec{
-					AzureClusterClassSpec: AzureClusterClassSpec{
+				Spec: infrav1.AzureClusterSpec{
+					AzureClusterClassSpec: infrav1.AzureClusterClassSpec{
 						AzureEnvironment: DefaultAzureCloud,
 					},
 				},
 			},
-			output: &AzureCluster{
+			output: &infrav1.AzureCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "foo",
 				},
-				Spec: AzureClusterSpec{
-					AzureClusterClassSpec: AzureClusterClassSpec{
+				Spec: infrav1.AzureClusterSpec{
+					AzureClusterClassSpec: infrav1.AzureClusterClassSpec{
 						AzureEnvironment: DefaultAzureCloud,
 					},
 				},
 			},
 		},
 		"azure env set to AzureGermanCloud": {
-			cluster: &AzureCluster{
+			cluster: &infrav1.AzureCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "foo",
 				},
-				Spec: AzureClusterSpec{
-					AzureClusterClassSpec: AzureClusterClassSpec{
+				Spec: infrav1.AzureClusterSpec{
+					AzureClusterClassSpec: infrav1.AzureClusterClassSpec{
 						AzureEnvironment: "AzureGermanCloud",
 					},
 				},
 			},
-			output: &AzureCluster{
+			output: &infrav1.AzureCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "foo",
 				},
-				Spec: AzureClusterSpec{
-					AzureClusterClassSpec: AzureClusterClassSpec{
+				Spec: infrav1.AzureClusterSpec{
+					AzureClusterClassSpec: infrav1.AzureClusterClassSpec{
 						AzureEnvironment: "AzureGermanCloud",
 					},
 				},
@@ -1746,68 +1746,68 @@ func TestAzureEnviromentDefault(t *testing.T) {
 func TestNodeOutboundLBDefaults(t *testing.T) {
 	cases := []struct {
 		name    string
-		cluster *AzureCluster
-		output  *AzureCluster
+		cluster *infrav1.AzureCluster
+		output  *infrav1.AzureCluster
 	}{
 		{
 			name: "default no lb for public clusters",
-			cluster: &AzureCluster{
+			cluster: &infrav1.AzureCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
-				Spec: AzureClusterSpec{
+				Spec: infrav1.AzureClusterSpec{
 					ControlPlaneEnabled: true,
-					NetworkSpec: NetworkSpec{
-						APIServerLB: &LoadBalancerSpec{LoadBalancerClassSpec: LoadBalancerClassSpec{Type: Public}},
-						Subnets: Subnets{
+					NetworkSpec: infrav1.NetworkSpec{
+						APIServerLB: &infrav1.LoadBalancerSpec{LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{Type: infrav1.Public}},
+						Subnets: infrav1.Subnets{
 							{
-								SubnetClassSpec: SubnetClassSpec{
-									Role: SubnetControlPlane,
+								SubnetClassSpec: infrav1.SubnetClassSpec{
+									Role: infrav1.SubnetControlPlane,
 									Name: "control-plane-subnet",
 								},
-								SecurityGroup: SecurityGroup{},
-								RouteTable:    RouteTable{},
+								SecurityGroup: infrav1.SecurityGroup{},
+								RouteTable:    infrav1.RouteTable{},
 							},
 							{
-								SubnetClassSpec: SubnetClassSpec{
-									Role: SubnetNode,
+								SubnetClassSpec: infrav1.SubnetClassSpec{
+									Role: infrav1.SubnetNode,
 									Name: "node-subnet",
 								},
-								SecurityGroup: SecurityGroup{},
-								RouteTable:    RouteTable{},
+								SecurityGroup: infrav1.SecurityGroup{},
+								RouteTable:    infrav1.RouteTable{},
 							},
 						},
 					},
 				},
 			},
-			output: &AzureCluster{
+			output: &infrav1.AzureCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
-				Spec: AzureClusterSpec{
+				Spec: infrav1.AzureClusterSpec{
 					ControlPlaneEnabled: true,
-					NetworkSpec: NetworkSpec{
-						Subnets: Subnets{
+					NetworkSpec: infrav1.NetworkSpec{
+						Subnets: infrav1.Subnets{
 							{
-								SubnetClassSpec: SubnetClassSpec{
-									Role: SubnetControlPlane,
+								SubnetClassSpec: infrav1.SubnetClassSpec{
+									Role: infrav1.SubnetControlPlane,
 									Name: "control-plane-subnet",
 								},
-								SecurityGroup: SecurityGroup{},
-								RouteTable:    RouteTable{},
+								SecurityGroup: infrav1.SecurityGroup{},
+								RouteTable:    infrav1.RouteTable{},
 							},
 							{
-								SubnetClassSpec: SubnetClassSpec{
-									Role: SubnetNode,
+								SubnetClassSpec: infrav1.SubnetClassSpec{
+									Role: infrav1.SubnetNode,
 									Name: "node-subnet",
 								},
-								SecurityGroup: SecurityGroup{},
-								RouteTable:    RouteTable{},
+								SecurityGroup: infrav1.SecurityGroup{},
+								RouteTable:    infrav1.RouteTable{},
 							},
 						},
-						APIServerLB: &LoadBalancerSpec{
-							LoadBalancerClassSpec: LoadBalancerClassSpec{
-								Type: Public,
+						APIServerLB: &infrav1.LoadBalancerSpec{
+							LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{
+								Type: infrav1.Public,
 							},
 						},
 					},
@@ -1816,82 +1816,82 @@ func TestNodeOutboundLBDefaults(t *testing.T) {
 		},
 		{
 			name: "IPv6 enabled",
-			cluster: &AzureCluster{
+			cluster: &infrav1.AzureCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
-				Spec: AzureClusterSpec{
+				Spec: infrav1.AzureClusterSpec{
 					ControlPlaneEnabled: true,
-					NetworkSpec: NetworkSpec{
-						APIServerLB: &LoadBalancerSpec{LoadBalancerClassSpec: LoadBalancerClassSpec{Type: Public}},
-						Subnets: Subnets{
+					NetworkSpec: infrav1.NetworkSpec{
+						APIServerLB: &infrav1.LoadBalancerSpec{LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{Type: infrav1.Public}},
+						Subnets: infrav1.Subnets{
 							{
-								SubnetClassSpec: SubnetClassSpec{
-									Role: SubnetControlPlane,
+								SubnetClassSpec: infrav1.SubnetClassSpec{
+									Role: infrav1.SubnetControlPlane,
 									Name: "control-plane-subnet",
 								},
-								SecurityGroup: SecurityGroup{},
-								RouteTable:    RouteTable{},
+								SecurityGroup: infrav1.SecurityGroup{},
+								RouteTable:    infrav1.RouteTable{},
 							},
 							{
-								SubnetClassSpec: SubnetClassSpec{
+								SubnetClassSpec: infrav1.SubnetClassSpec{
 									Role:       "node",
 									CIDRBlocks: []string{"2001:beea::1/64"},
 									Name:       "cluster-test-node-subnet",
 								},
-								SecurityGroup: SecurityGroup{},
-								RouteTable:    RouteTable{},
+								SecurityGroup: infrav1.SecurityGroup{},
+								RouteTable:    infrav1.RouteTable{},
 							},
 						},
 					},
 				},
 			},
-			output: &AzureCluster{
+			output: &infrav1.AzureCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
-				Spec: AzureClusterSpec{
+				Spec: infrav1.AzureClusterSpec{
 					ControlPlaneEnabled: true,
-					NetworkSpec: NetworkSpec{
-						Subnets: Subnets{
+					NetworkSpec: infrav1.NetworkSpec{
+						Subnets: infrav1.Subnets{
 							{
-								SubnetClassSpec: SubnetClassSpec{
-									Role: SubnetControlPlane,
+								SubnetClassSpec: infrav1.SubnetClassSpec{
+									Role: infrav1.SubnetControlPlane,
 									Name: "control-plane-subnet",
 								},
-								SecurityGroup: SecurityGroup{},
-								RouteTable:    RouteTable{},
+								SecurityGroup: infrav1.SecurityGroup{},
+								RouteTable:    infrav1.RouteTable{},
 							},
 							{
-								SubnetClassSpec: SubnetClassSpec{
+								SubnetClassSpec: infrav1.SubnetClassSpec{
 									Role:       "node",
 									CIDRBlocks: []string{"2001:beea::1/64"},
 									Name:       "cluster-test-node-subnet",
 								},
-								SecurityGroup: SecurityGroup{},
-								RouteTable:    RouteTable{},
+								SecurityGroup: infrav1.SecurityGroup{},
+								RouteTable:    infrav1.RouteTable{},
 							},
 						},
-						APIServerLB: &LoadBalancerSpec{
-							LoadBalancerClassSpec: LoadBalancerClassSpec{
-								Type: Public,
+						APIServerLB: &infrav1.LoadBalancerSpec{
+							LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{
+								Type: infrav1.Public,
 							},
 						},
-						NodeOutboundLB: &LoadBalancerSpec{
+						NodeOutboundLB: &infrav1.LoadBalancerSpec{
 							Name: "cluster-test",
-							FrontendIPs: []FrontendIP{{
+							FrontendIPs: []infrav1.FrontendIP{{
 								Name: "cluster-test-frontEnd",
-								PublicIP: &PublicIPSpec{
+								PublicIP: &infrav1.PublicIPSpec{
 									Name: "pip-cluster-test-node-outbound",
 								},
 							}},
-							BackendPool: BackendPool{
+							BackendPool: infrav1.BackendPool{
 								Name: "cluster-test-outboundBackendPool",
 							},
 							FrontendIPsCount: ptr.To[int32](1),
-							LoadBalancerClassSpec: LoadBalancerClassSpec{
-								SKU:                  SKUStandard,
-								Type:                 Public,
+							LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{
+								SKU:                  infrav1.SKUStandard,
+								Type:                 infrav1.Public,
 								IdleTimeoutInMinutes: ptr.To[int32](DefaultOutboundRuleIdleTimeoutInMinutes),
 							},
 						},
@@ -1901,98 +1901,98 @@ func TestNodeOutboundLBDefaults(t *testing.T) {
 		},
 		{
 			name: "IPv6 enabled on 1 of 2 node subnets",
-			cluster: &AzureCluster{
+			cluster: &infrav1.AzureCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
-				Spec: AzureClusterSpec{
+				Spec: infrav1.AzureClusterSpec{
 					ControlPlaneEnabled: true,
-					NetworkSpec: NetworkSpec{
-						APIServerLB: &LoadBalancerSpec{LoadBalancerClassSpec: LoadBalancerClassSpec{Type: Public}},
-						Subnets: Subnets{
+					NetworkSpec: infrav1.NetworkSpec{
+						APIServerLB: &infrav1.LoadBalancerSpec{LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{Type: infrav1.Public}},
+						Subnets: infrav1.Subnets{
 							{
-								SubnetClassSpec: SubnetClassSpec{
-									Role: SubnetControlPlane,
+								SubnetClassSpec: infrav1.SubnetClassSpec{
+									Role: infrav1.SubnetControlPlane,
 									Name: "control-plane-subnet",
 								},
-								SecurityGroup: SecurityGroup{},
-								RouteTable:    RouteTable{},
+								SecurityGroup: infrav1.SecurityGroup{},
+								RouteTable:    infrav1.RouteTable{},
 							},
 							{
-								SubnetClassSpec: SubnetClassSpec{
-									Role:       SubnetNode,
+								SubnetClassSpec: infrav1.SubnetClassSpec{
+									Role:       infrav1.SubnetNode,
 									CIDRBlocks: []string{"2001:beea::1/64"},
 									Name:       "node-subnet-1",
 								},
-								SecurityGroup: SecurityGroup{},
-								RouteTable:    RouteTable{},
+								SecurityGroup: infrav1.SecurityGroup{},
+								RouteTable:    infrav1.RouteTable{},
 							},
 							{
-								SubnetClassSpec: SubnetClassSpec{
-									Role: SubnetNode,
+								SubnetClassSpec: infrav1.SubnetClassSpec{
+									Role: infrav1.SubnetNode,
 									Name: "node-subnet-2",
 								},
-								SecurityGroup: SecurityGroup{},
-								RouteTable:    RouteTable{},
+								SecurityGroup: infrav1.SecurityGroup{},
+								RouteTable:    infrav1.RouteTable{},
 							},
 						},
 					},
 				},
 			},
-			output: &AzureCluster{
+			output: &infrav1.AzureCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
-				Spec: AzureClusterSpec{
+				Spec: infrav1.AzureClusterSpec{
 					ControlPlaneEnabled: true,
-					NetworkSpec: NetworkSpec{
-						Subnets: Subnets{
+					NetworkSpec: infrav1.NetworkSpec{
+						Subnets: infrav1.Subnets{
 							{
-								SubnetClassSpec: SubnetClassSpec{
-									Role: SubnetControlPlane,
+								SubnetClassSpec: infrav1.SubnetClassSpec{
+									Role: infrav1.SubnetControlPlane,
 									Name: "control-plane-subnet",
 								},
-								SecurityGroup: SecurityGroup{},
-								RouteTable:    RouteTable{},
+								SecurityGroup: infrav1.SecurityGroup{},
+								RouteTable:    infrav1.RouteTable{},
 							},
 							{
-								SubnetClassSpec: SubnetClassSpec{
-									Role:       SubnetNode,
+								SubnetClassSpec: infrav1.SubnetClassSpec{
+									Role:       infrav1.SubnetNode,
 									CIDRBlocks: []string{"2001:beea::1/64"},
 									Name:       "node-subnet-1",
 								},
-								SecurityGroup: SecurityGroup{},
-								RouteTable:    RouteTable{},
+								SecurityGroup: infrav1.SecurityGroup{},
+								RouteTable:    infrav1.RouteTable{},
 							},
 							{
-								SubnetClassSpec: SubnetClassSpec{
-									Role: SubnetNode,
+								SubnetClassSpec: infrav1.SubnetClassSpec{
+									Role: infrav1.SubnetNode,
 									Name: "node-subnet-2",
 								},
-								SecurityGroup: SecurityGroup{},
-								RouteTable:    RouteTable{},
+								SecurityGroup: infrav1.SecurityGroup{},
+								RouteTable:    infrav1.RouteTable{},
 							},
 						},
-						APIServerLB: &LoadBalancerSpec{
-							LoadBalancerClassSpec: LoadBalancerClassSpec{
-								Type: Public,
+						APIServerLB: &infrav1.LoadBalancerSpec{
+							LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{
+								Type: infrav1.Public,
 							},
 						},
-						NodeOutboundLB: &LoadBalancerSpec{
+						NodeOutboundLB: &infrav1.LoadBalancerSpec{
 							Name: "cluster-test",
-							FrontendIPs: []FrontendIP{{
+							FrontendIPs: []infrav1.FrontendIP{{
 								Name: "cluster-test-frontEnd",
-								PublicIP: &PublicIPSpec{
+								PublicIP: &infrav1.PublicIPSpec{
 									Name: "pip-cluster-test-node-outbound",
 								},
 							}},
-							BackendPool: BackendPool{
+							BackendPool: infrav1.BackendPool{
 								Name: "cluster-test-outboundBackendPool",
 							},
 							FrontendIPsCount: ptr.To[int32](1),
-							LoadBalancerClassSpec: LoadBalancerClassSpec{
-								SKU:                  SKUStandard,
-								Type:                 Public,
+							LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{
+								SKU:                  infrav1.SKUStandard,
+								Type:                 infrav1.Public,
 								IdleTimeoutInMinutes: ptr.To[int32](DefaultOutboundRuleIdleTimeoutInMinutes),
 							},
 						},
@@ -2002,93 +2002,93 @@ func TestNodeOutboundLBDefaults(t *testing.T) {
 		},
 		{
 			name: "multiple node subnets, IPv6 not enabled in any of them",
-			cluster: &AzureCluster{
+			cluster: &infrav1.AzureCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
-				Spec: AzureClusterSpec{
-					NetworkSpec: NetworkSpec{
-						APIServerLB: &LoadBalancerSpec{LoadBalancerClassSpec: LoadBalancerClassSpec{Type: Public}},
-						Subnets: Subnets{
+				Spec: infrav1.AzureClusterSpec{
+					NetworkSpec: infrav1.NetworkSpec{
+						APIServerLB: &infrav1.LoadBalancerSpec{LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{Type: infrav1.Public}},
+						Subnets: infrav1.Subnets{
 							{
-								SubnetClassSpec: SubnetClassSpec{
-									Role: SubnetControlPlane,
+								SubnetClassSpec: infrav1.SubnetClassSpec{
+									Role: infrav1.SubnetControlPlane,
 									Name: "control-plane-subnet",
 								},
-								SecurityGroup: SecurityGroup{},
-								RouteTable:    RouteTable{},
+								SecurityGroup: infrav1.SecurityGroup{},
+								RouteTable:    infrav1.RouteTable{},
 							},
 							{
-								SubnetClassSpec: SubnetClassSpec{
-									Role: SubnetNode,
+								SubnetClassSpec: infrav1.SubnetClassSpec{
+									Role: infrav1.SubnetNode,
 									Name: "node-subnet",
 								},
-								SecurityGroup: SecurityGroup{},
-								RouteTable:    RouteTable{},
+								SecurityGroup: infrav1.SecurityGroup{},
+								RouteTable:    infrav1.RouteTable{},
 							},
 							{
-								SubnetClassSpec: SubnetClassSpec{
-									Role: SubnetNode,
+								SubnetClassSpec: infrav1.SubnetClassSpec{
+									Role: infrav1.SubnetNode,
 									Name: "node-subnet-2",
 								},
-								SecurityGroup: SecurityGroup{},
-								RouteTable:    RouteTable{},
+								SecurityGroup: infrav1.SecurityGroup{},
+								RouteTable:    infrav1.RouteTable{},
 							},
 							{
-								SubnetClassSpec: SubnetClassSpec{
-									Role: SubnetNode,
+								SubnetClassSpec: infrav1.SubnetClassSpec{
+									Role: infrav1.SubnetNode,
 									Name: "node-subnet-3",
 								},
-								SecurityGroup: SecurityGroup{},
-								RouteTable:    RouteTable{},
+								SecurityGroup: infrav1.SecurityGroup{},
+								RouteTable:    infrav1.RouteTable{},
 							},
 						},
 					},
 				},
 			},
-			output: &AzureCluster{
+			output: &infrav1.AzureCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
-				Spec: AzureClusterSpec{
-					NetworkSpec: NetworkSpec{
-						Subnets: Subnets{
+				Spec: infrav1.AzureClusterSpec{
+					NetworkSpec: infrav1.NetworkSpec{
+						Subnets: infrav1.Subnets{
 							{
-								SubnetClassSpec: SubnetClassSpec{
-									Role: SubnetControlPlane,
+								SubnetClassSpec: infrav1.SubnetClassSpec{
+									Role: infrav1.SubnetControlPlane,
 									Name: "control-plane-subnet",
 								},
-								SecurityGroup: SecurityGroup{},
-								RouteTable:    RouteTable{},
+								SecurityGroup: infrav1.SecurityGroup{},
+								RouteTable:    infrav1.RouteTable{},
 							},
 							{
-								SubnetClassSpec: SubnetClassSpec{
-									Role: SubnetNode,
+								SubnetClassSpec: infrav1.SubnetClassSpec{
+									Role: infrav1.SubnetNode,
 									Name: "node-subnet",
 								},
-								SecurityGroup: SecurityGroup{},
-								RouteTable:    RouteTable{},
+								SecurityGroup: infrav1.SecurityGroup{},
+								RouteTable:    infrav1.RouteTable{},
 							},
 							{
-								SubnetClassSpec: SubnetClassSpec{
-									Role: SubnetNode,
+								SubnetClassSpec: infrav1.SubnetClassSpec{
+									Role: infrav1.SubnetNode,
 									Name: "node-subnet-2",
 								},
-								SecurityGroup: SecurityGroup{},
-								RouteTable:    RouteTable{},
+								SecurityGroup: infrav1.SecurityGroup{},
+								RouteTable:    infrav1.RouteTable{},
 							},
 							{
-								SubnetClassSpec: SubnetClassSpec{
-									Role: SubnetNode,
+								SubnetClassSpec: infrav1.SubnetClassSpec{
+									Role: infrav1.SubnetNode,
 									Name: "node-subnet-3",
 								},
-								SecurityGroup: SecurityGroup{},
-								RouteTable:    RouteTable{},
+								SecurityGroup: infrav1.SecurityGroup{},
+								RouteTable:    infrav1.RouteTable{},
 							},
 						},
-						APIServerLB: &LoadBalancerSpec{
-							LoadBalancerClassSpec: LoadBalancerClassSpec{
-								Type: Public,
+						APIServerLB: &infrav1.LoadBalancerSpec{
+							LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{
+								Type: infrav1.Public,
 							},
 						},
 					},
@@ -2097,118 +2097,118 @@ func TestNodeOutboundLBDefaults(t *testing.T) {
 		},
 		{
 			name: "multiple node subnets, IPv6 enabled on all of them",
-			cluster: &AzureCluster{
+			cluster: &infrav1.AzureCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
-				Spec: AzureClusterSpec{
+				Spec: infrav1.AzureClusterSpec{
 					ControlPlaneEnabled: true,
-					NetworkSpec: NetworkSpec{
-						APIServerLB: &LoadBalancerSpec{LoadBalancerClassSpec: LoadBalancerClassSpec{Type: Public}},
-						Subnets: Subnets{
+					NetworkSpec: infrav1.NetworkSpec{
+						APIServerLB: &infrav1.LoadBalancerSpec{LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{Type: infrav1.Public}},
+						Subnets: infrav1.Subnets{
 							{
-								SubnetClassSpec: SubnetClassSpec{
-									Role: SubnetControlPlane,
+								SubnetClassSpec: infrav1.SubnetClassSpec{
+									Role: infrav1.SubnetControlPlane,
 									Name: "control-plane-subnet",
 								},
-								SecurityGroup: SecurityGroup{},
-								RouteTable:    RouteTable{},
+								SecurityGroup: infrav1.SecurityGroup{},
+								RouteTable:    infrav1.RouteTable{},
 							},
 							{
-								SubnetClassSpec: SubnetClassSpec{
-									Role:       SubnetNode,
+								SubnetClassSpec: infrav1.SubnetClassSpec{
+									Role:       infrav1.SubnetNode,
 									CIDRBlocks: []string{"2001:beea::1/64"},
 									Name:       "node-subnet-1",
 								},
-								SecurityGroup: SecurityGroup{},
-								RouteTable:    RouteTable{},
+								SecurityGroup: infrav1.SecurityGroup{},
+								RouteTable:    infrav1.RouteTable{},
 							},
 							{
-								SubnetClassSpec: SubnetClassSpec{
-									Role:       SubnetNode,
+								SubnetClassSpec: infrav1.SubnetClassSpec{
+									Role:       infrav1.SubnetNode,
 									CIDRBlocks: []string{"2002:beee::1/64"},
 									Name:       "node-subnet-2",
 								},
-								SecurityGroup: SecurityGroup{},
-								RouteTable:    RouteTable{},
+								SecurityGroup: infrav1.SecurityGroup{},
+								RouteTable:    infrav1.RouteTable{},
 							},
 							{
-								SubnetClassSpec: SubnetClassSpec{
-									Role:       SubnetNode,
+								SubnetClassSpec: infrav1.SubnetClassSpec{
+									Role:       infrav1.SubnetNode,
 									CIDRBlocks: []string{"2003:befa::1/64"},
 									Name:       "node-subnet-3",
 								},
-								SecurityGroup: SecurityGroup{},
-								RouteTable:    RouteTable{},
+								SecurityGroup: infrav1.SecurityGroup{},
+								RouteTable:    infrav1.RouteTable{},
 							},
 						},
 					},
 				},
 			},
-			output: &AzureCluster{
+			output: &infrav1.AzureCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
-				Spec: AzureClusterSpec{
+				Spec: infrav1.AzureClusterSpec{
 					ControlPlaneEnabled: true,
-					NetworkSpec: NetworkSpec{
-						Subnets: Subnets{
+					NetworkSpec: infrav1.NetworkSpec{
+						Subnets: infrav1.Subnets{
 							{
-								SubnetClassSpec: SubnetClassSpec{
-									Role: SubnetControlPlane,
+								SubnetClassSpec: infrav1.SubnetClassSpec{
+									Role: infrav1.SubnetControlPlane,
 									Name: "control-plane-subnet",
 								},
-								SecurityGroup: SecurityGroup{},
-								RouteTable:    RouteTable{},
+								SecurityGroup: infrav1.SecurityGroup{},
+								RouteTable:    infrav1.RouteTable{},
 							},
 							{
-								SubnetClassSpec: SubnetClassSpec{
-									Role:       SubnetNode,
+								SubnetClassSpec: infrav1.SubnetClassSpec{
+									Role:       infrav1.SubnetNode,
 									CIDRBlocks: []string{"2001:beea::1/64"},
 									Name:       "node-subnet-1",
 								},
-								SecurityGroup: SecurityGroup{},
-								RouteTable:    RouteTable{},
+								SecurityGroup: infrav1.SecurityGroup{},
+								RouteTable:    infrav1.RouteTable{},
 							},
 							{
-								SubnetClassSpec: SubnetClassSpec{
-									Role:       SubnetNode,
+								SubnetClassSpec: infrav1.SubnetClassSpec{
+									Role:       infrav1.SubnetNode,
 									CIDRBlocks: []string{"2002:beee::1/64"},
 									Name:       "node-subnet-2",
 								},
-								SecurityGroup: SecurityGroup{},
-								RouteTable:    RouteTable{},
+								SecurityGroup: infrav1.SecurityGroup{},
+								RouteTable:    infrav1.RouteTable{},
 							},
 							{
-								SubnetClassSpec: SubnetClassSpec{
-									Role:       SubnetNode,
+								SubnetClassSpec: infrav1.SubnetClassSpec{
+									Role:       infrav1.SubnetNode,
 									CIDRBlocks: []string{"2003:befa::1/64"},
 									Name:       "node-subnet-3",
 								},
-								SecurityGroup: SecurityGroup{},
-								RouteTable:    RouteTable{},
+								SecurityGroup: infrav1.SecurityGroup{},
+								RouteTable:    infrav1.RouteTable{},
 							},
 						},
-						APIServerLB: &LoadBalancerSpec{
-							LoadBalancerClassSpec: LoadBalancerClassSpec{
-								Type: Public,
+						APIServerLB: &infrav1.LoadBalancerSpec{
+							LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{
+								Type: infrav1.Public,
 							},
 						},
-						NodeOutboundLB: &LoadBalancerSpec{
+						NodeOutboundLB: &infrav1.LoadBalancerSpec{
 							Name: "cluster-test",
-							FrontendIPs: []FrontendIP{{
+							FrontendIPs: []infrav1.FrontendIP{{
 								Name: "cluster-test-frontEnd",
-								PublicIP: &PublicIPSpec{
+								PublicIP: &infrav1.PublicIPSpec{
 									Name: "pip-cluster-test-node-outbound",
 								},
 							}},
-							BackendPool: BackendPool{
+							BackendPool: infrav1.BackendPool{
 								Name: "cluster-test-outboundBackendPool",
 							},
 							FrontendIPsCount: ptr.To[int32](1),
-							LoadBalancerClassSpec: LoadBalancerClassSpec{
-								SKU:                  SKUStandard,
-								Type:                 Public,
+							LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{
+								SKU:                  infrav1.SKUStandard,
+								Type:                 infrav1.Public,
 								IdleTimeoutInMinutes: ptr.To[int32](DefaultOutboundRuleIdleTimeoutInMinutes),
 							},
 						},
@@ -2218,25 +2218,25 @@ func TestNodeOutboundLBDefaults(t *testing.T) {
 		},
 		{
 			name: "no lb for private clusters",
-			cluster: &AzureCluster{
+			cluster: &infrav1.AzureCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
-				Spec: AzureClusterSpec{
-					NetworkSpec: NetworkSpec{
-						APIServerLB: &LoadBalancerSpec{LoadBalancerClassSpec: LoadBalancerClassSpec{Type: Internal}},
+				Spec: infrav1.AzureClusterSpec{
+					NetworkSpec: infrav1.NetworkSpec{
+						APIServerLB: &infrav1.LoadBalancerSpec{LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{Type: infrav1.Internal}},
 					},
 				},
 			},
-			output: &AzureCluster{
+			output: &infrav1.AzureCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
-				Spec: AzureClusterSpec{
-					NetworkSpec: NetworkSpec{
-						APIServerLB: &LoadBalancerSpec{
-							LoadBalancerClassSpec: LoadBalancerClassSpec{
-								Type: Internal,
+				Spec: infrav1.AzureClusterSpec{
+					NetworkSpec: infrav1.NetworkSpec{
+						APIServerLB: &infrav1.LoadBalancerSpec{
+							LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{
+								Type: infrav1.Internal,
 							},
 						},
 					},
@@ -2245,58 +2245,58 @@ func TestNodeOutboundLBDefaults(t *testing.T) {
 		},
 		{
 			name: "NodeOutboundLB declared as input with non-default IdleTimeoutInMinutes, FrontendIPsCount, BackendPool values",
-			cluster: &AzureCluster{
+			cluster: &infrav1.AzureCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
-				Spec: AzureClusterSpec{
-					NetworkSpec: NetworkSpec{
-						APIServerLB: &LoadBalancerSpec{LoadBalancerClassSpec: LoadBalancerClassSpec{Type: Public}},
-						NodeOutboundLB: &LoadBalancerSpec{
+				Spec: infrav1.AzureClusterSpec{
+					NetworkSpec: infrav1.NetworkSpec{
+						APIServerLB: &infrav1.LoadBalancerSpec{LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{Type: infrav1.Public}},
+						NodeOutboundLB: &infrav1.LoadBalancerSpec{
 							FrontendIPsCount: ptr.To[int32](2),
-							BackendPool: BackendPool{
+							BackendPool: infrav1.BackendPool{
 								Name: "custom-backend-pool",
 							},
-							LoadBalancerClassSpec: LoadBalancerClassSpec{
+							LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{
 								IdleTimeoutInMinutes: ptr.To[int32](15),
 							},
 						},
 					},
 				},
 			},
-			output: &AzureCluster{
+			output: &infrav1.AzureCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
-				Spec: AzureClusterSpec{
-					NetworkSpec: NetworkSpec{
-						APIServerLB: &LoadBalancerSpec{
-							LoadBalancerClassSpec: LoadBalancerClassSpec{
-								Type: Public,
+				Spec: infrav1.AzureClusterSpec{
+					NetworkSpec: infrav1.NetworkSpec{
+						APIServerLB: &infrav1.LoadBalancerSpec{
+							LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{
+								Type: infrav1.Public,
 							},
 						},
-						NodeOutboundLB: &LoadBalancerSpec{
-							FrontendIPs: []FrontendIP{
+						NodeOutboundLB: &infrav1.LoadBalancerSpec{
+							FrontendIPs: []infrav1.FrontendIP{
 								{
 									Name: "cluster-test-frontEnd-1",
-									PublicIP: &PublicIPSpec{
+									PublicIP: &infrav1.PublicIPSpec{
 										Name: "pip-cluster-test-node-outbound-1",
 									},
 								},
 								{
 									Name: "cluster-test-frontEnd-2",
-									PublicIP: &PublicIPSpec{
+									PublicIP: &infrav1.PublicIPSpec{
 										Name: "pip-cluster-test-node-outbound-2",
 									},
 								},
 							},
-							BackendPool: BackendPool{
+							BackendPool: infrav1.BackendPool{
 								Name: "custom-backend-pool",
 							},
 							FrontendIPsCount: ptr.To[int32](2), // we expect the original value to be respected here
-							LoadBalancerClassSpec: LoadBalancerClassSpec{
-								SKU:                  SKUStandard,
-								Type:                 Public,
+							LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{
+								SKU:                  infrav1.SKUStandard,
+								Type:                 infrav1.Public,
 								IdleTimeoutInMinutes: ptr.To[int32](15), // we expect the original value to be respected here
 							},
 							Name: "cluster-test",
@@ -2307,94 +2307,94 @@ func TestNodeOutboundLBDefaults(t *testing.T) {
 		},
 		{
 			name: "ensure that existing lb names are not overwritten",
-			cluster: &AzureCluster{
+			cluster: &infrav1.AzureCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
-				Spec: AzureClusterSpec{
-					NetworkSpec: NetworkSpec{
-						APIServerLB: &LoadBalancerSpec{
+				Spec: infrav1.AzureClusterSpec{
+					NetworkSpec: infrav1.NetworkSpec{
+						APIServerLB: &infrav1.LoadBalancerSpec{
 							Name: "user-defined-name",
-							LoadBalancerClassSpec: LoadBalancerClassSpec{
-								Type: Public,
+							LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{
+								Type: infrav1.Public,
 							},
 						},
-						Subnets: Subnets{
+						Subnets: infrav1.Subnets{
 							{
-								SubnetClassSpec: SubnetClassSpec{
-									Role: SubnetControlPlane,
+								SubnetClassSpec: infrav1.SubnetClassSpec{
+									Role: infrav1.SubnetControlPlane,
 									Name: "control-plane-subnet",
 								},
-								SecurityGroup: SecurityGroup{},
-								RouteTable:    RouteTable{},
+								SecurityGroup: infrav1.SecurityGroup{},
+								RouteTable:    infrav1.RouteTable{},
 							},
 							{
-								SubnetClassSpec: SubnetClassSpec{
-									Role: SubnetNode,
+								SubnetClassSpec: infrav1.SubnetClassSpec{
+									Role: infrav1.SubnetNode,
 									Name: "node-subnet",
 								},
-								SecurityGroup: SecurityGroup{},
-								RouteTable:    RouteTable{},
+								SecurityGroup: infrav1.SecurityGroup{},
+								RouteTable:    infrav1.RouteTable{},
 							},
 						},
-						ControlPlaneOutboundLB: &LoadBalancerSpec{
+						ControlPlaneOutboundLB: &infrav1.LoadBalancerSpec{
 							Name: "user-defined-name",
 						},
-						NodeOutboundLB: &LoadBalancerSpec{
+						NodeOutboundLB: &infrav1.LoadBalancerSpec{
 							Name: "user-defined-name",
 						},
 					},
 				},
 			},
-			output: &AzureCluster{
+			output: &infrav1.AzureCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
-				Spec: AzureClusterSpec{
-					NetworkSpec: NetworkSpec{
-						Subnets: Subnets{
+				Spec: infrav1.AzureClusterSpec{
+					NetworkSpec: infrav1.NetworkSpec{
+						Subnets: infrav1.Subnets{
 							{
-								SubnetClassSpec: SubnetClassSpec{
-									Role: SubnetControlPlane,
+								SubnetClassSpec: infrav1.SubnetClassSpec{
+									Role: infrav1.SubnetControlPlane,
 									Name: "control-plane-subnet",
 								},
-								SecurityGroup: SecurityGroup{},
-								RouteTable:    RouteTable{},
+								SecurityGroup: infrav1.SecurityGroup{},
+								RouteTable:    infrav1.RouteTable{},
 							},
 							{
-								SubnetClassSpec: SubnetClassSpec{
-									Role: SubnetNode,
+								SubnetClassSpec: infrav1.SubnetClassSpec{
+									Role: infrav1.SubnetNode,
 									Name: "node-subnet",
 								},
-								SecurityGroup: SecurityGroup{},
-								RouteTable:    RouteTable{},
+								SecurityGroup: infrav1.SecurityGroup{},
+								RouteTable:    infrav1.RouteTable{},
 							},
 						},
-						APIServerLB: &LoadBalancerSpec{
+						APIServerLB: &infrav1.LoadBalancerSpec{
 							Name: "user-defined-name",
-							LoadBalancerClassSpec: LoadBalancerClassSpec{
-								Type: Public,
+							LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{
+								Type: infrav1.Public,
 							},
 						},
-						NodeOutboundLB: &LoadBalancerSpec{
+						NodeOutboundLB: &infrav1.LoadBalancerSpec{
 							Name: "user-defined-name",
-							FrontendIPs: []FrontendIP{{
+							FrontendIPs: []infrav1.FrontendIP{{
 								Name: "user-defined-name-frontEnd",
-								PublicIP: &PublicIPSpec{
+								PublicIP: &infrav1.PublicIPSpec{
 									Name: "pip-cluster-test-node-outbound",
 								},
 							}},
-							BackendPool: BackendPool{
+							BackendPool: infrav1.BackendPool{
 								Name: "user-defined-name-outboundBackendPool",
 							},
 							FrontendIPsCount: ptr.To[int32](1),
-							LoadBalancerClassSpec: LoadBalancerClassSpec{
-								SKU:                  SKUStandard,
-								Type:                 Public,
+							LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{
+								SKU:                  infrav1.SKUStandard,
+								Type:                 infrav1.Public,
 								IdleTimeoutInMinutes: ptr.To[int32](DefaultOutboundRuleIdleTimeoutInMinutes),
 							},
 						},
-						ControlPlaneOutboundLB: &LoadBalancerSpec{
+						ControlPlaneOutboundLB: &infrav1.LoadBalancerSpec{
 							Name: "user-defined-name",
 						},
 					},
@@ -2420,30 +2420,30 @@ func TestNodeOutboundLBDefaults(t *testing.T) {
 func TestControlPlaneOutboundLBDefaults(t *testing.T) {
 	cases := []struct {
 		name    string
-		cluster *AzureCluster
-		output  *AzureCluster
+		cluster *infrav1.AzureCluster
+		output  *infrav1.AzureCluster
 	}{
 		{
 			name: "no cp lb for public clusters",
-			cluster: &AzureCluster{
+			cluster: &infrav1.AzureCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
-				Spec: AzureClusterSpec{
-					NetworkSpec: NetworkSpec{
-						APIServerLB: &LoadBalancerSpec{LoadBalancerClassSpec: LoadBalancerClassSpec{Type: Public}},
+				Spec: infrav1.AzureClusterSpec{
+					NetworkSpec: infrav1.NetworkSpec{
+						APIServerLB: &infrav1.LoadBalancerSpec{LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{Type: infrav1.Public}},
 					},
 				},
 			},
-			output: &AzureCluster{
+			output: &infrav1.AzureCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
-				Spec: AzureClusterSpec{
-					NetworkSpec: NetworkSpec{
-						APIServerLB: &LoadBalancerSpec{
-							LoadBalancerClassSpec: LoadBalancerClassSpec{
-								Type: Public,
+				Spec: infrav1.AzureClusterSpec{
+					NetworkSpec: infrav1.NetworkSpec{
+						APIServerLB: &infrav1.LoadBalancerSpec{
+							LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{
+								Type: infrav1.Public,
 							},
 						},
 					},
@@ -2452,25 +2452,25 @@ func TestControlPlaneOutboundLBDefaults(t *testing.T) {
 		},
 		{
 			name: "no cp lb for private clusters",
-			cluster: &AzureCluster{
+			cluster: &infrav1.AzureCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
-				Spec: AzureClusterSpec{
-					NetworkSpec: NetworkSpec{
-						APIServerLB: &LoadBalancerSpec{LoadBalancerClassSpec: LoadBalancerClassSpec{Type: Internal}},
+				Spec: infrav1.AzureClusterSpec{
+					NetworkSpec: infrav1.NetworkSpec{
+						APIServerLB: &infrav1.LoadBalancerSpec{LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{Type: infrav1.Internal}},
 					},
 				},
 			},
-			output: &AzureCluster{
+			output: &infrav1.AzureCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
-				Spec: AzureClusterSpec{
-					NetworkSpec: NetworkSpec{
-						APIServerLB: &LoadBalancerSpec{
-							LoadBalancerClassSpec: LoadBalancerClassSpec{
-								Type: Internal,
+				Spec: infrav1.AzureClusterSpec{
+					NetworkSpec: infrav1.NetworkSpec{
+						APIServerLB: &infrav1.LoadBalancerSpec{
+							LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{
+								Type: infrav1.Internal,
 							},
 						},
 					},
@@ -2479,56 +2479,56 @@ func TestControlPlaneOutboundLBDefaults(t *testing.T) {
 		},
 		{
 			name: "frontendIPsCount > 1",
-			cluster: &AzureCluster{
+			cluster: &infrav1.AzureCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
-				Spec: AzureClusterSpec{
-					NetworkSpec: NetworkSpec{
-						APIServerLB: &LoadBalancerSpec{LoadBalancerClassSpec: LoadBalancerClassSpec{Type: Internal}},
-						ControlPlaneOutboundLB: &LoadBalancerSpec{
+				Spec: infrav1.AzureClusterSpec{
+					NetworkSpec: infrav1.NetworkSpec{
+						APIServerLB: &infrav1.LoadBalancerSpec{LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{Type: infrav1.Internal}},
+						ControlPlaneOutboundLB: &infrav1.LoadBalancerSpec{
 							FrontendIPsCount: ptr.To[int32](2),
-							LoadBalancerClassSpec: LoadBalancerClassSpec{
+							LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{
 								IdleTimeoutInMinutes: ptr.To[int32](15),
 							},
 						},
 					},
 				},
 			},
-			output: &AzureCluster{
+			output: &infrav1.AzureCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
-				Spec: AzureClusterSpec{
-					NetworkSpec: NetworkSpec{
-						APIServerLB: &LoadBalancerSpec{
-							LoadBalancerClassSpec: LoadBalancerClassSpec{
-								Type: Internal,
+				Spec: infrav1.AzureClusterSpec{
+					NetworkSpec: infrav1.NetworkSpec{
+						APIServerLB: &infrav1.LoadBalancerSpec{
+							LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{
+								Type: infrav1.Internal,
 							},
 						},
-						ControlPlaneOutboundLB: &LoadBalancerSpec{
+						ControlPlaneOutboundLB: &infrav1.LoadBalancerSpec{
 							Name: "cluster-test-outbound-lb",
-							BackendPool: BackendPool{
+							BackendPool: infrav1.BackendPool{
 								Name: "cluster-test-outbound-lb-outboundBackendPool",
 							},
-							FrontendIPs: []FrontendIP{
+							FrontendIPs: []infrav1.FrontendIP{
 								{
 									Name: "cluster-test-outbound-lb-frontEnd-1",
-									PublicIP: &PublicIPSpec{
+									PublicIP: &infrav1.PublicIPSpec{
 										Name: "pip-cluster-test-controlplane-outbound-1",
 									},
 								},
 								{
 									Name: "cluster-test-outbound-lb-frontEnd-2",
-									PublicIP: &PublicIPSpec{
+									PublicIP: &infrav1.PublicIPSpec{
 										Name: "pip-cluster-test-controlplane-outbound-2",
 									},
 								},
 							},
 							FrontendIPsCount: ptr.To[int32](2),
-							LoadBalancerClassSpec: LoadBalancerClassSpec{
-								SKU:                  SKUStandard,
-								Type:                 Public,
+							LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{
+								SKU:                  infrav1.SKUStandard,
+								Type:                 infrav1.Public,
 								IdleTimeoutInMinutes: ptr.To[int32](15),
 							},
 						},
@@ -2538,52 +2538,52 @@ func TestControlPlaneOutboundLBDefaults(t *testing.T) {
 		},
 		{
 			name: "custom outbound lb backend pool",
-			cluster: &AzureCluster{
+			cluster: &infrav1.AzureCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
-				Spec: AzureClusterSpec{
-					NetworkSpec: NetworkSpec{
-						APIServerLB: &LoadBalancerSpec{LoadBalancerClassSpec: LoadBalancerClassSpec{Type: Internal}},
-						ControlPlaneOutboundLB: &LoadBalancerSpec{
-							BackendPool: BackendPool{
+				Spec: infrav1.AzureClusterSpec{
+					NetworkSpec: infrav1.NetworkSpec{
+						APIServerLB: &infrav1.LoadBalancerSpec{LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{Type: infrav1.Internal}},
+						ControlPlaneOutboundLB: &infrav1.LoadBalancerSpec{
+							BackendPool: infrav1.BackendPool{
 								Name: "custom-outbound-lb",
 							},
-							LoadBalancerClassSpec: LoadBalancerClassSpec{
+							LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{
 								IdleTimeoutInMinutes: ptr.To[int32](15),
 							},
 						},
 					},
 				},
 			},
-			output: &AzureCluster{
+			output: &infrav1.AzureCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-test",
 				},
-				Spec: AzureClusterSpec{
-					NetworkSpec: NetworkSpec{
-						APIServerLB: &LoadBalancerSpec{
-							LoadBalancerClassSpec: LoadBalancerClassSpec{
-								Type: Internal,
+				Spec: infrav1.AzureClusterSpec{
+					NetworkSpec: infrav1.NetworkSpec{
+						APIServerLB: &infrav1.LoadBalancerSpec{
+							LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{
+								Type: infrav1.Internal,
 							},
 						},
-						ControlPlaneOutboundLB: &LoadBalancerSpec{
+						ControlPlaneOutboundLB: &infrav1.LoadBalancerSpec{
 							Name: "cluster-test-outbound-lb",
-							BackendPool: BackendPool{
+							BackendPool: infrav1.BackendPool{
 								Name: "custom-outbound-lb",
 							},
-							FrontendIPs: []FrontendIP{
+							FrontendIPs: []infrav1.FrontendIP{
 								{
 									Name: "cluster-test-outbound-lb-frontEnd",
-									PublicIP: &PublicIPSpec{
+									PublicIP: &infrav1.PublicIPSpec{
 										Name: "pip-cluster-test-controlplane-outbound",
 									},
 								},
 							},
 							FrontendIPsCount: ptr.To[int32](1),
-							LoadBalancerClassSpec: LoadBalancerClassSpec{
-								SKU:                  SKUStandard,
-								Type:                 Public,
+							LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{
+								SKU:                  infrav1.SKUStandard,
+								Type:                 infrav1.Public,
 								IdleTimeoutInMinutes: ptr.To[int32](15),
 							},
 						},
@@ -2609,51 +2609,51 @@ func TestControlPlaneOutboundLBDefaults(t *testing.T) {
 
 func TestBastionDefault(t *testing.T) {
 	cases := map[string]struct {
-		cluster *AzureCluster
-		output  *AzureCluster
+		cluster *infrav1.AzureCluster
+		output  *infrav1.AzureCluster
 	}{
 		"no bastion set": {
-			cluster: &AzureCluster{
+			cluster: &infrav1.AzureCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "foo",
 				},
-				Spec: AzureClusterSpec{},
+				Spec: infrav1.AzureClusterSpec{},
 			},
-			output: &AzureCluster{
+			output: &infrav1.AzureCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "foo",
 				},
-				Spec: AzureClusterSpec{},
+				Spec: infrav1.AzureClusterSpec{},
 			},
 		},
 		"azure bastion enabled with no settings": {
-			cluster: &AzureCluster{
+			cluster: &infrav1.AzureCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "foo",
 				},
-				Spec: AzureClusterSpec{
-					BastionSpec: BastionSpec{
-						AzureBastion: &AzureBastion{},
+				Spec: infrav1.AzureClusterSpec{
+					BastionSpec: infrav1.BastionSpec{
+						AzureBastion: &infrav1.AzureBastion{},
 					},
 				},
 			},
-			output: &AzureCluster{
+			output: &infrav1.AzureCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "foo",
 				},
-				Spec: AzureClusterSpec{
-					BastionSpec: BastionSpec{
-						AzureBastion: &AzureBastion{
+				Spec: infrav1.AzureClusterSpec{
+					BastionSpec: infrav1.BastionSpec{
+						AzureBastion: &infrav1.AzureBastion{
 							Name: "foo-azure-bastion",
-							Subnet: SubnetSpec{
+							Subnet: infrav1.SubnetSpec{
 
-								SubnetClassSpec: SubnetClassSpec{
+								SubnetClassSpec: infrav1.SubnetClassSpec{
 									CIDRBlocks: []string{DefaultAzureBastionSubnetCIDR},
 									Role:       DefaultAzureBastionSubnetRole,
 									Name:       "AzureBastionSubnet",
 								},
 							},
-							PublicIP: PublicIPSpec{
+							PublicIP: infrav1.PublicIPSpec{
 								Name: "foo-azure-bastion-pip",
 							},
 						},
@@ -2662,35 +2662,35 @@ func TestBastionDefault(t *testing.T) {
 			},
 		},
 		"azure bastion enabled with name set": {
-			cluster: &AzureCluster{
+			cluster: &infrav1.AzureCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "foo",
 				},
-				Spec: AzureClusterSpec{
-					BastionSpec: BastionSpec{
-						AzureBastion: &AzureBastion{
+				Spec: infrav1.AzureClusterSpec{
+					BastionSpec: infrav1.BastionSpec{
+						AzureBastion: &infrav1.AzureBastion{
 							Name: "my-fancy-name",
 						},
 					},
 				},
 			},
-			output: &AzureCluster{
+			output: &infrav1.AzureCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "foo",
 				},
-				Spec: AzureClusterSpec{
-					BastionSpec: BastionSpec{
-						AzureBastion: &AzureBastion{
+				Spec: infrav1.AzureClusterSpec{
+					BastionSpec: infrav1.BastionSpec{
+						AzureBastion: &infrav1.AzureBastion{
 							Name: "my-fancy-name",
-							Subnet: SubnetSpec{
+							Subnet: infrav1.SubnetSpec{
 
-								SubnetClassSpec: SubnetClassSpec{
+								SubnetClassSpec: infrav1.SubnetClassSpec{
 									CIDRBlocks: []string{DefaultAzureBastionSubnetCIDR},
 									Role:       DefaultAzureBastionSubnetRole,
 									Name:       "AzureBastionSubnet",
 								},
 							},
-							PublicIP: PublicIPSpec{
+							PublicIP: infrav1.PublicIPSpec{
 								Name: "foo-azure-bastion-pip",
 							},
 						},
@@ -2699,34 +2699,34 @@ func TestBastionDefault(t *testing.T) {
 			},
 		},
 		"azure bastion enabled with subnet partially set": {
-			cluster: &AzureCluster{
+			cluster: &infrav1.AzureCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "foo",
 				},
-				Spec: AzureClusterSpec{
-					BastionSpec: BastionSpec{
-						AzureBastion: &AzureBastion{
-							Subnet: SubnetSpec{},
+				Spec: infrav1.AzureClusterSpec{
+					BastionSpec: infrav1.BastionSpec{
+						AzureBastion: &infrav1.AzureBastion{
+							Subnet: infrav1.SubnetSpec{},
 						},
 					},
 				},
 			},
-			output: &AzureCluster{
+			output: &infrav1.AzureCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "foo",
 				},
-				Spec: AzureClusterSpec{
-					BastionSpec: BastionSpec{
-						AzureBastion: &AzureBastion{
+				Spec: infrav1.AzureClusterSpec{
+					BastionSpec: infrav1.BastionSpec{
+						AzureBastion: &infrav1.AzureBastion{
 							Name: "foo-azure-bastion",
-							Subnet: SubnetSpec{
-								SubnetClassSpec: SubnetClassSpec{
+							Subnet: infrav1.SubnetSpec{
+								SubnetClassSpec: infrav1.SubnetClassSpec{
 									CIDRBlocks: []string{DefaultAzureBastionSubnetCIDR},
 									Role:       DefaultAzureBastionSubnetRole,
 									Name:       "AzureBastionSubnet",
 								},
 							},
-							PublicIP: PublicIPSpec{
+							PublicIP: infrav1.PublicIPSpec{
 								Name: "foo-azure-bastion-pip",
 							},
 						},
@@ -2735,15 +2735,15 @@ func TestBastionDefault(t *testing.T) {
 			},
 		},
 		"azure bastion enabled with subnet fully set": {
-			cluster: &AzureCluster{
+			cluster: &infrav1.AzureCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "foo",
 				},
-				Spec: AzureClusterSpec{
-					BastionSpec: BastionSpec{
-						AzureBastion: &AzureBastion{
-							Subnet: SubnetSpec{
-								SubnetClassSpec: SubnetClassSpec{
+				Spec: infrav1.AzureClusterSpec{
+					BastionSpec: infrav1.BastionSpec{
+						AzureBastion: &infrav1.AzureBastion{
+							Subnet: infrav1.SubnetSpec{
+								SubnetClassSpec: infrav1.SubnetClassSpec{
 									CIDRBlocks: []string{"10.10.0.0/16"},
 									Name:       "my-superfancy-name",
 								},
@@ -2752,22 +2752,22 @@ func TestBastionDefault(t *testing.T) {
 					},
 				},
 			},
-			output: &AzureCluster{
+			output: &infrav1.AzureCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "foo",
 				},
-				Spec: AzureClusterSpec{
-					BastionSpec: BastionSpec{
-						AzureBastion: &AzureBastion{
+				Spec: infrav1.AzureClusterSpec{
+					BastionSpec: infrav1.BastionSpec{
+						AzureBastion: &infrav1.AzureBastion{
 							Name: "foo-azure-bastion",
-							Subnet: SubnetSpec{
-								SubnetClassSpec: SubnetClassSpec{
+							Subnet: infrav1.SubnetSpec{
+								SubnetClassSpec: infrav1.SubnetClassSpec{
 									CIDRBlocks: []string{"10.10.0.0/16"},
 									Role:       DefaultAzureBastionSubnetRole,
 									Name:       "my-superfancy-name",
 								},
 							},
-							PublicIP: PublicIPSpec{
+							PublicIP: infrav1.PublicIPSpec{
 								Name: "foo-azure-bastion-pip",
 							},
 						},
@@ -2776,36 +2776,36 @@ func TestBastionDefault(t *testing.T) {
 			},
 		},
 		"azure bastion enabled with public IP name set": {
-			cluster: &AzureCluster{
+			cluster: &infrav1.AzureCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "foo",
 				},
-				Spec: AzureClusterSpec{
-					BastionSpec: BastionSpec{
-						AzureBastion: &AzureBastion{
-							PublicIP: PublicIPSpec{
+				Spec: infrav1.AzureClusterSpec{
+					BastionSpec: infrav1.BastionSpec{
+						AzureBastion: &infrav1.AzureBastion{
+							PublicIP: infrav1.PublicIPSpec{
 								Name: "my-ultrafancy-pip-name",
 							},
 						},
 					},
 				},
 			},
-			output: &AzureCluster{
+			output: &infrav1.AzureCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "foo",
 				},
-				Spec: AzureClusterSpec{
-					BastionSpec: BastionSpec{
-						AzureBastion: &AzureBastion{
+				Spec: infrav1.AzureClusterSpec{
+					BastionSpec: infrav1.BastionSpec{
+						AzureBastion: &infrav1.AzureBastion{
 							Name: "foo-azure-bastion",
-							Subnet: SubnetSpec{
-								SubnetClassSpec: SubnetClassSpec{
+							Subnet: infrav1.SubnetSpec{
+								SubnetClassSpec: infrav1.SubnetClassSpec{
 									CIDRBlocks: []string{DefaultAzureBastionSubnetCIDR},
 									Role:       DefaultAzureBastionSubnetRole,
 									Name:       "AzureBastionSubnet",
 								},
 							},
-							PublicIP: PublicIPSpec{
+							PublicIP: infrav1.PublicIPSpec{
 								Name: "my-ultrafancy-pip-name",
 							},
 						},

--- a/internal/api/v1beta1/azureclustertemplate_default.go
+++ b/internal/api/v1beta1/azureclustertemplate_default.go
@@ -19,17 +19,17 @@ package v1beta1
 import (
 	"fmt"
 
-	. "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
+	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 )
 
 // SetDefaultsAzureClusterTemplate sets default values for an AzureClusterTemplate.
-func SetDefaultsAzureClusterTemplate(c *AzureClusterTemplate) {
+func SetDefaultsAzureClusterTemplate(c *infrav1.AzureClusterTemplate) {
 	AzureClusterClassSpecSetDefaults(&c.Spec.Template.Spec.AzureClusterClassSpec)
 	setDefaultAzureClusterTemplateNetworkTemplateSpec(c)
 }
 
 // setDefaultAzureClusterTemplateNetworkTemplateSpec sets default values for an AzureClusterTemplate's NetworkTemplateSpec.
-func setDefaultAzureClusterTemplateNetworkTemplateSpec(c *AzureClusterTemplate) {
+func setDefaultAzureClusterTemplateNetworkTemplateSpec(c *infrav1.AzureClusterTemplate) {
 	setDefaultAzureClusterTemplateVnetTemplate(c)
 	setDefaultAzureClusterTemplateBastionTemplate(c)
 	setDefaultAzureClusterTemplateSubnetsTemplate(c)
@@ -41,12 +41,12 @@ func setDefaultAzureClusterTemplateNetworkTemplateSpec(c *AzureClusterTemplate) 
 }
 
 // setDefaultAzureClusterTemplateVnetTemplate sets default values for an AzureClusterTemplate's VNet template.
-func setDefaultAzureClusterTemplateVnetTemplate(c *AzureClusterTemplate) {
+func setDefaultAzureClusterTemplateVnetTemplate(c *infrav1.AzureClusterTemplate) {
 	VnetClassSpecSetDefaults(&c.Spec.Template.Spec.NetworkSpec.Vnet.VnetClassSpec)
 }
 
 // setDefaultAzureClusterTemplateBastionTemplate sets default values for an AzureClusterTemplate's bastion template.
-func setDefaultAzureClusterTemplateBastionTemplate(c *AzureClusterTemplate) {
+func setDefaultAzureClusterTemplateBastionTemplate(c *infrav1.AzureClusterTemplate) {
 	if c.Spec.Template.Spec.BastionSpec.AzureBastion != nil {
 		// Ensure defaults for Subnet settings.
 		if len(c.Spec.Template.Spec.BastionSpec.AzureBastion.Subnet.CIDRBlocks) == 0 {
@@ -59,22 +59,22 @@ func setDefaultAzureClusterTemplateBastionTemplate(c *AzureClusterTemplate) {
 }
 
 // setDefaultAzureClusterTemplateSubnetsTemplate sets default values for an AzureClusterTemplate's subnet templates.
-func setDefaultAzureClusterTemplateSubnetsTemplate(c *AzureClusterTemplate) {
-	clusterSubnet, err := c.Spec.Template.Spec.NetworkSpec.GetSubnetTemplate(SubnetCluster)
+func setDefaultAzureClusterTemplateSubnetsTemplate(c *infrav1.AzureClusterTemplate) {
+	clusterSubnet, err := c.Spec.Template.Spec.NetworkSpec.GetSubnetTemplate(infrav1.SubnetCluster)
 	clusterSubnetExists := err == nil
 	if clusterSubnetExists {
 		SubnetClassSpecSetDefaults(&clusterSubnet.SubnetClassSpec, DefaultClusterSubnetCIDR)
 		SecurityGroupClassSetDefaults(&clusterSubnet.SecurityGroup)
-		c.Spec.Template.Spec.NetworkSpec.UpdateSubnetTemplate(clusterSubnet, SubnetCluster)
+		c.Spec.Template.Spec.NetworkSpec.UpdateSubnetTemplate(clusterSubnet, infrav1.SubnetCluster)
 	}
 
-	cpSubnet, errcp := c.Spec.Template.Spec.NetworkSpec.GetSubnetTemplate(SubnetControlPlane)
+	cpSubnet, errcp := c.Spec.Template.Spec.NetworkSpec.GetSubnetTemplate(infrav1.SubnetControlPlane)
 	if errcp == nil {
 		SubnetClassSpecSetDefaults(&cpSubnet.SubnetClassSpec, DefaultControlPlaneSubnetCIDR)
 		SecurityGroupClassSetDefaults(&cpSubnet.SecurityGroup)
-		c.Spec.Template.Spec.NetworkSpec.UpdateSubnetTemplate(cpSubnet, SubnetControlPlane)
+		c.Spec.Template.Spec.NetworkSpec.UpdateSubnetTemplate(cpSubnet, infrav1.SubnetControlPlane)
 	} else if errcp != nil && !clusterSubnetExists {
-		cpSubnet = SubnetTemplateSpec{SubnetClassSpec: SubnetClassSpec{Role: SubnetControlPlane}}
+		cpSubnet = infrav1.SubnetTemplateSpec{SubnetClassSpec: infrav1.SubnetClassSpec{Role: infrav1.SubnetControlPlane}}
 		SubnetClassSpecSetDefaults(&cpSubnet.SubnetClassSpec, DefaultControlPlaneSubnetCIDR)
 		SecurityGroupClassSetDefaults(&cpSubnet.SecurityGroup)
 		c.Spec.Template.Spec.NetworkSpec.Subnets = append(c.Spec.Template.Spec.NetworkSpec.Subnets, cpSubnet)
@@ -83,7 +83,7 @@ func setDefaultAzureClusterTemplateSubnetsTemplate(c *AzureClusterTemplate) {
 	var nodeSubnetFound bool
 	var nodeSubnetCounter int
 	for i, subnet := range c.Spec.Template.Spec.NetworkSpec.Subnets {
-		if subnet.Role != SubnetNode {
+		if subnet.Role != infrav1.SubnetNode {
 			continue
 		}
 		nodeSubnetCounter++
@@ -94,9 +94,9 @@ func setDefaultAzureClusterTemplateSubnetsTemplate(c *AzureClusterTemplate) {
 	}
 
 	if !nodeSubnetFound && !clusterSubnetExists {
-		nodeSubnet := SubnetTemplateSpec{
-			SubnetClassSpec: SubnetClassSpec{
-				Role:       SubnetNode,
+		nodeSubnet := infrav1.SubnetTemplateSpec{
+			SubnetClassSpec: infrav1.SubnetClassSpec{
+				Role:       infrav1.SubnetNode,
 				CIDRBlocks: []string{DefaultNodeSubnetCIDR},
 			},
 		}
@@ -105,15 +105,15 @@ func setDefaultAzureClusterTemplateSubnetsTemplate(c *AzureClusterTemplate) {
 }
 
 // setDefaultAzureClusterTemplateNodeOutboundLB sets default values for an AzureClusterTemplate's node outbound LB.
-func setDefaultAzureClusterTemplateNodeOutboundLB(c *AzureClusterTemplate) {
+func setDefaultAzureClusterTemplateNodeOutboundLB(c *infrav1.AzureClusterTemplate) {
 	if c.Spec.Template.Spec.NetworkSpec.NodeOutboundLB == nil {
-		if c.Spec.Template.Spec.NetworkSpec.APIServerLB.Type == Internal {
+		if c.Spec.Template.Spec.NetworkSpec.APIServerLB.Type == infrav1.Internal {
 			return
 		}
 
 		var needsOutboundLB bool
 		for _, subnet := range c.Spec.Template.Spec.NetworkSpec.Subnets {
-			if (subnet.Role == SubnetNode || subnet.Role == SubnetCluster) && subnet.IsIPv6Enabled() {
+			if (subnet.Role == infrav1.SubnetNode || subnet.Role == infrav1.SubnetCluster) && subnet.IsIPv6Enabled() {
 				needsOutboundLB = true
 				break
 			}
@@ -126,14 +126,14 @@ func setDefaultAzureClusterTemplateNodeOutboundLB(c *AzureClusterTemplate) {
 			return
 		}
 
-		c.Spec.Template.Spec.NetworkSpec.NodeOutboundLB = &LoadBalancerClassSpec{}
+		c.Spec.Template.Spec.NetworkSpec.NodeOutboundLB = &infrav1.LoadBalancerClassSpec{}
 	}
 
 	setDefaultLoadBalancerClassSpecNodeOutboundLB(c.Spec.Template.Spec.NetworkSpec.NodeOutboundLB)
 }
 
 // setDefaultAzureClusterTemplateControlPlaneOutboundLB sets default values for an AzureClusterTemplate's control plane outbound LB.
-func setDefaultAzureClusterTemplateControlPlaneOutboundLB(c *AzureClusterTemplate) {
+func setDefaultAzureClusterTemplateControlPlaneOutboundLB(c *infrav1.AzureClusterTemplate) {
 	lb := c.Spec.Template.Spec.NetworkSpec.ControlPlaneOutboundLB
 	if lb == nil {
 		return

--- a/internal/api/v1beta1/azureclustertemplate_default_test.go
+++ b/internal/api/v1beta1/azureclustertemplate_default_test.go
@@ -24,35 +24,35 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 
-	. "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
+	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 )
 
 func TestVnetTemplateDefaults(t *testing.T) {
 	cases := []struct {
 		name            string
-		clusterTemplate *AzureClusterTemplate
-		outputTemplate  *AzureClusterTemplate
+		clusterTemplate *infrav1.AzureClusterTemplate
+		outputTemplate  *infrav1.AzureClusterTemplate
 	}{
 		{
 			name: "vnet not specified",
-			clusterTemplate: &AzureClusterTemplate{
+			clusterTemplate: &infrav1.AzureClusterTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster-template",
 				},
-				Spec: AzureClusterTemplateSpec{
-					Template: AzureClusterTemplateResource{},
+				Spec: infrav1.AzureClusterTemplateSpec{
+					Template: infrav1.AzureClusterTemplateResource{},
 				},
 			},
-			outputTemplate: &AzureClusterTemplate{
+			outputTemplate: &infrav1.AzureClusterTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster-template",
 				},
-				Spec: AzureClusterTemplateSpec{
-					Template: AzureClusterTemplateResource{
-						Spec: AzureClusterTemplateResourceSpec{
-							NetworkSpec: NetworkTemplateSpec{
-								Vnet: VnetTemplateSpec{
-									VnetClassSpec: VnetClassSpec{
+				Spec: infrav1.AzureClusterTemplateSpec{
+					Template: infrav1.AzureClusterTemplateResource{
+						Spec: infrav1.AzureClusterTemplateResourceSpec{
+							NetworkSpec: infrav1.NetworkTemplateSpec{
+								Vnet: infrav1.VnetTemplateSpec{
+									VnetClassSpec: infrav1.VnetClassSpec{
 										CIDRBlocks: []string{DefaultVnetCIDR},
 									},
 								},
@@ -64,16 +64,16 @@ func TestVnetTemplateDefaults(t *testing.T) {
 		},
 		{
 			name: "custom CIDR",
-			clusterTemplate: &AzureClusterTemplate{
+			clusterTemplate: &infrav1.AzureClusterTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster-template",
 				},
-				Spec: AzureClusterTemplateSpec{
-					Template: AzureClusterTemplateResource{
-						Spec: AzureClusterTemplateResourceSpec{
-							NetworkSpec: NetworkTemplateSpec{
-								Vnet: VnetTemplateSpec{
-									VnetClassSpec: VnetClassSpec{
+				Spec: infrav1.AzureClusterTemplateSpec{
+					Template: infrav1.AzureClusterTemplateResource{
+						Spec: infrav1.AzureClusterTemplateResourceSpec{
+							NetworkSpec: infrav1.NetworkTemplateSpec{
+								Vnet: infrav1.VnetTemplateSpec{
+									VnetClassSpec: infrav1.VnetClassSpec{
 										CIDRBlocks: []string{"10.0.0.0/16"},
 									},
 								},
@@ -82,16 +82,16 @@ func TestVnetTemplateDefaults(t *testing.T) {
 					},
 				},
 			},
-			outputTemplate: &AzureClusterTemplate{
+			outputTemplate: &infrav1.AzureClusterTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster-template",
 				},
-				Spec: AzureClusterTemplateSpec{
-					Template: AzureClusterTemplateResource{
-						Spec: AzureClusterTemplateResourceSpec{
-							NetworkSpec: NetworkTemplateSpec{
-								Vnet: VnetTemplateSpec{
-									VnetClassSpec: VnetClassSpec{
+				Spec: infrav1.AzureClusterTemplateSpec{
+					Template: infrav1.AzureClusterTemplateResource{
+						Spec: infrav1.AzureClusterTemplateResourceSpec{
+							NetworkSpec: infrav1.NetworkTemplateSpec{
+								Vnet: infrav1.VnetTemplateSpec{
+									VnetClassSpec: infrav1.VnetClassSpec{
 										CIDRBlocks: []string{"10.0.0.0/16"},
 									},
 								},
@@ -103,16 +103,16 @@ func TestVnetTemplateDefaults(t *testing.T) {
 		},
 		{
 			name: "IPv6 enabled",
-			clusterTemplate: &AzureClusterTemplate{
+			clusterTemplate: &infrav1.AzureClusterTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster-template",
 				},
-				Spec: AzureClusterTemplateSpec{
-					Template: AzureClusterTemplateResource{
-						Spec: AzureClusterTemplateResourceSpec{
-							NetworkSpec: NetworkTemplateSpec{
-								Vnet: VnetTemplateSpec{
-									VnetClassSpec: VnetClassSpec{
+				Spec: infrav1.AzureClusterTemplateSpec{
+					Template: infrav1.AzureClusterTemplateResource{
+						Spec: infrav1.AzureClusterTemplateResourceSpec{
+							NetworkSpec: infrav1.NetworkTemplateSpec{
+								Vnet: infrav1.VnetTemplateSpec{
+									VnetClassSpec: infrav1.VnetClassSpec{
 										CIDRBlocks: []string{"2001:1234:5678:9a00::/56"},
 									},
 								},
@@ -121,16 +121,16 @@ func TestVnetTemplateDefaults(t *testing.T) {
 					},
 				},
 			},
-			outputTemplate: &AzureClusterTemplate{
+			outputTemplate: &infrav1.AzureClusterTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster-template",
 				},
-				Spec: AzureClusterTemplateSpec{
-					Template: AzureClusterTemplateResource{
-						Spec: AzureClusterTemplateResourceSpec{
-							NetworkSpec: NetworkTemplateSpec{
-								Vnet: VnetTemplateSpec{
-									VnetClassSpec: VnetClassSpec{
+				Spec: infrav1.AzureClusterTemplateSpec{
+					Template: infrav1.AzureClusterTemplateResource{
+						Spec: infrav1.AzureClusterTemplateResourceSpec{
+							NetworkSpec: infrav1.NetworkTemplateSpec{
+								Vnet: infrav1.VnetTemplateSpec{
+									VnetClassSpec: infrav1.VnetClassSpec{
 										CIDRBlocks: []string{"2001:1234:5678:9a00::/56"},
 									},
 								},
@@ -159,41 +159,41 @@ func TestVnetTemplateDefaults(t *testing.T) {
 func TestSubnetsTemplateDefaults(t *testing.T) {
 	cases := []struct {
 		name            string
-		clusterTemplate *AzureClusterTemplate
-		outputTemplate  *AzureClusterTemplate
+		clusterTemplate *infrav1.AzureClusterTemplate
+		outputTemplate  *infrav1.AzureClusterTemplate
 	}{
 		{
 			name: "no subnets",
-			clusterTemplate: &AzureClusterTemplate{
+			clusterTemplate: &infrav1.AzureClusterTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster-template",
 				},
-				Spec: AzureClusterTemplateSpec{
-					Template: AzureClusterTemplateResource{
-						Spec: AzureClusterTemplateResourceSpec{
-							NetworkSpec: NetworkTemplateSpec{},
+				Spec: infrav1.AzureClusterTemplateSpec{
+					Template: infrav1.AzureClusterTemplateResource{
+						Spec: infrav1.AzureClusterTemplateResourceSpec{
+							NetworkSpec: infrav1.NetworkTemplateSpec{},
 						},
 					},
 				},
 			},
-			outputTemplate: &AzureClusterTemplate{
+			outputTemplate: &infrav1.AzureClusterTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster-template",
 				},
-				Spec: AzureClusterTemplateSpec{
-					Template: AzureClusterTemplateResource{
-						Spec: AzureClusterTemplateResourceSpec{
-							NetworkSpec: NetworkTemplateSpec{
-								Subnets: SubnetTemplatesSpec{
+				Spec: infrav1.AzureClusterTemplateSpec{
+					Template: infrav1.AzureClusterTemplateResource{
+						Spec: infrav1.AzureClusterTemplateResourceSpec{
+							NetworkSpec: infrav1.NetworkTemplateSpec{
+								Subnets: infrav1.SubnetTemplatesSpec{
 									{
-										SubnetClassSpec: SubnetClassSpec{
-											Role:       SubnetControlPlane,
+										SubnetClassSpec: infrav1.SubnetClassSpec{
+											Role:       infrav1.SubnetControlPlane,
 											CIDRBlocks: []string{DefaultControlPlaneSubnetCIDR},
 										},
 									},
 									{
-										SubnetClassSpec: SubnetClassSpec{
-											Role:       SubnetNode,
+										SubnetClassSpec: infrav1.SubnetClassSpec{
+											Role:       infrav1.SubnetNode,
 											CIDRBlocks: []string{DefaultNodeSubnetCIDR},
 										},
 									},
@@ -206,27 +206,27 @@ func TestSubnetsTemplateDefaults(t *testing.T) {
 		},
 		{
 			name: "subnet with custom attributes",
-			clusterTemplate: &AzureClusterTemplate{
+			clusterTemplate: &infrav1.AzureClusterTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster-template",
 				},
-				Spec: AzureClusterTemplateSpec{
-					Template: AzureClusterTemplateResource{
-						Spec: AzureClusterTemplateResourceSpec{
-							NetworkSpec: NetworkTemplateSpec{
-								Subnets: SubnetTemplatesSpec{
+				Spec: infrav1.AzureClusterTemplateSpec{
+					Template: infrav1.AzureClusterTemplateResource{
+						Spec: infrav1.AzureClusterTemplateResourceSpec{
+							NetworkSpec: infrav1.NetworkTemplateSpec{
+								Subnets: infrav1.SubnetTemplatesSpec{
 									{
-										SubnetClassSpec: SubnetClassSpec{
-											Role:       SubnetControlPlane,
+										SubnetClassSpec: infrav1.SubnetClassSpec{
+											Role:       infrav1.SubnetControlPlane,
 											CIDRBlocks: []string{"10.0.0.16/24"},
 										},
 									},
 									{
-										SubnetClassSpec: SubnetClassSpec{
-											Role:       SubnetNode,
+										SubnetClassSpec: infrav1.SubnetClassSpec{
+											Role:       infrav1.SubnetNode,
 											CIDRBlocks: []string{"10.1.0.16/24"},
 										},
-										NatGateway: NatGatewayClassSpec{
+										NatGateway: infrav1.NatGatewayClassSpec{
 											Name: "foo-natgw",
 										},
 									},
@@ -236,27 +236,27 @@ func TestSubnetsTemplateDefaults(t *testing.T) {
 					},
 				},
 			},
-			outputTemplate: &AzureClusterTemplate{
+			outputTemplate: &infrav1.AzureClusterTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster-template",
 				},
-				Spec: AzureClusterTemplateSpec{
-					Template: AzureClusterTemplateResource{
-						Spec: AzureClusterTemplateResourceSpec{
-							NetworkSpec: NetworkTemplateSpec{
-								Subnets: SubnetTemplatesSpec{
+				Spec: infrav1.AzureClusterTemplateSpec{
+					Template: infrav1.AzureClusterTemplateResource{
+						Spec: infrav1.AzureClusterTemplateResourceSpec{
+							NetworkSpec: infrav1.NetworkTemplateSpec{
+								Subnets: infrav1.SubnetTemplatesSpec{
 									{
-										SubnetClassSpec: SubnetClassSpec{
-											Role:       SubnetControlPlane,
+										SubnetClassSpec: infrav1.SubnetClassSpec{
+											Role:       infrav1.SubnetControlPlane,
 											CIDRBlocks: []string{"10.0.0.16/24"},
 										},
 									},
 									{
-										SubnetClassSpec: SubnetClassSpec{
-											Role:       SubnetNode,
+										SubnetClassSpec: infrav1.SubnetClassSpec{
+											Role:       infrav1.SubnetNode,
 											CIDRBlocks: []string{"10.1.0.16/24"},
 										},
-										NatGateway: NatGatewayClassSpec{Name: "foo-natgw"},
+										NatGateway: infrav1.NatGatewayClassSpec{Name: "foo-natgw"},
 									},
 								},
 							},
@@ -267,22 +267,22 @@ func TestSubnetsTemplateDefaults(t *testing.T) {
 		},
 		{
 			name: "subnet with custom attributes and security groups",
-			clusterTemplate: &AzureClusterTemplate{
+			clusterTemplate: &infrav1.AzureClusterTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster-template",
 				},
-				Spec: AzureClusterTemplateSpec{
-					Template: AzureClusterTemplateResource{
-						Spec: AzureClusterTemplateResourceSpec{
-							NetworkSpec: NetworkTemplateSpec{
-								Subnets: SubnetTemplatesSpec{
+				Spec: infrav1.AzureClusterTemplateSpec{
+					Template: infrav1.AzureClusterTemplateResource{
+						Spec: infrav1.AzureClusterTemplateResourceSpec{
+							NetworkSpec: infrav1.NetworkTemplateSpec{
+								Subnets: infrav1.SubnetTemplatesSpec{
 									{
-										SubnetClassSpec: SubnetClassSpec{
-											Role:       SubnetControlPlane,
+										SubnetClassSpec: infrav1.SubnetClassSpec{
+											Role:       infrav1.SubnetControlPlane,
 											CIDRBlocks: []string{"10.0.0.16/24"},
 										},
-										SecurityGroup: SecurityGroupClass{
-											SecurityRules: []SecurityRule{
+										SecurityGroup: infrav1.SecurityGroupClass{
+											SecurityRules: []infrav1.SecurityRule{
 												{
 													Name:             "allow_port_50000",
 													Description:      "allow port 50000",
@@ -292,21 +292,21 @@ func TestSubnetsTemplateDefaults(t *testing.T) {
 													DestinationPorts: ptr.To("*"),
 													Source:           ptr.To("*"),
 													Destination:      ptr.To("*"),
-													Action:           SecurityRuleActionAllow,
+													Action:           infrav1.SecurityRuleActionAllow,
 												},
 											},
 										},
 									},
 									{
-										SubnetClassSpec: SubnetClassSpec{
-											Role:       SubnetNode,
+										SubnetClassSpec: infrav1.SubnetClassSpec{
+											Role:       infrav1.SubnetNode,
 											CIDRBlocks: []string{"10.1.0.16/24"},
 										},
-										NatGateway: NatGatewayClassSpec{
+										NatGateway: infrav1.NatGatewayClassSpec{
 											Name: "foo-natgw",
 										},
-										SecurityGroup: SecurityGroupClass{
-											SecurityRules: []SecurityRule{
+										SecurityGroup: infrav1.SecurityGroupClass{
+											SecurityRules: []infrav1.SecurityRule{
 												{
 													Name:             "allow_port_50000",
 													Description:      "allow port 50000",
@@ -316,7 +316,7 @@ func TestSubnetsTemplateDefaults(t *testing.T) {
 													DestinationPorts: ptr.To("*"),
 													Source:           ptr.To("*"),
 													Destination:      ptr.To("*"),
-													Action:           SecurityRuleActionAllow,
+													Action:           infrav1.SecurityRuleActionAllow,
 												},
 											},
 										},
@@ -327,22 +327,22 @@ func TestSubnetsTemplateDefaults(t *testing.T) {
 					},
 				},
 			},
-			outputTemplate: &AzureClusterTemplate{
+			outputTemplate: &infrav1.AzureClusterTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster-template",
 				},
-				Spec: AzureClusterTemplateSpec{
-					Template: AzureClusterTemplateResource{
-						Spec: AzureClusterTemplateResourceSpec{
-							NetworkSpec: NetworkTemplateSpec{
-								Subnets: SubnetTemplatesSpec{
+				Spec: infrav1.AzureClusterTemplateSpec{
+					Template: infrav1.AzureClusterTemplateResource{
+						Spec: infrav1.AzureClusterTemplateResourceSpec{
+							NetworkSpec: infrav1.NetworkTemplateSpec{
+								Subnets: infrav1.SubnetTemplatesSpec{
 									{
-										SubnetClassSpec: SubnetClassSpec{
-											Role:       SubnetControlPlane,
+										SubnetClassSpec: infrav1.SubnetClassSpec{
+											Role:       infrav1.SubnetControlPlane,
 											CIDRBlocks: []string{"10.0.0.16/24"},
 										},
-										SecurityGroup: SecurityGroupClass{
-											SecurityRules: SecurityRules{
+										SecurityGroup: infrav1.SecurityGroupClass{
+											SecurityRules: infrav1.SecurityRules{
 												{
 													Name:             "allow_port_50000",
 													Description:      "allow port 50000",
@@ -352,20 +352,20 @@ func TestSubnetsTemplateDefaults(t *testing.T) {
 													DestinationPorts: ptr.To("*"),
 													Source:           ptr.To("*"),
 													Destination:      ptr.To("*"),
-													Direction:        SecurityRuleDirectionInbound,
-													Action:           SecurityRuleActionAllow,
+													Direction:        infrav1.SecurityRuleDirectionInbound,
+													Action:           infrav1.SecurityRuleActionAllow,
 												},
 											},
 										},
 									},
 									{
-										SubnetClassSpec: SubnetClassSpec{
-											Role:       SubnetNode,
+										SubnetClassSpec: infrav1.SubnetClassSpec{
+											Role:       infrav1.SubnetNode,
 											CIDRBlocks: []string{"10.1.0.16/24"},
 										},
-										NatGateway: NatGatewayClassSpec{Name: "foo-natgw"},
-										SecurityGroup: SecurityGroupClass{
-											SecurityRules: SecurityRules{
+										NatGateway: infrav1.NatGatewayClassSpec{Name: "foo-natgw"},
+										SecurityGroup: infrav1.SecurityGroupClass{
+											SecurityRules: infrav1.SecurityRules{
 												{
 													Name:             "allow_port_50000",
 													Description:      "allow port 50000",
@@ -375,8 +375,8 @@ func TestSubnetsTemplateDefaults(t *testing.T) {
 													DestinationPorts: ptr.To("*"),
 													Source:           ptr.To("*"),
 													Destination:      ptr.To("*"),
-													Direction:        SecurityRuleDirectionInbound,
-													Action:           SecurityRuleActionAllow,
+													Direction:        infrav1.SecurityRuleDirectionInbound,
+													Action:           infrav1.SecurityRuleActionAllow,
 												},
 											},
 										},
@@ -390,23 +390,23 @@ func TestSubnetsTemplateDefaults(t *testing.T) {
 		},
 		{
 			name: "subnets specified",
-			clusterTemplate: &AzureClusterTemplate{
+			clusterTemplate: &infrav1.AzureClusterTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster-template",
 				},
-				Spec: AzureClusterTemplateSpec{
-					Template: AzureClusterTemplateResource{
-						Spec: AzureClusterTemplateResourceSpec{
-							NetworkSpec: NetworkTemplateSpec{
-								Subnets: SubnetTemplatesSpec{
+				Spec: infrav1.AzureClusterTemplateSpec{
+					Template: infrav1.AzureClusterTemplateResource{
+						Spec: infrav1.AzureClusterTemplateResourceSpec{
+							NetworkSpec: infrav1.NetworkTemplateSpec{
+								Subnets: infrav1.SubnetTemplatesSpec{
 									{
-										SubnetClassSpec: SubnetClassSpec{
-											Role: SubnetControlPlane,
+										SubnetClassSpec: infrav1.SubnetClassSpec{
+											Role: infrav1.SubnetControlPlane,
 										},
 									},
 									{
-										SubnetClassSpec: SubnetClassSpec{
-											Role: SubnetNode,
+										SubnetClassSpec: infrav1.SubnetClassSpec{
+											Role: infrav1.SubnetNode,
 										},
 									},
 								},
@@ -415,24 +415,24 @@ func TestSubnetsTemplateDefaults(t *testing.T) {
 					},
 				},
 			},
-			outputTemplate: &AzureClusterTemplate{
+			outputTemplate: &infrav1.AzureClusterTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster-template",
 				},
-				Spec: AzureClusterTemplateSpec{
-					Template: AzureClusterTemplateResource{
-						Spec: AzureClusterTemplateResourceSpec{
-							NetworkSpec: NetworkTemplateSpec{
-								Subnets: SubnetTemplatesSpec{
+				Spec: infrav1.AzureClusterTemplateSpec{
+					Template: infrav1.AzureClusterTemplateResource{
+						Spec: infrav1.AzureClusterTemplateResourceSpec{
+							NetworkSpec: infrav1.NetworkTemplateSpec{
+								Subnets: infrav1.SubnetTemplatesSpec{
 									{
-										SubnetClassSpec: SubnetClassSpec{
-											Role:       SubnetControlPlane,
+										SubnetClassSpec: infrav1.SubnetClassSpec{
+											Role:       infrav1.SubnetControlPlane,
 											CIDRBlocks: []string{DefaultControlPlaneSubnetCIDR},
 										},
 									},
 									{
-										SubnetClassSpec: SubnetClassSpec{
-											Role:       SubnetNode,
+										SubnetClassSpec: infrav1.SubnetClassSpec{
+											Role:       infrav1.SubnetNode,
 											CIDRBlocks: []string{DefaultNodeSubnetCIDR},
 										},
 									},
@@ -445,21 +445,21 @@ func TestSubnetsTemplateDefaults(t *testing.T) {
 		},
 		{
 			name: "cluster subnet with custom attributes",
-			clusterTemplate: &AzureClusterTemplate{
+			clusterTemplate: &infrav1.AzureClusterTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster-template",
 				},
-				Spec: AzureClusterTemplateSpec{
-					Template: AzureClusterTemplateResource{
-						Spec: AzureClusterTemplateResourceSpec{
-							NetworkSpec: NetworkTemplateSpec{
-								Subnets: SubnetTemplatesSpec{
+				Spec: infrav1.AzureClusterTemplateSpec{
+					Template: infrav1.AzureClusterTemplateResource{
+						Spec: infrav1.AzureClusterTemplateResourceSpec{
+							NetworkSpec: infrav1.NetworkTemplateSpec{
+								Subnets: infrav1.SubnetTemplatesSpec{
 									{
-										SubnetClassSpec: SubnetClassSpec{
-											Role:       SubnetCluster,
+										SubnetClassSpec: infrav1.SubnetClassSpec{
+											Role:       infrav1.SubnetCluster,
 											CIDRBlocks: []string{"10.1.0.16/24"},
 										},
-										NatGateway: NatGatewayClassSpec{
+										NatGateway: infrav1.NatGatewayClassSpec{
 											Name: "foo-natgw",
 										},
 									},
@@ -469,21 +469,21 @@ func TestSubnetsTemplateDefaults(t *testing.T) {
 					},
 				},
 			},
-			outputTemplate: &AzureClusterTemplate{
+			outputTemplate: &infrav1.AzureClusterTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster-template",
 				},
-				Spec: AzureClusterTemplateSpec{
-					Template: AzureClusterTemplateResource{
-						Spec: AzureClusterTemplateResourceSpec{
-							NetworkSpec: NetworkTemplateSpec{
-								Subnets: SubnetTemplatesSpec{
+				Spec: infrav1.AzureClusterTemplateSpec{
+					Template: infrav1.AzureClusterTemplateResource{
+						Spec: infrav1.AzureClusterTemplateResourceSpec{
+							NetworkSpec: infrav1.NetworkTemplateSpec{
+								Subnets: infrav1.SubnetTemplatesSpec{
 									{
-										SubnetClassSpec: SubnetClassSpec{
-											Role:       SubnetCluster,
+										SubnetClassSpec: infrav1.SubnetClassSpec{
+											Role:       infrav1.SubnetCluster,
 											CIDRBlocks: []string{"10.1.0.16/24"},
 										},
-										NatGateway: NatGatewayClassSpec{Name: "foo-natgw"},
+										NatGateway: infrav1.NatGatewayClassSpec{Name: "foo-natgw"},
 									},
 								},
 							},
@@ -494,18 +494,18 @@ func TestSubnetsTemplateDefaults(t *testing.T) {
 		},
 		{
 			name: "subnets specified",
-			clusterTemplate: &AzureClusterTemplate{
+			clusterTemplate: &infrav1.AzureClusterTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster-template",
 				},
-				Spec: AzureClusterTemplateSpec{
-					Template: AzureClusterTemplateResource{
-						Spec: AzureClusterTemplateResourceSpec{
-							NetworkSpec: NetworkTemplateSpec{
-								Subnets: SubnetTemplatesSpec{
+				Spec: infrav1.AzureClusterTemplateSpec{
+					Template: infrav1.AzureClusterTemplateResource{
+						Spec: infrav1.AzureClusterTemplateResourceSpec{
+							NetworkSpec: infrav1.NetworkTemplateSpec{
+								Subnets: infrav1.SubnetTemplatesSpec{
 									{
-										SubnetClassSpec: SubnetClassSpec{
-											Role: SubnetCluster,
+										SubnetClassSpec: infrav1.SubnetClassSpec{
+											Role: infrav1.SubnetCluster,
 										},
 									},
 								},
@@ -514,18 +514,18 @@ func TestSubnetsTemplateDefaults(t *testing.T) {
 					},
 				},
 			},
-			outputTemplate: &AzureClusterTemplate{
+			outputTemplate: &infrav1.AzureClusterTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster-template",
 				},
-				Spec: AzureClusterTemplateSpec{
-					Template: AzureClusterTemplateResource{
-						Spec: AzureClusterTemplateResourceSpec{
-							NetworkSpec: NetworkTemplateSpec{
-								Subnets: SubnetTemplatesSpec{
+				Spec: infrav1.AzureClusterTemplateSpec{
+					Template: infrav1.AzureClusterTemplateResource{
+						Spec: infrav1.AzureClusterTemplateResourceSpec{
+							NetworkSpec: infrav1.NetworkTemplateSpec{
+								Subnets: infrav1.SubnetTemplatesSpec{
 									{
-										SubnetClassSpec: SubnetClassSpec{
-											Role:       SubnetCluster,
+										SubnetClassSpec: infrav1.SubnetClassSpec{
+											Role:       infrav1.SubnetCluster,
 											CIDRBlocks: []string{DefaultClusterSubnetCIDR},
 										},
 									},
@@ -538,18 +538,18 @@ func TestSubnetsTemplateDefaults(t *testing.T) {
 		},
 		{
 			name: "only node subnet specified",
-			clusterTemplate: &AzureClusterTemplate{
+			clusterTemplate: &infrav1.AzureClusterTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster-template",
 				},
-				Spec: AzureClusterTemplateSpec{
-					Template: AzureClusterTemplateResource{
-						Spec: AzureClusterTemplateResourceSpec{
-							NetworkSpec: NetworkTemplateSpec{
-								Subnets: SubnetTemplatesSpec{
+				Spec: infrav1.AzureClusterTemplateSpec{
+					Template: infrav1.AzureClusterTemplateResource{
+						Spec: infrav1.AzureClusterTemplateResourceSpec{
+							NetworkSpec: infrav1.NetworkTemplateSpec{
+								Subnets: infrav1.SubnetTemplatesSpec{
 									{
-										SubnetClassSpec: SubnetClassSpec{
-											Role: SubnetNode,
+										SubnetClassSpec: infrav1.SubnetClassSpec{
+											Role: infrav1.SubnetNode,
 										},
 									},
 								},
@@ -558,24 +558,24 @@ func TestSubnetsTemplateDefaults(t *testing.T) {
 					},
 				},
 			},
-			outputTemplate: &AzureClusterTemplate{
+			outputTemplate: &infrav1.AzureClusterTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster-template",
 				},
-				Spec: AzureClusterTemplateSpec{
-					Template: AzureClusterTemplateResource{
-						Spec: AzureClusterTemplateResourceSpec{
-							NetworkSpec: NetworkTemplateSpec{
-								Subnets: SubnetTemplatesSpec{
+				Spec: infrav1.AzureClusterTemplateSpec{
+					Template: infrav1.AzureClusterTemplateResource{
+						Spec: infrav1.AzureClusterTemplateResourceSpec{
+							NetworkSpec: infrav1.NetworkTemplateSpec{
+								Subnets: infrav1.SubnetTemplatesSpec{
 									{
-										SubnetClassSpec: SubnetClassSpec{
-											Role:       SubnetNode,
+										SubnetClassSpec: infrav1.SubnetClassSpec{
+											Role:       infrav1.SubnetNode,
 											CIDRBlocks: []string{DefaultNodeSubnetCIDR},
 										},
 									},
 									{
-										SubnetClassSpec: SubnetClassSpec{
-											Role:       SubnetControlPlane,
+										SubnetClassSpec: infrav1.SubnetClassSpec{
+											Role:       infrav1.SubnetControlPlane,
 											CIDRBlocks: []string{DefaultControlPlaneSubnetCIDR},
 										},
 									},
@@ -588,24 +588,24 @@ func TestSubnetsTemplateDefaults(t *testing.T) {
 		},
 		{
 			name: "subnets specified with IPv6 enabled",
-			clusterTemplate: &AzureClusterTemplate{
+			clusterTemplate: &infrav1.AzureClusterTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster-template",
 				},
-				Spec: AzureClusterTemplateSpec{
-					Template: AzureClusterTemplateResource{
-						Spec: AzureClusterTemplateResourceSpec{
-							NetworkSpec: NetworkTemplateSpec{
-								Subnets: SubnetTemplatesSpec{
+				Spec: infrav1.AzureClusterTemplateSpec{
+					Template: infrav1.AzureClusterTemplateResource{
+						Spec: infrav1.AzureClusterTemplateResourceSpec{
+							NetworkSpec: infrav1.NetworkTemplateSpec{
+								Subnets: infrav1.SubnetTemplatesSpec{
 									{
-										SubnetClassSpec: SubnetClassSpec{
-											Role:       SubnetControlPlane,
+										SubnetClassSpec: infrav1.SubnetClassSpec{
+											Role:       infrav1.SubnetControlPlane,
 											CIDRBlocks: []string{"2001:beef::1/64"},
 										},
 									},
 									{
-										SubnetClassSpec: SubnetClassSpec{
-											Role:       SubnetNode,
+										SubnetClassSpec: infrav1.SubnetClassSpec{
+											Role:       infrav1.SubnetNode,
 											CIDRBlocks: []string{"2001:beea::1/64"},
 										},
 									},
@@ -615,24 +615,24 @@ func TestSubnetsTemplateDefaults(t *testing.T) {
 					},
 				},
 			},
-			outputTemplate: &AzureClusterTemplate{
+			outputTemplate: &infrav1.AzureClusterTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster-template",
 				},
-				Spec: AzureClusterTemplateSpec{
-					Template: AzureClusterTemplateResource{
-						Spec: AzureClusterTemplateResourceSpec{
-							NetworkSpec: NetworkTemplateSpec{
-								Subnets: SubnetTemplatesSpec{
+				Spec: infrav1.AzureClusterTemplateSpec{
+					Template: infrav1.AzureClusterTemplateResource{
+						Spec: infrav1.AzureClusterTemplateResourceSpec{
+							NetworkSpec: infrav1.NetworkTemplateSpec{
+								Subnets: infrav1.SubnetTemplatesSpec{
 									{
-										SubnetClassSpec: SubnetClassSpec{
-											Role:       SubnetControlPlane,
+										SubnetClassSpec: infrav1.SubnetClassSpec{
+											Role:       infrav1.SubnetControlPlane,
 											CIDRBlocks: []string{"2001:beef::1/64"},
 										},
 									},
 									{
-										SubnetClassSpec: SubnetClassSpec{
-											Role:       SubnetNode,
+										SubnetClassSpec: infrav1.SubnetClassSpec{
+											Role:       infrav1.SubnetNode,
 											CIDRBlocks: []string{"2001:beea::1/64"},
 										},
 									},
@@ -662,34 +662,34 @@ func TestSubnetsTemplateDefaults(t *testing.T) {
 func TestAPIServerLBClassDefaults(t *testing.T) {
 	cases := []struct {
 		name            string
-		clusterTemplate *AzureClusterTemplate
-		outputTemplate  *AzureClusterTemplate
+		clusterTemplate *infrav1.AzureClusterTemplate
+		outputTemplate  *infrav1.AzureClusterTemplate
 	}{
 		{
 			name: "no lb",
-			clusterTemplate: &AzureClusterTemplate{
+			clusterTemplate: &infrav1.AzureClusterTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster-template",
 				},
-				Spec: AzureClusterTemplateSpec{
-					Template: AzureClusterTemplateResource{
-						Spec: AzureClusterTemplateResourceSpec{
-							NetworkSpec: NetworkTemplateSpec{},
+				Spec: infrav1.AzureClusterTemplateSpec{
+					Template: infrav1.AzureClusterTemplateResource{
+						Spec: infrav1.AzureClusterTemplateResourceSpec{
+							NetworkSpec: infrav1.NetworkTemplateSpec{},
 						},
 					},
 				},
 			},
-			outputTemplate: &AzureClusterTemplate{
+			outputTemplate: &infrav1.AzureClusterTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster-template",
 				},
-				Spec: AzureClusterTemplateSpec{
-					Template: AzureClusterTemplateResource{
-						Spec: AzureClusterTemplateResourceSpec{
-							NetworkSpec: NetworkTemplateSpec{
-								APIServerLB: LoadBalancerClassSpec{
-									SKU:                  SKUStandard,
-									Type:                 Public,
+				Spec: infrav1.AzureClusterTemplateSpec{
+					Template: infrav1.AzureClusterTemplateResource{
+						Spec: infrav1.AzureClusterTemplateResourceSpec{
+							NetworkSpec: infrav1.NetworkTemplateSpec{
+								APIServerLB: infrav1.LoadBalancerClassSpec{
+									SKU:                  infrav1.SKUStandard,
+									Type:                 infrav1.Public,
 									IdleTimeoutInMinutes: ptr.To[int32](DefaultOutboundRuleIdleTimeoutInMinutes),
 								},
 							},
@@ -700,33 +700,33 @@ func TestAPIServerLBClassDefaults(t *testing.T) {
 		},
 		{
 			name: "internal lb",
-			clusterTemplate: &AzureClusterTemplate{
+			clusterTemplate: &infrav1.AzureClusterTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster-template",
 				},
-				Spec: AzureClusterTemplateSpec{
-					Template: AzureClusterTemplateResource{
-						Spec: AzureClusterTemplateResourceSpec{
-							NetworkSpec: NetworkTemplateSpec{
-								APIServerLB: LoadBalancerClassSpec{
-									Type: Internal,
+				Spec: infrav1.AzureClusterTemplateSpec{
+					Template: infrav1.AzureClusterTemplateResource{
+						Spec: infrav1.AzureClusterTemplateResourceSpec{
+							NetworkSpec: infrav1.NetworkTemplateSpec{
+								APIServerLB: infrav1.LoadBalancerClassSpec{
+									Type: infrav1.Internal,
 								},
 							},
 						},
 					},
 				},
 			},
-			outputTemplate: &AzureClusterTemplate{
+			outputTemplate: &infrav1.AzureClusterTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster-template",
 				},
-				Spec: AzureClusterTemplateSpec{
-					Template: AzureClusterTemplateResource{
-						Spec: AzureClusterTemplateResourceSpec{
-							NetworkSpec: NetworkTemplateSpec{
-								APIServerLB: LoadBalancerClassSpec{
-									SKU:                  SKUStandard,
-									Type:                 Internal,
+				Spec: infrav1.AzureClusterTemplateSpec{
+					Template: infrav1.AzureClusterTemplateResource{
+						Spec: infrav1.AzureClusterTemplateResourceSpec{
+							NetworkSpec: infrav1.NetworkTemplateSpec{
+								APIServerLB: infrav1.LoadBalancerClassSpec{
+									SKU:                  infrav1.SKUStandard,
+									Type:                 infrav1.Internal,
 									IdleTimeoutInMinutes: ptr.To[int32](DefaultOutboundRuleIdleTimeoutInMinutes),
 								},
 							},
@@ -754,29 +754,29 @@ func TestAPIServerLBClassDefaults(t *testing.T) {
 func TestNodeOutboundLBClassDefaults(t *testing.T) {
 	cases := []struct {
 		name            string
-		clusterTemplate *AzureClusterTemplate
-		outputTemplate  *AzureClusterTemplate
+		clusterTemplate *infrav1.AzureClusterTemplate
+		outputTemplate  *infrav1.AzureClusterTemplate
 	}{
 		{
 			name: "default no lb for public clusters",
-			clusterTemplate: &AzureClusterTemplate{
+			clusterTemplate: &infrav1.AzureClusterTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster-template",
 				},
-				Spec: AzureClusterTemplateSpec{
-					Template: AzureClusterTemplateResource{
-						Spec: AzureClusterTemplateResourceSpec{
-							NetworkSpec: NetworkTemplateSpec{
-								APIServerLB: LoadBalancerClassSpec{Type: Public},
-								Subnets: SubnetTemplatesSpec{
+				Spec: infrav1.AzureClusterTemplateSpec{
+					Template: infrav1.AzureClusterTemplateResource{
+						Spec: infrav1.AzureClusterTemplateResourceSpec{
+							NetworkSpec: infrav1.NetworkTemplateSpec{
+								APIServerLB: infrav1.LoadBalancerClassSpec{Type: infrav1.Public},
+								Subnets: infrav1.SubnetTemplatesSpec{
 									{
-										SubnetClassSpec: SubnetClassSpec{
-											Role: SubnetControlPlane,
+										SubnetClassSpec: infrav1.SubnetClassSpec{
+											Role: infrav1.SubnetControlPlane,
 										},
 									},
 									{
-										SubnetClassSpec: SubnetClassSpec{
-											Role: SubnetNode,
+										SubnetClassSpec: infrav1.SubnetClassSpec{
+											Role: infrav1.SubnetNode,
 										},
 									},
 								},
@@ -785,24 +785,24 @@ func TestNodeOutboundLBClassDefaults(t *testing.T) {
 					},
 				},
 			},
-			outputTemplate: &AzureClusterTemplate{
+			outputTemplate: &infrav1.AzureClusterTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster-template",
 				},
-				Spec: AzureClusterTemplateSpec{
-					Template: AzureClusterTemplateResource{
-						Spec: AzureClusterTemplateResourceSpec{
-							NetworkSpec: NetworkTemplateSpec{
-								APIServerLB: LoadBalancerClassSpec{Type: Public},
-								Subnets: SubnetTemplatesSpec{
+				Spec: infrav1.AzureClusterTemplateSpec{
+					Template: infrav1.AzureClusterTemplateResource{
+						Spec: infrav1.AzureClusterTemplateResourceSpec{
+							NetworkSpec: infrav1.NetworkTemplateSpec{
+								APIServerLB: infrav1.LoadBalancerClassSpec{Type: infrav1.Public},
+								Subnets: infrav1.SubnetTemplatesSpec{
 									{
-										SubnetClassSpec: SubnetClassSpec{
-											Role: SubnetControlPlane,
+										SubnetClassSpec: infrav1.SubnetClassSpec{
+											Role: infrav1.SubnetControlPlane,
 										},
 									},
 									{
-										SubnetClassSpec: SubnetClassSpec{
-											Role: SubnetNode,
+										SubnetClassSpec: infrav1.SubnetClassSpec{
+											Role: infrav1.SubnetNode,
 										},
 									},
 								},
@@ -814,24 +814,24 @@ func TestNodeOutboundLBClassDefaults(t *testing.T) {
 		},
 		{
 			name: "default lb when IPv6 enabled",
-			clusterTemplate: &AzureClusterTemplate{
+			clusterTemplate: &infrav1.AzureClusterTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster-template",
 				},
-				Spec: AzureClusterTemplateSpec{
-					Template: AzureClusterTemplateResource{
-						Spec: AzureClusterTemplateResourceSpec{
-							NetworkSpec: NetworkTemplateSpec{
-								APIServerLB: LoadBalancerClassSpec{Type: Public},
-								Subnets: SubnetTemplatesSpec{
+				Spec: infrav1.AzureClusterTemplateSpec{
+					Template: infrav1.AzureClusterTemplateResource{
+						Spec: infrav1.AzureClusterTemplateResourceSpec{
+							NetworkSpec: infrav1.NetworkTemplateSpec{
+								APIServerLB: infrav1.LoadBalancerClassSpec{Type: infrav1.Public},
+								Subnets: infrav1.SubnetTemplatesSpec{
 									{
-										SubnetClassSpec: SubnetClassSpec{
-											Role: SubnetControlPlane,
+										SubnetClassSpec: infrav1.SubnetClassSpec{
+											Role: infrav1.SubnetControlPlane,
 										},
 									},
 									{
-										SubnetClassSpec: SubnetClassSpec{
-											Role:       SubnetNode,
+										SubnetClassSpec: infrav1.SubnetClassSpec{
+											Role:       infrav1.SubnetNode,
 											CIDRBlocks: []string{"2001:beea::1/64"},
 										},
 									},
@@ -841,31 +841,31 @@ func TestNodeOutboundLBClassDefaults(t *testing.T) {
 					},
 				},
 			},
-			outputTemplate: &AzureClusterTemplate{
+			outputTemplate: &infrav1.AzureClusterTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster-template",
 				},
-				Spec: AzureClusterTemplateSpec{
-					Template: AzureClusterTemplateResource{
-						Spec: AzureClusterTemplateResourceSpec{
-							NetworkSpec: NetworkTemplateSpec{
-								APIServerLB: LoadBalancerClassSpec{Type: Public},
-								Subnets: SubnetTemplatesSpec{
+				Spec: infrav1.AzureClusterTemplateSpec{
+					Template: infrav1.AzureClusterTemplateResource{
+						Spec: infrav1.AzureClusterTemplateResourceSpec{
+							NetworkSpec: infrav1.NetworkTemplateSpec{
+								APIServerLB: infrav1.LoadBalancerClassSpec{Type: infrav1.Public},
+								Subnets: infrav1.SubnetTemplatesSpec{
 									{
-										SubnetClassSpec: SubnetClassSpec{
-											Role: SubnetControlPlane,
+										SubnetClassSpec: infrav1.SubnetClassSpec{
+											Role: infrav1.SubnetControlPlane,
 										},
 									},
 									{
-										SubnetClassSpec: SubnetClassSpec{
-											Role:       SubnetNode,
+										SubnetClassSpec: infrav1.SubnetClassSpec{
+											Role:       infrav1.SubnetNode,
 											CIDRBlocks: []string{"2001:beea::1/64"},
 										},
 									},
 								},
-								NodeOutboundLB: &LoadBalancerClassSpec{
-									SKU:                  SKUStandard,
-									Type:                 Public,
+								NodeOutboundLB: &infrav1.LoadBalancerClassSpec{
+									SKU:                  infrav1.SKUStandard,
+									Type:                 infrav1.Public,
 									IdleTimeoutInMinutes: ptr.To[int32](DefaultOutboundRuleIdleTimeoutInMinutes),
 								},
 							},
@@ -876,30 +876,30 @@ func TestNodeOutboundLBClassDefaults(t *testing.T) {
 		},
 		{
 			name: "IPv6 enabled on 1 of 2 node subnets",
-			clusterTemplate: &AzureClusterTemplate{
+			clusterTemplate: &infrav1.AzureClusterTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster-template",
 				},
-				Spec: AzureClusterTemplateSpec{
-					Template: AzureClusterTemplateResource{
-						Spec: AzureClusterTemplateResourceSpec{
-							NetworkSpec: NetworkTemplateSpec{
-								APIServerLB: LoadBalancerClassSpec{Type: Public},
-								Subnets: SubnetTemplatesSpec{
+				Spec: infrav1.AzureClusterTemplateSpec{
+					Template: infrav1.AzureClusterTemplateResource{
+						Spec: infrav1.AzureClusterTemplateResourceSpec{
+							NetworkSpec: infrav1.NetworkTemplateSpec{
+								APIServerLB: infrav1.LoadBalancerClassSpec{Type: infrav1.Public},
+								Subnets: infrav1.SubnetTemplatesSpec{
 									{
-										SubnetClassSpec: SubnetClassSpec{
-											Role: SubnetControlPlane,
+										SubnetClassSpec: infrav1.SubnetClassSpec{
+											Role: infrav1.SubnetControlPlane,
 										},
 									},
 									{
-										SubnetClassSpec: SubnetClassSpec{
-											Role:       SubnetNode,
+										SubnetClassSpec: infrav1.SubnetClassSpec{
+											Role:       infrav1.SubnetNode,
 											CIDRBlocks: []string{"2001:beea::1/64"},
 										},
 									},
 									{
-										SubnetClassSpec: SubnetClassSpec{
-											Role: SubnetNode,
+										SubnetClassSpec: infrav1.SubnetClassSpec{
+											Role: infrav1.SubnetNode,
 										},
 									},
 								},
@@ -908,36 +908,36 @@ func TestNodeOutboundLBClassDefaults(t *testing.T) {
 					},
 				},
 			},
-			outputTemplate: &AzureClusterTemplate{
+			outputTemplate: &infrav1.AzureClusterTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster-template",
 				},
-				Spec: AzureClusterTemplateSpec{
-					Template: AzureClusterTemplateResource{
-						Spec: AzureClusterTemplateResourceSpec{
-							NetworkSpec: NetworkTemplateSpec{
-								APIServerLB: LoadBalancerClassSpec{Type: Public},
-								Subnets: SubnetTemplatesSpec{
+				Spec: infrav1.AzureClusterTemplateSpec{
+					Template: infrav1.AzureClusterTemplateResource{
+						Spec: infrav1.AzureClusterTemplateResourceSpec{
+							NetworkSpec: infrav1.NetworkTemplateSpec{
+								APIServerLB: infrav1.LoadBalancerClassSpec{Type: infrav1.Public},
+								Subnets: infrav1.SubnetTemplatesSpec{
 									{
-										SubnetClassSpec: SubnetClassSpec{
-											Role: SubnetControlPlane,
+										SubnetClassSpec: infrav1.SubnetClassSpec{
+											Role: infrav1.SubnetControlPlane,
 										},
 									},
 									{
-										SubnetClassSpec: SubnetClassSpec{
-											Role:       SubnetNode,
+										SubnetClassSpec: infrav1.SubnetClassSpec{
+											Role:       infrav1.SubnetNode,
 											CIDRBlocks: []string{"2001:beea::1/64"},
 										},
 									},
 									{
-										SubnetClassSpec: SubnetClassSpec{
-											Role: SubnetNode,
+										SubnetClassSpec: infrav1.SubnetClassSpec{
+											Role: infrav1.SubnetNode,
 										},
 									},
 								},
-								NodeOutboundLB: &LoadBalancerClassSpec{
-									SKU:                  SKUStandard,
-									Type:                 Public,
+								NodeOutboundLB: &infrav1.LoadBalancerClassSpec{
+									SKU:                  infrav1.SKUStandard,
+									Type:                 infrav1.Public,
 									IdleTimeoutInMinutes: ptr.To[int32](DefaultOutboundRuleIdleTimeoutInMinutes),
 								},
 							},
@@ -948,30 +948,30 @@ func TestNodeOutboundLBClassDefaults(t *testing.T) {
 		},
 		{
 			name: "multiple subnets specified with IPv6 enabled",
-			clusterTemplate: &AzureClusterTemplate{
+			clusterTemplate: &infrav1.AzureClusterTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster-template",
 				},
-				Spec: AzureClusterTemplateSpec{
-					Template: AzureClusterTemplateResource{
-						Spec: AzureClusterTemplateResourceSpec{
-							NetworkSpec: NetworkTemplateSpec{
-								APIServerLB: LoadBalancerClassSpec{Type: Public},
-								Subnets: SubnetTemplatesSpec{
+				Spec: infrav1.AzureClusterTemplateSpec{
+					Template: infrav1.AzureClusterTemplateResource{
+						Spec: infrav1.AzureClusterTemplateResourceSpec{
+							NetworkSpec: infrav1.NetworkTemplateSpec{
+								APIServerLB: infrav1.LoadBalancerClassSpec{Type: infrav1.Public},
+								Subnets: infrav1.SubnetTemplatesSpec{
 									{
-										SubnetClassSpec: SubnetClassSpec{
-											Role: SubnetControlPlane,
+										SubnetClassSpec: infrav1.SubnetClassSpec{
+											Role: infrav1.SubnetControlPlane,
 										},
 									},
 									{
-										SubnetClassSpec: SubnetClassSpec{
-											Role:       SubnetNode,
+										SubnetClassSpec: infrav1.SubnetClassSpec{
+											Role:       infrav1.SubnetNode,
 											CIDRBlocks: []string{"2001:beea::1/64"},
 										},
 									},
 									{
-										SubnetClassSpec: SubnetClassSpec{
-											Role:       SubnetNode,
+										SubnetClassSpec: infrav1.SubnetClassSpec{
+											Role:       infrav1.SubnetNode,
 											CIDRBlocks: []string{"2002:beeb::1/64"},
 										},
 									},
@@ -981,37 +981,37 @@ func TestNodeOutboundLBClassDefaults(t *testing.T) {
 					},
 				},
 			},
-			outputTemplate: &AzureClusterTemplate{
+			outputTemplate: &infrav1.AzureClusterTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster-template",
 				},
-				Spec: AzureClusterTemplateSpec{
-					Template: AzureClusterTemplateResource{
-						Spec: AzureClusterTemplateResourceSpec{
-							NetworkSpec: NetworkTemplateSpec{
-								APIServerLB: LoadBalancerClassSpec{Type: Public},
-								Subnets: SubnetTemplatesSpec{
+				Spec: infrav1.AzureClusterTemplateSpec{
+					Template: infrav1.AzureClusterTemplateResource{
+						Spec: infrav1.AzureClusterTemplateResourceSpec{
+							NetworkSpec: infrav1.NetworkTemplateSpec{
+								APIServerLB: infrav1.LoadBalancerClassSpec{Type: infrav1.Public},
+								Subnets: infrav1.SubnetTemplatesSpec{
 									{
-										SubnetClassSpec: SubnetClassSpec{
-											Role: SubnetControlPlane,
+										SubnetClassSpec: infrav1.SubnetClassSpec{
+											Role: infrav1.SubnetControlPlane,
 										},
 									},
 									{
-										SubnetClassSpec: SubnetClassSpec{
-											Role:       SubnetNode,
+										SubnetClassSpec: infrav1.SubnetClassSpec{
+											Role:       infrav1.SubnetNode,
 											CIDRBlocks: []string{"2001:beea::1/64"},
 										},
 									},
 									{
-										SubnetClassSpec: SubnetClassSpec{
-											Role:       SubnetNode,
+										SubnetClassSpec: infrav1.SubnetClassSpec{
+											Role:       infrav1.SubnetNode,
 											CIDRBlocks: []string{"2002:beeb::1/64"},
 										},
 									},
 								},
-								NodeOutboundLB: &LoadBalancerClassSpec{
-									SKU:                  SKUStandard,
-									Type:                 Public,
+								NodeOutboundLB: &infrav1.LoadBalancerClassSpec{
+									SKU:                  infrav1.SKUStandard,
+									Type:                 infrav1.Public,
 									IdleTimeoutInMinutes: ptr.To[int32](DefaultOutboundRuleIdleTimeoutInMinutes),
 								},
 							},
@@ -1022,29 +1022,29 @@ func TestNodeOutboundLBClassDefaults(t *testing.T) {
 		},
 		{
 			name: "multiple node subnets, Ipv6 not enabled in any of them",
-			clusterTemplate: &AzureClusterTemplate{
+			clusterTemplate: &infrav1.AzureClusterTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster-template",
 				},
-				Spec: AzureClusterTemplateSpec{
-					Template: AzureClusterTemplateResource{
-						Spec: AzureClusterTemplateResourceSpec{
-							NetworkSpec: NetworkTemplateSpec{
-								APIServerLB: LoadBalancerClassSpec{Type: Public},
-								Subnets: SubnetTemplatesSpec{
+				Spec: infrav1.AzureClusterTemplateSpec{
+					Template: infrav1.AzureClusterTemplateResource{
+						Spec: infrav1.AzureClusterTemplateResourceSpec{
+							NetworkSpec: infrav1.NetworkTemplateSpec{
+								APIServerLB: infrav1.LoadBalancerClassSpec{Type: infrav1.Public},
+								Subnets: infrav1.SubnetTemplatesSpec{
 									{
-										SubnetClassSpec: SubnetClassSpec{
-											Role: SubnetControlPlane,
+										SubnetClassSpec: infrav1.SubnetClassSpec{
+											Role: infrav1.SubnetControlPlane,
 										},
 									},
 									{
-										SubnetClassSpec: SubnetClassSpec{
-											Role: SubnetNode,
+										SubnetClassSpec: infrav1.SubnetClassSpec{
+											Role: infrav1.SubnetNode,
 										},
 									},
 									{
-										SubnetClassSpec: SubnetClassSpec{
-											Role: SubnetNode,
+										SubnetClassSpec: infrav1.SubnetClassSpec{
+											Role: infrav1.SubnetNode,
 										},
 									},
 								},
@@ -1053,29 +1053,29 @@ func TestNodeOutboundLBClassDefaults(t *testing.T) {
 					},
 				},
 			},
-			outputTemplate: &AzureClusterTemplate{
+			outputTemplate: &infrav1.AzureClusterTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster-template",
 				},
-				Spec: AzureClusterTemplateSpec{
-					Template: AzureClusterTemplateResource{
-						Spec: AzureClusterTemplateResourceSpec{
-							NetworkSpec: NetworkTemplateSpec{
-								APIServerLB: LoadBalancerClassSpec{Type: Public},
-								Subnets: SubnetTemplatesSpec{
+				Spec: infrav1.AzureClusterTemplateSpec{
+					Template: infrav1.AzureClusterTemplateResource{
+						Spec: infrav1.AzureClusterTemplateResourceSpec{
+							NetworkSpec: infrav1.NetworkTemplateSpec{
+								APIServerLB: infrav1.LoadBalancerClassSpec{Type: infrav1.Public},
+								Subnets: infrav1.SubnetTemplatesSpec{
 									{
-										SubnetClassSpec: SubnetClassSpec{
-											Role: SubnetControlPlane,
+										SubnetClassSpec: infrav1.SubnetClassSpec{
+											Role: infrav1.SubnetControlPlane,
 										},
 									},
 									{
-										SubnetClassSpec: SubnetClassSpec{
-											Role: SubnetNode,
+										SubnetClassSpec: infrav1.SubnetClassSpec{
+											Role: infrav1.SubnetNode,
 										},
 									},
 									{
-										SubnetClassSpec: SubnetClassSpec{
-											Role: SubnetNode,
+										SubnetClassSpec: infrav1.SubnetClassSpec{
+											Role: infrav1.SubnetNode,
 										},
 									},
 								},
@@ -1087,29 +1087,29 @@ func TestNodeOutboundLBClassDefaults(t *testing.T) {
 		},
 		{
 			name: "no LB for private clusters",
-			clusterTemplate: &AzureClusterTemplate{
+			clusterTemplate: &infrav1.AzureClusterTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster-template",
 				},
-				Spec: AzureClusterTemplateSpec{
-					Template: AzureClusterTemplateResource{
-						Spec: AzureClusterTemplateResourceSpec{
-							NetworkSpec: NetworkTemplateSpec{
-								APIServerLB: LoadBalancerClassSpec{Type: Internal},
+				Spec: infrav1.AzureClusterTemplateSpec{
+					Template: infrav1.AzureClusterTemplateResource{
+						Spec: infrav1.AzureClusterTemplateResourceSpec{
+							NetworkSpec: infrav1.NetworkTemplateSpec{
+								APIServerLB: infrav1.LoadBalancerClassSpec{Type: infrav1.Internal},
 							},
 						},
 					},
 				},
 			},
-			outputTemplate: &AzureClusterTemplate{
+			outputTemplate: &infrav1.AzureClusterTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster-template",
 				},
-				Spec: AzureClusterTemplateSpec{
-					Template: AzureClusterTemplateResource{
-						Spec: AzureClusterTemplateResourceSpec{
-							NetworkSpec: NetworkTemplateSpec{
-								APIServerLB: LoadBalancerClassSpec{Type: Internal},
+				Spec: infrav1.AzureClusterTemplateSpec{
+					Template: infrav1.AzureClusterTemplateResource{
+						Spec: infrav1.AzureClusterTemplateResourceSpec{
+							NetworkSpec: infrav1.NetworkTemplateSpec{
+								APIServerLB: infrav1.LoadBalancerClassSpec{Type: infrav1.Internal},
 							},
 						},
 					},
@@ -1118,16 +1118,16 @@ func TestNodeOutboundLBClassDefaults(t *testing.T) {
 		},
 		{
 			name: "NodeOutboundLB declared as input with non-default IdleTimeoutInMinutes",
-			clusterTemplate: &AzureClusterTemplate{
+			clusterTemplate: &infrav1.AzureClusterTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster-template",
 				},
-				Spec: AzureClusterTemplateSpec{
-					Template: AzureClusterTemplateResource{
-						Spec: AzureClusterTemplateResourceSpec{
-							NetworkSpec: NetworkTemplateSpec{
-								APIServerLB: LoadBalancerClassSpec{Type: Internal},
-								NodeOutboundLB: &LoadBalancerClassSpec{
+				Spec: infrav1.AzureClusterTemplateSpec{
+					Template: infrav1.AzureClusterTemplateResource{
+						Spec: infrav1.AzureClusterTemplateResourceSpec{
+							NetworkSpec: infrav1.NetworkTemplateSpec{
+								APIServerLB: infrav1.LoadBalancerClassSpec{Type: infrav1.Internal},
+								NodeOutboundLB: &infrav1.LoadBalancerClassSpec{
 									IdleTimeoutInMinutes: ptr.To[int32](15),
 								},
 							},
@@ -1135,19 +1135,19 @@ func TestNodeOutboundLBClassDefaults(t *testing.T) {
 					},
 				},
 			},
-			outputTemplate: &AzureClusterTemplate{
+			outputTemplate: &infrav1.AzureClusterTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster-template",
 				},
-				Spec: AzureClusterTemplateSpec{
-					Template: AzureClusterTemplateResource{
-						Spec: AzureClusterTemplateResourceSpec{
-							NetworkSpec: NetworkTemplateSpec{
-								APIServerLB: LoadBalancerClassSpec{Type: Internal},
-								NodeOutboundLB: &LoadBalancerClassSpec{
+				Spec: infrav1.AzureClusterTemplateSpec{
+					Template: infrav1.AzureClusterTemplateResource{
+						Spec: infrav1.AzureClusterTemplateResourceSpec{
+							NetworkSpec: infrav1.NetworkTemplateSpec{
+								APIServerLB: infrav1.LoadBalancerClassSpec{Type: infrav1.Internal},
+								NodeOutboundLB: &infrav1.LoadBalancerClassSpec{
 									IdleTimeoutInMinutes: ptr.To[int32](15),
-									SKU:                  SKUStandard,
-									Type:                 Public,
+									SKU:                  infrav1.SKUStandard,
+									Type:                 infrav1.Public,
 								},
 							},
 						},
@@ -1174,59 +1174,59 @@ func TestNodeOutboundLBClassDefaults(t *testing.T) {
 func TestBastionTemplateDefaults(t *testing.T) {
 	cases := []struct {
 		name            string
-		clusterTemplate *AzureClusterTemplate
-		outputTemplate  *AzureClusterTemplate
+		clusterTemplate *infrav1.AzureClusterTemplate
+		outputTemplate  *infrav1.AzureClusterTemplate
 	}{
 		{
 			name: "no bastion set",
-			clusterTemplate: &AzureClusterTemplate{
+			clusterTemplate: &infrav1.AzureClusterTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster-template",
 				},
-				Spec: AzureClusterTemplateSpec{
-					Template: AzureClusterTemplateResource{
-						Spec: AzureClusterTemplateResourceSpec{},
+				Spec: infrav1.AzureClusterTemplateSpec{
+					Template: infrav1.AzureClusterTemplateResource{
+						Spec: infrav1.AzureClusterTemplateResourceSpec{},
 					},
 				},
 			},
-			outputTemplate: &AzureClusterTemplate{
+			outputTemplate: &infrav1.AzureClusterTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster-template",
 				},
-				Spec: AzureClusterTemplateSpec{
-					Template: AzureClusterTemplateResource{
-						Spec: AzureClusterTemplateResourceSpec{},
+				Spec: infrav1.AzureClusterTemplateSpec{
+					Template: infrav1.AzureClusterTemplateResource{
+						Spec: infrav1.AzureClusterTemplateResourceSpec{},
 					},
 				},
 			},
 		},
 		{
 			name: "azure bastion enabled with no settings",
-			clusterTemplate: &AzureClusterTemplate{
+			clusterTemplate: &infrav1.AzureClusterTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster-template",
 				},
-				Spec: AzureClusterTemplateSpec{
-					Template: AzureClusterTemplateResource{
-						Spec: AzureClusterTemplateResourceSpec{
-							BastionSpec: BastionTemplateSpec{
-								AzureBastion: &AzureBastionTemplateSpec{},
+				Spec: infrav1.AzureClusterTemplateSpec{
+					Template: infrav1.AzureClusterTemplateResource{
+						Spec: infrav1.AzureClusterTemplateResourceSpec{
+							BastionSpec: infrav1.BastionTemplateSpec{
+								AzureBastion: &infrav1.AzureBastionTemplateSpec{},
 							},
 						},
 					},
 				},
 			},
-			outputTemplate: &AzureClusterTemplate{
+			outputTemplate: &infrav1.AzureClusterTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster-template",
 				},
-				Spec: AzureClusterTemplateSpec{
-					Template: AzureClusterTemplateResource{
-						Spec: AzureClusterTemplateResourceSpec{
-							BastionSpec: BastionTemplateSpec{
-								AzureBastion: &AzureBastionTemplateSpec{
-									Subnet: SubnetTemplateSpec{
-										SubnetClassSpec: SubnetClassSpec{
+				Spec: infrav1.AzureClusterTemplateSpec{
+					Template: infrav1.AzureClusterTemplateResource{
+						Spec: infrav1.AzureClusterTemplateResourceSpec{
+							BastionSpec: infrav1.BastionTemplateSpec{
+								AzureBastion: &infrav1.AzureBastionTemplateSpec{
+									Subnet: infrav1.SubnetTemplateSpec{
+										SubnetClassSpec: infrav1.SubnetClassSpec{
 											Role:       DefaultAzureBastionSubnetRole,
 											CIDRBlocks: []string{DefaultAzureBastionSubnetCIDR},
 										},
@@ -1240,17 +1240,17 @@ func TestBastionTemplateDefaults(t *testing.T) {
 		},
 		{
 			name: "azure bastion enabled with subnet partially set",
-			clusterTemplate: &AzureClusterTemplate{
+			clusterTemplate: &infrav1.AzureClusterTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster-template",
 				},
-				Spec: AzureClusterTemplateSpec{
-					Template: AzureClusterTemplateResource{
-						Spec: AzureClusterTemplateResourceSpec{
-							BastionSpec: BastionTemplateSpec{
-								AzureBastion: &AzureBastionTemplateSpec{
-									Subnet: SubnetTemplateSpec{
-										SubnetClassSpec: SubnetClassSpec{},
+				Spec: infrav1.AzureClusterTemplateSpec{
+					Template: infrav1.AzureClusterTemplateResource{
+						Spec: infrav1.AzureClusterTemplateResourceSpec{
+							BastionSpec: infrav1.BastionTemplateSpec{
+								AzureBastion: &infrav1.AzureBastionTemplateSpec{
+									Subnet: infrav1.SubnetTemplateSpec{
+										SubnetClassSpec: infrav1.SubnetClassSpec{},
 									},
 								},
 							},
@@ -1258,17 +1258,17 @@ func TestBastionTemplateDefaults(t *testing.T) {
 					},
 				},
 			},
-			outputTemplate: &AzureClusterTemplate{
+			outputTemplate: &infrav1.AzureClusterTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster-template",
 				},
-				Spec: AzureClusterTemplateSpec{
-					Template: AzureClusterTemplateResource{
-						Spec: AzureClusterTemplateResourceSpec{
-							BastionSpec: BastionTemplateSpec{
-								AzureBastion: &AzureBastionTemplateSpec{
-									Subnet: SubnetTemplateSpec{
-										SubnetClassSpec: SubnetClassSpec{
+				Spec: infrav1.AzureClusterTemplateSpec{
+					Template: infrav1.AzureClusterTemplateResource{
+						Spec: infrav1.AzureClusterTemplateResourceSpec{
+							BastionSpec: infrav1.BastionTemplateSpec{
+								AzureBastion: &infrav1.AzureBastionTemplateSpec{
+									Subnet: infrav1.SubnetTemplateSpec{
+										SubnetClassSpec: infrav1.SubnetClassSpec{
 											Role:       DefaultAzureBastionSubnetRole,
 											CIDRBlocks: []string{DefaultAzureBastionSubnetCIDR},
 										},
@@ -1282,17 +1282,17 @@ func TestBastionTemplateDefaults(t *testing.T) {
 		},
 		{
 			name: "azure bastion enabled with subnet fully set",
-			clusterTemplate: &AzureClusterTemplate{
+			clusterTemplate: &infrav1.AzureClusterTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster-template",
 				},
-				Spec: AzureClusterTemplateSpec{
-					Template: AzureClusterTemplateResource{
-						Spec: AzureClusterTemplateResourceSpec{
-							BastionSpec: BastionTemplateSpec{
-								AzureBastion: &AzureBastionTemplateSpec{
-									Subnet: SubnetTemplateSpec{
-										SubnetClassSpec: SubnetClassSpec{
+				Spec: infrav1.AzureClusterTemplateSpec{
+					Template: infrav1.AzureClusterTemplateResource{
+						Spec: infrav1.AzureClusterTemplateResourceSpec{
+							BastionSpec: infrav1.BastionTemplateSpec{
+								AzureBastion: &infrav1.AzureBastionTemplateSpec{
+									Subnet: infrav1.SubnetTemplateSpec{
+										SubnetClassSpec: infrav1.SubnetClassSpec{
 											Role:       DefaultAzureBastionSubnetRole,
 											CIDRBlocks: []string{"10.10.0.0/16"},
 										},
@@ -1303,17 +1303,17 @@ func TestBastionTemplateDefaults(t *testing.T) {
 					},
 				},
 			},
-			outputTemplate: &AzureClusterTemplate{
+			outputTemplate: &infrav1.AzureClusterTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster-template",
 				},
-				Spec: AzureClusterTemplateSpec{
-					Template: AzureClusterTemplateResource{
-						Spec: AzureClusterTemplateResourceSpec{
-							BastionSpec: BastionTemplateSpec{
-								AzureBastion: &AzureBastionTemplateSpec{
-									Subnet: SubnetTemplateSpec{
-										SubnetClassSpec: SubnetClassSpec{
+				Spec: infrav1.AzureClusterTemplateSpec{
+					Template: infrav1.AzureClusterTemplateResource{
+						Spec: infrav1.AzureClusterTemplateResourceSpec{
+							BastionSpec: infrav1.BastionTemplateSpec{
+								AzureBastion: &infrav1.AzureBastionTemplateSpec{
+									Subnet: infrav1.SubnetTemplateSpec{
+										SubnetClassSpec: infrav1.SubnetClassSpec{
 											Role:       DefaultAzureBastionSubnetRole,
 											CIDRBlocks: []string{"10.10.0.0/16"},
 										},

--- a/internal/api/v1beta1/azuremachine_default.go
+++ b/internal/api/v1beta1/azuremachine_default.go
@@ -28,7 +28,7 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	. "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
+	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	utilSSH "sigs.k8s.io/cluster-api-provider-azure/util/ssh"
 )
 
@@ -36,7 +36,7 @@ import (
 const ContributorRoleID = "b24988ac-6180-42a0-ab88-20f7382dd24c"
 
 // SetDefaultAzureMachineSpecSSHPublicKey sets the default SSHPublicKey for an AzureMachine.
-func SetDefaultAzureMachineSpecSSHPublicKey(s *AzureMachineSpec) error {
+func SetDefaultAzureMachineSpecSSHPublicKey(s *infrav1.AzureMachineSpec) error {
 	if sshKeyData := s.SSHPublicKey; sshKeyData == "" {
 		_, publicRsaKey, err := utilSSH.GenerateSSHKey()
 		if err != nil {
@@ -49,7 +49,7 @@ func SetDefaultAzureMachineSpecSSHPublicKey(s *AzureMachineSpec) error {
 }
 
 // SetDefaultAzureMachineSpecDataDisks sets the data disk defaults for an AzureMachine.
-func SetDefaultAzureMachineSpecDataDisks(s *AzureMachineSpec) {
+func SetDefaultAzureMachineSpecDataDisks(s *infrav1.AzureMachineSpec) {
 	set := make(map[int32]struct{})
 	// populate all the existing values in the set
 	for _, disk := range s.DataDisks {
@@ -81,16 +81,16 @@ func SetDefaultAzureMachineSpecDataDisks(s *AzureMachineSpec) {
 }
 
 // SetDefaultAzureMachineSpecIdentity sets the defaults for VM Identity.
-func SetDefaultAzureMachineSpecIdentity(s *AzureMachineSpec, subscriptionID string) {
+func SetDefaultAzureMachineSpecIdentity(s *infrav1.AzureMachineSpec, subscriptionID string) {
 	// Ensure the deprecated fields and new fields are not populated simultaneously
 	if s.RoleAssignmentName != "" && s.SystemAssignedIdentityRole != nil && s.SystemAssignedIdentityRole.Name != "" { //nolint:staticcheck
 		// Both the deprecated and the new fields are both set, return without changes
 		// and reject the request in the validating webhook which runs later.
 		return
 	}
-	if s.Identity == VMIdentitySystemAssigned {
+	if s.Identity == infrav1.VMIdentitySystemAssigned {
 		if s.SystemAssignedIdentityRole == nil {
-			s.SystemAssignedIdentityRole = &SystemAssignedIdentityRole{}
+			s.SystemAssignedIdentityRole = &infrav1.SystemAssignedIdentityRole{}
 		}
 		if s.RoleAssignmentName != "" { //nolint:staticcheck
 			// Move the existing value from the deprecated RoleAssignmentName field.
@@ -112,23 +112,23 @@ func SetDefaultAzureMachineSpecIdentity(s *AzureMachineSpec, subscriptionID stri
 }
 
 // setDefaultAzureMachineSpecSpotEvictionPolicy sets the defaults for the spot VM eviction policy.
-func setDefaultAzureMachineSpecSpotEvictionPolicy(s *AzureMachineSpec) {
+func setDefaultAzureMachineSpecSpotEvictionPolicy(s *infrav1.AzureMachineSpec) {
 	if s.SpotVMOptions != nil && s.SpotVMOptions.EvictionPolicy == nil {
-		defaultPolicy := SpotEvictionPolicyDeallocate
+		defaultPolicy := infrav1.SpotEvictionPolicyDeallocate
 		if s.OSDisk.DiffDiskSettings != nil && s.OSDisk.DiffDiskSettings.Option == "Local" {
-			defaultPolicy = SpotEvictionPolicyDelete
+			defaultPolicy = infrav1.SpotEvictionPolicyDelete
 		}
 		s.SpotVMOptions.EvictionPolicy = &defaultPolicy
 	}
 }
 
 // setDefaultAzureMachineSpecDiagnostics sets the defaults for Diagnostic settings for an AzureMachine.
-func setDefaultAzureMachineSpecDiagnostics(s *AzureMachineSpec) {
-	bootDiagnosticsDefault := &BootDiagnostics{
-		StorageAccountType: ManagedDiagnosticsStorage,
+func setDefaultAzureMachineSpecDiagnostics(s *infrav1.AzureMachineSpec) {
+	bootDiagnosticsDefault := &infrav1.BootDiagnostics{
+		StorageAccountType: infrav1.ManagedDiagnosticsStorage,
 	}
 
-	diagnosticsDefault := &Diagnostics{Boot: bootDiagnosticsDefault}
+	diagnosticsDefault := &infrav1.Diagnostics{Boot: bootDiagnosticsDefault}
 
 	if s.Diagnostics == nil {
 		s.Diagnostics = diagnosticsDefault
@@ -140,7 +140,7 @@ func setDefaultAzureMachineSpecDiagnostics(s *AzureMachineSpec) {
 }
 
 // SetDefaultAzureMachineSpecNetworkInterfaces sets the defaults for the network interfaces.
-func SetDefaultAzureMachineSpecNetworkInterfaces(s *AzureMachineSpec) {
+func SetDefaultAzureMachineSpecNetworkInterfaces(s *infrav1.AzureMachineSpec) {
 	// Ensure the deprecated fields and new fields are not populated simultaneously
 	if (s.SubnetName != "" || s.AcceleratedNetworking != nil) && len(s.NetworkInterfaces) > 0 { //nolint:staticcheck
 		// Both the deprecated and the new fields are both set, return without changes
@@ -149,7 +149,7 @@ func SetDefaultAzureMachineSpecNetworkInterfaces(s *AzureMachineSpec) {
 	}
 
 	if len(s.NetworkInterfaces) == 0 {
-		s.NetworkInterfaces = []NetworkInterface{
+		s.NetworkInterfaces = []infrav1.NetworkInterface{
 			{
 				SubnetName:            s.SubnetName,            //nolint:staticcheck
 				AcceleratedNetworking: s.AcceleratedNetworking, //nolint:staticcheck
@@ -168,7 +168,7 @@ func SetDefaultAzureMachineSpecNetworkInterfaces(s *AzureMachineSpec) {
 }
 
 // SetDefaultsAzureMachine sets the defaults for the AzureMachine.
-func SetDefaultsAzureMachine(m *AzureMachine, client client.Client) error {
+func SetDefaultsAzureMachine(m *infrav1.AzureMachine, client client.Client) error {
 	var errs []error
 	if err := SetDefaultAzureMachineSpecSSHPublicKey(&m.Spec); err != nil {
 		errs = append(errs, errors.Wrap(err, "failed to set default SSH public key"))

--- a/internal/api/v1beta1/azuremachine_default_test.go
+++ b/internal/api/v1beta1/azuremachine_default_test.go
@@ -31,7 +31,7 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	. "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
+	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	apifixtures "sigs.k8s.io/cluster-api-provider-azure/internal/test/apifixtures"
 )
 
@@ -39,7 +39,7 @@ func TestAzureMachineSpec_SetDefaultSSHPublicKey(t *testing.T) {
 	g := NewWithT(t)
 
 	type test struct {
-		machine *AzureMachine
+		machine *infrav1.AzureMachine
 	}
 
 	existingPublicKey := "testpublickey"
@@ -59,7 +59,7 @@ func TestAzureMachineSpec_SetIdentityDefaults(t *testing.T) {
 	g := NewWithT(t)
 
 	type test struct {
-		machine *AzureMachine
+		machine *infrav1.AzureMachine
 	}
 
 	fakeSubscriptionID := uuid.New().String()
@@ -67,35 +67,35 @@ func TestAzureMachineSpec_SetIdentityDefaults(t *testing.T) {
 	fakeRoleDefinitionID := "testroledefinitionid"
 	fakeScope := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s", fakeSubscriptionID, fakeClusterName)
 	existingRoleAssignmentName := "42862306-e485-4319-9bf0-35dbc6f6fe9c"
-	roleAssignmentExistTest := test{machine: &AzureMachine{Spec: AzureMachineSpec{
-		Identity: VMIdentitySystemAssigned,
-		SystemAssignedIdentityRole: &SystemAssignedIdentityRole{
+	roleAssignmentExistTest := test{machine: &infrav1.AzureMachine{Spec: infrav1.AzureMachineSpec{
+		Identity: infrav1.VMIdentitySystemAssigned,
+		SystemAssignedIdentityRole: &infrav1.SystemAssignedIdentityRole{
 			Name: existingRoleAssignmentName,
 		},
 	}}}
-	notSystemAssignedTest := test{machine: &AzureMachine{Spec: AzureMachineSpec{
-		Identity:                   VMIdentityUserAssigned,
-		SystemAssignedIdentityRole: &SystemAssignedIdentityRole{},
+	notSystemAssignedTest := test{machine: &infrav1.AzureMachine{Spec: infrav1.AzureMachineSpec{
+		Identity:                   infrav1.VMIdentityUserAssigned,
+		SystemAssignedIdentityRole: &infrav1.SystemAssignedIdentityRole{},
 	}}}
-	systemAssignedIdentityRoleExistTest := test{machine: &AzureMachine{Spec: AzureMachineSpec{
-		Identity: VMIdentitySystemAssigned,
-		SystemAssignedIdentityRole: &SystemAssignedIdentityRole{
+	systemAssignedIdentityRoleExistTest := test{machine: &infrav1.AzureMachine{Spec: infrav1.AzureMachineSpec{
+		Identity: infrav1.VMIdentitySystemAssigned,
+		SystemAssignedIdentityRole: &infrav1.SystemAssignedIdentityRole{
 			Scope:        fakeScope,
 			DefinitionID: fakeRoleDefinitionID,
 		},
 	}}}
-	deprecatedRoleAssignmentNameTest := test{machine: &AzureMachine{Spec: AzureMachineSpec{
-		Identity:           VMIdentitySystemAssigned,
+	deprecatedRoleAssignmentNameTest := test{machine: &infrav1.AzureMachine{Spec: infrav1.AzureMachineSpec{
+		Identity:           infrav1.VMIdentitySystemAssigned,
 		RoleAssignmentName: existingRoleAssignmentName,
 	}}}
-	emptyTest := test{machine: &AzureMachine{Spec: AzureMachineSpec{
-		Identity:                   VMIdentitySystemAssigned,
-		SystemAssignedIdentityRole: &SystemAssignedIdentityRole{},
+	emptyTest := test{machine: &infrav1.AzureMachine{Spec: infrav1.AzureMachineSpec{
+		Identity:                   infrav1.VMIdentitySystemAssigned,
+		SystemAssignedIdentityRole: &infrav1.SystemAssignedIdentityRole{},
 	}}}
-	bothDeprecatedRoleAssignmentNameAndSystemAssignedIdentityRoleTest := test{machine: &AzureMachine{Spec: AzureMachineSpec{
-		Identity:           VMIdentitySystemAssigned,
+	bothDeprecatedRoleAssignmentNameAndSystemAssignedIdentityRoleTest := test{machine: &infrav1.AzureMachine{Spec: infrav1.AzureMachineSpec{
+		Identity:           infrav1.VMIdentitySystemAssigned,
 		RoleAssignmentName: existingRoleAssignmentName,
-		SystemAssignedIdentityRole: &SystemAssignedIdentityRole{
+		SystemAssignedIdentityRole: &infrav1.SystemAssignedIdentityRole{
 			Name: existingRoleAssignmentName,
 		},
 	}}}
@@ -127,27 +127,27 @@ func TestAzureMachineSpec_SetIdentityDefaults(t *testing.T) {
 }
 
 func TestAzureMachineSpec_SetSpotEvictionPolicyDefaults(t *testing.T) {
-	deallocatePolicy := SpotEvictionPolicyDeallocate
-	deletePolicy := SpotEvictionPolicyDelete
+	deallocatePolicy := infrav1.SpotEvictionPolicyDeallocate
+	deletePolicy := infrav1.SpotEvictionPolicyDelete
 
 	g := NewWithT(t)
 
 	type test struct {
-		machine *AzureMachine
+		machine *infrav1.AzureMachine
 	}
 
-	spotVMOptionsExistTest := test{machine: &AzureMachine{Spec: AzureMachineSpec{
-		SpotVMOptions: &SpotVMOptions{
+	spotVMOptionsExistTest := test{machine: &infrav1.AzureMachine{Spec: infrav1.AzureMachineSpec{
+		SpotVMOptions: &infrav1.SpotVMOptions{
 			MaxPrice: &resource.Quantity{Format: "vmoptions-0"},
 		},
 	}}}
 
-	localDiffDiskSettingsExistTest := test{machine: &AzureMachine{Spec: AzureMachineSpec{
-		SpotVMOptions: &SpotVMOptions{
+	localDiffDiskSettingsExistTest := test{machine: &infrav1.AzureMachine{Spec: infrav1.AzureMachineSpec{
+		SpotVMOptions: &infrav1.SpotVMOptions{
 			MaxPrice: &resource.Quantity{},
 		},
-		OSDisk: OSDisk{
-			DiffDiskSettings: &DiffDiskSettings{
+		OSDisk: infrav1.OSDisk{
+			DiffDiskSettings: &infrav1.DiffDiskSettings{
 				Option: "Local",
 			},
 		},
@@ -163,17 +163,17 @@ func TestAzureMachineSpec_SetSpotEvictionPolicyDefaults(t *testing.T) {
 func TestAzureMachineSpec_SetDataDisksDefaults(t *testing.T) {
 	cases := []struct {
 		name   string
-		disks  []DataDisk
-		output []DataDisk
+		disks  []infrav1.DataDisk
+		output []infrav1.DataDisk
 	}{
 		{
 			name:   "no disks",
-			disks:  []DataDisk{},
-			output: []DataDisk{},
+			disks:  []infrav1.DataDisk{},
+			output: []infrav1.DataDisk{},
 		},
 		{
 			name: "no LUNs specified",
-			disks: []DataDisk{
+			disks: []infrav1.DataDisk{
 				{
 					NameSuffix:  "testdisk1",
 					DiskSizeGB:  30,
@@ -185,7 +185,7 @@ func TestAzureMachineSpec_SetDataDisksDefaults(t *testing.T) {
 					CachingType: "ReadWrite",
 				},
 			},
-			output: []DataDisk{
+			output: []infrav1.DataDisk{
 				{
 					NameSuffix:  "testdisk1",
 					DiskSizeGB:  30,
@@ -202,7 +202,7 @@ func TestAzureMachineSpec_SetDataDisksDefaults(t *testing.T) {
 		},
 		{
 			name: "All LUNs specified",
-			disks: []DataDisk{
+			disks: []infrav1.DataDisk{
 				{
 					NameSuffix:  "testdisk1",
 					DiskSizeGB:  30,
@@ -216,7 +216,7 @@ func TestAzureMachineSpec_SetDataDisksDefaults(t *testing.T) {
 					CachingType: "ReadWrite",
 				},
 			},
-			output: []DataDisk{
+			output: []infrav1.DataDisk{
 				{
 					NameSuffix:  "testdisk1",
 					DiskSizeGB:  30,
@@ -233,7 +233,7 @@ func TestAzureMachineSpec_SetDataDisksDefaults(t *testing.T) {
 		},
 		{
 			name: "Some LUNs missing",
-			disks: []DataDisk{
+			disks: []infrav1.DataDisk{
 				{
 					NameSuffix:  "testdisk1",
 					DiskSizeGB:  30,
@@ -257,7 +257,7 @@ func TestAzureMachineSpec_SetDataDisksDefaults(t *testing.T) {
 					CachingType: "ReadWrite",
 				},
 			},
-			output: []DataDisk{
+			output: []infrav1.DataDisk{
 				{
 					NameSuffix:  "testdisk1",
 					DiskSizeGB:  30,
@@ -286,7 +286,7 @@ func TestAzureMachineSpec_SetDataDisksDefaults(t *testing.T) {
 		},
 		{
 			name: "CachingType unspecified",
-			disks: []DataDisk{
+			disks: []infrav1.DataDisk{
 				{
 					NameSuffix: "testdisk1",
 					DiskSizeGB: 30,
@@ -300,13 +300,13 @@ func TestAzureMachineSpec_SetDataDisksDefaults(t *testing.T) {
 				{
 					NameSuffix: "testdisk3",
 					DiskSizeGB: 30,
-					ManagedDisk: &ManagedDiskParameters{
+					ManagedDisk: &infrav1.ManagedDiskParameters{
 						StorageAccountType: "UltraSSD_LRS",
 					},
 					Lun: ptr.To[int32](3),
 				},
 			},
-			output: []DataDisk{
+			output: []infrav1.DataDisk{
 				{
 					NameSuffix:  "testdisk1",
 					DiskSizeGB:  30,
@@ -323,7 +323,7 @@ func TestAzureMachineSpec_SetDataDisksDefaults(t *testing.T) {
 					NameSuffix: "testdisk3",
 					DiskSizeGB: 30,
 					Lun:        ptr.To[int32](3),
-					ManagedDisk: &ManagedDiskParameters{
+					ManagedDisk: &infrav1.ManagedDiskParameters{
 						StorageAccountType: "UltraSSD_LRS",
 					},
 					CachingType: "None",
@@ -351,20 +351,20 @@ func TestAzureMachineSpec_SetDataDisksDefaults(t *testing.T) {
 func TestAzureMachineSpec_SetNetworkInterfacesDefaults(t *testing.T) {
 	tests := []struct {
 		name    string
-		machine *AzureMachine
-		want    *AzureMachine
+		machine *infrav1.AzureMachine
+		want    *infrav1.AzureMachine
 	}{
 		{
 			name: "defaulting webhook updates machine with deprecated subnetName field",
-			machine: &AzureMachine{
-				Spec: AzureMachineSpec{
+			machine: &infrav1.AzureMachine{
+				Spec: infrav1.AzureMachineSpec{
 					SubnetName: "test-subnet",
 				},
 			},
-			want: &AzureMachine{
-				Spec: AzureMachineSpec{
+			want: &infrav1.AzureMachine{
+				Spec: infrav1.AzureMachineSpec{
 					SubnetName: "",
-					NetworkInterfaces: []NetworkInterface{
+					NetworkInterfaces: []infrav1.NetworkInterface{
 						{
 							SubnetName:       "test-subnet",
 							PrivateIPConfigs: 1,
@@ -375,16 +375,16 @@ func TestAzureMachineSpec_SetNetworkInterfacesDefaults(t *testing.T) {
 		},
 		{
 			name: "defaulting webhook updates machine with deprecated subnetName field and empty NetworkInterfaces slice",
-			machine: &AzureMachine{
-				Spec: AzureMachineSpec{
+			machine: &infrav1.AzureMachine{
+				Spec: infrav1.AzureMachineSpec{
 					SubnetName:        "test-subnet",
-					NetworkInterfaces: []NetworkInterface{},
+					NetworkInterfaces: []infrav1.NetworkInterface{},
 				},
 			},
-			want: &AzureMachine{
-				Spec: AzureMachineSpec{
+			want: &infrav1.AzureMachine{
+				Spec: infrav1.AzureMachineSpec{
 					SubnetName: "",
-					NetworkInterfaces: []NetworkInterface{
+					NetworkInterfaces: []infrav1.NetworkInterface{
 						{
 							SubnetName:       "test-subnet",
 							PrivateIPConfigs: 1,
@@ -395,17 +395,17 @@ func TestAzureMachineSpec_SetNetworkInterfacesDefaults(t *testing.T) {
 		},
 		{
 			name: "defaulting webhook updates machine with deprecated acceleratedNetworking field",
-			machine: &AzureMachine{
-				Spec: AzureMachineSpec{
+			machine: &infrav1.AzureMachine{
+				Spec: infrav1.AzureMachineSpec{
 					SubnetName:            "test-subnet",
 					AcceleratedNetworking: ptr.To(true),
 				},
 			},
-			want: &AzureMachine{
-				Spec: AzureMachineSpec{
+			want: &infrav1.AzureMachine{
+				Spec: infrav1.AzureMachineSpec{
 					SubnetName:            "",
 					AcceleratedNetworking: nil,
-					NetworkInterfaces: []NetworkInterface{
+					NetworkInterfaces: []infrav1.NetworkInterface{
 						{
 							SubnetName:            "test-subnet",
 							PrivateIPConfigs:      1,
@@ -417,19 +417,19 @@ func TestAzureMachineSpec_SetNetworkInterfacesDefaults(t *testing.T) {
 		},
 		{
 			name: "defaulting webhook does nothing if both new and deprecated subnetName fields are set",
-			machine: &AzureMachine{
-				Spec: AzureMachineSpec{
+			machine: &infrav1.AzureMachine{
+				Spec: infrav1.AzureMachineSpec{
 					SubnetName: "test-subnet",
-					NetworkInterfaces: []NetworkInterface{{
+					NetworkInterfaces: []infrav1.NetworkInterface{{
 						SubnetName: "test-subnet",
 					}},
 				},
 			},
-			want: &AzureMachine{
-				Spec: AzureMachineSpec{
+			want: &infrav1.AzureMachine{
+				Spec: infrav1.AzureMachineSpec{
 					SubnetName:            "test-subnet",
 					AcceleratedNetworking: nil,
-					NetworkInterfaces: []NetworkInterface{
+					NetworkInterfaces: []infrav1.NetworkInterface{
 						{
 							SubnetName: "test-subnet",
 						},
@@ -563,13 +563,13 @@ func (m mockClient) Get(ctx context.Context, key client.ObjectKey, obj client.Ob
 	}
 	// Check if we're calling Get on an AzureCluster or a Cluster
 	switch obj := obj.(type) {
-	case *AzureCluster:
+	case *infrav1.AzureCluster:
 		obj.Spec.SubscriptionID = "test-subscription-id"
 	case *clusterv1.Cluster:
 		obj.Namespace = "default"
 		obj.Spec = clusterv1.ClusterSpec{
 			InfrastructureRef: clusterv1.ContractVersionedObjectReference{
-				Kind: AzureClusterKind,
+				Kind: infrav1.AzureClusterKind,
 				Name: "test-cluster",
 			},
 			ClusterNetwork: clusterv1.ClusterNetwork{

--- a/internal/api/v1beta1/azuremanagedcontrolplane_default.go
+++ b/internal/api/v1beta1/azuremanagedcontrolplane_default.go
@@ -25,7 +25,7 @@ import (
 	"k8s.io/utils/ptr"
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 
-	. "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
+	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	utilSSH "sigs.k8s.io/cluster-api-provider-azure/util/ssh"
 )
 
@@ -41,7 +41,7 @@ const (
 )
 
 // DefaultFleetsMember sets the default FleetsMember for an AzureManagedControlPlane.
-func DefaultFleetsMember(fleetsMember *FleetsMember, labels map[string]string) *FleetsMember {
+func DefaultFleetsMember(fleetsMember *infrav1.FleetsMember, labels map[string]string) *infrav1.FleetsMember {
 	result := fleetsMember.DeepCopy()
 	if fleetsMember != nil {
 		if clusterName, ok := labels[clusterv1.ClusterNameLabel]; ok && fleetsMember.Name == "" {
@@ -52,20 +52,20 @@ func DefaultFleetsMember(fleetsMember *FleetsMember, labels map[string]string) *
 }
 
 // DefaultSku returns the default SKU for an AzureManagedControlPlane.
-func DefaultSku(log logr.Logger, sku *AKSSku) *AKSSku {
+func DefaultSku(log logr.Logger, sku *infrav1.AKSSku) *infrav1.AKSSku {
 	result := sku.DeepCopy()
 	if sku == nil {
-		result = new(AKSSku)
-		result.Tier = FreeManagedControlPlaneTier
-	} else if sku.Tier == PaidManagedControlPlaneTier {
-		result.Tier = StandardManagedControlPlaneTier
+		result = new(infrav1.AKSSku)
+		result.Tier = infrav1.FreeManagedControlPlaneTier
+	} else if sku.Tier == infrav1.PaidManagedControlPlaneTier {
+		result.Tier = infrav1.StandardManagedControlPlaneTier
 		log.Info("Paid SKU tier is deprecated and has been replaced by Standard")
 	}
 	return result
 }
 
 // SetDefaultAzureManagedControlPlaneResourceGroupName sets the default ResourceGroupName for an AzureManagedControlPlane.
-func SetDefaultAzureManagedControlPlaneResourceGroupName(m *AzureManagedControlPlane) {
+func SetDefaultAzureManagedControlPlaneResourceGroupName(m *infrav1.AzureManagedControlPlane) {
 	if m.Spec.ResourceGroupName == "" {
 		if clusterName, ok := m.Labels[clusterv1.ClusterNameLabel]; ok {
 			m.Spec.ResourceGroupName = clusterName
@@ -74,7 +74,7 @@ func SetDefaultAzureManagedControlPlaneResourceGroupName(m *AzureManagedControlP
 }
 
 // SetDefaultAzureManagedControlPlaneSSHPublicKey sets the default SSHPublicKey for an AzureManagedControlPlane.
-func SetDefaultAzureManagedControlPlaneSSHPublicKey(m *AzureManagedControlPlane) error {
+func SetDefaultAzureManagedControlPlaneSSHPublicKey(m *infrav1.AzureManagedControlPlane) error {
 	if sshKey := m.Spec.SSHPublicKey; sshKey != nil && *sshKey == "" {
 		_, publicRsaKey, err := utilSSH.GenerateSSHKey()
 		if err != nil {
@@ -88,20 +88,20 @@ func SetDefaultAzureManagedControlPlaneSSHPublicKey(m *AzureManagedControlPlane)
 }
 
 // SetDefaultAzureManagedControlPlaneNodeResourceGroupName sets the default NodeResourceGroup for an AzureManagedControlPlane.
-func SetDefaultAzureManagedControlPlaneNodeResourceGroupName(m *AzureManagedControlPlane) {
+func SetDefaultAzureManagedControlPlaneNodeResourceGroupName(m *infrav1.AzureManagedControlPlane) {
 	if m.Spec.NodeResourceGroupName == "" {
 		m.Spec.NodeResourceGroupName = fmt.Sprintf("MC_%s_%s_%s", m.Spec.ResourceGroupName, m.Name, m.Spec.Location)
 	}
 }
 
 // SetDefaultAzureManagedControlPlaneVirtualNetwork sets the default VirtualNetwork for an AzureManagedControlPlane.
-func SetDefaultAzureManagedControlPlaneVirtualNetwork(m *AzureManagedControlPlane) {
+func SetDefaultAzureManagedControlPlaneVirtualNetwork(m *infrav1.AzureManagedControlPlane) {
 	if m.Spec.VirtualNetwork.Name == "" {
 		m.Spec.VirtualNetwork.Name = m.Name
 	}
 	if m.Spec.VirtualNetwork.CIDRBlock == "" {
 		m.Spec.VirtualNetwork.CIDRBlock = DefaultAKSVnetCIDR
-		if ptr.Deref(m.Spec.NetworkPluginMode, "") == NetworkPluginModeOverlay {
+		if ptr.Deref(m.Spec.NetworkPluginMode, "") == infrav1.NetworkPluginModeOverlay {
 			m.Spec.VirtualNetwork.CIDRBlock = DefaultAKSVnetCIDRForOverlay
 		}
 	}
@@ -111,34 +111,34 @@ func SetDefaultAzureManagedControlPlaneVirtualNetwork(m *AzureManagedControlPlan
 }
 
 // SetDefaultAzureManagedControlPlaneSubnet sets the default Subnet for an AzureManagedControlPlane.
-func SetDefaultAzureManagedControlPlaneSubnet(m *AzureManagedControlPlane) {
+func SetDefaultAzureManagedControlPlaneSubnet(m *infrav1.AzureManagedControlPlane) {
 	if m.Spec.VirtualNetwork.Subnet.Name == "" {
 		m.Spec.VirtualNetwork.Subnet.Name = m.Name
 	}
 	if m.Spec.VirtualNetwork.Subnet.CIDRBlock == "" {
 		m.Spec.VirtualNetwork.Subnet.CIDRBlock = DefaultAKSNodeSubnetCIDR
-		if ptr.Deref(m.Spec.NetworkPluginMode, "") == NetworkPluginModeOverlay {
+		if ptr.Deref(m.Spec.NetworkPluginMode, "") == infrav1.NetworkPluginModeOverlay {
 			m.Spec.VirtualNetwork.Subnet.CIDRBlock = DefaultAKSNodeSubnetCIDRForOverlay
 		}
 	}
 }
 
 // SetDefaultAzureManagedControlPlaneOIDCIssuerProfile sets the default OIDCIssuerProfile for an AzureManagedControlPlane.
-func SetDefaultAzureManagedControlPlaneOIDCIssuerProfile(m *AzureManagedControlPlane) {
+func SetDefaultAzureManagedControlPlaneOIDCIssuerProfile(m *infrav1.AzureManagedControlPlane) {
 	if m.Spec.OIDCIssuerProfile == nil {
-		m.Spec.OIDCIssuerProfile = &OIDCIssuerProfile{}
+		m.Spec.OIDCIssuerProfile = &infrav1.OIDCIssuerProfile{}
 	}
 }
 
 // SetDefaultAzureManagedControlPlaneDNSPrefix sets the default DNSPrefix for an AzureManagedControlPlane.
-func SetDefaultAzureManagedControlPlaneDNSPrefix(m *AzureManagedControlPlane) {
+func SetDefaultAzureManagedControlPlaneDNSPrefix(m *infrav1.AzureManagedControlPlane) {
 	if m.Spec.DNSPrefix == nil {
 		m.Spec.DNSPrefix = ptr.To(m.Name)
 	}
 }
 
 // SetDefaultAzureManagedControlPlaneAKSExtensions sets the default AKS extensions for an AzureManagedControlPlane.
-func SetDefaultAzureManagedControlPlaneAKSExtensions(m *AzureManagedControlPlane) {
+func SetDefaultAzureManagedControlPlaneAKSExtensions(m *infrav1.AzureManagedControlPlane) {
 	for _, extension := range m.Spec.Extensions {
 		if extension.Plan != nil && extension.Plan.Name == "" {
 			extension.Plan.Name = fmt.Sprintf("%s-%s", m.Name, extension.Plan.Product)

--- a/internal/api/v1beta1/azuremanagedcontrolplane_default_test.go
+++ b/internal/api/v1beta1/azuremanagedcontrolplane_default_test.go
@@ -21,14 +21,14 @@ import (
 
 	. "github.com/onsi/gomega"
 
-	. "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
+	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 )
 
 func TestAzureManagedControlPlane_SetDefaultSSHPublicKey(t *testing.T) {
 	g := NewWithT(t)
 
 	type test struct {
-		m *AzureManagedControlPlane
+		m *infrav1.AzureManagedControlPlane
 	}
 
 	existingPublicKey := "testpublickey"
@@ -44,13 +44,13 @@ func TestAzureManagedControlPlane_SetDefaultSSHPublicKey(t *testing.T) {
 	g.Expect(*publicKeyNotExistTest.m.Spec.SSHPublicKey).NotTo(BeEmpty())
 }
 
-func createAzureManagedControlPlaneWithSSHPublicKey(sshPublicKey string) *AzureManagedControlPlane {
+func createAzureManagedControlPlaneWithSSHPublicKey(sshPublicKey string) *infrav1.AzureManagedControlPlane {
 	return hardcodedAzureManagedControlPlaneWithSSHKey(sshPublicKey)
 }
 
-func hardcodedAzureManagedControlPlaneWithSSHKey(sshPublicKey string) *AzureManagedControlPlane {
-	return &AzureManagedControlPlane{
-		Spec: AzureManagedControlPlaneSpec{
+func hardcodedAzureManagedControlPlaneWithSSHKey(sshPublicKey string) *infrav1.AzureManagedControlPlane {
+	return &infrav1.AzureManagedControlPlane{
+		Spec: infrav1.AzureManagedControlPlaneSpec{
 			SSHPublicKey: &sshPublicKey,
 		},
 	}

--- a/internal/api/v1beta1/azuremanagedcontrolplanetemplate_default.go
+++ b/internal/api/v1beta1/azuremanagedcontrolplanetemplate_default.go
@@ -22,12 +22,12 @@ import (
 	"github.com/go-logr/logr"
 	"k8s.io/utils/ptr"
 
-	. "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
+	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 )
 
 // SetDefaultsAzureManagedControlPlaneTemplate sets the default values for an AzureManagedControlPlaneTemplate.
-func SetDefaultsAzureManagedControlPlaneTemplate(log logr.Logger, mcp *AzureManagedControlPlaneTemplate) {
-	SetZeroPointerDefault[*string](&mcp.Spec.Template.Spec.NetworkPlugin, ptr.To(AzureNetworkPluginName))
+func SetDefaultsAzureManagedControlPlaneTemplate(log logr.Logger, mcp *infrav1.AzureManagedControlPlaneTemplate) {
+	SetZeroPointerDefault[*string](&mcp.Spec.Template.Spec.NetworkPlugin, ptr.To(infrav1.AzureNetworkPluginName))
 	SetZeroPointerDefault[*string](&mcp.Spec.Template.Spec.LoadBalancerSKU, ptr.To("Standard"))
 	SetZeroPointerDefault[*bool](&mcp.Spec.Template.Spec.EnablePreviewFeatures, ptr.To(false))
 
@@ -41,7 +41,7 @@ func SetDefaultsAzureManagedControlPlaneTemplate(log logr.Logger, mcp *AzureMana
 }
 
 // setDefaultAzureManagedControlPlaneTemplateVirtualNetwork sets the default VirtualNetwork for an AzureManagedControlPlaneTemplate.
-func setDefaultAzureManagedControlPlaneTemplateVirtualNetwork(log logr.Logger, mcp *AzureManagedControlPlaneTemplate) {
+func setDefaultAzureManagedControlPlaneTemplateVirtualNetwork(log logr.Logger, mcp *infrav1.AzureManagedControlPlaneTemplate) {
 	if mcp.Spec.Template.Spec.VirtualNetwork.Name != "" {
 		// Being able to set the vnet name in the template type is a bug, as vnet names cannot be reused across clusters.
 		// To avoid a breaking API change, a warning is logged.
@@ -53,7 +53,7 @@ func setDefaultAzureManagedControlPlaneTemplateVirtualNetwork(log logr.Logger, m
 }
 
 // setDefaultAzureManagedControlPlaneTemplateSubnet sets the default Subnet for an AzureManagedControlPlaneTemplate.
-func setDefaultAzureManagedControlPlaneTemplateSubnet(mcp *AzureManagedControlPlaneTemplate) {
+func setDefaultAzureManagedControlPlaneTemplateSubnet(mcp *infrav1.AzureManagedControlPlaneTemplate) {
 	if mcp.Spec.Template.Spec.VirtualNetwork.Subnet.Name == "" {
 		mcp.Spec.Template.Spec.VirtualNetwork.Subnet.Name = mcp.Name
 	}

--- a/internal/api/v1beta1/azuremanagedcontrolplanetemplate_default_test.go
+++ b/internal/api/v1beta1/azuremanagedcontrolplanetemplate_default_test.go
@@ -25,35 +25,35 @@ import (
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	. "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
+	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 )
 
 func TestDefaultVirtualNetworkTemplate(t *testing.T) {
 	cases := []struct {
 		name                 string
-		controlPlaneTemplate *AzureManagedControlPlaneTemplate
-		outputTemplate       *AzureManagedControlPlaneTemplate
+		controlPlaneTemplate *infrav1.AzureManagedControlPlaneTemplate
+		outputTemplate       *infrav1.AzureManagedControlPlaneTemplate
 	}{
 		{
 			name: "virtual network not specified",
-			controlPlaneTemplate: &AzureManagedControlPlaneTemplate{
+			controlPlaneTemplate: &infrav1.AzureManagedControlPlaneTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster-template",
 				},
-				Spec: AzureManagedControlPlaneTemplateSpec{
-					Template: AzureManagedControlPlaneTemplateResource{},
+				Spec: infrav1.AzureManagedControlPlaneTemplateSpec{
+					Template: infrav1.AzureManagedControlPlaneTemplateResource{},
 				},
 			},
-			outputTemplate: &AzureManagedControlPlaneTemplate{
+			outputTemplate: &infrav1.AzureManagedControlPlaneTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster-template",
 				},
-				Spec: AzureManagedControlPlaneTemplateSpec{
-					Template: AzureManagedControlPlaneTemplateResource{
-						Spec: AzureManagedControlPlaneTemplateResourceSpec{
-							AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
-								VirtualNetwork: ManagedControlPlaneVirtualNetwork{
-									ManagedControlPlaneVirtualNetworkClassSpec: ManagedControlPlaneVirtualNetworkClassSpec{
+				Spec: infrav1.AzureManagedControlPlaneTemplateSpec{
+					Template: infrav1.AzureManagedControlPlaneTemplateResource{
+						Spec: infrav1.AzureManagedControlPlaneTemplateResourceSpec{
+							AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
+								VirtualNetwork: infrav1.ManagedControlPlaneVirtualNetwork{
+									ManagedControlPlaneVirtualNetworkClassSpec: infrav1.ManagedControlPlaneVirtualNetworkClassSpec{
 										CIDRBlock: DefaultAKSVnetCIDR,
 									},
 								},
@@ -65,16 +65,16 @@ func TestDefaultVirtualNetworkTemplate(t *testing.T) {
 		},
 		{
 			name: "custom cidr block",
-			controlPlaneTemplate: &AzureManagedControlPlaneTemplate{
+			controlPlaneTemplate: &infrav1.AzureManagedControlPlaneTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster-template",
 				},
-				Spec: AzureManagedControlPlaneTemplateSpec{
-					Template: AzureManagedControlPlaneTemplateResource{
-						Spec: AzureManagedControlPlaneTemplateResourceSpec{
-							AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
-								VirtualNetwork: ManagedControlPlaneVirtualNetwork{
-									ManagedControlPlaneVirtualNetworkClassSpec: ManagedControlPlaneVirtualNetworkClassSpec{
+				Spec: infrav1.AzureManagedControlPlaneTemplateSpec{
+					Template: infrav1.AzureManagedControlPlaneTemplateResource{
+						Spec: infrav1.AzureManagedControlPlaneTemplateResourceSpec{
+							AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
+								VirtualNetwork: infrav1.ManagedControlPlaneVirtualNetwork{
+									ManagedControlPlaneVirtualNetworkClassSpec: infrav1.ManagedControlPlaneVirtualNetworkClassSpec{
 										CIDRBlock: "10.0.0.16/24",
 									},
 								},
@@ -83,16 +83,16 @@ func TestDefaultVirtualNetworkTemplate(t *testing.T) {
 					},
 				},
 			},
-			outputTemplate: &AzureManagedControlPlaneTemplate{
+			outputTemplate: &infrav1.AzureManagedControlPlaneTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster-template",
 				},
-				Spec: AzureManagedControlPlaneTemplateSpec{
-					Template: AzureManagedControlPlaneTemplateResource{
-						Spec: AzureManagedControlPlaneTemplateResourceSpec{
-							AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
-								VirtualNetwork: ManagedControlPlaneVirtualNetwork{
-									ManagedControlPlaneVirtualNetworkClassSpec: ManagedControlPlaneVirtualNetworkClassSpec{
+				Spec: infrav1.AzureManagedControlPlaneTemplateSpec{
+					Template: infrav1.AzureManagedControlPlaneTemplateResource{
+						Spec: infrav1.AzureManagedControlPlaneTemplateResourceSpec{
+							AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
+								VirtualNetwork: infrav1.ManagedControlPlaneVirtualNetwork{
+									ManagedControlPlaneVirtualNetworkClassSpec: infrav1.ManagedControlPlaneVirtualNetworkClassSpec{
 										CIDRBlock: "10.0.0.16/24",
 									},
 								},
@@ -121,30 +121,30 @@ func TestDefaultVirtualNetworkTemplate(t *testing.T) {
 func TestDefaultSubnetTemplate(t *testing.T) {
 	cases := []struct {
 		name                 string
-		controlPlaneTemplate *AzureManagedControlPlaneTemplate
-		outputTemplate       *AzureManagedControlPlaneTemplate
+		controlPlaneTemplate *infrav1.AzureManagedControlPlaneTemplate
+		outputTemplate       *infrav1.AzureManagedControlPlaneTemplate
 	}{
 		{
 			name: "subnet not specified",
-			controlPlaneTemplate: &AzureManagedControlPlaneTemplate{
+			controlPlaneTemplate: &infrav1.AzureManagedControlPlaneTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster-template",
 				},
-				Spec: AzureManagedControlPlaneTemplateSpec{
-					Template: AzureManagedControlPlaneTemplateResource{},
+				Spec: infrav1.AzureManagedControlPlaneTemplateSpec{
+					Template: infrav1.AzureManagedControlPlaneTemplateResource{},
 				},
 			},
-			outputTemplate: &AzureManagedControlPlaneTemplate{
+			outputTemplate: &infrav1.AzureManagedControlPlaneTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster-template",
 				},
-				Spec: AzureManagedControlPlaneTemplateSpec{
-					Template: AzureManagedControlPlaneTemplateResource{
-						Spec: AzureManagedControlPlaneTemplateResourceSpec{
-							AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
-								VirtualNetwork: ManagedControlPlaneVirtualNetwork{
-									ManagedControlPlaneVirtualNetworkClassSpec: ManagedControlPlaneVirtualNetworkClassSpec{
-										Subnet: ManagedControlPlaneSubnet{
+				Spec: infrav1.AzureManagedControlPlaneTemplateSpec{
+					Template: infrav1.AzureManagedControlPlaneTemplateResource{
+						Spec: infrav1.AzureManagedControlPlaneTemplateResourceSpec{
+							AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
+								VirtualNetwork: infrav1.ManagedControlPlaneVirtualNetwork{
+									ManagedControlPlaneVirtualNetworkClassSpec: infrav1.ManagedControlPlaneVirtualNetworkClassSpec{
+										Subnet: infrav1.ManagedControlPlaneSubnet{
 											Name:      "test-cluster-template",
 											CIDRBlock: DefaultAKSNodeSubnetCIDR,
 										},
@@ -158,17 +158,17 @@ func TestDefaultSubnetTemplate(t *testing.T) {
 		},
 		{
 			name: "custom name",
-			controlPlaneTemplate: &AzureManagedControlPlaneTemplate{
+			controlPlaneTemplate: &infrav1.AzureManagedControlPlaneTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster-template",
 				},
-				Spec: AzureManagedControlPlaneTemplateSpec{
-					Template: AzureManagedControlPlaneTemplateResource{
-						Spec: AzureManagedControlPlaneTemplateResourceSpec{
-							AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
-								VirtualNetwork: ManagedControlPlaneVirtualNetwork{
-									ManagedControlPlaneVirtualNetworkClassSpec: ManagedControlPlaneVirtualNetworkClassSpec{
-										Subnet: ManagedControlPlaneSubnet{
+				Spec: infrav1.AzureManagedControlPlaneTemplateSpec{
+					Template: infrav1.AzureManagedControlPlaneTemplateResource{
+						Spec: infrav1.AzureManagedControlPlaneTemplateResourceSpec{
+							AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
+								VirtualNetwork: infrav1.ManagedControlPlaneVirtualNetwork{
+									ManagedControlPlaneVirtualNetworkClassSpec: infrav1.ManagedControlPlaneVirtualNetworkClassSpec{
+										Subnet: infrav1.ManagedControlPlaneSubnet{
 											Name: "custom-subnet-name",
 										},
 									},
@@ -178,17 +178,17 @@ func TestDefaultSubnetTemplate(t *testing.T) {
 					},
 				},
 			},
-			outputTemplate: &AzureManagedControlPlaneTemplate{
+			outputTemplate: &infrav1.AzureManagedControlPlaneTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster-template",
 				},
-				Spec: AzureManagedControlPlaneTemplateSpec{
-					Template: AzureManagedControlPlaneTemplateResource{
-						Spec: AzureManagedControlPlaneTemplateResourceSpec{
-							AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
-								VirtualNetwork: ManagedControlPlaneVirtualNetwork{
-									ManagedControlPlaneVirtualNetworkClassSpec: ManagedControlPlaneVirtualNetworkClassSpec{
-										Subnet: ManagedControlPlaneSubnet{
+				Spec: infrav1.AzureManagedControlPlaneTemplateSpec{
+					Template: infrav1.AzureManagedControlPlaneTemplateResource{
+						Spec: infrav1.AzureManagedControlPlaneTemplateResourceSpec{
+							AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
+								VirtualNetwork: infrav1.ManagedControlPlaneVirtualNetwork{
+									ManagedControlPlaneVirtualNetworkClassSpec: infrav1.ManagedControlPlaneVirtualNetworkClassSpec{
+										Subnet: infrav1.ManagedControlPlaneSubnet{
 											Name:      "custom-subnet-name",
 											CIDRBlock: DefaultAKSNodeSubnetCIDR,
 										},
@@ -202,17 +202,17 @@ func TestDefaultSubnetTemplate(t *testing.T) {
 		},
 		{
 			name: "custom cidr block",
-			controlPlaneTemplate: &AzureManagedControlPlaneTemplate{
+			controlPlaneTemplate: &infrav1.AzureManagedControlPlaneTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster-template",
 				},
-				Spec: AzureManagedControlPlaneTemplateSpec{
-					Template: AzureManagedControlPlaneTemplateResource{
-						Spec: AzureManagedControlPlaneTemplateResourceSpec{
-							AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
-								VirtualNetwork: ManagedControlPlaneVirtualNetwork{
-									ManagedControlPlaneVirtualNetworkClassSpec: ManagedControlPlaneVirtualNetworkClassSpec{
-										Subnet: ManagedControlPlaneSubnet{
+				Spec: infrav1.AzureManagedControlPlaneTemplateSpec{
+					Template: infrav1.AzureManagedControlPlaneTemplateResource{
+						Spec: infrav1.AzureManagedControlPlaneTemplateResourceSpec{
+							AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
+								VirtualNetwork: infrav1.ManagedControlPlaneVirtualNetwork{
+									ManagedControlPlaneVirtualNetworkClassSpec: infrav1.ManagedControlPlaneVirtualNetworkClassSpec{
+										Subnet: infrav1.ManagedControlPlaneSubnet{
 											CIDRBlock: "10.0.0.16/24",
 										},
 									},
@@ -222,17 +222,17 @@ func TestDefaultSubnetTemplate(t *testing.T) {
 					},
 				},
 			},
-			outputTemplate: &AzureManagedControlPlaneTemplate{
+			outputTemplate: &infrav1.AzureManagedControlPlaneTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster-template",
 				},
-				Spec: AzureManagedControlPlaneTemplateSpec{
-					Template: AzureManagedControlPlaneTemplateResource{
-						Spec: AzureManagedControlPlaneTemplateResourceSpec{
-							AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
-								VirtualNetwork: ManagedControlPlaneVirtualNetwork{
-									ManagedControlPlaneVirtualNetworkClassSpec: ManagedControlPlaneVirtualNetworkClassSpec{
-										Subnet: ManagedControlPlaneSubnet{
+				Spec: infrav1.AzureManagedControlPlaneTemplateSpec{
+					Template: infrav1.AzureManagedControlPlaneTemplateResource{
+						Spec: infrav1.AzureManagedControlPlaneTemplateResourceSpec{
+							AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
+								VirtualNetwork: infrav1.ManagedControlPlaneVirtualNetwork{
+									ManagedControlPlaneVirtualNetworkClassSpec: infrav1.ManagedControlPlaneVirtualNetworkClassSpec{
+										Subnet: infrav1.ManagedControlPlaneSubnet{
 											Name:      "test-cluster-template",
 											CIDRBlock: "10.0.0.16/24",
 										},

--- a/internal/api/v1beta1/class_defaults.go
+++ b/internal/api/v1beta1/class_defaults.go
@@ -17,35 +17,35 @@ limitations under the License.
 package v1beta1
 
 import (
-	. "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
+	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 )
 
 // AzureClusterClassSpecSetDefaults sets default values for AzureClusterClassSpec.
-func AzureClusterClassSpecSetDefaults(acc *AzureClusterClassSpec) {
+func AzureClusterClassSpecSetDefaults(acc *infrav1.AzureClusterClassSpec) {
 	if acc.AzureEnvironment == "" {
 		acc.AzureEnvironment = DefaultAzureCloud
 	}
 }
 
 // VnetClassSpecSetDefaults sets default values for VnetClassSpec.
-func VnetClassSpecSetDefaults(vc *VnetClassSpec) {
+func VnetClassSpecSetDefaults(vc *infrav1.VnetClassSpec) {
 	if len(vc.CIDRBlocks) == 0 {
 		vc.CIDRBlocks = []string{DefaultVnetCIDR}
 	}
 }
 
 // SubnetClassSpecSetDefaults sets default values for SubnetClassSpec.
-func SubnetClassSpecSetDefaults(sc *SubnetClassSpec, cidr string) {
+func SubnetClassSpecSetDefaults(sc *infrav1.SubnetClassSpec, cidr string) {
 	if len(sc.CIDRBlocks) == 0 {
 		sc.CIDRBlocks = []string{cidr}
 	}
 }
 
 // SecurityGroupClassSetDefaults sets default values for SecurityGroupClass.
-func SecurityGroupClassSetDefaults(sgc *SecurityGroupClass) {
+func SecurityGroupClassSetDefaults(sgc *infrav1.SecurityGroupClass) {
 	for i := range sgc.SecurityRules {
 		if sgc.SecurityRules[i].Direction == "" {
-			sgc.SecurityRules[i].Direction = SecurityRuleDirectionInbound
+			sgc.SecurityRules[i].Direction = infrav1.SecurityRuleDirectionInbound
 		}
 	}
 }

--- a/internal/api/v1beta1/helpers.go
+++ b/internal/api/v1beta1/helpers.go
@@ -24,7 +24,7 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	. "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
+	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 )
 
 // GetOwnerAzureClusterNameAndNamespace returns the owner azure cluster's name and namespace for the given cluster name and namespace.
@@ -55,7 +55,7 @@ func GetOwnerAzureClusterNameAndNamespace(cli client.Client, clusterName string,
 func GetSubscriptionID(cli client.Client, ownerAzureClusterName string, ownerAzureClusterNamespace string, maxAttempts int) (string, error) {
 	ctx := context.Background()
 
-	ownerAzureCluster := &AzureCluster{}
+	ownerAzureCluster := &infrav1.AzureCluster{}
 	key := client.ObjectKey{
 		Namespace: ownerAzureClusterNamespace,
 		Name:      ownerAzureClusterName,

--- a/internal/test/apifixtures/cluster.go
+++ b/internal/test/apifixtures/cluster.go
@@ -21,19 +21,19 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 
-	. "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
+	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 )
 
 // CreateValidClusterWithClusterSubnet returns a valid AzureCluster with a cluster subnet.
-func CreateValidClusterWithClusterSubnet() *AzureCluster {
-	return &AzureCluster{
+func CreateValidClusterWithClusterSubnet() *infrav1.AzureCluster {
+	return &infrav1.AzureCluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-cluster",
 		},
-		Spec: AzureClusterSpec{
+		Spec: infrav1.AzureClusterSpec{
 			ControlPlaneEnabled: true,
 			NetworkSpec:         CreateValidNetworkSpecWithClusterSubnet(),
-			AzureClusterClassSpec: AzureClusterClassSpec{
+			AzureClusterClassSpec: infrav1.AzureClusterClassSpec{
 				IdentityRef: &corev1.ObjectReference{
 					Kind: "AzureClusterIdentity",
 				},
@@ -43,17 +43,17 @@ func CreateValidClusterWithClusterSubnet() *AzureCluster {
 }
 
 // CreateValidCluster returns a valid AzureCluster.
-func CreateValidCluster() *AzureCluster {
-	return &AzureCluster{
+func CreateValidCluster() *infrav1.AzureCluster {
+	return &infrav1.AzureCluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-cluster",
 		},
-		Spec: AzureClusterSpec{
+		Spec: infrav1.AzureClusterSpec{
 			ControlPlaneEnabled: true,
 			NetworkSpec:         CreateValidNetworkSpec(),
-			AzureClusterClassSpec: AzureClusterClassSpec{
+			AzureClusterClassSpec: infrav1.AzureClusterClassSpec{
 				IdentityRef: &corev1.ObjectReference{
-					Kind: AzureClusterIdentityKind,
+					Kind: infrav1.AzureClusterIdentityKind,
 				},
 			},
 		},
@@ -61,15 +61,15 @@ func CreateValidCluster() *AzureCluster {
 }
 
 // CreateClusterNetworkSpec returns a NetworkSpec for a cluster subnet topology.
-func CreateClusterNetworkSpec() NetworkSpec {
-	return NetworkSpec{
-		Vnet: VnetSpec{
+func CreateClusterNetworkSpec() infrav1.NetworkSpec {
+	return infrav1.NetworkSpec{
+		Vnet: infrav1.VnetSpec{
 			ResourceGroup: "custom-vnet",
 			Name:          "my-vnet",
 		},
-		Subnets: Subnets{
+		Subnets: infrav1.Subnets{
 			{
-				SubnetClassSpec: SubnetClassSpec{
+				SubnetClassSpec: infrav1.SubnetClassSpec{
 					Role: "cluster",
 					Name: "cluster-subnet",
 				},
@@ -81,15 +81,15 @@ func CreateClusterNetworkSpec() NetworkSpec {
 }
 
 // CreateValidNetworkSpecWithClusterSubnet returns a valid NetworkSpec with a cluster subnet.
-func CreateValidNetworkSpecWithClusterSubnet() NetworkSpec {
-	return NetworkSpec{
-		Vnet: VnetSpec{
+func CreateValidNetworkSpecWithClusterSubnet() infrav1.NetworkSpec {
+	return infrav1.NetworkSpec{
+		Vnet: infrav1.VnetSpec{
 			ResourceGroup: "custom-vnet",
 			Name:          "my-vnet",
 		},
-		Subnets: Subnets{
+		Subnets: infrav1.Subnets{
 			{
-				SubnetClassSpec: SubnetClassSpec{
+				SubnetClassSpec: infrav1.SubnetClassSpec{
 					Role: "cluster",
 					Name: "cluster-subnet",
 				},
@@ -101,9 +101,9 @@ func CreateValidNetworkSpecWithClusterSubnet() NetworkSpec {
 }
 
 // CreateValidNetworkSpec returns a valid NetworkSpec.
-func CreateValidNetworkSpec() NetworkSpec {
-	return NetworkSpec{
-		Vnet: VnetSpec{
+func CreateValidNetworkSpec() infrav1.NetworkSpec {
+	return infrav1.NetworkSpec{
+		Vnet: infrav1.VnetSpec{
 			ResourceGroup: "custom-vnet",
 			Name:          "my-vnet",
 		},
@@ -114,16 +114,16 @@ func CreateValidNetworkSpec() NetworkSpec {
 }
 
 // CreateValidSubnets returns a valid set of Subnets with control-plane and node roles.
-func CreateValidSubnets() Subnets {
-	return Subnets{
+func CreateValidSubnets() infrav1.Subnets {
+	return infrav1.Subnets{
 		{
-			SubnetClassSpec: SubnetClassSpec{
+			SubnetClassSpec: infrav1.SubnetClassSpec{
 				Role: "control-plane",
 				Name: "control-plane-subnet",
 			},
 		},
 		{
-			SubnetClassSpec: SubnetClassSpec{
+			SubnetClassSpec: infrav1.SubnetClassSpec{
 				Role: "node",
 				Name: "node-subnet",
 			},
@@ -132,58 +132,58 @@ func CreateValidSubnets() Subnets {
 }
 
 // CreateValidVnet returns a valid VnetSpec.
-func CreateValidVnet() VnetSpec {
-	return VnetSpec{
+func CreateValidVnet() infrav1.VnetSpec {
+	return infrav1.VnetSpec{
 		ResourceGroup: "custom-vnet",
 		Name:          "my-vnet",
-		VnetClassSpec: VnetClassSpec{
+		VnetClassSpec: infrav1.VnetClassSpec{
 			CIDRBlocks: []string{"10.0.0.0/8"},
 		},
 	}
 }
 
 // CreateValidAPIServerLB returns a valid public API server LoadBalancerSpec.
-func CreateValidAPIServerLB() *LoadBalancerSpec {
-	return &LoadBalancerSpec{
+func CreateValidAPIServerLB() *infrav1.LoadBalancerSpec {
+	return &infrav1.LoadBalancerSpec{
 		Name: "my-lb",
-		FrontendIPs: []FrontendIP{
+		FrontendIPs: []infrav1.FrontendIP{
 			{
 				Name: "ip-config",
-				PublicIP: &PublicIPSpec{
+				PublicIP: &infrav1.PublicIPSpec{
 					Name:    "public-ip",
 					DNSName: "myfqdn.azure.com",
 				},
 			},
 		},
-		LoadBalancerClassSpec: LoadBalancerClassSpec{
-			SKU:  SKUStandard,
-			Type: Public,
+		LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{
+			SKU:  infrav1.SKUStandard,
+			Type: infrav1.Public,
 		},
 	}
 }
 
 // CreateValidNodeOutboundLB returns a valid node outbound LoadBalancerSpec.
-func CreateValidNodeOutboundLB() *LoadBalancerSpec {
-	return &LoadBalancerSpec{
+func CreateValidNodeOutboundLB() *infrav1.LoadBalancerSpec {
+	return &infrav1.LoadBalancerSpec{
 		FrontendIPsCount: ptr.To[int32](1),
 	}
 }
 
 // CreateValidAPIServerInternalLB returns a valid internal API server LoadBalancerSpec.
-func CreateValidAPIServerInternalLB() *LoadBalancerSpec {
-	return &LoadBalancerSpec{
+func CreateValidAPIServerInternalLB() *infrav1.LoadBalancerSpec {
+	return &infrav1.LoadBalancerSpec{
 		Name: "my-lb",
-		FrontendIPs: []FrontendIP{
+		FrontendIPs: []infrav1.FrontendIP{
 			{
 				Name: "ip-config-private",
-				FrontendIPClass: FrontendIPClass{
+				FrontendIPClass: infrav1.FrontendIPClass{
 					PrivateIPAddress: "10.10.1.1",
 				},
 			},
 		},
-		LoadBalancerClassSpec: LoadBalancerClassSpec{
-			SKU:  SKUStandard,
-			Type: Internal,
+		LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{
+			SKU:  infrav1.SKUStandard,
+			Type: infrav1.Internal,
 		},
 	}
 }

--- a/internal/test/apifixtures/machine.go
+++ b/internal/test/apifixtures/machine.go
@@ -22,44 +22,44 @@ import (
 	"k8s.io/utils/ptr"
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 
-	. "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
+	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 )
 
 // CreateMachineWithSSHPublicKey returns an AzureMachine with the given SSH public key.
-func CreateMachineWithSSHPublicKey(sshPublicKey string) *AzureMachine {
+func CreateMachineWithSSHPublicKey(sshPublicKey string) *infrav1.AzureMachine {
 	machine := HardcodedAzureMachineWithSSHKey(sshPublicKey)
 	return machine
 }
 
 // CreateMachineWithUserAssignedIdentities returns an AzureMachine with user-assigned identities.
-func CreateMachineWithUserAssignedIdentities(identitiesList []UserAssignedIdentity) *AzureMachine {
+func CreateMachineWithUserAssignedIdentities(identitiesList []infrav1.UserAssignedIdentity) *infrav1.AzureMachine {
 	machine := HardcodedAzureMachineWithSSHKey(GenerateSSHPublicKey(true))
-	machine.Spec.Identity = VMIdentityUserAssigned
+	machine.Spec.Identity = infrav1.VMIdentityUserAssigned
 	machine.Spec.UserAssignedIdentities = identitiesList
 	return machine
 }
 
 // CreateMachineWithUserAssignedIdentitiesWithBadIdentity returns an AzureMachine with invalid identity configuration.
-func CreateMachineWithUserAssignedIdentitiesWithBadIdentity(identitiesList []UserAssignedIdentity) *AzureMachine {
+func CreateMachineWithUserAssignedIdentitiesWithBadIdentity(identitiesList []infrav1.UserAssignedIdentity) *infrav1.AzureMachine {
 	machine := HardcodedAzureMachineWithSSHKey(GenerateSSHPublicKey(true))
-	machine.Spec.Identity = VMIdentitySystemAssigned
+	machine.Spec.Identity = infrav1.VMIdentitySystemAssigned
 	machine.Spec.UserAssignedIdentities = identitiesList
 	return machine
 }
 
 // HardcodedAzureMachineWithSSHKey returns an AzureMachine with hardcoded fields and the given SSH public key.
-func HardcodedAzureMachineWithSSHKey(sshPublicKey string) *AzureMachine {
-	return &AzureMachine{
+func HardcodedAzureMachineWithSSHKey(sshPublicKey string) *infrav1.AzureMachine {
+	return &infrav1.AzureMachine{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: map[string]string{
 				clusterv1.ClusterNameLabel: "test-cluster",
 			},
 		},
-		Spec: AzureMachineSpec{
+		Spec: infrav1.AzureMachineSpec{
 			SSHPublicKey: sshPublicKey,
 			OSDisk:       GenerateValidOSDisk(),
-			Image: &Image{
-				SharedGallery: &AzureSharedGalleryImage{
+			Image: &infrav1.Image{
+				SharedGallery: &infrav1.AzureSharedGalleryImage{
 					SubscriptionID: "SUB123",
 					ResourceGroup:  "RG123",
 					Name:           "NAME123",
@@ -72,11 +72,11 @@ func HardcodedAzureMachineWithSSHKey(sshPublicKey string) *AzureMachine {
 }
 
 // GenerateValidOSDisk returns a valid OSDisk configuration.
-func GenerateValidOSDisk() OSDisk {
-	return OSDisk{
+func GenerateValidOSDisk() infrav1.OSDisk {
+	return infrav1.OSDisk{
 		DiskSizeGB: ptr.To[int32](30),
-		OSType:     LinuxOS,
-		ManagedDisk: &ManagedDiskParameters{
+		OSType:     infrav1.LinuxOS,
+		ManagedDisk: &infrav1.ManagedDiskParameters{
 			StorageAccountType: "Premium_LRS",
 		},
 		CachingType: string(armcompute.PossibleCachingTypesValues()[0]),
@@ -84,7 +84,7 @@ func GenerateValidOSDisk() OSDisk {
 }
 
 // CreateOSDiskWithCacheType returns a valid OSDisk with the given cache type.
-func CreateOSDiskWithCacheType(cacheType string) OSDisk {
+func CreateOSDiskWithCacheType(cacheType string) infrav1.OSDisk {
 	osDisk := GenerateValidOSDisk()
 	osDisk.CachingType = cacheType
 	return osDisk

--- a/internal/webhooks/azureasomanagedcluster_webhook.go
+++ b/internal/webhooks/azureasomanagedcluster_webhook.go
@@ -26,14 +26,14 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
-	. "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
+	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/feature"
 )
 
 // SetupWebhookWithManager sets up and registers the webhook with the manager.
 func (ampw *AzureASOManagedClusterWebhook) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
-		For(&AzureASOManagedCluster{}).
+		For(&infrav1.AzureASOManagedCluster{}).
 		WithValidator(ampw).
 		Complete()
 }
@@ -46,7 +46,7 @@ type AzureASOManagedClusterWebhook struct {
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
 func (ampw *AzureASOManagedClusterWebhook) ValidateCreate(_ context.Context, obj runtime.Object) (admission.Warnings, error) {
-	_, ok := obj.(*AzureASOManagedCluster)
+	_, ok := obj.(*infrav1.AzureASOManagedCluster)
 	if !ok {
 		return nil, apierrors.NewBadRequest("expected an AzureASOManagedCluster")
 	}

--- a/internal/webhooks/azureasomanagedcontrolplane_webhook.go
+++ b/internal/webhooks/azureasomanagedcontrolplane_webhook.go
@@ -26,14 +26,14 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
-	. "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
+	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/feature"
 )
 
 // SetupWebhookWithManager sets up and registers the webhook with the manager.
 func (ampw *AzureASOManagedControlPlaneWebhook) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
-		For(&AzureASOManagedControlPlane{}).
+		For(&infrav1.AzureASOManagedControlPlane{}).
 		WithValidator(ampw).
 		Complete()
 }
@@ -46,7 +46,7 @@ type AzureASOManagedControlPlaneWebhook struct {
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
 func (ampw *AzureASOManagedControlPlaneWebhook) ValidateCreate(_ context.Context, obj runtime.Object) (admission.Warnings, error) {
-	_, ok := obj.(*AzureASOManagedControlPlane)
+	_, ok := obj.(*infrav1.AzureASOManagedControlPlane)
 	if !ok {
 		return nil, apierrors.NewBadRequest("expected an AzureASOManagedControlPlane")
 	}

--- a/internal/webhooks/azureasomanagedmachinepool_webhook.go
+++ b/internal/webhooks/azureasomanagedmachinepool_webhook.go
@@ -26,14 +26,14 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
-	. "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
+	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/feature"
 )
 
 // SetupWebhookWithManager sets up and registers the webhook with the manager.
 func (ampw *AzureASOManagedMachinePoolWebhook) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
-		For(&AzureASOManagedMachinePool{}).
+		For(&infrav1.AzureASOManagedMachinePool{}).
 		WithValidator(ampw).
 		Complete()
 }
@@ -46,7 +46,7 @@ type AzureASOManagedMachinePoolWebhook struct {
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
 func (ampw *AzureASOManagedMachinePoolWebhook) ValidateCreate(_ context.Context, obj runtime.Object) (admission.Warnings, error) {
-	_, ok := obj.(*AzureASOManagedMachinePool)
+	_, ok := obj.(*infrav1.AzureASOManagedMachinePool)
 	if !ok {
 		return nil, apierrors.NewBadRequest("expected an AzureASOManagedMachinePool")
 	}

--- a/internal/webhooks/azurecluster_validation.go
+++ b/internal/webhooks/azurecluster_validation.go
@@ -30,7 +30,7 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
-	. "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
+	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/feature"
 )
 
@@ -72,7 +72,7 @@ var (
 )
 
 // validateAzureCluster validates a cluster.
-func validateAzureCluster(c *AzureCluster, old *AzureCluster) (admission.Warnings, error) {
+func validateAzureCluster(c *infrav1.AzureCluster, old *infrav1.AzureCluster) (admission.Warnings, error) {
 	var allErrs field.ErrorList
 	allErrs = append(allErrs, validateAzureClusterName(c)...)
 	allErrs = append(allErrs, validateAzureClusterSpec(c, old)...)
@@ -81,21 +81,21 @@ func validateAzureCluster(c *AzureCluster, old *AzureCluster) (admission.Warning
 	}
 
 	return nil, apierrors.NewInvalid(
-		schema.GroupKind{Group: "infrastructure.cluster.x-k8s.io", Kind: AzureClusterKind},
+		schema.GroupKind{Group: "infrastructure.cluster.x-k8s.io", Kind: infrav1.AzureClusterKind},
 		c.Name, allErrs)
 }
 
 // validateAzureClusterSpec validates a ClusterSpec.
-func validateAzureClusterSpec(c *AzureCluster, old *AzureCluster) field.ErrorList {
+func validateAzureClusterSpec(c *infrav1.AzureCluster, old *infrav1.AzureCluster) field.ErrorList {
 	var allErrs field.ErrorList
-	var oldNetworkSpec NetworkSpec
+	var oldNetworkSpec infrav1.NetworkSpec
 	if old != nil {
 		oldNetworkSpec = old.Spec.NetworkSpec
 	}
 
 	allErrs = append(allErrs, validateNetworkSpec(c.Spec.ControlPlaneEnabled, c.Spec.NetworkSpec, oldNetworkSpec, field.NewPath("spec").Child("networkSpec"))...)
 
-	var oldCloudProviderConfigOverrides *CloudProviderConfigOverrides
+	var oldCloudProviderConfigOverrides *infrav1.CloudProviderConfigOverrides
 	if old != nil {
 		oldCloudProviderConfigOverrides = old.Spec.CloudProviderConfigOverrides
 	}
@@ -119,7 +119,7 @@ func validateAzureClusterSpec(c *AzureCluster, old *AzureCluster) field.ErrorLis
 }
 
 // validateAzureClusterName validates ClusterName.
-func validateAzureClusterName(c *AzureCluster) field.ErrorList {
+func validateAzureClusterName(c *infrav1.AzureCluster) field.ErrorList {
 	var allErrs field.ErrorList
 	if len(c.Name) > clusterNameMaxLength {
 		allErrs = append(allErrs, field.Invalid(field.NewPath("metadata").Child("Name"), c.Name,
@@ -137,8 +137,8 @@ func validateAzureClusterName(c *AzureCluster) field.ErrorList {
 }
 
 // validateBastionSpec validates a BastionSpec.
-func validateBastionSpec(bastionSpec BastionSpec, fldPath *field.Path) *field.Error {
-	if bastionSpec.AzureBastion != nil && bastionSpec.AzureBastion.Sku != StandardBastionHostSku && bastionSpec.AzureBastion.EnableTunneling {
+func validateBastionSpec(bastionSpec infrav1.BastionSpec, fldPath *field.Path) *field.Error {
+	if bastionSpec.AzureBastion != nil && bastionSpec.AzureBastion.Sku != infrav1.StandardBastionHostSku && bastionSpec.AzureBastion.EnableTunneling {
 		return field.Invalid(fldPath.Child("sku"), bastionSpec.AzureBastion.Sku,
 			"sku must be Standard if tunneling is enabled")
 	}
@@ -150,14 +150,14 @@ func validateIdentityRef(identityRef *corev1.ObjectReference, fldPath *field.Pat
 	if identityRef == nil {
 		return field.Required(fldPath, "identityRef is required")
 	}
-	if identityRef.Kind != AzureClusterIdentityKind {
+	if identityRef.Kind != infrav1.AzureClusterIdentityKind {
 		return field.NotSupported(fldPath.Child("name"), identityRef.Name, []string{"AzureClusterIdentity"})
 	}
 	return nil
 }
 
 // validateNetworkSpec validates a NetworkSpec.
-func validateNetworkSpec(controlPlaneEnabled bool, networkSpec NetworkSpec, old NetworkSpec, fldPath *field.Path) field.ErrorList {
+func validateNetworkSpec(controlPlaneEnabled bool, networkSpec infrav1.NetworkSpec, old infrav1.NetworkSpec, fldPath *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
 	// If the user specifies a resourceGroup for vnet, it means
 	// that they intend to use a pre-existing vnet. In this case,
@@ -188,7 +188,7 @@ func validateNetworkSpec(controlPlaneEnabled bool, networkSpec NetworkSpec, old 
 
 	var needOutboundLB bool
 	for _, subnet := range networkSpec.Subnets {
-		if (subnet.Role == SubnetNode || subnet.Role == SubnetCluster) && subnet.IsIPv6Enabled() {
+		if (subnet.Role == infrav1.SubnetNode || subnet.Role == infrav1.SubnetCluster) && subnet.IsIPv6Enabled() {
 			needOutboundLB = true
 			break
 		}
@@ -199,7 +199,7 @@ func validateNetworkSpec(controlPlaneEnabled bool, networkSpec NetworkSpec, old 
 	if controlPlaneEnabled {
 		allErrs = append(allErrs, validateControlPlaneOutboundLB(networkSpec.ControlPlaneOutboundLB, networkSpec.APIServerLB, fldPath.Child("controlPlaneOutboundLB"))...)
 	}
-	var lbType = Internal
+	var lbType = infrav1.Internal
 	if networkSpec.APIServerLB != nil {
 		lbType = networkSpec.APIServerLB.Type
 	}
@@ -223,7 +223,7 @@ func validateResourceGroup(resourceGroup string, fldPath *field.Path) *field.Err
 
 // validateSubnets validates a list of Subnets.
 // When configuring a cluster, it is essential to include either a control-plane subnet and a node subnet, or a user can configure a cluster subnet which will be used as a control-plane subnet and a node subnet.
-func validateSubnets(controlPlaneEnabled bool, subnets Subnets, vnet VnetSpec, fldPath *field.Path) field.ErrorList {
+func validateSubnets(controlPlaneEnabled bool, subnets infrav1.Subnets, vnet infrav1.VnetSpec, fldPath *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
 	subnetNames := make(map[string]bool, len(subnets))
 	requiredSubnetRoles := map[string]bool{
@@ -241,7 +241,7 @@ func validateSubnets(controlPlaneEnabled bool, subnets Subnets, vnet VnetSpec, f
 			allErrs = append(allErrs, field.Duplicate(fldPath, subnet.Name))
 		}
 		subnetNames[subnet.Name] = true
-		if subnet.Role == SubnetCluster {
+		if subnet.Role == infrav1.SubnetCluster {
 			clusterSubnet = true
 		} else {
 			for role := range requiredSubnetRoles {
@@ -339,7 +339,7 @@ func validateVnetCIDR(vnetCIDRBlocks []string, fldPath *field.Path) field.ErrorL
 }
 
 // validateVnetPeerings validates a list of virtual network peerings.
-func validateVnetPeerings(peerings VnetPeerings, fldPath *field.Path) field.ErrorList {
+func validateVnetPeerings(peerings infrav1.VnetPeerings, fldPath *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
 	vnetIdentifiers := make(map[string]bool, len(peerings))
 
@@ -380,7 +380,7 @@ func validateInternalLBIPAddress(address string, cidrs []string, fldPath *field.
 }
 
 // validateSecurityRule validates a SecurityRule.
-func validateSecurityRule(rule SecurityRule, fldPath *field.Path) (allErrs field.ErrorList) {
+func validateSecurityRule(rule infrav1.SecurityRule, fldPath *field.Path) (allErrs field.ErrorList) {
 	if rule.Priority < minRulePriority || rule.Priority > maxRulePriority {
 		allErrs = append(allErrs, field.Invalid(fldPath, rule.Priority, fmt.Sprintf("security rule priorities should be between %d and %d", minRulePriority, maxRulePriority)))
 	}
@@ -392,11 +392,11 @@ func validateSecurityRule(rule SecurityRule, fldPath *field.Path) (allErrs field
 	return allErrs
 }
 
-func validateAPIServerLB(lb *LoadBalancerSpec, old *LoadBalancerSpec, cidrs []string, fldPath *field.Path) field.ErrorList {
+func validateAPIServerLB(lb *infrav1.LoadBalancerSpec, old *infrav1.LoadBalancerSpec, cidrs []string, fldPath *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
 
 	lbClassSpec := lb.LoadBalancerClassSpec
-	var olLBClassSpec LoadBalancerClassSpec
+	var olLBClassSpec infrav1.LoadBalancerClassSpec
 	if old != nil {
 		olLBClassSpec = old.LoadBalancerClassSpec
 	}
@@ -423,7 +423,7 @@ func validateAPIServerLB(lb *LoadBalancerSpec, old *LoadBalancerSpec, cidrs []st
 			privateIP = lb.FrontendIPs[i].PrivateIPAddress
 		}
 	}
-	if lb.Type == Public {
+	if lb.Type == infrav1.Public {
 		// there should be one public IP for public LB.
 		if publicIPCount != 1 || ptr.Deref[int32](lb.FrontendIPsCount, 1) != 1 {
 			// Note: FrontendIPsCount creates public IPs when set. Therefore, we check for both publicIPCount and FrontendIPsCount to be 1.
@@ -444,7 +444,7 @@ func validateAPIServerLB(lb *LoadBalancerSpec, old *LoadBalancerSpec, cidrs []st
 	}
 
 	// internal LB should not have a public IP.
-	if lb.Type == Internal {
+	if lb.Type == infrav1.Internal {
 		if publicIPCount != 0 {
 			allErrs = append(allErrs, field.Forbidden(fldPath.Child("frontendIPConfigs").Index(0).Child("publicIP"),
 				"Internal Load Balancers cannot have a Public IP"))
@@ -466,10 +466,10 @@ func validateAPIServerLB(lb *LoadBalancerSpec, old *LoadBalancerSpec, cidrs []st
 	return allErrs
 }
 
-func validateNodeOutboundLB(lb *LoadBalancerSpec, old *LoadBalancerSpec, apiserverLB *LoadBalancerSpec, fldPath *field.Path) field.ErrorList {
+func validateNodeOutboundLB(lb *infrav1.LoadBalancerSpec, old *infrav1.LoadBalancerSpec, apiserverLB *infrav1.LoadBalancerSpec, fldPath *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
 
-	var lbClassSpec, oldClassSpec *LoadBalancerClassSpec
+	var lbClassSpec, oldClassSpec *infrav1.LoadBalancerClassSpec
 	if lb != nil {
 		lbClassSpec = &lb.LoadBalancerClassSpec
 	}
@@ -516,10 +516,10 @@ func validateNodeOutboundLB(lb *LoadBalancerSpec, old *LoadBalancerSpec, apiserv
 	return allErrs
 }
 
-func validateControlPlaneOutboundLB(lb *LoadBalancerSpec, apiserverLB *LoadBalancerSpec, fldPath *field.Path) field.ErrorList {
+func validateControlPlaneOutboundLB(lb *infrav1.LoadBalancerSpec, apiserverLB *infrav1.LoadBalancerSpec, fldPath *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
 
-	var lbClassSpec *LoadBalancerClassSpec
+	var lbClassSpec *infrav1.LoadBalancerClassSpec
 	if lb != nil {
 		lbClassSpec = &lb.LoadBalancerClassSpec
 	}
@@ -527,7 +527,7 @@ func validateControlPlaneOutboundLB(lb *LoadBalancerSpec, apiserverLB *LoadBalan
 
 	allErrs = append(allErrs, validateClassSpecForControlPlaneOutboundLB(lbClassSpec, apiServerLBClassSpec, fldPath)...)
 
-	if apiServerLBClassSpec.Type == Internal && lb != nil {
+	if apiServerLBClassSpec.Type == infrav1.Internal && lb != nil {
 		if lb.FrontendIPsCount != nil && *lb.FrontendIPsCount > MaxLoadBalancerOutboundIPs {
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("frontendIPsCount"), *lb.FrontendIPsCount,
 				fmt.Sprintf("Max front end ips allowed is %d", MaxLoadBalancerOutboundIPs)))
@@ -538,11 +538,11 @@ func validateControlPlaneOutboundLB(lb *LoadBalancerSpec, apiserverLB *LoadBalan
 }
 
 // validatePrivateDNSZoneName validates the PrivateDNSZoneName.
-func validatePrivateDNSZoneName(privateDNSZoneName string, controlPlaneEnabled bool, apiserverLBType LBType, fldPath *field.Path) field.ErrorList {
+func validatePrivateDNSZoneName(privateDNSZoneName string, controlPlaneEnabled bool, apiserverLBType infrav1.LBType, fldPath *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
 
 	if privateDNSZoneName != "" {
-		if controlPlaneEnabled && apiserverLBType != Internal {
+		if controlPlaneEnabled && apiserverLBType != infrav1.Internal {
 			allErrs = append(allErrs, field.Invalid(fldPath, apiserverLBType,
 				"PrivateDNSZoneName is available only if APIServerLB.Type is Internal"))
 		}
@@ -575,7 +575,7 @@ func validatePrivateDNSZoneResourceGroup(privateDNSZoneName string, privateDNSZo
 }
 
 // validateCloudProviderConfigOverrides validates CloudProviderConfigOverrides.
-func validateCloudProviderConfigOverrides(oldConfig, newConfig *CloudProviderConfigOverrides, fldPath *field.Path) field.ErrorList {
+func validateCloudProviderConfigOverrides(oldConfig, newConfig *infrav1.CloudProviderConfigOverrides, fldPath *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
 	if !reflect.DeepEqual(oldConfig, newConfig) {
 		allErrs = append(allErrs, field.Invalid(fldPath, newConfig, "cannot change cloudProviderConfigOverrides cluster creation"))
@@ -583,18 +583,18 @@ func validateCloudProviderConfigOverrides(oldConfig, newConfig *CloudProviderCon
 	return allErrs
 }
 
-func validateClassSpecForAPIServerLB(lb LoadBalancerClassSpec, old *LoadBalancerClassSpec, apiServerLBPath *field.Path) field.ErrorList {
+func validateClassSpecForAPIServerLB(lb infrav1.LoadBalancerClassSpec, old *infrav1.LoadBalancerClassSpec, apiServerLBPath *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
 
 	// SKU should be Standard
-	if lb.SKU != SKUStandard {
-		allErrs = append(allErrs, field.NotSupported(apiServerLBPath.Child("sku"), lb.SKU, []string{string(SKUStandard)}))
+	if lb.SKU != infrav1.SKUStandard {
+		allErrs = append(allErrs, field.NotSupported(apiServerLBPath.Child("sku"), lb.SKU, []string{string(infrav1.SKUStandard)}))
 	}
 
 	// Type should be Public or Internal.
-	if lb.Type != Internal && lb.Type != Public {
+	if lb.Type != infrav1.Internal && lb.Type != infrav1.Public {
 		allErrs = append(allErrs, field.NotSupported(apiServerLBPath.Child("type"), lb.Type,
-			[]string{string(Public), string(Internal)}))
+			[]string{string(infrav1.Public), string(infrav1.Internal)}))
 	}
 
 	// SKU should be immutable.
@@ -620,11 +620,11 @@ func validateClassSpecForAPIServerLB(lb LoadBalancerClassSpec, old *LoadBalancer
 	return allErrs
 }
 
-func validateClassSpecForNodeOutboundLB(lb *LoadBalancerClassSpec, old *LoadBalancerClassSpec, apiserverLB LoadBalancerClassSpec, fldPath *field.Path) field.ErrorList {
+func validateClassSpecForNodeOutboundLB(lb *infrav1.LoadBalancerClassSpec, old *infrav1.LoadBalancerClassSpec, apiserverLB infrav1.LoadBalancerClassSpec, fldPath *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
 
 	// LB can be nil when disabled for private clusters.
-	if lb == nil && apiserverLB.Type == Internal {
+	if lb == nil && apiserverLB.Type == infrav1.Internal {
 		return allErrs
 	}
 
@@ -653,15 +653,15 @@ func validateClassSpecForNodeOutboundLB(lb *LoadBalancerClassSpec, old *LoadBala
 	return allErrs
 }
 
-func validateClassSpecForControlPlaneOutboundLB(lb *LoadBalancerClassSpec, apiserverLB LoadBalancerClassSpec, fldPath *field.Path) field.ErrorList {
+func validateClassSpecForControlPlaneOutboundLB(lb *infrav1.LoadBalancerClassSpec, apiserverLB infrav1.LoadBalancerClassSpec, fldPath *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
 
 	switch apiserverLB.Type {
-	case Public:
+	case infrav1.Public:
 		if lb != nil {
 			allErrs = append(allErrs, field.Forbidden(fldPath, "Control plane outbound load balancer cannot be set for public clusters."))
 		}
-	case Internal:
+	case infrav1.Internal:
 		// Control plane outbound lb can be nil when it's disabled for private clusters.
 		if lb == nil {
 			return nil
@@ -676,7 +676,7 @@ func validateClassSpecForControlPlaneOutboundLB(lb *LoadBalancerClassSpec, apise
 	return allErrs
 }
 
-func validateServiceEndpoints(serviceEndpoints []ServiceEndpointSpec, fldPath *field.Path) field.ErrorList {
+func validateServiceEndpoints(serviceEndpoints []infrav1.ServiceEndpointSpec, fldPath *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
 
 	serviceEndpointsServices := make(map[string]bool, len(serviceEndpoints))
@@ -726,7 +726,7 @@ func validateServiceEndpointLocationName(location string, fldPath *field.Path) *
 	return nil
 }
 
-func validatePrivateEndpoints(privateEndpointSpecs []PrivateEndpointSpec, subnetCIDRs []string, fldPath *field.Path) field.ErrorList {
+func validatePrivateEndpoints(privateEndpointSpecs []infrav1.PrivateEndpointSpec, subnetCIDRs []string, fldPath *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
 
 	for i, pe := range privateEndpointSpecs {
@@ -772,7 +772,7 @@ func validatePrivateEndpointName(name string, fldPath *field.Path) *field.Error 
 }
 
 // validatePrivateEndpointServiceID validates the service ID of a Private Endpoint.
-func validatePrivateEndpointPrivateLinkServiceConnection(privateLinkServiceConnection PrivateLinkServiceConnection, fldPath *field.Path) *field.Error {
+func validatePrivateEndpointPrivateLinkServiceConnection(privateLinkServiceConnection infrav1.PrivateLinkServiceConnection, fldPath *field.Path) *field.Error {
 	if success, _ := regexp.MatchString(resourceIDPattern, privateLinkServiceConnection.PrivateLinkServiceID); !success {
 		return field.Invalid(fldPath, privateLinkServiceConnection.PrivateLinkServiceID,
 			fmt.Sprintf("private endpoint privateLinkServiceConnection service ID doesn't match regex %s", resourceIDPattern))
@@ -806,10 +806,10 @@ func validatePrivateEndpointIPAddress(address string, cidrs []string, fldPath *f
 }
 
 // validateAzureClusterSubnetUpdate validates a ClusterSpec.NetworkSpec.Subnets for immutability.
-func validateAzureClusterSubnetUpdate(c *AzureCluster, old *AzureCluster) field.ErrorList {
+func validateAzureClusterSubnetUpdate(c *infrav1.AzureCluster, old *infrav1.AzureCluster) field.ErrorList {
 	var allErrs field.ErrorList
 
-	oldSubnetMap := make(map[string]SubnetSpec, len(old.Spec.NetworkSpec.Subnets))
+	oldSubnetMap := make(map[string]infrav1.SubnetSpec, len(old.Spec.NetworkSpec.Subnets))
 	oldSubnetIndex := make(map[string]int, len(old.Spec.NetworkSpec.Subnets))
 	for i, subnet := range old.Spec.NetworkSpec.Subnets {
 		oldSubnetMap[subnet.Name] = subnet

--- a/internal/webhooks/azurecluster_validation_test.go
+++ b/internal/webhooks/azurecluster_validation_test.go
@@ -26,7 +26,7 @@ import (
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/utils/ptr"
 
-	. "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
+	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/feature"
 	apifixtures "sigs.k8s.io/cluster-api-provider-azure/internal/test/apifixtures"
 )
@@ -91,7 +91,7 @@ func TestClusterNameValidation(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			g := NewWithT(t)
-			azureCluster := AzureCluster{
+			azureCluster := infrav1.AzureCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: tc.clusterName,
 				},
@@ -110,7 +110,7 @@ func TestClusterNameValidation(t *testing.T) {
 func TestClusterWithPreexistingVnetValid(t *testing.T) {
 	type tests struct {
 		name    string
-		cluster *AzureCluster
+		cluster *infrav1.AzureCluster
 	}
 	testCase := []tests{
 		{
@@ -134,16 +134,16 @@ func TestClusterWithPreexistingVnetValid(t *testing.T) {
 func TestClusterWithPreexistingVnetInvalid(t *testing.T) {
 	tests := []struct {
 		name    string
-		cluster *AzureCluster
+		cluster *infrav1.AzureCluster
 		wantErr bool
 	}{
 		{
 			name: "azurecluster with pre-existing vnet - invalid",
-			cluster: func() *AzureCluster {
+			cluster: func() *infrav1.AzureCluster {
 				cluster := apifixtures.CreateValidCluster()
 				// invalid because it doesn't specify a controlplane subnet
-				cluster.Spec.NetworkSpec.Subnets[0] = SubnetSpec{
-					SubnetClassSpec: SubnetClassSpec{
+				cluster.Spec.NetworkSpec.Subnets[0] = infrav1.SubnetSpec{
+					SubnetClassSpec: infrav1.SubnetClassSpec{
 						Role: "random",
 						Name: "random-subnet",
 					},
@@ -171,7 +171,7 @@ func TestClusterWithPreexistingVnetInvalid(t *testing.T) {
 func TestClusterWithoutPreexistingVnetValid(t *testing.T) {
 	type tests struct {
 		name    string
-		cluster *AzureCluster
+		cluster *infrav1.AzureCluster
 	}
 
 	testCase := []tests{
@@ -200,7 +200,7 @@ func TestClusterWithoutPreexistingVnetValid(t *testing.T) {
 func TestClusterSpecWithPreexistingVnetValid(t *testing.T) {
 	type tests struct {
 		name    string
-		cluster *AzureCluster
+		cluster *infrav1.AzureCluster
 	}
 
 	testCase := []tests{
@@ -225,7 +225,7 @@ func TestClusterSpecWithPreexistingVnetValid(t *testing.T) {
 func TestClusterSpecWithPreexistingVnetInvalid(t *testing.T) {
 	type test struct {
 		name    string
-		cluster *AzureCluster
+		cluster *infrav1.AzureCluster
 	}
 
 	testCase := test{
@@ -234,8 +234,8 @@ func TestClusterSpecWithPreexistingVnetInvalid(t *testing.T) {
 	}
 
 	// invalid because it doesn't specify a controlplane subnet
-	testCase.cluster.Spec.NetworkSpec.Subnets[0] = SubnetSpec{
-		SubnetClassSpec: SubnetClassSpec{
+	testCase.cluster.Spec.NetworkSpec.Subnets[0] = infrav1.SubnetSpec{
+		SubnetClassSpec: infrav1.SubnetClassSpec{
 			Role: "random",
 			Name: "random-subnet",
 		},
@@ -251,7 +251,7 @@ func TestClusterSpecWithPreexistingVnetInvalid(t *testing.T) {
 func TestClusterSpecWithoutPreexistingVnetValid(t *testing.T) {
 	type test struct {
 		name    string
-		cluster *AzureCluster
+		cluster *infrav1.AzureCluster
 	}
 
 	testCase := test{
@@ -273,7 +273,7 @@ func TestClusterSpecWithoutPreexistingVnetValid(t *testing.T) {
 func TestClusterSpecWithoutIdentityRefInvalid(t *testing.T) {
 	type test struct {
 		name    string
-		cluster *AzureCluster
+		cluster *infrav1.AzureCluster
 	}
 
 	testCase := test{
@@ -294,7 +294,7 @@ func TestClusterSpecWithoutIdentityRefInvalid(t *testing.T) {
 func TestClusterSpecWithWrongKindInvalid(t *testing.T) {
 	type test struct {
 		name    string
-		cluster *AzureCluster
+		cluster *infrav1.AzureCluster
 	}
 
 	testCase := test{
@@ -315,7 +315,7 @@ func TestClusterSpecWithWrongKindInvalid(t *testing.T) {
 func TestNetworkSpecWithPreexistingVnetValid(t *testing.T) {
 	type tests struct {
 		name        string
-		networkSpec NetworkSpec
+		networkSpec infrav1.NetworkSpec
 	}
 
 	testCase := []tests{
@@ -332,20 +332,20 @@ func TestNetworkSpecWithPreexistingVnetValid(t *testing.T) {
 	for _, test := range testCase {
 		t.Run(test.name, func(t *testing.T) {
 			g := NewWithT(t)
-			errs := validateNetworkSpec(true, test.networkSpec, NetworkSpec{
-				Vnet:    VnetSpec{},
+			errs := validateNetworkSpec(true, test.networkSpec, infrav1.NetworkSpec{
+				Vnet:    infrav1.VnetSpec{},
 				Subnets: nil,
-				APIServerLB: &LoadBalancerSpec{
+				APIServerLB: &infrav1.LoadBalancerSpec{
 					ID:                    "",
 					Name:                  "",
 					FrontendIPs:           nil,
 					FrontendIPsCount:      nil,
-					BackendPool:           BackendPool{},
-					LoadBalancerClassSpec: LoadBalancerClassSpec{},
+					BackendPool:           infrav1.BackendPool{},
+					LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{},
 				},
 				NodeOutboundLB:         nil,
 				ControlPlaneOutboundLB: nil,
-				NetworkClassSpec:       NetworkClassSpec{},
+				NetworkClassSpec:       infrav1.NetworkClassSpec{},
 			}, field.NewPath("spec").Child("networkSpec"))
 			g.Expect(errs).To(BeNil())
 		})
@@ -355,7 +355,7 @@ func TestNetworkSpecWithPreexistingVnetValid(t *testing.T) {
 func TestNetworkSpecWithPreexistingVnetLackRequiredSubnets(t *testing.T) {
 	type test struct {
 		name        string
-		networkSpec NetworkSpec
+		networkSpec infrav1.NetworkSpec
 	}
 
 	testCase := test{
@@ -368,20 +368,20 @@ func TestNetworkSpecWithPreexistingVnetLackRequiredSubnets(t *testing.T) {
 
 	t.Run(testCase.name, func(t *testing.T) {
 		g := NewWithT(t)
-		errs := validateNetworkSpec(true, testCase.networkSpec, NetworkSpec{
-			Vnet:    VnetSpec{},
+		errs := validateNetworkSpec(true, testCase.networkSpec, infrav1.NetworkSpec{
+			Vnet:    infrav1.VnetSpec{},
 			Subnets: nil,
-			APIServerLB: &LoadBalancerSpec{
+			APIServerLB: &infrav1.LoadBalancerSpec{
 				ID:                    "",
 				Name:                  "",
 				FrontendIPs:           nil,
 				FrontendIPsCount:      nil,
-				BackendPool:           BackendPool{},
-				LoadBalancerClassSpec: LoadBalancerClassSpec{},
+				BackendPool:           infrav1.BackendPool{},
+				LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{},
 			},
 			NodeOutboundLB:         nil,
 			ControlPlaneOutboundLB: nil,
-			NetworkClassSpec:       NetworkClassSpec{},
+			NetworkClassSpec:       infrav1.NetworkClassSpec{},
 		}, field.NewPath("spec").Child("networkSpec"))
 		g.Expect(errs).To(HaveLen(1))
 		g.Expect(errs[0].Type).To(Equal(field.ErrorTypeRequired))
@@ -393,7 +393,7 @@ func TestNetworkSpecWithPreexistingVnetLackRequiredSubnets(t *testing.T) {
 func TestNetworkSpecWithPreexistingVnetInvalidResourceGroup(t *testing.T) {
 	type test struct {
 		name        string
-		networkSpec NetworkSpec
+		networkSpec infrav1.NetworkSpec
 	}
 
 	testCase := test{
@@ -405,20 +405,20 @@ func TestNetworkSpecWithPreexistingVnetInvalidResourceGroup(t *testing.T) {
 
 	t.Run(testCase.name, func(t *testing.T) {
 		g := NewWithT(t)
-		errs := validateNetworkSpec(true, testCase.networkSpec, NetworkSpec{
-			Vnet:    VnetSpec{},
+		errs := validateNetworkSpec(true, testCase.networkSpec, infrav1.NetworkSpec{
+			Vnet:    infrav1.VnetSpec{},
 			Subnets: nil,
-			APIServerLB: &LoadBalancerSpec{
+			APIServerLB: &infrav1.LoadBalancerSpec{
 				ID:                    "",
 				Name:                  "",
 				FrontendIPs:           nil,
 				FrontendIPsCount:      nil,
-				BackendPool:           BackendPool{},
-				LoadBalancerClassSpec: LoadBalancerClassSpec{},
+				BackendPool:           infrav1.BackendPool{},
+				LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{},
 			},
 			NodeOutboundLB:         nil,
 			ControlPlaneOutboundLB: nil,
-			NetworkClassSpec:       NetworkClassSpec{},
+			NetworkClassSpec:       infrav1.NetworkClassSpec{},
 		}, field.NewPath("spec").Child("networkSpec"))
 		g.Expect(errs).To(HaveLen(1))
 		g.Expect(errs[0].Type).To(Equal(field.ErrorTypeInvalid))
@@ -430,7 +430,7 @@ func TestNetworkSpecWithPreexistingVnetInvalidResourceGroup(t *testing.T) {
 func TestNetworkSpecWithoutPreexistingVnetValid(t *testing.T) {
 	type test struct {
 		name        string
-		networkSpec NetworkSpec
+		networkSpec infrav1.NetworkSpec
 	}
 
 	testCase := test{
@@ -442,20 +442,20 @@ func TestNetworkSpecWithoutPreexistingVnetValid(t *testing.T) {
 
 	t.Run(testCase.name, func(t *testing.T) {
 		g := NewWithT(t)
-		errs := validateNetworkSpec(true, testCase.networkSpec, NetworkSpec{
-			Vnet:    VnetSpec{},
+		errs := validateNetworkSpec(true, testCase.networkSpec, infrav1.NetworkSpec{
+			Vnet:    infrav1.VnetSpec{},
 			Subnets: nil,
-			APIServerLB: &LoadBalancerSpec{
+			APIServerLB: &infrav1.LoadBalancerSpec{
 				ID:                    "",
 				Name:                  "",
 				FrontendIPs:           nil,
 				FrontendIPsCount:      nil,
-				BackendPool:           BackendPool{},
-				LoadBalancerClassSpec: LoadBalancerClassSpec{},
+				BackendPool:           infrav1.BackendPool{},
+				LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{},
 			},
 			NodeOutboundLB:         nil,
 			ControlPlaneOutboundLB: nil,
-			NetworkClassSpec:       NetworkClassSpec{},
+			NetworkClassSpec:       infrav1.NetworkClassSpec{},
 		}, field.NewPath("spec").Child("networkSpec"))
 		g.Expect(errs).To(BeNil())
 	})
@@ -542,23 +542,23 @@ func TestValidateVnetCIDR(t *testing.T) {
 func TestClusterSubnetsValid(t *testing.T) {
 	type test struct {
 		name    string
-		subnets Subnets
+		subnets infrav1.Subnets
 		err     field.ErrorList
 	}
 	var nilList field.ErrorList
 	testCases := []test{
 		{
 			name: "subnets - valid",
-			subnets: Subnets{
+			subnets: infrav1.Subnets{
 				{
-					SubnetClassSpec: SubnetClassSpec{
-						Role: SubnetCluster,
+					SubnetClassSpec: infrav1.SubnetClassSpec{
+						Role: infrav1.SubnetCluster,
 						Name: "cluster-subnet-1",
 					},
 				},
 				{
-					SubnetClassSpec: SubnetClassSpec{
-						Role: SubnetCluster,
+					SubnetClassSpec: infrav1.SubnetClassSpec{
+						Role: infrav1.SubnetCluster,
 						Name: "cluster-subnet-2",
 					},
 				},
@@ -567,22 +567,22 @@ func TestClusterSubnetsValid(t *testing.T) {
 		},
 		{
 			name: "duplicate subnets - invalid",
-			subnets: Subnets{
+			subnets: infrav1.Subnets{
 				{
-					SubnetClassSpec: SubnetClassSpec{
-						Role: SubnetCluster,
+					SubnetClassSpec: infrav1.SubnetClassSpec{
+						Role: infrav1.SubnetCluster,
 						Name: "cluster-subnet-1",
 					},
 				},
 				{
-					SubnetClassSpec: SubnetClassSpec{
-						Role: SubnetCluster,
+					SubnetClassSpec: infrav1.SubnetClassSpec{
+						Role: infrav1.SubnetCluster,
 						Name: "cluster-subnet-1",
 					},
 				},
 				{
-					SubnetClassSpec: SubnetClassSpec{
-						Role: SubnetCluster,
+					SubnetClassSpec: infrav1.SubnetClassSpec{
+						Role: infrav1.SubnetCluster,
 						Name: "#$cluster-subnet-1",
 					},
 				},
@@ -603,7 +603,7 @@ func TestClusterSubnetsValid(t *testing.T) {
 		},
 		{
 			name:    "no subnet",
-			subnets: Subnets{},
+			subnets: infrav1.Subnets{},
 			err: field.ErrorList{
 				{
 					Type:     "FieldValueRequired",
@@ -633,7 +633,7 @@ func TestClusterSubnetsValid(t *testing.T) {
 func TestSubnetsValid(t *testing.T) {
 	type test struct {
 		name    string
-		subnets Subnets
+		subnets infrav1.Subnets
 	}
 
 	testCase := test{
@@ -652,7 +652,7 @@ func TestSubnetsValid(t *testing.T) {
 func TestSubnetsInvalidSubnetName(t *testing.T) {
 	type test struct {
 		name    string
-		subnets Subnets
+		subnets infrav1.Subnets
 	}
 
 	testCase := test{
@@ -676,7 +676,7 @@ func TestSubnetsInvalidSubnetName(t *testing.T) {
 func TestSubnetsInvalidLackRequiredSubnet(t *testing.T) {
 	type test struct {
 		name    string
-		subnets Subnets
+		subnets infrav1.Subnets
 	}
 
 	testCase := test{
@@ -700,7 +700,7 @@ func TestSubnetsInvalidLackRequiredSubnet(t *testing.T) {
 func TestSubnetNamesNotUnique(t *testing.T) {
 	type test struct {
 		name    string
-		subnets Subnets
+		subnets infrav1.Subnets
 	}
 
 	testCase := test{
@@ -824,12 +824,12 @@ func TestValidateSubnetCIDR(t *testing.T) {
 func TestValidateSecurityRule(t *testing.T) {
 	tests := []struct {
 		name      string
-		validRule SecurityRule
+		validRule infrav1.SecurityRule
 		wantErr   bool
 	}{
 		{
 			name: "security rule - valid priority",
-			validRule: SecurityRule{
+			validRule: infrav1.SecurityRule{
 				Name:        "allow_apiserver",
 				Description: "Allow K8s API Server",
 				Priority:    101,
@@ -838,7 +838,7 @@ func TestValidateSecurityRule(t *testing.T) {
 		},
 		{
 			name: "security rule - invalid low priority",
-			validRule: SecurityRule{
+			validRule: infrav1.SecurityRule{
 				Name:        "allow_apiserver",
 				Description: "Allow K8s API Server",
 				Priority:    99,
@@ -847,7 +847,7 @@ func TestValidateSecurityRule(t *testing.T) {
 		},
 		{
 			name: "security rule - invalid high priority",
-			validRule: SecurityRule{
+			validRule: infrav1.SecurityRule{
 				Name:        "allow_apiserver",
 				Description: "Allow K8s API Server",
 				Priority:    5000,
@@ -856,7 +856,7 @@ func TestValidateSecurityRule(t *testing.T) {
 		},
 		{
 			name: "security rule - invalid sources priority",
-			validRule: SecurityRule{
+			validRule: infrav1.SecurityRule{
 				Name:        "allow_apiserver",
 				Description: "Allow K8s API Server",
 				Priority:    4000,
@@ -870,7 +870,7 @@ func TestValidateSecurityRule(t *testing.T) {
 		},
 		{
 			name: "security rule - valid sources",
-			validRule: SecurityRule{
+			validRule: infrav1.SecurityRule{
 				Name:        "allow_apiserver",
 				Description: "Allow K8s API Server",
 				Priority:    4000,
@@ -905,24 +905,24 @@ func TestValidateAPIServerLB(t *testing.T) {
 	testcases := []struct {
 		name        string
 		featureGate featuregate.Feature
-		lb          *LoadBalancerSpec
-		old         *LoadBalancerSpec
+		lb          *infrav1.LoadBalancerSpec
+		old         *infrav1.LoadBalancerSpec
 		cpCIDRS     []string
 		wantErr     bool
 		expectedErr field.Error
 	}{
 		{
 			name: "invalid SKU",
-			lb: &LoadBalancerSpec{
+			lb: &infrav1.LoadBalancerSpec{
 				Name: "my-awesome-lb",
-				FrontendIPs: []FrontendIP{
+				FrontendIPs: []infrav1.FrontendIP{
 					{
 						Name: "ip-config",
 					},
 				},
-				LoadBalancerClassSpec: LoadBalancerClassSpec{
+				LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{
 					SKU:  "Awesome",
-					Type: Public,
+					Type: infrav1.Public,
 				},
 			},
 			wantErr: true,
@@ -935,8 +935,8 @@ func TestValidateAPIServerLB(t *testing.T) {
 		},
 		{
 			name: "invalid Type",
-			lb: &LoadBalancerSpec{
-				LoadBalancerClassSpec: LoadBalancerClassSpec{
+			lb: &infrav1.LoadBalancerSpec{
+				LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{
 					Type: "Foo",
 				},
 			},
@@ -950,7 +950,7 @@ func TestValidateAPIServerLB(t *testing.T) {
 		},
 		{
 			name: "invalid Name",
-			lb: &LoadBalancerSpec{
+			lb: &infrav1.LoadBalancerSpec{
 				Name: "***",
 			},
 			wantErr: true,
@@ -963,11 +963,11 @@ func TestValidateAPIServerLB(t *testing.T) {
 		},
 		{
 			name: "too many IP configs",
-			lb: &LoadBalancerSpec{
-				LoadBalancerClassSpec: LoadBalancerClassSpec{
-					Type: Public,
+			lb: &infrav1.LoadBalancerSpec{
+				LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{
+					Type: infrav1.Public,
 				},
-				FrontendIPs: []FrontendIP{
+				FrontendIPs: []infrav1.FrontendIP{
 					{
 						Name: "ip-1",
 					},
@@ -980,7 +980,7 @@ func TestValidateAPIServerLB(t *testing.T) {
 			expectedErr: field.Error{
 				Type:  "FieldValueInvalid",
 				Field: "apiServerLB.frontendIPConfigs",
-				BadValue: []FrontendIP{
+				BadValue: []infrav1.FrontendIP{
 					{
 						Name: "ip-1",
 					},
@@ -994,11 +994,11 @@ func TestValidateAPIServerLB(t *testing.T) {
 		{
 			name:        "too many IP configs with feature flag APIServerILB enabled",
 			featureGate: feature.APIServerILB,
-			lb: &LoadBalancerSpec{
-				LoadBalancerClassSpec: LoadBalancerClassSpec{
-					Type: Public,
+			lb: &infrav1.LoadBalancerSpec{
+				LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{
+					Type: infrav1.Public,
 				},
-				FrontendIPs: []FrontendIP{
+				FrontendIPs: []infrav1.FrontendIP{
 					{
 						Name: "ip-1",
 					},
@@ -1011,7 +1011,7 @@ func TestValidateAPIServerLB(t *testing.T) {
 			expectedErr: field.Error{
 				Type:  "FieldValueInvalid",
 				Field: "apiServerLB.frontendIPConfigs",
-				BadValue: []FrontendIP{
+				BadValue: []infrav1.FrontendIP{
 					{
 						Name: "ip-1",
 					},
@@ -1024,17 +1024,17 @@ func TestValidateAPIServerLB(t *testing.T) {
 		},
 		{
 			name: "public LB with private IP",
-			lb: &LoadBalancerSpec{
-				FrontendIPs: []FrontendIP{
+			lb: &infrav1.LoadBalancerSpec{
+				FrontendIPs: []infrav1.FrontendIP{
 					{
 						Name: "ip-1",
-						FrontendIPClass: FrontendIPClass{
+						FrontendIPClass: infrav1.FrontendIPClass{
 							PrivateIPAddress: "10.0.0.4",
 						},
 					},
 				},
-				LoadBalancerClassSpec: LoadBalancerClassSpec{
-					Type: Public,
+				LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{
+					Type: infrav1.Public,
 				},
 			},
 			wantErr: true,
@@ -1047,26 +1047,26 @@ func TestValidateAPIServerLB(t *testing.T) {
 		{
 			name:        "public LB with private IP with feature flag APIServerILB enabled",
 			featureGate: feature.APIServerILB,
-			lb: &LoadBalancerSpec{
+			lb: &infrav1.LoadBalancerSpec{
 				Name: "my-awesome-lb",
-				FrontendIPs: []FrontendIP{
+				FrontendIPs: []infrav1.FrontendIP{
 					{
 						Name: "ip-1",
-						PublicIP: &PublicIPSpec{
+						PublicIP: &infrav1.PublicIPSpec{
 							Name:    "my-valid-frontend-ip",
 							DNSName: "my-valid-frontend-ip",
 						},
 					},
 					{
 						Name: "ip-2",
-						FrontendIPClass: FrontendIPClass{
+						FrontendIPClass: infrav1.FrontendIPClass{
 							PrivateIPAddress: "10.0.0.111",
 						},
 					},
 				},
-				LoadBalancerClassSpec: LoadBalancerClassSpec{
-					Type: Public,
-					SKU:  SKUStandard,
+				LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{
+					Type: infrav1.Public,
+					SKU:  infrav1.SKUStandard,
 				},
 			},
 			cpCIDRS: []string{"10.0.0.0/24"},
@@ -1074,17 +1074,17 @@ func TestValidateAPIServerLB(t *testing.T) {
 		},
 		{
 			name: "internal LB with public IP",
-			lb: &LoadBalancerSpec{
-				FrontendIPs: []FrontendIP{
+			lb: &infrav1.LoadBalancerSpec{
+				FrontendIPs: []infrav1.FrontendIP{
 					{
 						Name: "ip-1",
-						PublicIP: &PublicIPSpec{
+						PublicIP: &infrav1.PublicIPSpec{
 							Name: "my-invalid-ip",
 						},
 					},
 				},
-				LoadBalancerClassSpec: LoadBalancerClassSpec{
-					Type: Internal,
+				LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{
+					Type: infrav1.Internal,
 				},
 			},
 			wantErr: true,
@@ -1097,17 +1097,17 @@ func TestValidateAPIServerLB(t *testing.T) {
 		{
 			name:        "internal LB with public IP with feature flag APIServerILB enabled",
 			featureGate: feature.APIServerILB,
-			lb: &LoadBalancerSpec{
-				FrontendIPs: []FrontendIP{
+			lb: &infrav1.LoadBalancerSpec{
+				FrontendIPs: []infrav1.FrontendIP{
 					{
 						Name: "ip-1",
-						PublicIP: &PublicIPSpec{
+						PublicIP: &infrav1.PublicIPSpec{
 							Name: "my-invalid-ip",
 						},
 					},
 				},
-				LoadBalancerClassSpec: LoadBalancerClassSpec{
-					Type: Internal,
+				LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{
+					Type: infrav1.Internal,
 				},
 			},
 			wantErr: true,
@@ -1119,17 +1119,17 @@ func TestValidateAPIServerLB(t *testing.T) {
 		},
 		{
 			name: "internal LB with invalid private IP",
-			lb: &LoadBalancerSpec{
-				FrontendIPs: []FrontendIP{
+			lb: &infrav1.LoadBalancerSpec{
+				FrontendIPs: []infrav1.FrontendIP{
 					{
 						Name: "ip-1",
-						FrontendIPClass: FrontendIPClass{
+						FrontendIPClass: infrav1.FrontendIPClass{
 							PrivateIPAddress: "NAIP",
 						},
 					},
 				},
-				LoadBalancerClassSpec: LoadBalancerClassSpec{
-					Type: Internal,
+				LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{
+					Type: infrav1.Internal,
 				},
 			},
 			wantErr: true,
@@ -1143,17 +1143,17 @@ func TestValidateAPIServerLB(t *testing.T) {
 		{
 			name:        "internal LB with invalid private IP with feature flag APIServerILB enabled",
 			featureGate: feature.APIServerILB,
-			lb: &LoadBalancerSpec{
-				FrontendIPs: []FrontendIP{
+			lb: &infrav1.LoadBalancerSpec{
+				FrontendIPs: []infrav1.FrontendIP{
 					{
 						Name: "ip-1",
-						FrontendIPClass: FrontendIPClass{
+						FrontendIPClass: infrav1.FrontendIPClass{
 							PrivateIPAddress: "NAIP",
 						},
 					},
 				},
-				LoadBalancerClassSpec: LoadBalancerClassSpec{
-					Type: Internal,
+				LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{
+					Type: infrav1.Internal,
 				},
 			},
 			wantErr: true,
@@ -1166,17 +1166,17 @@ func TestValidateAPIServerLB(t *testing.T) {
 		},
 		{
 			name: "internal LB with out of range private IP",
-			lb: &LoadBalancerSpec{
-				FrontendIPs: []FrontendIP{
+			lb: &infrav1.LoadBalancerSpec{
+				FrontendIPs: []infrav1.FrontendIP{
 					{
 						Name: "ip-1",
-						FrontendIPClass: FrontendIPClass{
+						FrontendIPClass: infrav1.FrontendIPClass{
 							PrivateIPAddress: "20.1.2.3",
 						},
 					},
 				},
-				LoadBalancerClassSpec: LoadBalancerClassSpec{
-					Type: Internal,
+				LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{
+					Type: infrav1.Internal,
 				},
 			},
 			cpCIDRS: []string{"10.0.0.0/24", "10.1.0.0/24"},
@@ -1191,17 +1191,17 @@ func TestValidateAPIServerLB(t *testing.T) {
 		{
 			name:        "internal LB with out of range private IP with feature flag APIServerILB enabled",
 			featureGate: feature.APIServerILB,
-			lb: &LoadBalancerSpec{
-				FrontendIPs: []FrontendIP{
+			lb: &infrav1.LoadBalancerSpec{
+				FrontendIPs: []infrav1.FrontendIP{
 					{
 						Name: "ip-1",
-						FrontendIPClass: FrontendIPClass{
+						FrontendIPClass: infrav1.FrontendIPClass{
 							PrivateIPAddress: "20.1.2.3",
 						},
 					},
 				},
-				LoadBalancerClassSpec: LoadBalancerClassSpec{
-					Type: Internal,
+				LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{
+					Type: infrav1.Internal,
 				},
 			},
 			cpCIDRS: []string{"10.0.0.0/24", "10.1.0.0/24"},
@@ -1215,18 +1215,18 @@ func TestValidateAPIServerLB(t *testing.T) {
 		},
 		{
 			name: "internal LB with in range private IP",
-			lb: &LoadBalancerSpec{
-				FrontendIPs: []FrontendIP{
+			lb: &infrav1.LoadBalancerSpec{
+				FrontendIPs: []infrav1.FrontendIP{
 					{
 						Name: "ip-1",
-						FrontendIPClass: FrontendIPClass{
+						FrontendIPClass: infrav1.FrontendIPClass{
 							PrivateIPAddress: "10.1.0.3",
 						},
 					},
 				},
-				LoadBalancerClassSpec: LoadBalancerClassSpec{
-					Type: Internal,
-					SKU:  SKUStandard,
+				LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{
+					Type: infrav1.Internal,
+					SKU:  infrav1.SKUStandard,
 				},
 				Name: "my-private-lb",
 			},
@@ -1236,25 +1236,25 @@ func TestValidateAPIServerLB(t *testing.T) {
 		{
 			name:        "public LB with in-range private IP with feature flag APIServerILB enabled",
 			featureGate: feature.APIServerILB,
-			lb: &LoadBalancerSpec{
-				FrontendIPs: []FrontendIP{
+			lb: &infrav1.LoadBalancerSpec{
+				FrontendIPs: []infrav1.FrontendIP{
 					{
 						Name: "ip-1",
-						FrontendIPClass: FrontendIPClass{
+						FrontendIPClass: infrav1.FrontendIPClass{
 							PrivateIPAddress: "10.0.0.123",
 						},
 					},
 					{
 						Name: "ip-2",
-						PublicIP: &PublicIPSpec{
+						PublicIP: &infrav1.PublicIPSpec{
 							Name:    "my-valid-ip",
 							DNSName: "my-valid-ip",
 						},
 					},
 				},
-				LoadBalancerClassSpec: LoadBalancerClassSpec{
-					Type: Public,
-					SKU:  SKUStandard,
+				LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{
+					Type: infrav1.Public,
+					SKU:  infrav1.SKUStandard,
 				},
 				Name: "my-private-lb",
 			},
@@ -1264,17 +1264,17 @@ func TestValidateAPIServerLB(t *testing.T) {
 		{
 			name:        "public LB with out of range private IP with feature flag APIServerILB enabled",
 			featureGate: feature.APIServerILB,
-			lb: &LoadBalancerSpec{
-				FrontendIPs: []FrontendIP{
+			lb: &infrav1.LoadBalancerSpec{
+				FrontendIPs: []infrav1.FrontendIP{
 					{
 						Name: "ip-1",
-						FrontendIPClass: FrontendIPClass{
+						FrontendIPClass: infrav1.FrontendIPClass{
 							PrivateIPAddress: "20.1.2.3",
 						},
 					},
 				},
-				LoadBalancerClassSpec: LoadBalancerClassSpec{
-					Type: Public,
+				LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{
+					Type: infrav1.Public,
 				},
 			},
 			cpCIDRS: []string{"10.0.0.0/24", "10.1.0.0/24"},
@@ -1306,14 +1306,14 @@ func TestValidateAPIServerLB(t *testing.T) {
 func TestPrivateDNSZoneName(t *testing.T) {
 	testcases := []struct {
 		name        string
-		network     NetworkSpec
+		network     infrav1.NetworkSpec
 		wantErr     bool
 		expectedErr field.Error
 	}{
 		{
 			name: "testInvalidPrivateDNSZoneName",
-			network: NetworkSpec{
-				NetworkClassSpec: NetworkClassSpec{
+			network: infrav1.NetworkSpec{
+				NetworkClassSpec: infrav1.NetworkClassSpec{
 					PrivateDNSZoneName: "wrong@d_ns.io",
 				},
 				APIServerLB: apifixtures.CreateValidAPIServerInternalLB(),
@@ -1328,8 +1328,8 @@ func TestPrivateDNSZoneName(t *testing.T) {
 		},
 		{
 			name: "testValidPrivateDNSZoneName",
-			network: NetworkSpec{
-				NetworkClassSpec: NetworkClassSpec{
+			network: infrav1.NetworkSpec{
+				NetworkClassSpec: infrav1.NetworkClassSpec{
 					PrivateDNSZoneName: "good.dns.io",
 				},
 				APIServerLB: apifixtures.CreateValidAPIServerInternalLB(),
@@ -1338,8 +1338,8 @@ func TestPrivateDNSZoneName(t *testing.T) {
 		},
 		{
 			name: "testValidPrivateDNSZoneNameWithUnderscore",
-			network: NetworkSpec{
-				NetworkClassSpec: NetworkClassSpec{
+			network: infrav1.NetworkSpec{
+				NetworkClassSpec: infrav1.NetworkClassSpec{
 					PrivateDNSZoneName: "_good.__dns.io",
 				},
 				APIServerLB: apifixtures.CreateValidAPIServerInternalLB(),
@@ -1348,14 +1348,14 @@ func TestPrivateDNSZoneName(t *testing.T) {
 		},
 		{
 			name: "testBadAPIServerLBType",
-			network: NetworkSpec{
-				NetworkClassSpec: NetworkClassSpec{
+			network: infrav1.NetworkSpec{
+				NetworkClassSpec: infrav1.NetworkClassSpec{
 					PrivateDNSZoneName: "good.dns.io",
 				},
-				APIServerLB: &LoadBalancerSpec{
+				APIServerLB: &infrav1.LoadBalancerSpec{
 					Name: "my-lb",
-					LoadBalancerClassSpec: LoadBalancerClassSpec{
-						Type: Public,
+					LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{
+						Type: infrav1.Public,
 					},
 				},
 			},
@@ -1386,14 +1386,14 @@ func TestPrivateDNSZoneName(t *testing.T) {
 func TestPrivateDNSZoneResourceGroup(t *testing.T) {
 	testcases := []struct {
 		name        string
-		network     NetworkSpec
+		network     infrav1.NetworkSpec
 		wantErr     bool
 		expectedErr field.Error
 	}{
 		{
 			name: "testEmptyPrivateDNSZoneNameAndResourceGroup",
-			network: NetworkSpec{
-				NetworkClassSpec: NetworkClassSpec{
+			network: infrav1.NetworkSpec{
+				NetworkClassSpec: infrav1.NetworkClassSpec{
 					PrivateDNSZoneName:          "",
 					PrivateDNSZoneResourceGroup: "",
 				},
@@ -1402,8 +1402,8 @@ func TestPrivateDNSZoneResourceGroup(t *testing.T) {
 		},
 		{
 			name: "testValidPrivateDNSZoneNameAndResourceGroup",
-			network: NetworkSpec{
-				NetworkClassSpec: NetworkClassSpec{
+			network: infrav1.NetworkSpec{
+				NetworkClassSpec: infrav1.NetworkClassSpec{
 					PrivateDNSZoneName:          "good.dns.io",
 					PrivateDNSZoneResourceGroup: "test-rg",
 				},
@@ -1412,8 +1412,8 @@ func TestPrivateDNSZoneResourceGroup(t *testing.T) {
 		},
 		{
 			name: "testInvalidPrivateDNSZoneResourceGroup",
-			network: NetworkSpec{
-				NetworkClassSpec: NetworkClassSpec{
+			network: infrav1.NetworkSpec{
+				NetworkClassSpec: infrav1.NetworkClassSpec{
 					PrivateDNSZoneName:          "good.dns.io",
 					PrivateDNSZoneResourceGroup: "inv@lid-rg",
 				},
@@ -1428,8 +1428,8 @@ func TestPrivateDNSZoneResourceGroup(t *testing.T) {
 		},
 		{
 			name: "testEmptyPrivateDNSZoneNameWithValidResourceGroup",
-			network: NetworkSpec{
-				NetworkClassSpec: NetworkClassSpec{
+			network: infrav1.NetworkSpec{
+				NetworkClassSpec: infrav1.NetworkClassSpec{
 					PrivateDNSZoneName:          "",
 					PrivateDNSZoneResourceGroup: "test-rg",
 				},
@@ -1461,18 +1461,18 @@ func TestPrivateDNSZoneResourceGroup(t *testing.T) {
 func TestValidateNodeOutboundLB(t *testing.T) {
 	testcases := []struct {
 		name        string
-		lb          *LoadBalancerSpec
-		old         *LoadBalancerSpec
-		apiServerLB LoadBalancerSpec
+		lb          *infrav1.LoadBalancerSpec
+		old         *infrav1.LoadBalancerSpec
+		apiServerLB infrav1.LoadBalancerSpec
 		wantErr     bool
 		expectedErr field.Error
 	}{
 		{
 			name: "no lb for public clusters",
 			lb:   nil,
-			apiServerLB: LoadBalancerSpec{
-				LoadBalancerClassSpec: LoadBalancerClassSpec{
-					Type: Public,
+			apiServerLB: infrav1.LoadBalancerSpec{
+				LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{
+					Type: infrav1.Public,
 				},
 			},
 			wantErr: true,
@@ -1486,19 +1486,19 @@ func TestValidateNodeOutboundLB(t *testing.T) {
 		{
 			name: "no lb allowed for internal clusters",
 			lb:   nil,
-			apiServerLB: LoadBalancerSpec{
-				LoadBalancerClassSpec: LoadBalancerClassSpec{
-					Type: Internal,
+			apiServerLB: infrav1.LoadBalancerSpec{
+				LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{
+					Type: infrav1.Internal,
 				},
 			},
 			wantErr: false,
 		},
 		{
 			name: "invalid ID update",
-			lb: &LoadBalancerSpec{
+			lb: &infrav1.LoadBalancerSpec{
 				ID: "some-id",
 			},
-			old: &LoadBalancerSpec{
+			old: &infrav1.LoadBalancerSpec{
 				ID: "old-id",
 			},
 			wantErr: true,
@@ -1511,10 +1511,10 @@ func TestValidateNodeOutboundLB(t *testing.T) {
 		},
 		{
 			name: "invalid Name update",
-			lb: &LoadBalancerSpec{
+			lb: &infrav1.LoadBalancerSpec{
 				Name: "some-name",
 			},
-			old: &LoadBalancerSpec{
+			old: &infrav1.LoadBalancerSpec{
 				Name: "old-name",
 			},
 			wantErr: true,
@@ -1527,13 +1527,13 @@ func TestValidateNodeOutboundLB(t *testing.T) {
 		},
 		{
 			name: "invalid SKU update",
-			lb: &LoadBalancerSpec{
-				LoadBalancerClassSpec: LoadBalancerClassSpec{
+			lb: &infrav1.LoadBalancerSpec{
+				LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{
 					SKU: "some-sku",
 				},
 			},
-			old: &LoadBalancerSpec{
-				LoadBalancerClassSpec: LoadBalancerClassSpec{
+			old: &infrav1.LoadBalancerSpec{
+				LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{
 					SKU: "old-sku",
 				},
 			},
@@ -1547,13 +1547,13 @@ func TestValidateNodeOutboundLB(t *testing.T) {
 		},
 		{
 			name: "invalid FrontendIps update",
-			lb: &LoadBalancerSpec{
-				FrontendIPs: []FrontendIP{{
+			lb: &infrav1.LoadBalancerSpec{
+				FrontendIPs: []infrav1.FrontendIP{{
 					Name: "some-frontend-ip",
 				}},
 			},
-			old: &LoadBalancerSpec{
-				FrontendIPs: []FrontendIP{{
+			old: &infrav1.LoadBalancerSpec{
+				FrontendIPs: []infrav1.FrontendIP{{
 					Name: "old-frontend-ip",
 				}},
 			},
@@ -1561,7 +1561,7 @@ func TestValidateNodeOutboundLB(t *testing.T) {
 			expectedErr: field.Error{
 				Type:  "FieldValueForbidden",
 				Field: "nodeOutboundLB.frontendIPs[0]",
-				BadValue: FrontendIP{
+				BadValue: infrav1.FrontendIP{
 					Name: "some-frontend-ip",
 				},
 				Detail: "Node outbound load balancer FrontendIPs cannot be modified after AzureCluster creation.",
@@ -1569,25 +1569,25 @@ func TestValidateNodeOutboundLB(t *testing.T) {
 		},
 		{
 			name: "FrontendIps can update when frontendIpsCount changes",
-			lb: &LoadBalancerSpec{
-				FrontendIPs: []FrontendIP{{
+			lb: &infrav1.LoadBalancerSpec{
+				FrontendIPs: []infrav1.FrontendIP{{
 					Name: "some-frontend-ip-1",
 				}, {
 					Name: "some-frontend-ip-2",
 				}},
 				FrontendIPsCount: ptr.To[int32](2),
 			},
-			old: &LoadBalancerSpec{
-				FrontendIPs: []FrontendIP{{
+			old: &infrav1.LoadBalancerSpec{
+				FrontendIPs: []infrav1.FrontendIP{{
 					Name: "old-frontend-ip",
 				}},
-				LoadBalancerClassSpec: LoadBalancerClassSpec{},
+				LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{},
 			},
 			wantErr: false,
 		},
 		{
 			name: "frontend ips count exceeds max value",
-			lb: &LoadBalancerSpec{
+			lb: &infrav1.LoadBalancerSpec{
 				FrontendIPsCount: ptr.To[int32](100),
 			},
 			wantErr: true,
@@ -1617,34 +1617,34 @@ func TestValidateNodeOutboundLB(t *testing.T) {
 func TestValidateControlPlaneNodeOutboundLB(t *testing.T) {
 	testcases := []struct {
 		name        string
-		lb          *LoadBalancerSpec
-		old         *LoadBalancerSpec
-		apiServerLB LoadBalancerSpec
+		lb          *infrav1.LoadBalancerSpec
+		old         *infrav1.LoadBalancerSpec
+		apiServerLB infrav1.LoadBalancerSpec
 		wantErr     bool
 		expectedErr field.Error
 	}{
 		{
 			name: "cp outbound lb cannot be set for public clusters",
-			lb:   &LoadBalancerSpec{Name: "foo"},
-			apiServerLB: LoadBalancerSpec{
-				LoadBalancerClassSpec: LoadBalancerClassSpec{
-					Type: Public,
+			lb:   &infrav1.LoadBalancerSpec{Name: "foo"},
+			apiServerLB: infrav1.LoadBalancerSpec{
+				LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{
+					Type: infrav1.Public,
 				},
 			},
 			wantErr: true,
 			expectedErr: field.Error{
 				Type:     "FieldValueForbidden",
 				Field:    "controlPlaneOutboundLB",
-				BadValue: LoadBalancerSpec{Name: "foo"},
+				BadValue: infrav1.LoadBalancerSpec{Name: "foo"},
 				Detail:   "Control plane outbound load balancer cannot be set for public clusters.",
 			},
 		},
 		{
 			name: "cp outbound lb can be set for private clusters",
-			lb:   &LoadBalancerSpec{Name: "foo"},
-			apiServerLB: LoadBalancerSpec{
-				LoadBalancerClassSpec: LoadBalancerClassSpec{
-					Type: Internal,
+			lb:   &infrav1.LoadBalancerSpec{Name: "foo"},
+			apiServerLB: infrav1.LoadBalancerSpec{
+				LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{
+					Type: infrav1.Internal,
 				},
 			},
 			wantErr: false,
@@ -1652,21 +1652,21 @@ func TestValidateControlPlaneNodeOutboundLB(t *testing.T) {
 		{
 			name: "cp outbound lb can be nil for private clusters",
 			lb:   nil,
-			apiServerLB: LoadBalancerSpec{
-				LoadBalancerClassSpec: LoadBalancerClassSpec{
-					Type: Internal,
+			apiServerLB: infrav1.LoadBalancerSpec{
+				LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{
+					Type: infrav1.Internal,
 				},
 			},
 			wantErr: false,
 		},
 		{
 			name: "frontend ips count exceeds max value",
-			lb: &LoadBalancerSpec{
+			lb: &infrav1.LoadBalancerSpec{
 				FrontendIPsCount: ptr.To[int32](100),
 			},
-			apiServerLB: LoadBalancerSpec{
-				LoadBalancerClassSpec: LoadBalancerClassSpec{
-					Type: Internal,
+			apiServerLB: infrav1.LoadBalancerSpec{
+				LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{
+					Type: infrav1.Internal,
 				},
 			},
 			wantErr: true,
@@ -1696,8 +1696,8 @@ func TestValidateControlPlaneNodeOutboundLB(t *testing.T) {
 func TestValidateCloudProviderConfigOverrides(t *testing.T) {
 	tests := []struct {
 		name        string
-		oldConfig   *CloudProviderConfigOverrides
-		newConfig   *CloudProviderConfigOverrides
+		oldConfig   *infrav1.CloudProviderConfigOverrides
+		newConfig   *infrav1.CloudProviderConfigOverrides
 		wantErr     bool
 		expectedErr field.Error
 	}{
@@ -1707,42 +1707,42 @@ func TestValidateCloudProviderConfigOverrides(t *testing.T) {
 		},
 		{
 			name: "both old and new config are same",
-			oldConfig: &CloudProviderConfigOverrides{RateLimits: []RateLimitSpec{{
+			oldConfig: &infrav1.CloudProviderConfigOverrides{RateLimits: []infrav1.RateLimitSpec{{
 				Name:   "foo",
-				Config: RateLimitConfig{CloudProviderRateLimitBucket: 10, CloudProviderRateLimit: true},
+				Config: infrav1.RateLimitConfig{CloudProviderRateLimitBucket: 10, CloudProviderRateLimit: true},
 			}}},
-			newConfig: &CloudProviderConfigOverrides{RateLimits: []RateLimitSpec{{
+			newConfig: &infrav1.CloudProviderConfigOverrides{RateLimits: []infrav1.RateLimitSpec{{
 				Name:   "foo",
-				Config: RateLimitConfig{CloudProviderRateLimitBucket: 10, CloudProviderRateLimit: true},
+				Config: infrav1.RateLimitConfig{CloudProviderRateLimitBucket: 10, CloudProviderRateLimit: true},
 			}}},
 			wantErr: false,
 		},
 		{
 			name: "old and new config are not same",
-			oldConfig: &CloudProviderConfigOverrides{RateLimits: []RateLimitSpec{{
+			oldConfig: &infrav1.CloudProviderConfigOverrides{RateLimits: []infrav1.RateLimitSpec{{
 				Name:   "foo",
-				Config: RateLimitConfig{CloudProviderRateLimitBucket: 10, CloudProviderRateLimit: true},
+				Config: infrav1.RateLimitConfig{CloudProviderRateLimitBucket: 10, CloudProviderRateLimit: true},
 			}}},
-			newConfig: &CloudProviderConfigOverrides{RateLimits: []RateLimitSpec{{
+			newConfig: &infrav1.CloudProviderConfigOverrides{RateLimits: []infrav1.RateLimitSpec{{
 				Name:   "foo",
-				Config: RateLimitConfig{CloudProviderRateLimitBucket: 11, CloudProviderRateLimit: true},
+				Config: infrav1.RateLimitConfig{CloudProviderRateLimitBucket: 11, CloudProviderRateLimit: true},
 			}}},
 			wantErr: true,
 			expectedErr: field.Error{
 				Type:  "FieldValueInvalid",
 				Field: "spec.cloudProviderConfigOverrides",
-				BadValue: CloudProviderConfigOverrides{RateLimits: []RateLimitSpec{{
+				BadValue: infrav1.CloudProviderConfigOverrides{RateLimits: []infrav1.RateLimitSpec{{
 					Name:   "foo",
-					Config: RateLimitConfig{CloudProviderRateLimitBucket: 11, CloudProviderRateLimit: true},
+					Config: infrav1.RateLimitConfig{CloudProviderRateLimitBucket: 11, CloudProviderRateLimit: true},
 				}}},
 				Detail: "cannot change cloudProviderConfigOverrides cluster creation",
 			},
 		},
 		{
 			name: "new config is nil",
-			oldConfig: &CloudProviderConfigOverrides{RateLimits: []RateLimitSpec{{
+			oldConfig: &infrav1.CloudProviderConfigOverrides{RateLimits: []infrav1.RateLimitSpec{{
 				Name:   "foo",
-				Config: RateLimitConfig{CloudProviderRateLimitBucket: 10, CloudProviderRateLimit: true},
+				Config: infrav1.RateLimitConfig{CloudProviderRateLimitBucket: 10, CloudProviderRateLimit: true},
 			}}},
 			wantErr: true,
 			expectedErr: field.Error{
@@ -1754,17 +1754,17 @@ func TestValidateCloudProviderConfigOverrides(t *testing.T) {
 		},
 		{
 			name: "old config is nil",
-			newConfig: &CloudProviderConfigOverrides{RateLimits: []RateLimitSpec{{
+			newConfig: &infrav1.CloudProviderConfigOverrides{RateLimits: []infrav1.RateLimitSpec{{
 				Name:   "foo",
-				Config: RateLimitConfig{CloudProviderRateLimitBucket: 10, CloudProviderRateLimit: true},
+				Config: infrav1.RateLimitConfig{CloudProviderRateLimitBucket: 10, CloudProviderRateLimit: true},
 			}}},
 			wantErr: true,
 			expectedErr: field.Error{
 				Type:  "FieldValueInvalid",
 				Field: "spec.cloudProviderConfigOverrides",
-				BadValue: &CloudProviderConfigOverrides{RateLimits: []RateLimitSpec{{
+				BadValue: &infrav1.CloudProviderConfigOverrides{RateLimits: []infrav1.RateLimitSpec{{
 					Name:   "foo",
-					Config: RateLimitConfig{CloudProviderRateLimitBucket: 10, CloudProviderRateLimit: true},
+					Config: infrav1.RateLimitConfig{CloudProviderRateLimitBucket: 10, CloudProviderRateLimit: true},
 				}}},
 				Detail: "cannot change cloudProviderConfigOverrides cluster creation",
 			},
@@ -1786,13 +1786,13 @@ func TestValidateCloudProviderConfigOverrides(t *testing.T) {
 func TestValidateServiceEndpoints(t *testing.T) {
 	tests := []struct {
 		name             string
-		serviceEndpoints ServiceEndpoints
+		serviceEndpoints infrav1.ServiceEndpoints
 		wantErr          bool
 		expectedErr      field.Error
 	}{
 		{
 			name: "valid service endpoint",
-			serviceEndpoints: []ServiceEndpointSpec{{
+			serviceEndpoints: []infrav1.ServiceEndpointSpec{{
 				Service:   "Microsoft.Foo",
 				Locations: []string{"*", "eastus2"},
 			}},
@@ -1800,7 +1800,7 @@ func TestValidateServiceEndpoints(t *testing.T) {
 		},
 		{
 			name: "invalid service endpoint name doesn't start with Microsoft",
-			serviceEndpoints: []ServiceEndpointSpec{{
+			serviceEndpoints: []infrav1.ServiceEndpointSpec{{
 				Service:   "Foo",
 				Locations: []string{"*"},
 			}},
@@ -1814,7 +1814,7 @@ func TestValidateServiceEndpoints(t *testing.T) {
 		},
 		{
 			name: "invalid service endpoint name contains invalid characters",
-			serviceEndpoints: []ServiceEndpointSpec{{
+			serviceEndpoints: []infrav1.ServiceEndpointSpec{{
 				Service:   "Microsoft.Foo",
 				Locations: []string{"*"},
 			}, {
@@ -1831,7 +1831,7 @@ func TestValidateServiceEndpoints(t *testing.T) {
 		},
 		{
 			name: "invalid service endpoint location contains invalid characters",
-			serviceEndpoints: []ServiceEndpointSpec{{
+			serviceEndpoints: []infrav1.ServiceEndpointSpec{{
 				Service:   "Microsoft.Foo",
 				Locations: []string{"*"},
 			}, {
@@ -1864,12 +1864,12 @@ func TestValidateServiceEndpoints(t *testing.T) {
 func TestServiceEndpointsLackRequiredFieldService(t *testing.T) {
 	type test struct {
 		name             string
-		serviceEndpoints ServiceEndpoints
+		serviceEndpoints infrav1.ServiceEndpoints
 	}
 
 	testCase := test{
 		name: "service endpoint missing service name",
-		serviceEndpoints: []ServiceEndpointSpec{{
+		serviceEndpoints: []infrav1.ServiceEndpointSpec{{
 			Locations: []string{"*"},
 		}},
 	}
@@ -1887,12 +1887,12 @@ func TestServiceEndpointsLackRequiredFieldService(t *testing.T) {
 func TestServiceEndpointsLackRequiredFieldLocations(t *testing.T) {
 	type test struct {
 		name             string
-		serviceEndpoints ServiceEndpoints
+		serviceEndpoints infrav1.ServiceEndpoints
 	}
 
 	testCase := test{
 		name: "service endpoint missing locations",
-		serviceEndpoints: []ServiceEndpointSpec{{
+		serviceEndpoints: []infrav1.ServiceEndpointSpec{{
 			Service: "Microsoft.Foo",
 		}},
 	}
@@ -1910,14 +1910,14 @@ func TestServiceEndpointsLackRequiredFieldLocations(t *testing.T) {
 func TestClusterWithExtendedLocationInvalid(t *testing.T) {
 	tests := []struct {
 		name    string
-		cluster *AzureCluster
+		cluster *infrav1.AzureCluster
 		wantErr bool
 	}{
 		{
 			name: "azurecluster spec with extended location but not enable EdgeZone feature gate flag",
-			cluster: func() *AzureCluster {
+			cluster: func() *infrav1.AzureCluster {
 				cluster := apifixtures.CreateValidCluster()
-				cluster.Spec.ExtendedLocation = &ExtendedLocationSpec{
+				cluster.Spec.ExtendedLocation = &infrav1.ExtendedLocationSpec{
 					Name: "rr4",
 					Type: "EdgeZone",
 				}

--- a/internal/webhooks/azurecluster_webhook.go
+++ b/internal/webhooks/azurecluster_webhook.go
@@ -28,7 +28,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
-	. "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
+	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	apiinternal "sigs.k8s.io/cluster-api-provider-azure/internal/api/v1beta1"
 	webhookutils "sigs.k8s.io/cluster-api-provider-azure/util/webhook"
 )
@@ -36,7 +36,7 @@ import (
 // SetupWebhookWithManager sets up and registers the webhook with the manager.
 func (w *AzureClusterWebhook) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
-		For(&AzureCluster{}).
+		For(&infrav1.AzureCluster{}).
 		WithValidator(w).
 		WithDefaulter(w).
 		Complete()
@@ -53,7 +53,7 @@ var _ webhook.CustomDefaulter = &AzureClusterWebhook{}
 
 // Default implements webhook.CustomDefaulter so a webhook will be registered for the type.
 func (*AzureClusterWebhook) Default(_ context.Context, obj runtime.Object) error {
-	c, ok := obj.(*AzureCluster)
+	c, ok := obj.(*infrav1.AzureCluster)
 	if !ok {
 		return fmt.Errorf("expected an AzureCluster object but got %T", c)
 	}
@@ -64,7 +64,7 @@ func (*AzureClusterWebhook) Default(_ context.Context, obj runtime.Object) error
 
 // ValidateCreate implements webhook.CustomValidator so a webhook will be registered for the type.
 func (*AzureClusterWebhook) ValidateCreate(_ context.Context, obj runtime.Object) (admission.Warnings, error) {
-	c, ok := obj.(*AzureCluster)
+	c, ok := obj.(*infrav1.AzureCluster)
 	if !ok {
 		return nil, fmt.Errorf("expected an AzureCluster object but got %T", c)
 	}
@@ -74,13 +74,13 @@ func (*AzureClusterWebhook) ValidateCreate(_ context.Context, obj runtime.Object
 
 // ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type.
 func (*AzureClusterWebhook) ValidateUpdate(_ context.Context, oldRaw, newObj runtime.Object) (admission.Warnings, error) {
-	c, ok := newObj.(*AzureCluster)
+	c, ok := newObj.(*infrav1.AzureCluster)
 	if !ok {
 		return nil, fmt.Errorf("expected an AzureCluster object but got %T", c)
 	}
 
 	var allErrs field.ErrorList
-	old := oldRaw.(*AzureCluster)
+	old := oldRaw.(*infrav1.AzureCluster)
 
 	if err := webhookutils.ValidateImmutable(
 		field.NewPath("spec", "resourceGroup"),
@@ -176,7 +176,7 @@ func (*AzureClusterWebhook) ValidateUpdate(_ context.Context, oldRaw, newObj run
 		return validateAzureCluster(c, old)
 	}
 
-	return nil, apierrors.NewInvalid(GroupVersion.WithKind(AzureClusterKind).GroupKind(), c.Name, allErrs)
+	return nil, apierrors.NewInvalid(infrav1.GroupVersion.WithKind(infrav1.AzureClusterKind).GroupKind(), c.Name, allErrs)
 }
 
 // ValidateDelete implements webhook.CustomValidator so a webhook will be registered for the type.

--- a/internal/webhooks/azurecluster_webhook_test.go
+++ b/internal/webhooks/azurecluster_webhook_test.go
@@ -22,14 +22,14 @@ import (
 	. "github.com/onsi/gomega"
 	clusterv1beta1 "sigs.k8s.io/cluster-api/api/core/v1beta1"
 
-	. "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
+	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	apifixtures "sigs.k8s.io/cluster-api-provider-azure/internal/test/apifixtures"
 )
 
 func TestAzureCluster_ValidateCreate(t *testing.T) {
 	tests := []struct {
 		name    string
-		cluster *AzureCluster
+		cluster *infrav1.AzureCluster
 		wantErr bool
 	}{
 		{
@@ -39,7 +39,7 @@ func TestAzureCluster_ValidateCreate(t *testing.T) {
 		},
 		{
 			name: "azurecluster with pre-existing control plane endpoint - valid spec",
-			cluster: func() *AzureCluster {
+			cluster: func() *infrav1.AzureCluster {
 				cluster := apifixtures.CreateValidCluster()
 				cluster.Spec.ControlPlaneEndpoint = clusterv1beta1.APIEndpoint{
 					Host: "apiserver.example.com",
@@ -51,7 +51,7 @@ func TestAzureCluster_ValidateCreate(t *testing.T) {
 		},
 		{
 			name: "azurecluster without pre-existing vnet - valid spec",
-			cluster: func() *AzureCluster {
+			cluster: func() *infrav1.AzureCluster {
 				cluster := apifixtures.CreateValidCluster()
 				cluster.Spec.NetworkSpec.Vnet.ResourceGroup = ""
 				return cluster
@@ -60,7 +60,7 @@ func TestAzureCluster_ValidateCreate(t *testing.T) {
 		},
 		{
 			name: "azurecluster with pre-existing vnet - lack control plane subnet",
-			cluster: func() *AzureCluster {
+			cluster: func() *infrav1.AzureCluster {
 				cluster := apifixtures.CreateValidCluster()
 				cluster.Spec.NetworkSpec.Subnets = cluster.Spec.NetworkSpec.Subnets[1:]
 				return cluster
@@ -69,7 +69,7 @@ func TestAzureCluster_ValidateCreate(t *testing.T) {
 		},
 		{
 			name: "azurecluster with pre-existing vnet - lack node subnet",
-			cluster: func() *AzureCluster {
+			cluster: func() *infrav1.AzureCluster {
 				cluster := apifixtures.CreateValidCluster()
 				cluster.Spec.NetworkSpec.Subnets = cluster.Spec.NetworkSpec.Subnets[:1]
 				return cluster
@@ -78,7 +78,7 @@ func TestAzureCluster_ValidateCreate(t *testing.T) {
 		},
 		{
 			name: "azurecluster with pre-existing vnet - invalid resourcegroup name",
-			cluster: func() *AzureCluster {
+			cluster: func() *infrav1.AzureCluster {
 				cluster := apifixtures.CreateValidCluster()
 				cluster.Spec.NetworkSpec.Vnet.ResourceGroup = "invalid-rg-name###"
 				return cluster
@@ -87,19 +87,19 @@ func TestAzureCluster_ValidateCreate(t *testing.T) {
 		},
 		{
 			name: "azurecluster with pre-existing vnet - invalid subnet name",
-			cluster: func() *AzureCluster {
+			cluster: func() *infrav1.AzureCluster {
 				cluster := apifixtures.CreateValidCluster()
 				cluster.Spec.NetworkSpec.Subnets = append(cluster.Spec.NetworkSpec.Subnets,
-					SubnetSpec{SubnetClassSpec: SubnetClassSpec{Name: "invalid-subnet-name###", Role: "random-role"}})
+					infrav1.SubnetSpec{SubnetClassSpec: infrav1.SubnetClassSpec{Name: "invalid-subnet-name###", Role: "random-role"}})
 				return cluster
 			}(),
 			wantErr: true,
 		},
 		{
 			name: "azurecluster with ExtendedLocation and false EdgeZone feature flag",
-			cluster: func() *AzureCluster {
+			cluster: func() *infrav1.AzureCluster {
 				cluster := apifixtures.CreateValidCluster()
-				cluster.Spec.ExtendedLocation = &ExtendedLocationSpec{
+				cluster.Spec.ExtendedLocation = &infrav1.ExtendedLocationSpec{
 					Name: "rr4",
 					Type: "EdgeZone",
 				}
@@ -124,13 +124,13 @@ func TestAzureCluster_ValidateCreate(t *testing.T) {
 func TestAzureCluster_ValidateUpdate(t *testing.T) {
 	tests := []struct {
 		name       string
-		oldCluster *AzureCluster
-		cluster    *AzureCluster
+		oldCluster *infrav1.AzureCluster
+		cluster    *infrav1.AzureCluster
 		wantErr    bool
 	}{
 		{
 			name: "azurecluster with pre-existing control plane endpoint - valid spec",
-			oldCluster: func() *AzureCluster {
+			oldCluster: func() *infrav1.AzureCluster {
 				cluster := apifixtures.CreateValidCluster()
 				cluster.Spec.ControlPlaneEndpoint = clusterv1beta1.APIEndpoint{
 					Host: "apiserver.example.com",
@@ -138,7 +138,7 @@ func TestAzureCluster_ValidateUpdate(t *testing.T) {
 				}
 				return cluster
 			}(),
-			cluster: func() *AzureCluster {
+			cluster: func() *infrav1.AzureCluster {
 				cluster := apifixtures.CreateValidCluster()
 				cluster.Spec.ControlPlaneEndpoint = clusterv1beta1.APIEndpoint{
 					Host: "apiserver.example.io",
@@ -151,7 +151,7 @@ func TestAzureCluster_ValidateUpdate(t *testing.T) {
 		{
 			name:       "azurecluster with no control plane endpoint - valid spec",
 			oldCluster: apifixtures.CreateValidCluster(),
-			cluster: func() *AzureCluster {
+			cluster: func() *infrav1.AzureCluster {
 				cluster := apifixtures.CreateValidCluster()
 				cluster.Spec.ControlPlaneEndpoint = clusterv1beta1.APIEndpoint{
 					Host: "apiserver.example.com",
@@ -169,12 +169,12 @@ func TestAzureCluster_ValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "azurecluster without pre-existing vnet - valid spec",
-			oldCluster: func() *AzureCluster {
+			oldCluster: func() *infrav1.AzureCluster {
 				cluster := apifixtures.CreateValidCluster()
 				cluster.Spec.NetworkSpec.Vnet.ResourceGroup = ""
 				return cluster
 			}(),
-			cluster: func() *AzureCluster {
+			cluster: func() *infrav1.AzureCluster {
 				cluster := apifixtures.CreateValidCluster()
 				cluster.Spec.NetworkSpec.Vnet.ResourceGroup = ""
 				return cluster
@@ -184,7 +184,7 @@ func TestAzureCluster_ValidateUpdate(t *testing.T) {
 		{
 			name:       "azurecluster with pre-existing vnet - lack control plane subnet",
 			oldCluster: apifixtures.CreateValidCluster(),
-			cluster: func() *AzureCluster {
+			cluster: func() *infrav1.AzureCluster {
 				cluster := apifixtures.CreateValidCluster()
 				cluster.Spec.NetworkSpec.Subnets = cluster.Spec.NetworkSpec.Subnets[1:]
 				return cluster
@@ -194,7 +194,7 @@ func TestAzureCluster_ValidateUpdate(t *testing.T) {
 		{
 			name:       "azurecluster with pre-existing vnet - lack node subnet",
 			oldCluster: apifixtures.CreateValidCluster(),
-			cluster: func() *AzureCluster {
+			cluster: func() *infrav1.AzureCluster {
 				cluster := apifixtures.CreateValidCluster()
 				cluster.Spec.NetworkSpec.Subnets = cluster.Spec.NetworkSpec.Subnets[:1]
 				return cluster
@@ -204,7 +204,7 @@ func TestAzureCluster_ValidateUpdate(t *testing.T) {
 		{
 			name:       "azurecluster with pre-existing vnet - invalid resourcegroup name",
 			oldCluster: apifixtures.CreateValidCluster(),
-			cluster: func() *AzureCluster {
+			cluster: func() *infrav1.AzureCluster {
 				cluster := apifixtures.CreateValidCluster()
 				cluster.Spec.NetworkSpec.Vnet.ResourceGroup = "invalid-name###"
 				return cluster
@@ -214,23 +214,23 @@ func TestAzureCluster_ValidateUpdate(t *testing.T) {
 		{
 			name:       "azurecluster with pre-existing vnet - invalid subnet name",
 			oldCluster: apifixtures.CreateValidCluster(),
-			cluster: func() *AzureCluster {
+			cluster: func() *infrav1.AzureCluster {
 				cluster := apifixtures.CreateValidCluster()
 				cluster.Spec.NetworkSpec.Subnets = append(cluster.Spec.NetworkSpec.Subnets,
-					SubnetSpec{SubnetClassSpec: SubnetClassSpec{Name: "invalid-name###", Role: "random-role"}})
+					infrav1.SubnetSpec{SubnetClassSpec: infrav1.SubnetClassSpec{Name: "invalid-name###", Role: "random-role"}})
 				return cluster
 			}(),
 			wantErr: true,
 		},
 		{
 			name: "azurecluster resource group is immutable",
-			oldCluster: &AzureCluster{
-				Spec: AzureClusterSpec{
+			oldCluster: &infrav1.AzureCluster{
+				Spec: infrav1.AzureClusterSpec{
 					ResourceGroup: "demoResourceGroup",
 				},
 			},
-			cluster: &AzureCluster{
-				Spec: AzureClusterSpec{
+			cluster: &infrav1.AzureCluster{
+				Spec: infrav1.AzureClusterSpec{
 					ResourceGroup: "demoResourceGroup-2",
 				},
 			},
@@ -238,16 +238,16 @@ func TestAzureCluster_ValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "azurecluster subscription ID is immutable",
-			oldCluster: &AzureCluster{
-				Spec: AzureClusterSpec{
-					AzureClusterClassSpec: AzureClusterClassSpec{
+			oldCluster: &infrav1.AzureCluster{
+				Spec: infrav1.AzureClusterSpec{
+					AzureClusterClassSpec: infrav1.AzureClusterClassSpec{
 						SubscriptionID: "212ec1q8",
 					},
 				},
 			},
-			cluster: &AzureCluster{
-				Spec: AzureClusterSpec{
-					AzureClusterClassSpec: AzureClusterClassSpec{
+			cluster: &infrav1.AzureCluster{
+				Spec: infrav1.AzureClusterSpec{
+					AzureClusterClassSpec: infrav1.AzureClusterClassSpec{
 						SubscriptionID: "212ec1q9",
 					},
 				},
@@ -256,16 +256,16 @@ func TestAzureCluster_ValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "azurecluster location is immutable",
-			oldCluster: &AzureCluster{
-				Spec: AzureClusterSpec{
-					AzureClusterClassSpec: AzureClusterClassSpec{
+			oldCluster: &infrav1.AzureCluster{
+				Spec: infrav1.AzureClusterSpec{
+					AzureClusterClassSpec: infrav1.AzureClusterClassSpec{
 						Location: "North Europe",
 					},
 				},
 			},
-			cluster: &AzureCluster{
-				Spec: AzureClusterSpec{
-					AzureClusterClassSpec: AzureClusterClassSpec{
+			cluster: &infrav1.AzureCluster{
+				Spec: infrav1.AzureClusterSpec{
+					AzureClusterClassSpec: infrav1.AzureClusterClassSpec{
 						Location: "West Europe",
 					},
 				},
@@ -274,16 +274,16 @@ func TestAzureCluster_ValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "azurecluster azureEnvironment is immutable",
-			oldCluster: &AzureCluster{
-				Spec: AzureClusterSpec{
-					AzureClusterClassSpec: AzureClusterClassSpec{
+			oldCluster: &infrav1.AzureCluster{
+				Spec: infrav1.AzureClusterSpec{
+					AzureClusterClassSpec: infrav1.AzureClusterClassSpec{
 						AzureEnvironment: "AzureGermanCloud",
 					},
 				},
 			},
-			cluster: &AzureCluster{
-				Spec: AzureClusterSpec{
-					AzureClusterClassSpec: AzureClusterClassSpec{
+			cluster: &infrav1.AzureCluster{
+				Spec: infrav1.AzureClusterSpec{
+					AzureClusterClassSpec: infrav1.AzureClusterClassSpec{
 						AzureEnvironment: "AzureChinaCloud",
 					},
 				},
@@ -293,7 +293,7 @@ func TestAzureCluster_ValidateUpdate(t *testing.T) {
 		{
 			name:       "azurecluster azureEnvironment default mismatch",
 			oldCluster: apifixtures.CreateValidCluster(),
-			cluster: func() *AzureCluster {
+			cluster: func() *infrav1.AzureCluster {
 				cluster := apifixtures.CreateValidCluster()
 				cluster.Spec.AzureEnvironment = "AzurePublicCloud"
 				return cluster
@@ -302,17 +302,17 @@ func TestAzureCluster_ValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "control plane outbound lb is immutable",
-			oldCluster: &AzureCluster{
-				Spec: AzureClusterSpec{
-					NetworkSpec: NetworkSpec{
-						ControlPlaneOutboundLB: &LoadBalancerSpec{Name: "cp-lb"},
+			oldCluster: &infrav1.AzureCluster{
+				Spec: infrav1.AzureClusterSpec{
+					NetworkSpec: infrav1.NetworkSpec{
+						ControlPlaneOutboundLB: &infrav1.LoadBalancerSpec{Name: "cp-lb"},
 					},
 				},
 			},
-			cluster: &AzureCluster{
-				Spec: AzureClusterSpec{
-					NetworkSpec: NetworkSpec{
-						ControlPlaneOutboundLB: &LoadBalancerSpec{Name: "cp-lb-new"},
+			cluster: &infrav1.AzureCluster{
+				Spec: infrav1.AzureClusterSpec{
+					NetworkSpec: infrav1.NetworkSpec{
+						ControlPlaneOutboundLB: &infrav1.LoadBalancerSpec{Name: "cp-lb-new"},
 					},
 				},
 			},
@@ -320,12 +320,12 @@ func TestAzureCluster_ValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "natGateway name is immutable",
-			oldCluster: func() *AzureCluster {
+			oldCluster: func() *infrav1.AzureCluster {
 				cluster := apifixtures.CreateValidCluster()
 				cluster.Spec.NetworkSpec.Subnets[0].NatGateway.Name = "cluster-test-node-natgw-0"
 				return cluster
 			}(),
-			cluster: func() *AzureCluster {
+			cluster: func() *infrav1.AzureCluster {
 				cluster := apifixtures.CreateValidCluster()
 				cluster.Spec.NetworkSpec.Subnets[0].NatGateway.Name = "cluster-test-node-natgw-1"
 				return cluster
@@ -335,7 +335,7 @@ func TestAzureCluster_ValidateUpdate(t *testing.T) {
 		{
 			name:       "natGateway name can be empty before AzureCluster is updated",
 			oldCluster: apifixtures.CreateValidCluster(),
-			cluster: func() *AzureCluster {
+			cluster: func() *infrav1.AzureCluster {
 				cluster := apifixtures.CreateValidCluster()
 				cluster.Spec.NetworkSpec.Subnets[0].NatGateway.Name = "cluster-test-node-natgw"
 				return cluster

--- a/internal/webhooks/azureclusteridentity_validation.go
+++ b/internal/webhooks/azureclusteridentity_validation.go
@@ -23,20 +23,20 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
-	. "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
+	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 )
 
-func validateAzureClusterIdentity(c *AzureClusterIdentity) (admission.Warnings, error) {
+func validateAzureClusterIdentity(c *infrav1.AzureClusterIdentity) (admission.Warnings, error) {
 	var allErrs field.ErrorList
-	if c.Spec.Type != UserAssignedMSI && c.Spec.ResourceID != "" { //nolint:staticcheck
+	if c.Spec.Type != infrav1.UserAssignedMSI && c.Spec.ResourceID != "" { //nolint:staticcheck
 		allErrs = append(allErrs, field.Forbidden(field.NewPath("spec", "resourceID"), c.Spec.ResourceID)) //nolint:staticcheck
 	}
-	if c.Spec.Type != UserAssignedIdentityCredential && (c.Spec.UserAssignedIdentityCredentialsPath != "" || c.Spec.UserAssignedIdentityCredentialsCloudType != "") {
+	if c.Spec.Type != infrav1.UserAssignedIdentityCredential && (c.Spec.UserAssignedIdentityCredentialsPath != "" || c.Spec.UserAssignedIdentityCredentialsCloudType != "") {
 		allErrs = append(allErrs, field.Forbidden(field.NewPath("spec", "userAssignedIdentityCredentialsPath"), fmt.Sprintf("%s can only be set when AzureClusterIdentity is of type UserAssignedIdentityCredential", c.Spec.UserAssignedIdentityCredentialsPath)))
 		allErrs = append(allErrs, field.Forbidden(field.NewPath("spec", "userAssignedIdentityCredentialsCloudType"), fmt.Sprintf("%s can only be set when AzureClusterIdentity is of type UserAssignedIdentityCredential ", c.Spec.UserAssignedIdentityCredentialsCloudType)))
 	}
 	if len(allErrs) == 0 {
 		return nil, nil
 	}
-	return nil, apierrors.NewInvalid(GroupVersion.WithKind(AzureClusterIdentityKind).GroupKind(), c.Name, allErrs)
+	return nil, apierrors.NewInvalid(infrav1.GroupVersion.WithKind(infrav1.AzureClusterIdentityKind).GroupKind(), c.Name, allErrs)
 }

--- a/internal/webhooks/azureclusteridentity_webhook.go
+++ b/internal/webhooks/azureclusteridentity_webhook.go
@@ -27,14 +27,14 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
-	. "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
+	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	webhookutils "sigs.k8s.io/cluster-api-provider-azure/util/webhook"
 )
 
 // SetupWebhookWithManager sets up and registers the webhook with the manager.
 func (w *AzureClusterIdentityWebhook) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
-		For(&AzureClusterIdentity{}).
+		For(&infrav1.AzureClusterIdentity{}).
 		WithValidator(w).
 		Complete()
 }
@@ -48,7 +48,7 @@ var _ webhook.CustomValidator = &AzureClusterIdentityWebhook{}
 
 // ValidateCreate implements webhook.CustomValidator so a webhook will be registered for the type.
 func (*AzureClusterIdentityWebhook) ValidateCreate(_ context.Context, obj runtime.Object) (admission.Warnings, error) {
-	c, ok := obj.(*AzureClusterIdentity)
+	c, ok := obj.(*infrav1.AzureClusterIdentity)
 	if !ok {
 		return nil, fmt.Errorf("expected an AzureClusterIdentity object but got %T", c)
 	}
@@ -58,13 +58,13 @@ func (*AzureClusterIdentityWebhook) ValidateCreate(_ context.Context, obj runtim
 
 // ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type.
 func (*AzureClusterIdentityWebhook) ValidateUpdate(_ context.Context, oldRaw, newObj runtime.Object) (admission.Warnings, error) {
-	c, ok := newObj.(*AzureClusterIdentity)
+	c, ok := newObj.(*infrav1.AzureClusterIdentity)
 	if !ok {
 		return nil, fmt.Errorf("expected an AzureClusterIdentity object but got %T", c)
 	}
 
 	var allErrs field.ErrorList
-	old := oldRaw.(*AzureClusterIdentity)
+	old := oldRaw.(*infrav1.AzureClusterIdentity)
 	if err := webhookutils.ValidateImmutable(
 		field.NewPath("Spec", "Type"),
 		old.Spec.Type,
@@ -74,7 +74,7 @@ func (*AzureClusterIdentityWebhook) ValidateUpdate(_ context.Context, oldRaw, ne
 	if len(allErrs) == 0 {
 		return validateAzureClusterIdentity(c)
 	}
-	return nil, apierrors.NewInvalid(GroupVersion.WithKind(AzureClusterIdentityKind).GroupKind(), c.Name, allErrs)
+	return nil, apierrors.NewInvalid(infrav1.GroupVersion.WithKind(infrav1.AzureClusterIdentityKind).GroupKind(), c.Name, allErrs)
 }
 
 // ValidateDelete implements webhook.CustomValidator so a webhook will be registered for the type.

--- a/internal/webhooks/azureclusteridentity_webhook_test.go
+++ b/internal/webhooks/azureclusteridentity_webhook_test.go
@@ -21,7 +21,7 @@ import (
 
 	. "github.com/onsi/gomega"
 
-	. "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
+	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 )
 
 const fakeClientID = "fake-client-id"
@@ -31,14 +31,14 @@ const fakeResourceID = "fake-resource-id"
 func TestAzureClusterIdentity_ValidateCreate(t *testing.T) {
 	tests := []struct {
 		name            string
-		clusterIdentity *AzureClusterIdentity
+		clusterIdentity *infrav1.AzureClusterIdentity
 		wantErr         bool
 	}{
 		{
 			name: "azureclusteridentity with service principal",
-			clusterIdentity: &AzureClusterIdentity{
-				Spec: AzureClusterIdentitySpec{
-					Type:     ServicePrincipal,
+			clusterIdentity: &infrav1.AzureClusterIdentity{
+				Spec: infrav1.AzureClusterIdentitySpec{
+					Type:     infrav1.ServicePrincipal,
 					ClientID: fakeClientID,
 					TenantID: fakeTenantID,
 				},
@@ -47,9 +47,9 @@ func TestAzureClusterIdentity_ValidateCreate(t *testing.T) {
 		},
 		{
 			name: "azureclusteridentity with service principal and resource id",
-			clusterIdentity: &AzureClusterIdentity{
-				Spec: AzureClusterIdentitySpec{
-					Type:       ServicePrincipal,
+			clusterIdentity: &infrav1.AzureClusterIdentity{
+				Spec: infrav1.AzureClusterIdentitySpec{
+					Type:       infrav1.ServicePrincipal,
 					ClientID:   fakeClientID,
 					TenantID:   fakeTenantID,
 					ResourceID: fakeResourceID,
@@ -59,9 +59,9 @@ func TestAzureClusterIdentity_ValidateCreate(t *testing.T) {
 		},
 		{
 			name: "azureclusteridentity with user assigned msi and resource id",
-			clusterIdentity: &AzureClusterIdentity{
-				Spec: AzureClusterIdentitySpec{
-					Type:       UserAssignedMSI,
+			clusterIdentity: &infrav1.AzureClusterIdentity{
+				Spec: infrav1.AzureClusterIdentitySpec{
+					Type:       infrav1.UserAssignedMSI,
 					ClientID:   fakeClientID,
 					TenantID:   fakeTenantID,
 					ResourceID: fakeResourceID,
@@ -71,9 +71,9 @@ func TestAzureClusterIdentity_ValidateCreate(t *testing.T) {
 		},
 		{
 			name: "azureclusteridentity with user assigned msi and no resource id",
-			clusterIdentity: &AzureClusterIdentity{
-				Spec: AzureClusterIdentitySpec{
-					Type:     UserAssignedMSI,
+			clusterIdentity: &infrav1.AzureClusterIdentity{
+				Spec: infrav1.AzureClusterIdentitySpec{
+					Type:     infrav1.UserAssignedMSI,
 					ClientID: fakeClientID,
 					TenantID: fakeTenantID,
 				},
@@ -98,22 +98,22 @@ func TestAzureClusterIdentity_ValidateCreate(t *testing.T) {
 func TestAzureClusterIdentity_ValidateUpdate(t *testing.T) {
 	tests := []struct {
 		name               string
-		oldClusterIdentity *AzureClusterIdentity
-		clusterIdentity    *AzureClusterIdentity
+		oldClusterIdentity *infrav1.AzureClusterIdentity
+		clusterIdentity    *infrav1.AzureClusterIdentity
 		wantErr            bool
 	}{
 		{
 			name: "azureclusteridentity with no change",
-			clusterIdentity: &AzureClusterIdentity{
-				Spec: AzureClusterIdentitySpec{
-					Type:     ServicePrincipal,
+			clusterIdentity: &infrav1.AzureClusterIdentity{
+				Spec: infrav1.AzureClusterIdentitySpec{
+					Type:     infrav1.ServicePrincipal,
 					ClientID: fakeClientID,
 					TenantID: fakeTenantID,
 				},
 			},
-			oldClusterIdentity: &AzureClusterIdentity{
-				Spec: AzureClusterIdentitySpec{
-					Type:     ServicePrincipal,
+			oldClusterIdentity: &infrav1.AzureClusterIdentity{
+				Spec: infrav1.AzureClusterIdentitySpec{
+					Type:     infrav1.ServicePrincipal,
 					ClientID: fakeClientID,
 					TenantID: fakeTenantID,
 				},
@@ -122,17 +122,17 @@ func TestAzureClusterIdentity_ValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "azureclusteridentity with a change in type",
-			clusterIdentity: &AzureClusterIdentity{
-				Spec: AzureClusterIdentitySpec{
-					Type:       ServicePrincipal,
+			clusterIdentity: &infrav1.AzureClusterIdentity{
+				Spec: infrav1.AzureClusterIdentitySpec{
+					Type:       infrav1.ServicePrincipal,
 					ClientID:   fakeClientID,
 					TenantID:   fakeTenantID,
 					ResourceID: fakeResourceID,
 				},
 			},
-			oldClusterIdentity: &AzureClusterIdentity{
-				Spec: AzureClusterIdentitySpec{
-					Type:       WorkloadIdentity,
+			oldClusterIdentity: &infrav1.AzureClusterIdentity{
+				Spec: infrav1.AzureClusterIdentitySpec{
+					Type:       infrav1.WorkloadIdentity,
 					ClientID:   fakeClientID,
 					TenantID:   fakeTenantID,
 					ResourceID: fakeResourceID,
@@ -142,17 +142,17 @@ func TestAzureClusterIdentity_ValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "azureclusteridentity with a change in client ID",
-			clusterIdentity: &AzureClusterIdentity{
-				Spec: AzureClusterIdentitySpec{
-					Type:       ServicePrincipal,
+			clusterIdentity: &infrav1.AzureClusterIdentity{
+				Spec: infrav1.AzureClusterIdentitySpec{
+					Type:       infrav1.ServicePrincipal,
 					ClientID:   fakeClientID,
 					TenantID:   fakeTenantID,
 					ResourceID: fakeResourceID,
 				},
 			},
-			oldClusterIdentity: &AzureClusterIdentity{
-				Spec: AzureClusterIdentitySpec{
-					Type:       WorkloadIdentity,
+			oldClusterIdentity: &infrav1.AzureClusterIdentity{
+				Spec: infrav1.AzureClusterIdentitySpec{
+					Type:       infrav1.WorkloadIdentity,
 					ClientID:   "diff-fake-Client-ID",
 					TenantID:   fakeTenantID,
 					ResourceID: fakeResourceID,

--- a/internal/webhooks/azureclustertemplate_validation.go
+++ b/internal/webhooks/azureclustertemplate_validation.go
@@ -24,11 +24,11 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
-	. "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
+	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 )
 
 // validateAzureClusterTemplate validates an AzureClusterTemplate.
-func validateAzureClusterTemplate(c *AzureClusterTemplate) (admission.Warnings, error) {
+func validateAzureClusterTemplate(c *infrav1.AzureClusterTemplate) (admission.Warnings, error) {
 	var allErrs field.ErrorList
 	allErrs = append(allErrs, validateAzureClusterTemplateSpec(c)...)
 
@@ -42,7 +42,7 @@ func validateAzureClusterTemplate(c *AzureClusterTemplate) (admission.Warnings, 
 }
 
 // validateAzureClusterTemplateSpec validates the spec of an AzureClusterTemplate.
-func validateAzureClusterTemplateSpec(c *AzureClusterTemplate) field.ErrorList {
+func validateAzureClusterTemplateSpec(c *infrav1.AzureClusterTemplate) field.ErrorList {
 	var allErrs field.ErrorList
 
 	allErrs = append(allErrs, validateVnetCIDR(
@@ -72,13 +72,13 @@ func validateAzureClusterTemplateSpec(c *AzureClusterTemplate) field.ErrorList {
 }
 
 // validateAzureClusterTemplateNetworkSpec validates the network spec of an AzureClusterTemplate.
-func validateAzureClusterTemplateNetworkSpec(c *AzureClusterTemplate) field.ErrorList {
+func validateAzureClusterTemplateNetworkSpec(c *infrav1.AzureClusterTemplate) field.ErrorList {
 	var allErrs field.ErrorList
 
 	var needOutboundLB bool
 	networkSpec := c.Spec.Template.Spec.NetworkSpec
 	for _, subnet := range networkSpec.Subnets {
-		if subnet.Role == SubnetNode && subnet.IsIPv6Enabled() {
+		if subnet.Role == infrav1.SubnetNode && subnet.IsIPv6Enabled() {
 			needOutboundLB = true
 			break
 		}
@@ -90,7 +90,7 @@ func validateAzureClusterTemplateNetworkSpec(c *AzureClusterTemplate) field.Erro
 	return allErrs
 }
 
-func validateSubnetTemplates(subnets SubnetTemplatesSpec, vnet VnetTemplateSpec, fld *field.Path) field.ErrorList {
+func validateSubnetTemplates(subnets infrav1.SubnetTemplatesSpec, vnet infrav1.VnetTemplateSpec, fld *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
 	subnetNames := make(map[string]bool, len(subnets))
 	requiredSubnetRoles := map[string]bool{
@@ -131,7 +131,7 @@ func validateSubnetTemplates(subnets SubnetTemplatesSpec, vnet VnetTemplateSpec,
 }
 
 // validateAzureClusterTemplateAPIServerLB validates the API server load balancer of an AzureClusterTemplate.
-func validateAzureClusterTemplateAPIServerLB(c *AzureClusterTemplate, apiServerLBPath *field.Path) field.ErrorList {
+func validateAzureClusterTemplateAPIServerLB(c *infrav1.AzureClusterTemplate, apiServerLBPath *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
 	lb := c.Spec.Template.Spec.NetworkSpec.APIServerLB
 	allErrs = append(allErrs, validateClassSpecForAPIServerLB(lb, nil, apiServerLBPath)...)
@@ -139,7 +139,7 @@ func validateAzureClusterTemplateAPIServerLB(c *AzureClusterTemplate, apiServerL
 }
 
 // validateAzureClusterTemplateNodeOutboundLB validates the node outbound load balancer of an AzureClusterTemplate.
-func validateAzureClusterTemplateNodeOutboundLB(c *AzureClusterTemplate) field.ErrorList {
+func validateAzureClusterTemplateNodeOutboundLB(c *infrav1.AzureClusterTemplate) field.ErrorList {
 	var allErrs field.ErrorList
 
 	fldPath := field.NewPath("spec").Child("template").Child("spec").Child("networkSpec").Child("nodeOutboundLB")
@@ -152,7 +152,7 @@ func validateAzureClusterTemplateNodeOutboundLB(c *AzureClusterTemplate) field.E
 }
 
 // validateAzureClusterTemplateControlPlaneOutboundLB validates the control plane outbound load balancer of an AzureClusterTemplate.
-func validateAzureClusterTemplateControlPlaneOutboundLB(c *AzureClusterTemplate) field.ErrorList {
+func validateAzureClusterTemplateControlPlaneOutboundLB(c *infrav1.AzureClusterTemplate) field.ErrorList {
 	var allErrs field.ErrorList
 
 	fldPath := field.NewPath("spec").Child("template").Child("spec").Child("networkSpec").Child("controlPlaneOutboundLB")
@@ -165,7 +165,7 @@ func validateAzureClusterTemplateControlPlaneOutboundLB(c *AzureClusterTemplate)
 }
 
 // validateAzureClusterTemplatePrivateDNSZoneName validates the private DNS zone name of an AzureClusterTemplate.
-func validateAzureClusterTemplatePrivateDNSZoneName(c *AzureClusterTemplate) field.ErrorList {
+func validateAzureClusterTemplatePrivateDNSZoneName(c *infrav1.AzureClusterTemplate) field.ErrorList {
 	var allErrs field.ErrorList
 
 	fldPath := field.NewPath("spec").Child("template").Child("spec").Child("networkSpec").Child("privateDNSZoneName")
@@ -182,7 +182,7 @@ func validateAzureClusterTemplatePrivateDNSZoneName(c *AzureClusterTemplate) fie
 }
 
 // validateAzureClusterTemplatePrivateDNSZoneResourceGroup validates the private DNS zone resource group of an AzureClusterTemplate.
-func validateAzureClusterTemplatePrivateDNSZoneResourceGroup(c *AzureClusterTemplate) field.ErrorList {
+func validateAzureClusterTemplatePrivateDNSZoneResourceGroup(c *infrav1.AzureClusterTemplate) field.ErrorList {
 	var allErrs field.ErrorList
 
 	fldPath := field.NewPath("spec").Child("template").Child("spec").Child("networkSpec").Child("privateDNSZoneResourceGroup")

--- a/internal/webhooks/azureclustertemplate_validation_test.go
+++ b/internal/webhooks/azureclustertemplate_validation_test.go
@@ -24,28 +24,28 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/utils/ptr"
 
-	. "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
+	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	apiinternal "sigs.k8s.io/cluster-api-provider-azure/internal/api/v1beta1"
 )
 
 func TestValdateVnetCIDRs(t *testing.T) {
 	cases := []struct {
 		name            string
-		clusterTemplate *AzureClusterTemplate
+		clusterTemplate *infrav1.AzureClusterTemplate
 		expectValid     bool
 	}{
 		{
 			name: "valid vnet",
-			clusterTemplate: &AzureClusterTemplate{
+			clusterTemplate: &infrav1.AzureClusterTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster-template",
 				},
-				Spec: AzureClusterTemplateSpec{
-					Template: AzureClusterTemplateResource{
-						Spec: AzureClusterTemplateResourceSpec{
-							NetworkSpec: NetworkTemplateSpec{
-								Vnet: VnetTemplateSpec{
-									VnetClassSpec: VnetClassSpec{
+				Spec: infrav1.AzureClusterTemplateSpec{
+					Template: infrav1.AzureClusterTemplateResource{
+						Spec: infrav1.AzureClusterTemplateResourceSpec{
+							NetworkSpec: infrav1.NetworkTemplateSpec{
+								Vnet: infrav1.VnetTemplateSpec{
+									VnetClassSpec: infrav1.VnetClassSpec{
 										CIDRBlocks: []string{apiinternal.DefaultVnetCIDR},
 									},
 								},
@@ -58,16 +58,16 @@ func TestValdateVnetCIDRs(t *testing.T) {
 		},
 		{
 			name: "invalid vnet CIDR",
-			clusterTemplate: &AzureClusterTemplate{
+			clusterTemplate: &infrav1.AzureClusterTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster-template",
 				},
-				Spec: AzureClusterTemplateSpec{
-					Template: AzureClusterTemplateResource{
-						Spec: AzureClusterTemplateResourceSpec{
-							NetworkSpec: NetworkTemplateSpec{
-								Vnet: VnetTemplateSpec{
-									VnetClassSpec: VnetClassSpec{
+				Spec: infrav1.AzureClusterTemplateSpec{
+					Template: infrav1.AzureClusterTemplateResource{
+						Spec: infrav1.AzureClusterTemplateResourceSpec{
+							NetworkSpec: infrav1.NetworkTemplateSpec{
+								Vnet: infrav1.VnetTemplateSpec{
+									VnetClassSpec: infrav1.VnetClassSpec{
 										CIDRBlocks: []string{"1.2.3/12"},
 									},
 								},
@@ -102,35 +102,35 @@ func TestValdateVnetCIDRs(t *testing.T) {
 func TestValidateSubnetTemplates(t *testing.T) {
 	cases := []struct {
 		name            string
-		clusterTemplate *AzureClusterTemplate
+		clusterTemplate *infrav1.AzureClusterTemplate
 		expectValid     bool
 	}{
 		{
 			name: "valid subnets",
-			clusterTemplate: &AzureClusterTemplate{
+			clusterTemplate: &infrav1.AzureClusterTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster-template",
 				},
-				Spec: AzureClusterTemplateSpec{
-					Template: AzureClusterTemplateResource{
-						Spec: AzureClusterTemplateResourceSpec{
-							NetworkSpec: NetworkTemplateSpec{
-								Vnet: VnetTemplateSpec{
-									VnetClassSpec: VnetClassSpec{
+				Spec: infrav1.AzureClusterTemplateSpec{
+					Template: infrav1.AzureClusterTemplateResource{
+						Spec: infrav1.AzureClusterTemplateResourceSpec{
+							NetworkSpec: infrav1.NetworkTemplateSpec{
+								Vnet: infrav1.VnetTemplateSpec{
+									VnetClassSpec: infrav1.VnetClassSpec{
 										CIDRBlocks: []string{apiinternal.DefaultVnetCIDR},
 									},
 								},
-								Subnets: SubnetTemplatesSpec{
+								Subnets: infrav1.SubnetTemplatesSpec{
 									{
-										SubnetClassSpec: SubnetClassSpec{
-											Role:       SubnetControlPlane,
+										SubnetClassSpec: infrav1.SubnetClassSpec{
+											Role:       infrav1.SubnetControlPlane,
 											CIDRBlocks: []string{apiinternal.DefaultControlPlaneSubnetCIDR},
 											Name:       "foo-controlPlane-subnet",
 										},
 									},
 									{
-										SubnetClassSpec: SubnetClassSpec{
-											Role:       SubnetNode,
+										SubnetClassSpec: infrav1.SubnetClassSpec{
+											Role:       infrav1.SubnetNode,
 											CIDRBlocks: []string{apiinternal.DefaultNodeSubnetCIDR},
 											Name:       "foo-workerSubnet-subnet",
 										},
@@ -145,30 +145,30 @@ func TestValidateSubnetTemplates(t *testing.T) {
 		},
 		{
 			name: "invalid subnets - missing/empty subnet name",
-			clusterTemplate: &AzureClusterTemplate{
+			clusterTemplate: &infrav1.AzureClusterTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster-template",
 				},
-				Spec: AzureClusterTemplateSpec{
-					Template: AzureClusterTemplateResource{
-						Spec: AzureClusterTemplateResourceSpec{
-							NetworkSpec: NetworkTemplateSpec{
-								Vnet: VnetTemplateSpec{
-									VnetClassSpec: VnetClassSpec{
+				Spec: infrav1.AzureClusterTemplateSpec{
+					Template: infrav1.AzureClusterTemplateResource{
+						Spec: infrav1.AzureClusterTemplateResourceSpec{
+							NetworkSpec: infrav1.NetworkTemplateSpec{
+								Vnet: infrav1.VnetTemplateSpec{
+									VnetClassSpec: infrav1.VnetClassSpec{
 										CIDRBlocks: []string{apiinternal.DefaultVnetCIDR},
 									},
 								},
-								Subnets: SubnetTemplatesSpec{
+								Subnets: infrav1.SubnetTemplatesSpec{
 									{
-										SubnetClassSpec: SubnetClassSpec{
-											Role:       SubnetControlPlane,
+										SubnetClassSpec: infrav1.SubnetClassSpec{
+											Role:       infrav1.SubnetControlPlane,
 											CIDRBlocks: []string{apiinternal.DefaultControlPlaneSubnetCIDR},
 											Name:       "",
 										},
 									},
 									{
-										SubnetClassSpec: SubnetClassSpec{
-											Role:       SubnetNode,
+										SubnetClassSpec: infrav1.SubnetClassSpec{
+											Role:       infrav1.SubnetNode,
 											CIDRBlocks: []string{apiinternal.DefaultNodeSubnetCIDR},
 											Name:       "",
 										},
@@ -183,37 +183,37 @@ func TestValidateSubnetTemplates(t *testing.T) {
 		},
 		{
 			name: "invalid subnets - duplicate subnet names",
-			clusterTemplate: &AzureClusterTemplate{
+			clusterTemplate: &infrav1.AzureClusterTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster-template",
 				},
-				Spec: AzureClusterTemplateSpec{
-					Template: AzureClusterTemplateResource{
-						Spec: AzureClusterTemplateResourceSpec{
-							NetworkSpec: NetworkTemplateSpec{
-								Vnet: VnetTemplateSpec{
-									VnetClassSpec: VnetClassSpec{
+				Spec: infrav1.AzureClusterTemplateSpec{
+					Template: infrav1.AzureClusterTemplateResource{
+						Spec: infrav1.AzureClusterTemplateResourceSpec{
+							NetworkSpec: infrav1.NetworkTemplateSpec{
+								Vnet: infrav1.VnetTemplateSpec{
+									VnetClassSpec: infrav1.VnetClassSpec{
 										CIDRBlocks: []string{apiinternal.DefaultVnetCIDR},
 									},
 								},
-								Subnets: SubnetTemplatesSpec{
+								Subnets: infrav1.SubnetTemplatesSpec{
 									{
-										SubnetClassSpec: SubnetClassSpec{
-											Role:       SubnetControlPlane,
+										SubnetClassSpec: infrav1.SubnetClassSpec{
+											Role:       infrav1.SubnetControlPlane,
 											CIDRBlocks: []string{apiinternal.DefaultControlPlaneSubnetCIDR},
 											Name:       "foo-controlPlane-subnet",
 										},
 									},
 									{
-										SubnetClassSpec: SubnetClassSpec{
-											Role:       SubnetNode,
+										SubnetClassSpec: infrav1.SubnetClassSpec{
+											Role:       infrav1.SubnetNode,
 											CIDRBlocks: []string{apiinternal.DefaultNodeSubnetCIDR},
 											Name:       "foo-workerSubnet-subnet",
 										},
 									},
 									{
-										SubnetClassSpec: SubnetClassSpec{
-											Role:       SubnetNode,
+										SubnetClassSpec: infrav1.SubnetClassSpec{
+											Role:       infrav1.SubnetNode,
 											CIDRBlocks: []string{"10.2.0.0/16"},
 											Name:       "foo-workerSubnet-subnet",
 										},
@@ -228,36 +228,36 @@ func TestValidateSubnetTemplates(t *testing.T) {
 		},
 		{
 			name: "invalid subnets - wrong security rule priorities - lower than minimum",
-			clusterTemplate: &AzureClusterTemplate{
+			clusterTemplate: &infrav1.AzureClusterTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster-template",
 				},
-				Spec: AzureClusterTemplateSpec{
-					Template: AzureClusterTemplateResource{
-						Spec: AzureClusterTemplateResourceSpec{
-							NetworkSpec: NetworkTemplateSpec{
-								Vnet: VnetTemplateSpec{
-									VnetClassSpec: VnetClassSpec{
+				Spec: infrav1.AzureClusterTemplateSpec{
+					Template: infrav1.AzureClusterTemplateResource{
+						Spec: infrav1.AzureClusterTemplateResourceSpec{
+							NetworkSpec: infrav1.NetworkTemplateSpec{
+								Vnet: infrav1.VnetTemplateSpec{
+									VnetClassSpec: infrav1.VnetClassSpec{
 										CIDRBlocks: []string{apiinternal.DefaultVnetCIDR},
 									},
 								},
-								Subnets: SubnetTemplatesSpec{
+								Subnets: infrav1.SubnetTemplatesSpec{
 									{
-										SubnetClassSpec: SubnetClassSpec{
-											Role:       SubnetControlPlane,
+										SubnetClassSpec: infrav1.SubnetClassSpec{
+											Role:       infrav1.SubnetControlPlane,
 											CIDRBlocks: []string{apiinternal.DefaultControlPlaneSubnetCIDR},
 										},
-										SecurityGroup: SecurityGroupClass{
-											SecurityRules: SecurityRules{
-												SecurityRule{
+										SecurityGroup: infrav1.SecurityGroupClass{
+											SecurityRules: infrav1.SecurityRules{
+												infrav1.SecurityRule{
 													Priority: 50,
 												},
 											},
 										},
 									},
 									{
-										SubnetClassSpec: SubnetClassSpec{
-											Role:       SubnetNode,
+										SubnetClassSpec: infrav1.SubnetClassSpec{
+											Role:       infrav1.SubnetNode,
 											CIDRBlocks: []string{apiinternal.DefaultNodeSubnetCIDR},
 										},
 									},
@@ -271,36 +271,36 @@ func TestValidateSubnetTemplates(t *testing.T) {
 		},
 		{
 			name: "invalid subnets - wrong security rule priorities - higher than maximum",
-			clusterTemplate: &AzureClusterTemplate{
+			clusterTemplate: &infrav1.AzureClusterTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster-template",
 				},
-				Spec: AzureClusterTemplateSpec{
-					Template: AzureClusterTemplateResource{
-						Spec: AzureClusterTemplateResourceSpec{
-							NetworkSpec: NetworkTemplateSpec{
-								Vnet: VnetTemplateSpec{
-									VnetClassSpec: VnetClassSpec{
+				Spec: infrav1.AzureClusterTemplateSpec{
+					Template: infrav1.AzureClusterTemplateResource{
+						Spec: infrav1.AzureClusterTemplateResourceSpec{
+							NetworkSpec: infrav1.NetworkTemplateSpec{
+								Vnet: infrav1.VnetTemplateSpec{
+									VnetClassSpec: infrav1.VnetClassSpec{
 										CIDRBlocks: []string{apiinternal.DefaultVnetCIDR},
 									},
 								},
-								Subnets: SubnetTemplatesSpec{
+								Subnets: infrav1.SubnetTemplatesSpec{
 									{
-										SubnetClassSpec: SubnetClassSpec{
-											Role:       SubnetControlPlane,
+										SubnetClassSpec: infrav1.SubnetClassSpec{
+											Role:       infrav1.SubnetControlPlane,
 											CIDRBlocks: []string{apiinternal.DefaultControlPlaneSubnetCIDR},
 										},
-										SecurityGroup: SecurityGroupClass{
-											SecurityRules: SecurityRules{
-												SecurityRule{
+										SecurityGroup: infrav1.SecurityGroupClass{
+											SecurityRules: infrav1.SecurityRules{
+												infrav1.SecurityRule{
 													Priority: 4097,
 												},
 											},
 										},
 									},
 									{
-										SubnetClassSpec: SubnetClassSpec{
-											Role:       SubnetNode,
+										SubnetClassSpec: infrav1.SubnetClassSpec{
+											Role:       infrav1.SubnetNode,
 											CIDRBlocks: []string{apiinternal.DefaultNodeSubnetCIDR},
 										},
 									},
@@ -314,29 +314,29 @@ func TestValidateSubnetTemplates(t *testing.T) {
 		},
 		{
 			name: "invalid subnet CIDR",
-			clusterTemplate: &AzureClusterTemplate{
+			clusterTemplate: &infrav1.AzureClusterTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster-template",
 				},
-				Spec: AzureClusterTemplateSpec{
-					Template: AzureClusterTemplateResource{
-						Spec: AzureClusterTemplateResourceSpec{
-							NetworkSpec: NetworkTemplateSpec{
-								Vnet: VnetTemplateSpec{
-									VnetClassSpec: VnetClassSpec{
+				Spec: infrav1.AzureClusterTemplateSpec{
+					Template: infrav1.AzureClusterTemplateResource{
+						Spec: infrav1.AzureClusterTemplateResourceSpec{
+							NetworkSpec: infrav1.NetworkTemplateSpec{
+								Vnet: infrav1.VnetTemplateSpec{
+									VnetClassSpec: infrav1.VnetClassSpec{
 										CIDRBlocks: []string{apiinternal.DefaultVnetCIDR},
 									},
 								},
-								Subnets: SubnetTemplatesSpec{
+								Subnets: infrav1.SubnetTemplatesSpec{
 									{
-										SubnetClassSpec: SubnetClassSpec{
-											Role:       SubnetControlPlane,
+										SubnetClassSpec: infrav1.SubnetClassSpec{
+											Role:       infrav1.SubnetControlPlane,
 											CIDRBlocks: []string{"11.0.0.0/16"},
 										},
 									},
 									{
-										SubnetClassSpec: SubnetClassSpec{
-											Role:       SubnetNode,
+										SubnetClassSpec: infrav1.SubnetClassSpec{
+											Role:       infrav1.SubnetNode,
 											CIDRBlocks: []string{apiinternal.DefaultNodeSubnetCIDR},
 										},
 									},
@@ -350,23 +350,23 @@ func TestValidateSubnetTemplates(t *testing.T) {
 		},
 		{
 			name: "missing required control plane role",
-			clusterTemplate: &AzureClusterTemplate{
+			clusterTemplate: &infrav1.AzureClusterTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster-template",
 				},
-				Spec: AzureClusterTemplateSpec{
-					Template: AzureClusterTemplateResource{
-						Spec: AzureClusterTemplateResourceSpec{
-							NetworkSpec: NetworkTemplateSpec{
-								Vnet: VnetTemplateSpec{
-									VnetClassSpec: VnetClassSpec{
+				Spec: infrav1.AzureClusterTemplateSpec{
+					Template: infrav1.AzureClusterTemplateResource{
+						Spec: infrav1.AzureClusterTemplateResourceSpec{
+							NetworkSpec: infrav1.NetworkTemplateSpec{
+								Vnet: infrav1.VnetTemplateSpec{
+									VnetClassSpec: infrav1.VnetClassSpec{
 										CIDRBlocks: []string{apiinternal.DefaultVnetCIDR},
 									},
 								},
-								Subnets: SubnetTemplatesSpec{
+								Subnets: infrav1.SubnetTemplatesSpec{
 									{
-										SubnetClassSpec: SubnetClassSpec{
-											Role:       SubnetNode,
+										SubnetClassSpec: infrav1.SubnetClassSpec{
+											Role:       infrav1.SubnetNode,
 											CIDRBlocks: []string{apiinternal.DefaultNodeSubnetCIDR},
 										},
 									},
@@ -380,23 +380,23 @@ func TestValidateSubnetTemplates(t *testing.T) {
 		},
 		{
 			name: "missing required node role",
-			clusterTemplate: &AzureClusterTemplate{
+			clusterTemplate: &infrav1.AzureClusterTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster-template",
 				},
-				Spec: AzureClusterTemplateSpec{
-					Template: AzureClusterTemplateResource{
-						Spec: AzureClusterTemplateResourceSpec{
-							NetworkSpec: NetworkTemplateSpec{
-								Vnet: VnetTemplateSpec{
-									VnetClassSpec: VnetClassSpec{
+				Spec: infrav1.AzureClusterTemplateSpec{
+					Template: infrav1.AzureClusterTemplateResource{
+						Spec: infrav1.AzureClusterTemplateResourceSpec{
+							NetworkSpec: infrav1.NetworkTemplateSpec{
+								Vnet: infrav1.VnetTemplateSpec{
+									VnetClassSpec: infrav1.VnetClassSpec{
 										CIDRBlocks: []string{apiinternal.DefaultVnetCIDR},
 									},
 								},
-								Subnets: SubnetTemplatesSpec{
+								Subnets: infrav1.SubnetTemplatesSpec{
 									{
-										SubnetClassSpec: SubnetClassSpec{
-											Role:       SubnetControlPlane,
+										SubnetClassSpec: infrav1.SubnetClassSpec{
+											Role:       infrav1.SubnetControlPlane,
 											CIDRBlocks: []string{apiinternal.DefaultControlPlaneSubnetCIDR},
 										},
 									},
@@ -433,22 +433,22 @@ func TestValidateSubnetTemplates(t *testing.T) {
 func TestValidateAPIServerLBTemplate(t *testing.T) {
 	cases := []struct {
 		name            string
-		clusterTemplate *AzureClusterTemplate
+		clusterTemplate *infrav1.AzureClusterTemplate
 		expectValid     bool
 	}{
 		{
 			name: "valid lb",
-			clusterTemplate: &AzureClusterTemplate{
+			clusterTemplate: &infrav1.AzureClusterTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster-template",
 				},
-				Spec: AzureClusterTemplateSpec{
-					Template: AzureClusterTemplateResource{
-						Spec: AzureClusterTemplateResourceSpec{
-							NetworkSpec: NetworkTemplateSpec{
-								APIServerLB: LoadBalancerClassSpec{
-									SKU:                  SKUStandard,
-									Type:                 Public,
+				Spec: infrav1.AzureClusterTemplateSpec{
+					Template: infrav1.AzureClusterTemplateResource{
+						Spec: infrav1.AzureClusterTemplateResourceSpec{
+							NetworkSpec: infrav1.NetworkTemplateSpec{
+								APIServerLB: infrav1.LoadBalancerClassSpec{
+									SKU:                  infrav1.SKUStandard,
+									Type:                 infrav1.Public,
 									IdleTimeoutInMinutes: ptr.To[int32](apiinternal.DefaultOutboundRuleIdleTimeoutInMinutes),
 								},
 							},
@@ -460,17 +460,17 @@ func TestValidateAPIServerLBTemplate(t *testing.T) {
 		},
 		{
 			name: "invalid lb SKU",
-			clusterTemplate: &AzureClusterTemplate{
+			clusterTemplate: &infrav1.AzureClusterTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster-template",
 				},
-				Spec: AzureClusterTemplateSpec{
-					Template: AzureClusterTemplateResource{
-						Spec: AzureClusterTemplateResourceSpec{
-							NetworkSpec: NetworkTemplateSpec{
-								APIServerLB: LoadBalancerClassSpec{
-									SKU:                  SKU("wrong"),
-									Type:                 Public,
+				Spec: infrav1.AzureClusterTemplateSpec{
+					Template: infrav1.AzureClusterTemplateResource{
+						Spec: infrav1.AzureClusterTemplateResourceSpec{
+							NetworkSpec: infrav1.NetworkTemplateSpec{
+								APIServerLB: infrav1.LoadBalancerClassSpec{
+									SKU:                  infrav1.SKU("wrong"),
+									Type:                 infrav1.Public,
 									IdleTimeoutInMinutes: ptr.To[int32](apiinternal.DefaultOutboundRuleIdleTimeoutInMinutes),
 								},
 							},
@@ -482,17 +482,17 @@ func TestValidateAPIServerLBTemplate(t *testing.T) {
 		},
 		{
 			name: "invalid lb Type",
-			clusterTemplate: &AzureClusterTemplate{
+			clusterTemplate: &infrav1.AzureClusterTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster-template",
 				},
-				Spec: AzureClusterTemplateSpec{
-					Template: AzureClusterTemplateResource{
-						Spec: AzureClusterTemplateResourceSpec{
-							NetworkSpec: NetworkTemplateSpec{
-								APIServerLB: LoadBalancerClassSpec{
-									SKU:                  SKUStandard,
-									Type:                 LBType("wrong"),
+				Spec: infrav1.AzureClusterTemplateSpec{
+					Template: infrav1.AzureClusterTemplateResource{
+						Spec: infrav1.AzureClusterTemplateResourceSpec{
+							NetworkSpec: infrav1.NetworkTemplateSpec{
+								APIServerLB: infrav1.LoadBalancerClassSpec{
+									SKU:                  infrav1.SKUStandard,
+									Type:                 infrav1.LBType("wrong"),
 									IdleTimeoutInMinutes: ptr.To[int32](apiinternal.DefaultOutboundRuleIdleTimeoutInMinutes),
 								},
 							},
@@ -525,21 +525,21 @@ func TestValidateAPIServerLBTemplate(t *testing.T) {
 func TestControlPlaneOutboundLBTemplate(t *testing.T) {
 	cases := []struct {
 		name            string
-		clusterTemplate *AzureClusterTemplate
+		clusterTemplate *infrav1.AzureClusterTemplate
 		expectValid     bool
 	}{
 		{
 			name: "valid controlplaneoutbound LB",
-			clusterTemplate: &AzureClusterTemplate{
+			clusterTemplate: &infrav1.AzureClusterTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster-template",
 				},
-				Spec: AzureClusterTemplateSpec{
-					Template: AzureClusterTemplateResource{
-						Spec: AzureClusterTemplateResourceSpec{
-							NetworkSpec: NetworkTemplateSpec{
-								APIServerLB: LoadBalancerClassSpec{
-									Type: Public,
+				Spec: infrav1.AzureClusterTemplateSpec{
+					Template: infrav1.AzureClusterTemplateResource{
+						Spec: infrav1.AzureClusterTemplateResourceSpec{
+							NetworkSpec: infrav1.NetworkTemplateSpec{
+								APIServerLB: infrav1.LoadBalancerClassSpec{
+									Type: infrav1.Public,
 								},
 							},
 						},
@@ -550,18 +550,18 @@ func TestControlPlaneOutboundLBTemplate(t *testing.T) {
 		},
 		{
 			name: "invalid controlplaneoutbound LB - should not have a controlplane outbound lb for public clusters",
-			clusterTemplate: &AzureClusterTemplate{
+			clusterTemplate: &infrav1.AzureClusterTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster-template",
 				},
-				Spec: AzureClusterTemplateSpec{
-					Template: AzureClusterTemplateResource{
-						Spec: AzureClusterTemplateResourceSpec{
-							NetworkSpec: NetworkTemplateSpec{
-								APIServerLB: LoadBalancerClassSpec{
-									Type: Public,
+				Spec: infrav1.AzureClusterTemplateSpec{
+					Template: infrav1.AzureClusterTemplateResource{
+						Spec: infrav1.AzureClusterTemplateResourceSpec{
+							NetworkSpec: infrav1.NetworkTemplateSpec{
+								APIServerLB: infrav1.LoadBalancerClassSpec{
+									Type: infrav1.Public,
 								},
-								ControlPlaneOutboundLB: &LoadBalancerClassSpec{},
+								ControlPlaneOutboundLB: &infrav1.LoadBalancerClassSpec{},
 							},
 						},
 					},
@@ -571,18 +571,18 @@ func TestControlPlaneOutboundLBTemplate(t *testing.T) {
 		},
 		{
 			name: "invalid controlplaneoutbound LB - IdleTimeoutInMinutes less than minimum for private clusters",
-			clusterTemplate: &AzureClusterTemplate{
+			clusterTemplate: &infrav1.AzureClusterTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster-template",
 				},
-				Spec: AzureClusterTemplateSpec{
-					Template: AzureClusterTemplateResource{
-						Spec: AzureClusterTemplateResourceSpec{
-							NetworkSpec: NetworkTemplateSpec{
-								APIServerLB: LoadBalancerClassSpec{
-									Type: Internal,
+				Spec: infrav1.AzureClusterTemplateSpec{
+					Template: infrav1.AzureClusterTemplateResource{
+						Spec: infrav1.AzureClusterTemplateResourceSpec{
+							NetworkSpec: infrav1.NetworkTemplateSpec{
+								APIServerLB: infrav1.LoadBalancerClassSpec{
+									Type: infrav1.Internal,
 								},
-								ControlPlaneOutboundLB: &LoadBalancerClassSpec{
+								ControlPlaneOutboundLB: &infrav1.LoadBalancerClassSpec{
 									IdleTimeoutInMinutes: ptr.To[int32](2),
 								},
 							},
@@ -594,18 +594,18 @@ func TestControlPlaneOutboundLBTemplate(t *testing.T) {
 		},
 		{
 			name: "invalid controlplaneoutbound LB - IdleTimeoutInMinutes more than maximum for private clusters",
-			clusterTemplate: &AzureClusterTemplate{
+			clusterTemplate: &infrav1.AzureClusterTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster-template",
 				},
-				Spec: AzureClusterTemplateSpec{
-					Template: AzureClusterTemplateResource{
-						Spec: AzureClusterTemplateResourceSpec{
-							NetworkSpec: NetworkTemplateSpec{
-								APIServerLB: LoadBalancerClassSpec{
-									Type: Internal,
+				Spec: infrav1.AzureClusterTemplateSpec{
+					Template: infrav1.AzureClusterTemplateResource{
+						Spec: infrav1.AzureClusterTemplateResourceSpec{
+							NetworkSpec: infrav1.NetworkTemplateSpec{
+								APIServerLB: infrav1.LoadBalancerClassSpec{
+									Type: infrav1.Internal,
 								},
-								ControlPlaneOutboundLB: &LoadBalancerClassSpec{
+								ControlPlaneOutboundLB: &infrav1.LoadBalancerClassSpec{
 									IdleTimeoutInMinutes: ptr.To[int32](60),
 								},
 							},
@@ -617,16 +617,16 @@ func TestControlPlaneOutboundLBTemplate(t *testing.T) {
 		},
 		{
 			name: "valid controlplaneoutbound LB - can be empty for private clusters",
-			clusterTemplate: &AzureClusterTemplate{
+			clusterTemplate: &infrav1.AzureClusterTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster-template",
 				},
-				Spec: AzureClusterTemplateSpec{
-					Template: AzureClusterTemplateResource{
-						Spec: AzureClusterTemplateResourceSpec{
-							NetworkSpec: NetworkTemplateSpec{
-								APIServerLB: LoadBalancerClassSpec{
-									Type: Internal,
+				Spec: infrav1.AzureClusterTemplateSpec{
+					Template: infrav1.AzureClusterTemplateResource{
+						Spec: infrav1.AzureClusterTemplateResourceSpec{
+							NetworkSpec: infrav1.NetworkTemplateSpec{
+								APIServerLB: infrav1.LoadBalancerClassSpec{
+									Type: infrav1.Internal,
 								},
 							},
 						},
@@ -656,21 +656,21 @@ func TestControlPlaneOutboundLBTemplate(t *testing.T) {
 func TestNodeOutboundLBTemplate(t *testing.T) {
 	cases := []struct {
 		name            string
-		clusterTemplate *AzureClusterTemplate
+		clusterTemplate *infrav1.AzureClusterTemplate
 		expectValid     bool
 	}{
 		{
 			name: "cannot be nil for public clusters",
-			clusterTemplate: &AzureClusterTemplate{
+			clusterTemplate: &infrav1.AzureClusterTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster-template",
 				},
-				Spec: AzureClusterTemplateSpec{
-					Template: AzureClusterTemplateResource{
-						Spec: AzureClusterTemplateResourceSpec{
-							NetworkSpec: NetworkTemplateSpec{
-								APIServerLB: LoadBalancerClassSpec{
-									Type: Public,
+				Spec: infrav1.AzureClusterTemplateSpec{
+					Template: infrav1.AzureClusterTemplateResource{
+						Spec: infrav1.AzureClusterTemplateResourceSpec{
+							NetworkSpec: infrav1.NetworkTemplateSpec{
+								APIServerLB: infrav1.LoadBalancerClassSpec{
+									Type: infrav1.Public,
 								},
 							},
 						},
@@ -681,16 +681,16 @@ func TestNodeOutboundLBTemplate(t *testing.T) {
 		},
 		{
 			name: "can be nil for private clusters",
-			clusterTemplate: &AzureClusterTemplate{
+			clusterTemplate: &infrav1.AzureClusterTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster-template",
 				},
-				Spec: AzureClusterTemplateSpec{
-					Template: AzureClusterTemplateResource{
-						Spec: AzureClusterTemplateResourceSpec{
-							NetworkSpec: NetworkTemplateSpec{
-								APIServerLB: LoadBalancerClassSpec{
-									Type: Internal,
+				Spec: infrav1.AzureClusterTemplateSpec{
+					Template: infrav1.AzureClusterTemplateResource{
+						Spec: infrav1.AzureClusterTemplateResourceSpec{
+							NetworkSpec: infrav1.NetworkTemplateSpec{
+								APIServerLB: infrav1.LoadBalancerClassSpec{
+									Type: infrav1.Internal,
 								},
 							},
 						},
@@ -701,18 +701,18 @@ func TestNodeOutboundLBTemplate(t *testing.T) {
 		},
 		{
 			name: "timeout should not be less than minimum",
-			clusterTemplate: &AzureClusterTemplate{
+			clusterTemplate: &infrav1.AzureClusterTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster-template",
 				},
-				Spec: AzureClusterTemplateSpec{
-					Template: AzureClusterTemplateResource{
-						Spec: AzureClusterTemplateResourceSpec{
-							NetworkSpec: NetworkTemplateSpec{
-								APIServerLB: LoadBalancerClassSpec{
-									Type: Public,
+				Spec: infrav1.AzureClusterTemplateSpec{
+					Template: infrav1.AzureClusterTemplateResource{
+						Spec: infrav1.AzureClusterTemplateResourceSpec{
+							NetworkSpec: infrav1.NetworkTemplateSpec{
+								APIServerLB: infrav1.LoadBalancerClassSpec{
+									Type: infrav1.Public,
 								},
-								NodeOutboundLB: &LoadBalancerClassSpec{
+								NodeOutboundLB: &infrav1.LoadBalancerClassSpec{
 									IdleTimeoutInMinutes: ptr.To[int32](2),
 								},
 							},
@@ -724,18 +724,18 @@ func TestNodeOutboundLBTemplate(t *testing.T) {
 		},
 		{
 			name: "timeout should not be more than maximum",
-			clusterTemplate: &AzureClusterTemplate{
+			clusterTemplate: &infrav1.AzureClusterTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster-template",
 				},
-				Spec: AzureClusterTemplateSpec{
-					Template: AzureClusterTemplateResource{
-						Spec: AzureClusterTemplateResourceSpec{
-							NetworkSpec: NetworkTemplateSpec{
-								APIServerLB: LoadBalancerClassSpec{
-									Type: Public,
+				Spec: infrav1.AzureClusterTemplateSpec{
+					Template: infrav1.AzureClusterTemplateResource{
+						Spec: infrav1.AzureClusterTemplateResourceSpec{
+							NetworkSpec: infrav1.NetworkTemplateSpec{
+								APIServerLB: infrav1.LoadBalancerClassSpec{
+									Type: infrav1.Public,
 								},
-								NodeOutboundLB: &LoadBalancerClassSpec{
+								NodeOutboundLB: &infrav1.LoadBalancerClassSpec{
 									IdleTimeoutInMinutes: ptr.To[int32](60),
 								},
 							},
@@ -766,19 +766,19 @@ func TestNodeOutboundLBTemplate(t *testing.T) {
 func TestValidatePrivateDNSZoneName(t *testing.T) {
 	cases := []struct {
 		name            string
-		clusterTemplate *AzureClusterTemplate
+		clusterTemplate *infrav1.AzureClusterTemplate
 		expectValid     bool
 	}{
 		{
 			name: "not set",
-			clusterTemplate: &AzureClusterTemplate{
+			clusterTemplate: &infrav1.AzureClusterTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster-template",
 				},
-				Spec: AzureClusterTemplateSpec{
-					Template: AzureClusterTemplateResource{
-						Spec: AzureClusterTemplateResourceSpec{
-							NetworkSpec: NetworkTemplateSpec{},
+				Spec: infrav1.AzureClusterTemplateSpec{
+					Template: infrav1.AzureClusterTemplateResource{
+						Spec: infrav1.AzureClusterTemplateResourceSpec{
+							NetworkSpec: infrav1.NetworkTemplateSpec{},
 						},
 					},
 				},
@@ -787,18 +787,18 @@ func TestValidatePrivateDNSZoneName(t *testing.T) {
 		},
 		{
 			name: "show not be set if APIServerLB.Type is not internal",
-			clusterTemplate: &AzureClusterTemplate{
+			clusterTemplate: &infrav1.AzureClusterTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster-template",
 				},
-				Spec: AzureClusterTemplateSpec{
-					Template: AzureClusterTemplateResource{
-						Spec: AzureClusterTemplateResourceSpec{
-							NetworkSpec: NetworkTemplateSpec{
-								APIServerLB: LoadBalancerClassSpec{
-									Type: Public,
+				Spec: infrav1.AzureClusterTemplateSpec{
+					Template: infrav1.AzureClusterTemplateResource{
+						Spec: infrav1.AzureClusterTemplateResourceSpec{
+							NetworkSpec: infrav1.NetworkTemplateSpec{
+								APIServerLB: infrav1.LoadBalancerClassSpec{
+									Type: infrav1.Public,
 								},
-								NetworkClassSpec: NetworkClassSpec{
+								NetworkClassSpec: infrav1.NetworkClassSpec{
 									PrivateDNSZoneName: "a.b.c",
 								},
 							},
@@ -829,20 +829,20 @@ func TestValidatePrivateDNSZoneName(t *testing.T) {
 func TestValidatePrivateDNSZoneResourceGroup(t *testing.T) {
 	cases := []struct {
 		name            string
-		clusterTemplate *AzureClusterTemplate
+		clusterTemplate *infrav1.AzureClusterTemplate
 		expectValid     bool
 		expectedErr     field.Error
 	}{
 		{
 			name: "not set",
-			clusterTemplate: &AzureClusterTemplate{
+			clusterTemplate: &infrav1.AzureClusterTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster-template",
 				},
-				Spec: AzureClusterTemplateSpec{
-					Template: AzureClusterTemplateResource{
-						Spec: AzureClusterTemplateResourceSpec{
-							NetworkSpec: NetworkTemplateSpec{},
+				Spec: infrav1.AzureClusterTemplateSpec{
+					Template: infrav1.AzureClusterTemplateResource{
+						Spec: infrav1.AzureClusterTemplateResourceSpec{
+							NetworkSpec: infrav1.NetworkTemplateSpec{},
 						},
 					},
 				},
@@ -851,15 +851,15 @@ func TestValidatePrivateDNSZoneResourceGroup(t *testing.T) {
 		},
 		{
 			name: "should be set if PrivateDNSZoneName is given",
-			clusterTemplate: &AzureClusterTemplate{
+			clusterTemplate: &infrav1.AzureClusterTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster-template",
 				},
-				Spec: AzureClusterTemplateSpec{
-					Template: AzureClusterTemplateResource{
-						Spec: AzureClusterTemplateResourceSpec{
-							NetworkSpec: NetworkTemplateSpec{
-								NetworkClassSpec: NetworkClassSpec{
+				Spec: infrav1.AzureClusterTemplateSpec{
+					Template: infrav1.AzureClusterTemplateResource{
+						Spec: infrav1.AzureClusterTemplateResourceSpec{
+							NetworkSpec: infrav1.NetworkTemplateSpec{
+								NetworkClassSpec: infrav1.NetworkClassSpec{
 									PrivateDNSZoneName:          "e.f.g",
 									PrivateDNSZoneResourceGroup: "a.b.c",
 								},
@@ -872,15 +872,15 @@ func TestValidatePrivateDNSZoneResourceGroup(t *testing.T) {
 		},
 		{
 			name: "should not be set if PrivateDNSZoneName is not given",
-			clusterTemplate: &AzureClusterTemplate{
+			clusterTemplate: &infrav1.AzureClusterTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster-template",
 				},
-				Spec: AzureClusterTemplateSpec{
-					Template: AzureClusterTemplateResource{
-						Spec: AzureClusterTemplateResourceSpec{
-							NetworkSpec: NetworkTemplateSpec{
-								NetworkClassSpec: NetworkClassSpec{
+				Spec: infrav1.AzureClusterTemplateSpec{
+					Template: infrav1.AzureClusterTemplateResource{
+						Spec: infrav1.AzureClusterTemplateResourceSpec{
+							NetworkSpec: infrav1.NetworkTemplateSpec{
+								NetworkClassSpec: infrav1.NetworkClassSpec{
 									PrivateDNSZoneResourceGroup: "a.b.c",
 								},
 							},
@@ -918,23 +918,23 @@ func TestValidatePrivateDNSZoneResourceGroup(t *testing.T) {
 func TestValidateNetworkSpec(t *testing.T) {
 	cases := []struct {
 		name            string
-		clusterTemplate *AzureClusterTemplate
+		clusterTemplate *infrav1.AzureClusterTemplate
 		expectValid     bool
 	}{
 		{
 			name: "subnet with SubnetNode role and enabled IPv6 triggers needOutboundLB and calls validateNodeOutboundLB",
-			clusterTemplate: &AzureClusterTemplate{
+			clusterTemplate: &infrav1.AzureClusterTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster-template",
 				},
-				Spec: AzureClusterTemplateSpec{
-					Template: AzureClusterTemplateResource{
-						Spec: AzureClusterTemplateResourceSpec{
-							NetworkSpec: NetworkTemplateSpec{
-								Subnets: SubnetTemplatesSpec{
+				Spec: infrav1.AzureClusterTemplateSpec{
+					Template: infrav1.AzureClusterTemplateResource{
+						Spec: infrav1.AzureClusterTemplateResourceSpec{
+							NetworkSpec: infrav1.NetworkTemplateSpec{
+								Subnets: infrav1.SubnetTemplatesSpec{
 									{
-										SubnetClassSpec: SubnetClassSpec{
-											Role:       SubnetNode,
+										SubnetClassSpec: infrav1.SubnetClassSpec{
+											Role:       infrav1.SubnetNode,
 											CIDRBlocks: []string{"2001:beea::1/64"},
 										},
 									},
@@ -948,17 +948,17 @@ func TestValidateNetworkSpec(t *testing.T) {
 		},
 		{
 			name: "subnet with non-SubnetNode role",
-			clusterTemplate: &AzureClusterTemplate{
+			clusterTemplate: &infrav1.AzureClusterTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster-template",
 				},
-				Spec: AzureClusterTemplateSpec{
-					Template: AzureClusterTemplateResource{
-						Spec: AzureClusterTemplateResourceSpec{
-							NetworkSpec: NetworkTemplateSpec{
-								Subnets: SubnetTemplatesSpec{
+				Spec: infrav1.AzureClusterTemplateSpec{
+					Template: infrav1.AzureClusterTemplateResource{
+						Spec: infrav1.AzureClusterTemplateResourceSpec{
+							NetworkSpec: infrav1.NetworkTemplateSpec{
+								Subnets: infrav1.SubnetTemplatesSpec{
 									{
-										SubnetClassSpec: SubnetClassSpec{
+										SubnetClassSpec: infrav1.SubnetClassSpec{
 											Role:       "SomeOtherRole",
 											CIDRBlocks: []string{"10.0.0.0/24"},
 										},

--- a/internal/webhooks/azureclustertemplate_webhook.go
+++ b/internal/webhooks/azureclustertemplate_webhook.go
@@ -28,7 +28,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
-	. "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
+	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	apiinternal "sigs.k8s.io/cluster-api-provider-azure/internal/api/v1beta1"
 )
 
@@ -38,7 +38,7 @@ const AzureClusterTemplateImmutableMsg = "AzureClusterTemplate spec.template.spe
 // SetupWebhookWithManager will set up the webhook to be managed by the specified manager.
 func (w *AzureClusterTemplateWebhook) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
-		For(&AzureClusterTemplate{}).
+		For(&infrav1.AzureClusterTemplate{}).
 		WithValidator(w).
 		WithDefaulter(w).
 		Complete()
@@ -54,7 +54,7 @@ var _ webhook.CustomDefaulter = &AzureClusterTemplateWebhook{}
 
 // Default implements webhook.CustomDefaulter so a webhook will be registered for the type.
 func (*AzureClusterTemplateWebhook) Default(_ context.Context, obj runtime.Object) error {
-	c, ok := obj.(*AzureClusterTemplate)
+	c, ok := obj.(*infrav1.AzureClusterTemplate)
 	if !ok {
 		return fmt.Errorf("expected an AzureClusterTemplate object but got %T", c)
 	}
@@ -67,7 +67,7 @@ var _ webhook.CustomValidator = &AzureClusterTemplateWebhook{}
 
 // ValidateCreate implements webhook.CustomValidator so a webhook will be registered for the type.
 func (*AzureClusterTemplateWebhook) ValidateCreate(_ context.Context, obj runtime.Object) (admission.Warnings, error) {
-	c, ok := obj.(*AzureClusterTemplate)
+	c, ok := obj.(*infrav1.AzureClusterTemplate)
 	if !ok {
 		return nil, fmt.Errorf("expected an AzureClusterTemplate object but got %T", c)
 	}
@@ -77,13 +77,13 @@ func (*AzureClusterTemplateWebhook) ValidateCreate(_ context.Context, obj runtim
 
 // ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type.
 func (*AzureClusterTemplateWebhook) ValidateUpdate(_ context.Context, oldRaw, newObj runtime.Object) (admission.Warnings, error) {
-	c, ok := newObj.(*AzureClusterTemplate)
+	c, ok := newObj.(*infrav1.AzureClusterTemplate)
 	if !ok {
 		return nil, fmt.Errorf("expected an AzureClusterTemplate object but got %T", c)
 	}
 
 	var allErrs field.ErrorList
-	old := oldRaw.(*AzureClusterTemplate)
+	old := oldRaw.(*infrav1.AzureClusterTemplate)
 	if !reflect.DeepEqual(c.Spec.Template.Spec, old.Spec.Template.Spec) {
 		allErrs = append(allErrs,
 			field.Invalid(field.NewPath("AzureClusterTemplate", "spec", "template", "spec"), c, AzureClusterTemplateImmutableMsg),
@@ -93,7 +93,7 @@ func (*AzureClusterTemplateWebhook) ValidateUpdate(_ context.Context, oldRaw, ne
 	if len(allErrs) == 0 {
 		return nil, nil
 	}
-	return nil, apierrors.NewInvalid(GroupVersion.WithKind(AzureClusterTemplateKind).GroupKind(), c.Name, allErrs)
+	return nil, apierrors.NewInvalid(infrav1.GroupVersion.WithKind(infrav1.AzureClusterTemplateKind).GroupKind(), c.Name, allErrs)
 }
 
 // ValidateDelete implements webhook.CustomValidator so a webhook will be registered for the type.

--- a/internal/webhooks/azureclustertemplate_webhook_test.go
+++ b/internal/webhooks/azureclustertemplate_webhook_test.go
@@ -21,17 +21,17 @@ import (
 
 	. "github.com/onsi/gomega"
 
-	. "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
+	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 )
 
 func TestValidateUpdate(t *testing.T) {
-	oldClusterTemplate := &AzureClusterTemplate{
-		Spec: AzureClusterTemplateSpec{
-			Template: AzureClusterTemplateResource{
-				Spec: AzureClusterTemplateResourceSpec{
-					NetworkSpec: NetworkTemplateSpec{
-						Vnet: VnetTemplateSpec{
-							VnetClassSpec: VnetClassSpec{
+	oldClusterTemplate := &infrav1.AzureClusterTemplate{
+		Spec: infrav1.AzureClusterTemplateSpec{
+			Template: infrav1.AzureClusterTemplateResource{
+				Spec: infrav1.AzureClusterTemplateResourceSpec{
+					NetworkSpec: infrav1.NetworkTemplateSpec{
+						Vnet: infrav1.VnetTemplateSpec{
+							VnetClassSpec: infrav1.VnetClassSpec{
 								CIDRBlocks: []string{"10.0.0.0/16"},
 							},
 						},
@@ -41,13 +41,13 @@ func TestValidateUpdate(t *testing.T) {
 		},
 	}
 
-	newClusterTemplate := &AzureClusterTemplate{
-		Spec: AzureClusterTemplateSpec{
-			Template: AzureClusterTemplateResource{
-				Spec: AzureClusterTemplateResourceSpec{
-					NetworkSpec: NetworkTemplateSpec{
-						Vnet: VnetTemplateSpec{
-							VnetClassSpec: VnetClassSpec{
+	newClusterTemplate := &infrav1.AzureClusterTemplate{
+		Spec: infrav1.AzureClusterTemplateSpec{
+			Template: infrav1.AzureClusterTemplateResource{
+				Spec: infrav1.AzureClusterTemplateResourceSpec{
+					NetworkSpec: infrav1.NetworkTemplateSpec{
+						Vnet: infrav1.VnetTemplateSpec{
+							VnetClassSpec: infrav1.VnetClassSpec{
 								CIDRBlocks: []string{"11.0.0.0/16"},
 							},
 						},

--- a/internal/webhooks/azureimage_validation.go
+++ b/internal/webhooks/azureimage_validation.go
@@ -19,11 +19,11 @@ package webhooks
 import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
-	. "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
+	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 )
 
 // ValidateImage validates an image.
-func ValidateImage(image *Image, fldPath *field.Path) field.ErrorList {
+func ValidateImage(image *infrav1.Image, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	if image == nil {
@@ -49,7 +49,7 @@ func ValidateImage(image *Image, fldPath *field.Path) field.ErrorList {
 	return allErrs
 }
 
-func validateSingleDetailsOnly(image *Image, fldPath *field.Path) field.ErrorList {
+func validateSingleDetailsOnly(image *infrav1.Image, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 	imageDetailsFound := (image.ID != nil)
 
@@ -84,7 +84,7 @@ func validateSingleDetailsOnly(image *Image, fldPath *field.Path) field.ErrorLis
 	return allErrs
 }
 
-func validateComputeGalleryImage(image *Image, fldPath *field.Path) field.ErrorList {
+func validateComputeGalleryImage(image *infrav1.Image, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	if image.ComputeGallery.SubscriptionID != nil && image.ComputeGallery.ResourceGroup == nil {
@@ -97,7 +97,7 @@ func validateComputeGalleryImage(image *Image, fldPath *field.Path) field.ErrorL
 	return allErrs
 }
 
-func validateSharedGalleryImage(image *Image, fldPath *field.Path) field.ErrorList {
+func validateSharedGalleryImage(image *infrav1.Image, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	if image.SharedGallery.SubscriptionID == "" {
@@ -119,7 +119,7 @@ func validateSharedGalleryImage(image *Image, fldPath *field.Path) field.ErrorLi
 	return allErrs
 }
 
-func validateMarketplaceImage(image *Image, fldPath *field.Path) field.ErrorList {
+func validateMarketplaceImage(image *infrav1.Image, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	if image.Marketplace.Publisher == "" {
@@ -137,7 +137,7 @@ func validateMarketplaceImage(image *Image, fldPath *field.Path) field.ErrorList
 	return allErrs
 }
 
-func validateSpecificImage(image *Image, fldPath *field.Path) field.ErrorList {
+func validateSpecificImage(image *infrav1.Image, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	if *image.ID == "" {

--- a/internal/webhooks/azureimage_validation_test.go
+++ b/internal/webhooks/azureimage_validation_test.go
@@ -23,14 +23,14 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/utils/ptr"
 
-	. "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
+	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 )
 
 func TestImageOptional(t *testing.T) {
 	g := NewWithT(t)
 
 	type test struct {
-		Image *Image
+		Image *infrav1.Image
 	}
 
 	extension := test{}
@@ -42,16 +42,16 @@ func TestImageOptional(t *testing.T) {
 func TestImageTooManyDetails(t *testing.T) {
 	g := NewWithT(t)
 
-	image := &Image{
-		Marketplace: &AzureMarketplaceImage{
-			ImagePlan: ImagePlan{
+	image := &infrav1.Image{
+		Marketplace: &infrav1.AzureMarketplaceImage{
+			ImagePlan: infrav1.ImagePlan{
 				Offer:     "OFFER",
 				Publisher: "PUBLISHER",
 				SKU:       "SKU",
 			},
 			Version: "1.0.0.",
 		},
-		SharedGallery: &AzureSharedGalleryImage{
+		SharedGallery: &infrav1.AzureSharedGalleryImage{
 			Gallery:        "GALLERY",
 			Name:           "GALLERY1",
 			ResourceGroup:  "RG1",
@@ -65,7 +65,7 @@ func TestImageTooManyDetails(t *testing.T) {
 
 func TestComputeImageGalleryValid(t *testing.T) {
 	testCases := map[string]struct {
-		image          *Image
+		image          *infrav1.Image
 		expectedErrors int
 	}{
 		"AzureComputeGalleryImage - fully specified community image": {
@@ -94,7 +94,7 @@ func TestComputeImageGalleryValid(t *testing.T) {
 
 func TestSharedImageGalleryValid(t *testing.T) {
 	testCases := map[string]struct {
-		image          *Image
+		image          *infrav1.Image
 		expectedErrors int
 	}{
 		"AzureSharedGalleryImage - fully specified": {
@@ -131,7 +131,7 @@ func TestSharedImageGalleryValid(t *testing.T) {
 
 func TestMarketPlaceImageValid(t *testing.T) {
 	testCases := map[string]struct {
-		image          *Image
+		image          *infrav1.Image
 		expectedErrors int
 	}{
 		"AzureMarketplaceImage - fully specified": {
@@ -164,7 +164,7 @@ func TestMarketPlaceImageValid(t *testing.T) {
 
 func TestImageByIDValid(t *testing.T) {
 	testCases := map[string]struct {
-		image          *Image
+		image          *infrav1.Image
 		expectedErrors int
 	}{
 		"AzureImageByID - with id": {
@@ -183,9 +183,9 @@ func TestImageByIDValid(t *testing.T) {
 	}
 }
 
-func createTestComputeImage(subscriptionID, resourceGroup *string) *Image {
-	return &Image{
-		ComputeGallery: &AzureComputeGalleryImage{
+func createTestComputeImage(subscriptionID, resourceGroup *string) *infrav1.Image {
+	return &infrav1.Image{
+		ComputeGallery: &infrav1.AzureComputeGalleryImage{
 			Name:           "IMAGENAME",
 			Gallery:        "GALLERY9876",
 			Version:        "1.0.0",
@@ -195,9 +195,9 @@ func createTestComputeImage(subscriptionID, resourceGroup *string) *Image {
 	}
 }
 
-func createTestSharedImage(subscriptionID, resourceGroup, name, gallery, version string) *Image {
-	return &Image{
-		SharedGallery: &AzureSharedGalleryImage{
+func createTestSharedImage(subscriptionID, resourceGroup, name, gallery, version string) *infrav1.Image {
+	return &infrav1.Image{
+		SharedGallery: &infrav1.AzureSharedGalleryImage{
 			SubscriptionID: subscriptionID,
 			ResourceGroup:  resourceGroup,
 			Name:           name,
@@ -207,10 +207,10 @@ func createTestSharedImage(subscriptionID, resourceGroup, name, gallery, version
 	}
 }
 
-func createTestMarketPlaceImage(publisher, offer, sku, version string) *Image {
-	return &Image{
-		Marketplace: &AzureMarketplaceImage{
-			ImagePlan: ImagePlan{
+func createTestMarketPlaceImage(publisher, offer, sku, version string) *infrav1.Image {
+	return &infrav1.Image{
+		Marketplace: &infrav1.AzureMarketplaceImage{
+			ImagePlan: infrav1.ImagePlan{
 				Publisher: publisher,
 				Offer:     offer,
 				SKU:       sku,
@@ -220,22 +220,22 @@ func createTestMarketPlaceImage(publisher, offer, sku, version string) *Image {
 	}
 }
 
-func createTestImageByID(imageID string) *Image {
-	return &Image{
+func createTestImageByID(imageID string) *infrav1.Image {
+	return &infrav1.Image{
 		ID: &imageID,
 	}
 }
 
 func TestValidateSingleDetailsOnly(t *testing.T) {
 	testCases := map[string]struct {
-		image          *Image
+		image          *infrav1.Image
 		expectedErrors field.ErrorList
 	}{
 		"image.Marketplace != nil, image details are found": {
-			image: &Image{
+			image: &infrav1.Image{
 				ID: ptr.To("ID1234"),
-				Marketplace: &AzureMarketplaceImage{
-					ImagePlan: ImagePlan{
+				Marketplace: &infrav1.AzureMarketplaceImage{
+					ImagePlan: infrav1.ImagePlan{
 						Offer:     "OFFER",
 						Publisher: "PUBLISHER",
 						SKU:       "SKU",
@@ -253,9 +253,9 @@ func TestValidateSingleDetailsOnly(t *testing.T) {
 			},
 		},
 		"image.Marketplace == nil, image.ComputeGallery != nil, image details are found": {
-			image: &Image{
+			image: &infrav1.Image{
 				ID: ptr.To("ID1234"),
-				ComputeGallery: &AzureComputeGalleryImage{
+				ComputeGallery: &infrav1.AzureComputeGalleryImage{
 					Name:           "IMAGENAME",
 					Gallery:        "GALLERY9876",
 					Version:        "1.0.0",
@@ -273,7 +273,7 @@ func TestValidateSingleDetailsOnly(t *testing.T) {
 			},
 		},
 		"image.Marketplace == nil, image.ComputeGallery == nil, image details not found": {
-			image: &Image{},
+			image: &infrav1.Image{},
 			expectedErrors: field.ErrorList{
 				{
 					Type:     "FieldValueRequired",

--- a/internal/webhooks/azuremachine_validation.go
+++ b/internal/webhooks/azuremachine_validation.go
@@ -26,12 +26,12 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/utils/ptr"
 
-	. "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
+	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	azureutil "sigs.k8s.io/cluster-api-provider-azure/util/azure"
 )
 
 // validateAzureMachineSpec checks an AzureMachineSpec and returns any validation errors.
-func validateAzureMachineSpec(spec AzureMachineSpec) field.ErrorList {
+func validateAzureMachineSpec(spec infrav1.AzureMachineSpec) field.ErrorList {
 	var allErrs field.ErrorList
 
 	if errs := ValidateImage(spec.Image, field.NewPath("image")); len(errs) > 0 {
@@ -82,7 +82,7 @@ func validateAzureMachineSpec(spec AzureMachineSpec) field.ErrorList {
 }
 
 // ValidateNetwork validates the network configuration.
-func ValidateNetwork(subnetName string, acceleratedNetworking *bool, networkInterfaces []NetworkInterface, fldPath *field.Path) field.ErrorList {
+func ValidateNetwork(subnetName string, acceleratedNetworking *bool, networkInterfaces []infrav1.NetworkInterface, fldPath *field.Path) field.ErrorList {
 	if (networkInterfaces != nil) && len(networkInterfaces) > 0 && subnetName != "" {
 		return field.ErrorList{field.Invalid(fldPath, networkInterfaces, "cannot set both networkInterfaces and machine subnetName")}
 	}
@@ -119,10 +119,10 @@ func ValidateSSHKey(sshKey string, fldPath *field.Path) field.ErrorList {
 }
 
 // ValidateSystemAssignedIdentity validates the system-assigned identities list.
-func ValidateSystemAssignedIdentity(identityType VMIdentity, oldIdentity, newIdentity string, fldPath *field.Path) field.ErrorList {
+func ValidateSystemAssignedIdentity(identityType infrav1.VMIdentity, oldIdentity, newIdentity string, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	if identityType == VMIdentitySystemAssigned {
+	if identityType == infrav1.VMIdentitySystemAssigned {
 		if _, err := uuid.Parse(newIdentity); err != nil {
 			allErrs = append(allErrs, field.Invalid(fldPath, newIdentity, "Role assignment name must be a valid GUID. It is optional and will be auto-generated when not specified."))
 		}
@@ -137,14 +137,14 @@ func ValidateSystemAssignedIdentity(identityType VMIdentity, oldIdentity, newIde
 }
 
 // ValidateUserAssignedIdentity validates the user-assigned identities list.
-func ValidateUserAssignedIdentity(identityType VMIdentity, userAssignedIdentities []UserAssignedIdentity, fldPath *field.Path) field.ErrorList {
+func ValidateUserAssignedIdentity(identityType infrav1.VMIdentity, userAssignedIdentities []infrav1.UserAssignedIdentity, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	if len(userAssignedIdentities) > 0 && identityType != VMIdentityUserAssigned {
+	if len(userAssignedIdentities) > 0 && identityType != infrav1.VMIdentityUserAssigned {
 		allErrs = append(allErrs, field.Invalid(fldPath, identityType, "must be set to 'UserAssigned' when assigning any user identity to the machine"))
 	}
 
-	if identityType == VMIdentityUserAssigned {
+	if identityType == infrav1.VMIdentityUserAssigned {
 		if len(userAssignedIdentities) == 0 {
 			allErrs = append(allErrs, field.Required(fldPath, "must be specified for the 'UserAssigned' identity type"))
 		}
@@ -161,12 +161,12 @@ func ValidateUserAssignedIdentity(identityType VMIdentity, userAssignedIdentitie
 }
 
 // ValidateSystemAssignedIdentityRole validates the system-assigned identity role.
-func ValidateSystemAssignedIdentityRole(identityType VMIdentity, roleAssignmentName string, role *SystemAssignedIdentityRole, fldPath *field.Path) field.ErrorList {
+func ValidateSystemAssignedIdentityRole(identityType infrav1.VMIdentity, roleAssignmentName string, role *infrav1.SystemAssignedIdentityRole, fldPath *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
 	if roleAssignmentName != "" && role != nil && role.Name != "" {
 		allErrs = append(allErrs, field.Invalid(fldPath, role.Name, "cannot set both roleAssignmentName and systemAssignedIdentityRole.name"))
 	}
-	if identityType == VMIdentitySystemAssigned && role != nil {
+	if identityType == infrav1.VMIdentitySystemAssigned && role != nil {
 		if role.DefinitionID == "" {
 			allErrs = append(allErrs, field.Invalid(field.NewPath("spec", "systemAssignedIdentityRole", "definitionID"), role.DefinitionID, "the definitionID field cannot be empty"))
 		}
@@ -174,14 +174,14 @@ func ValidateSystemAssignedIdentityRole(identityType VMIdentity, roleAssignmentN
 			allErrs = append(allErrs, field.Invalid(field.NewPath("spec", "systemAssignedIdentityRole", "scope"), role.Scope, "the scope field cannot be empty"))
 		}
 	}
-	if identityType != VMIdentitySystemAssigned && role != nil {
+	if identityType != infrav1.VMIdentitySystemAssigned && role != nil {
 		allErrs = append(allErrs, field.Forbidden(field.NewPath("spec", "role"), "systemAssignedIdentityRole can only be set when identity is set to SystemAssigned"))
 	}
 	return allErrs
 }
 
 // ValidateDataDisks validates a list of data disks.
-func ValidateDataDisks(dataDisks []DataDisk, fieldPath *field.Path) field.ErrorList {
+func ValidateDataDisks(dataDisks []infrav1.DataDisk, fieldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 	lunSet := make(map[int32]struct{})
 	nameSet := make(map[string]struct{})
@@ -226,7 +226,7 @@ func ValidateDataDisks(dataDisks []DataDisk, fieldPath *field.Path) field.ErrorL
 }
 
 // ValidateOSDisk validates the OSDisk spec.
-func ValidateOSDisk(osDisk OSDisk, fieldPath *field.Path) field.ErrorList {
+func ValidateOSDisk(osDisk infrav1.OSDisk, fieldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	if osDisk.DiskSizeGB != nil {
@@ -268,7 +268,7 @@ func ValidateOSDisk(osDisk OSDisk, fieldPath *field.Path) field.ErrorList {
 }
 
 // validateManagedDisk validates updates to the ManagedDiskParameters field.
-func validateManagedDisk(m *ManagedDiskParameters, fieldPath *field.Path, isOSDisk bool) field.ErrorList {
+func validateManagedDisk(m *infrav1.ManagedDiskParameters, fieldPath *field.Path, isOSDisk bool) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	if m != nil {
@@ -277,7 +277,7 @@ func validateManagedDisk(m *ManagedDiskParameters, fieldPath *field.Path, isOSDi
 		// DiskEncryptionSet can only be set when SecurityEncryptionType is set to DiskWithVMGuestState
 		// https://learn.microsoft.com/en-us/rest/api/compute/virtual-machines/create-or-update?tabs=HTTP#securityencryptiontypes
 		if isOSDisk && m.SecurityProfile != nil && m.SecurityProfile.DiskEncryptionSet != nil {
-			if m.SecurityProfile.SecurityEncryptionType != SecurityEncryptionTypeDiskWithVMGuestState {
+			if m.SecurityProfile.SecurityEncryptionType != infrav1.SecurityEncryptionTypeDiskWithVMGuestState {
 				allErrs = append(allErrs, field.Invalid(
 					fieldPath.Child("securityProfile").Child("diskEncryptionSet"),
 					m.SecurityProfile.DiskEncryptionSet.ID,
@@ -311,7 +311,7 @@ func validateStorageAccountType(storageAccountType string, fieldPath *field.Path
 	return allErrs
 }
 
-func validateCachingType(cachingType string, fieldPath *field.Path, managedDisk *ManagedDiskParameters) field.ErrorList {
+func validateCachingType(cachingType string, fieldPath *field.Path, managedDisk *infrav1.ManagedDiskParameters) field.ErrorList {
 	allErrs := field.ErrorList{}
 	cachingTypeChildPath := fieldPath.Child("CachingType")
 
@@ -332,32 +332,32 @@ func validateCachingType(cachingType string, fieldPath *field.Path, managedDisk 
 }
 
 // ValidateDiagnostics validates the Diagnostic spec.
-func ValidateDiagnostics(diagnostics *Diagnostics, fieldPath *field.Path) field.ErrorList {
+func ValidateDiagnostics(diagnostics *infrav1.Diagnostics, fieldPath *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
 
 	if diagnostics != nil && diagnostics.Boot != nil {
 		switch diagnostics.Boot.StorageAccountType {
-		case UserManagedDiagnosticsStorage:
+		case infrav1.UserManagedDiagnosticsStorage:
 			if diagnostics.Boot.UserManaged == nil {
 				allErrs = append(allErrs, field.Required(fieldPath.Child("UserManaged"),
-					fmt.Sprintf("userManaged must be specified when storageAccountType is '%s'", UserManagedDiagnosticsStorage)))
+					fmt.Sprintf("userManaged must be specified when storageAccountType is '%s'", infrav1.UserManagedDiagnosticsStorage)))
 			} else if diagnostics.Boot.UserManaged.StorageAccountURI == "" {
 				allErrs = append(allErrs, field.Required(fieldPath.Child("StorageAccountURI"),
-					fmt.Sprintf("StorageAccountURI cannot be empty when storageAccountType is '%s'", UserManagedDiagnosticsStorage)))
+					fmt.Sprintf("StorageAccountURI cannot be empty when storageAccountType is '%s'", infrav1.UserManagedDiagnosticsStorage)))
 			}
-		case ManagedDiagnosticsStorage:
+		case infrav1.ManagedDiagnosticsStorage:
 			if diagnostics.Boot.UserManaged != nil &&
 				diagnostics.Boot.UserManaged.StorageAccountURI != "" {
 				allErrs = append(allErrs, field.Invalid(fieldPath.Child("StorageAccountURI"), diagnostics.Boot.UserManaged.StorageAccountURI,
 					fmt.Sprintf("StorageAccountURI cannot be set when storageAccountType is '%s'",
-						ManagedDiagnosticsStorage)))
+						infrav1.ManagedDiagnosticsStorage)))
 			}
-		case DisabledDiagnosticsStorage:
+		case infrav1.DisabledDiagnosticsStorage:
 			if diagnostics.Boot.UserManaged != nil &&
 				diagnostics.Boot.UserManaged.StorageAccountURI != "" {
 				allErrs = append(allErrs, field.Invalid(fieldPath.Child("StorageAccountURI"), diagnostics.Boot.UserManaged.StorageAccountURI,
 					fmt.Sprintf("StorageAccountURI cannot be set when storageAccountType is '%s'",
-						ManagedDiagnosticsStorage)))
+						infrav1.ManagedDiagnosticsStorage)))
 			}
 		}
 	}
@@ -369,10 +369,10 @@ func ValidateDiagnostics(diagnostics *Diagnostics, fieldPath *field.Path) field.
 // https://learn.microsoft.com/en-us/rest/api/compute/virtual-machines/create-or-update?tabs=HTTP#vmdisksecurityprofile
 // https://learn.microsoft.com/en-us/rest/api/compute/virtual-machines/create-or-update?tabs=HTTP#securityencryptiontypes
 // https://learn.microsoft.com/en-us/rest/api/compute/virtual-machines/create-or-update?tabs=HTTP#uefisettings
-func ValidateConfidentialCompute(managedDisk *ManagedDiskParameters, profile *SecurityProfile, fieldPath *field.Path) field.ErrorList {
+func ValidateConfidentialCompute(managedDisk *infrav1.ManagedDiskParameters, profile *infrav1.SecurityProfile, fieldPath *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
 
-	var securityEncryptionType SecurityEncryptionType
+	var securityEncryptionType infrav1.SecurityEncryptionType
 
 	if managedDisk != nil && managedDisk.SecurityProfile != nil {
 		securityEncryptionType = managedDisk.SecurityProfile.SecurityEncryptionType
@@ -380,9 +380,9 @@ func ValidateConfidentialCompute(managedDisk *ManagedDiskParameters, profile *Se
 
 	if profile != nil && securityEncryptionType != "" {
 		// SecurityEncryptionType can only be set for Confindential VMs
-		if profile.SecurityType != SecurityTypesConfidentialVM {
+		if profile.SecurityType != infrav1.SecurityTypesConfidentialVM {
 			allErrs = append(allErrs, field.Invalid(fieldPath.Child("SecurityType"), profile.SecurityType,
-				fmt.Sprintf("SecurityType should be set to '%s' when securityEncryptionType is defined", SecurityTypesConfidentialVM)))
+				fmt.Sprintf("SecurityType should be set to '%s' when securityEncryptionType is defined", infrav1.SecurityTypesConfidentialVM)))
 		}
 
 		// Confidential VMs require vTPM to be enabled, irrespective of the SecurityEncryptionType used
@@ -396,17 +396,17 @@ func ValidateConfidentialCompute(managedDisk *ManagedDiskParameters, profile *Se
 				"VTpmEnabled should be set to true when securityEncryptionType is defined"))
 		}
 
-		if securityEncryptionType == SecurityEncryptionTypeDiskWithVMGuestState {
+		if securityEncryptionType == infrav1.SecurityEncryptionTypeDiskWithVMGuestState {
 			// DiskWithVMGuestState encryption type is not compatible with EncryptionAtHost
 			if profile.EncryptionAtHost != nil && *profile.EncryptionAtHost {
 				allErrs = append(allErrs, field.Invalid(fieldPath.Child("EncryptionAtHost"), profile.EncryptionAtHost,
-					fmt.Sprintf("EncryptionAtHost cannot be set to 'true' when securityEncryptionType is set to '%s'", SecurityEncryptionTypeDiskWithVMGuestState)))
+					fmt.Sprintf("EncryptionAtHost cannot be set to 'true' when securityEncryptionType is set to '%s'", infrav1.SecurityEncryptionTypeDiskWithVMGuestState)))
 			}
 
 			// DiskWithVMGuestState encryption type requires SecureBoot to be enabled
 			if profile.UefiSettings != nil && (profile.UefiSettings.SecureBootEnabled == nil || !*profile.UefiSettings.SecureBootEnabled) {
 				allErrs = append(allErrs, field.Invalid(fieldPath.Child("SecureBootEnabled"), profile.UefiSettings.SecureBootEnabled,
-					fmt.Sprintf("SecureBootEnabled should be set to true when securityEncryptionType is set to '%s'", SecurityEncryptionTypeDiskWithVMGuestState)))
+					fmt.Sprintf("SecureBootEnabled should be set to true when securityEncryptionType is set to '%s'", infrav1.SecurityEncryptionTypeDiskWithVMGuestState)))
 			}
 		}
 	}
@@ -428,7 +428,7 @@ func ValidateCapacityReservationGroupID(capacityReservationGroupID *string, fldP
 }
 
 // ValidateVMExtensions validates the VMExtensions spec.
-func ValidateVMExtensions(disableExtensionOperations *bool, vmExtensions []VMExtension, _ *field.Path) field.ErrorList {
+func ValidateVMExtensions(disableExtensionOperations *bool, vmExtensions []infrav1.VMExtension, _ *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	if ptr.Deref(disableExtensionOperations, false) && len(vmExtensions) > 0 {

--- a/internal/webhooks/azuremachine_validation_test.go
+++ b/internal/webhooks/azuremachine_validation_test.go
@@ -30,7 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/utils/ptr"
 
-	. "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
+	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	apifixtures "sigs.k8s.io/cluster-api-provider-azure/internal/test/apifixtures"
 )
 
@@ -82,7 +82,7 @@ func generateSSHPublicKey(b64Enconded bool) string {
 type osDiskTestInput struct {
 	name    string
 	wantErr bool
-	osDisk  OSDisk
+	osDisk  infrav1.OSDisk
 }
 
 func TestAzureMachine_ValidateOSDisk(t *testing.T) {
@@ -100,14 +100,14 @@ func TestAzureMachine_ValidateOSDisk(t *testing.T) {
 		{
 			name:    "valid ephemeral os disk spec",
 			wantErr: false,
-			osDisk: OSDisk{
+			osDisk: infrav1.OSDisk{
 				DiskSizeGB:  ptr.To[int32](30),
 				CachingType: "None",
 				OSType:      "blah",
-				DiffDiskSettings: &DiffDiskSettings{
+				DiffDiskSettings: &infrav1.DiffDiskSettings{
 					Option: string(armcompute.DiffDiskOptionsLocal),
 				},
-				ManagedDisk: &ManagedDiskParameters{
+				ManagedDisk: &infrav1.ManagedDiskParameters{
 					StorageAccountType: "Standard_LRS",
 				},
 			},
@@ -115,15 +115,15 @@ func TestAzureMachine_ValidateOSDisk(t *testing.T) {
 		{
 			name:    "valid resourceDisk placement spec with option local",
 			wantErr: false,
-			osDisk: OSDisk{
+			osDisk: infrav1.OSDisk{
 				DiskSizeGB:  ptr.To[int32](30),
 				CachingType: "None",
 				OSType:      "blah",
-				DiffDiskSettings: &DiffDiskSettings{
+				DiffDiskSettings: &infrav1.DiffDiskSettings{
 					Option:    string(armcompute.DiffDiskOptionsLocal),
-					Placement: ptr.To(DiffDiskPlacementResourceDisk),
+					Placement: ptr.To(infrav1.DiffDiskPlacementResourceDisk),
 				},
-				ManagedDisk: &ManagedDiskParameters{
+				ManagedDisk: &infrav1.ManagedDiskParameters{
 					StorageAccountType: "Standard_LRS",
 				},
 			},
@@ -131,14 +131,14 @@ func TestAzureMachine_ValidateOSDisk(t *testing.T) {
 		{
 			name:    "valid resourceDisk placement spec requires option local",
 			wantErr: true,
-			osDisk: OSDisk{
+			osDisk: infrav1.OSDisk{
 				DiskSizeGB:  ptr.To[int32](30),
 				CachingType: "None",
 				OSType:      "blah",
-				DiffDiskSettings: &DiffDiskSettings{
-					Placement: ptr.To(DiffDiskPlacementResourceDisk),
+				DiffDiskSettings: &infrav1.DiffDiskSettings{
+					Placement: ptr.To(infrav1.DiffDiskPlacementResourceDisk),
 				},
-				ManagedDisk: &ManagedDiskParameters{
+				ManagedDisk: &infrav1.ManagedDiskParameters{
 					StorageAccountType: "Standard_LRS",
 				},
 			},
@@ -146,16 +146,16 @@ func TestAzureMachine_ValidateOSDisk(t *testing.T) {
 		{
 			name:    "byoc encryption with ephemeral os disk spec",
 			wantErr: true,
-			osDisk: OSDisk{
+			osDisk: infrav1.OSDisk{
 				DiskSizeGB:  ptr.To[int32](30),
 				CachingType: "None",
 				OSType:      "blah",
-				DiffDiskSettings: &DiffDiskSettings{
+				DiffDiskSettings: &infrav1.DiffDiskSettings{
 					Option: string(armcompute.DiffDiskOptionsLocal),
 				},
-				ManagedDisk: &ManagedDiskParameters{
+				ManagedDisk: &infrav1.ManagedDiskParameters{
 					StorageAccountType: "Standard_LRS",
-					DiskEncryptionSet: &DiskEncryptionSetParameters{
+					DiskEncryptionSet: &infrav1.DiskEncryptionSetParameters{
 						ID: "disk-encryption-set",
 					},
 				},
@@ -181,7 +181,7 @@ func generateNegativeTestCases() []osDiskTestInput {
 	inputs := []osDiskTestInput{}
 	testCaseName := "invalid os disk spec"
 
-	invalidDiskSpecs := []OSDisk{
+	invalidDiskSpecs := []infrav1.OSDisk{
 		{},
 		{
 			DiskSizeGB: ptr.To[int32](0),
@@ -202,29 +202,29 @@ func generateNegativeTestCases() []osDiskTestInput {
 		{
 			DiskSizeGB:  ptr.To[int32](30),
 			OSType:      "blah",
-			ManagedDisk: &ManagedDiskParameters{},
+			ManagedDisk: &infrav1.ManagedDiskParameters{},
 		},
 		{
 			DiskSizeGB: ptr.To[int32](30),
 			OSType:     "blah",
-			ManagedDisk: &ManagedDiskParameters{
+			ManagedDisk: &infrav1.ManagedDiskParameters{
 				StorageAccountType: "",
 			},
 		},
 		{
 			DiskSizeGB: ptr.To[int32](30),
 			OSType:     "blah",
-			ManagedDisk: &ManagedDiskParameters{
+			ManagedDisk: &infrav1.ManagedDiskParameters{
 				StorageAccountType: "invalid_type",
 			},
 		},
 		{
 			DiskSizeGB: ptr.To[int32](30),
 			OSType:     "blah",
-			ManagedDisk: &ManagedDiskParameters{
+			ManagedDisk: &infrav1.ManagedDiskParameters{
 				StorageAccountType: "Premium_LRS",
 			},
-			DiffDiskSettings: &DiffDiskSettings{
+			DiffDiskSettings: &infrav1.DiffDiskSettings{
 				Option: string(armcompute.DiffDiskOptionsLocal),
 			},
 		},
@@ -244,7 +244,7 @@ func generateNegativeTestCases() []osDiskTestInput {
 func TestAzureMachine_ValidateDataDisks(t *testing.T) {
 	testcases := []struct {
 		name    string
-		disks   []DataDisk
+		disks   []infrav1.DataDisk
 		wantErr bool
 	}{
 		{
@@ -254,12 +254,12 @@ func TestAzureMachine_ValidateDataDisks(t *testing.T) {
 		},
 		{
 			name:    "valid empty data disks",
-			disks:   []DataDisk{},
+			disks:   []infrav1.DataDisk{},
 			wantErr: false,
 		},
 		{
 			name: "valid disks",
-			disks: []DataDisk{
+			disks: []infrav1.DataDisk{
 				{
 					NameSuffix:  "my_disk",
 					DiskSizeGB:  64,
@@ -277,7 +277,7 @@ func TestAzureMachine_ValidateDataDisks(t *testing.T) {
 		},
 		{
 			name: "duplicate names",
-			disks: []DataDisk{
+			disks: []infrav1.DataDisk{
 				{
 					NameSuffix:  "disk",
 					DiskSizeGB:  64,
@@ -295,7 +295,7 @@ func TestAzureMachine_ValidateDataDisks(t *testing.T) {
 		},
 		{
 			name: "duplicate LUNs",
-			disks: []DataDisk{
+			disks: []infrav1.DataDisk{
 				{
 					NameSuffix:  "my_disk",
 					DiskSizeGB:  64,
@@ -313,7 +313,7 @@ func TestAzureMachine_ValidateDataDisks(t *testing.T) {
 		},
 		{
 			name: "invalid disk size",
-			disks: []DataDisk{
+			disks: []infrav1.DataDisk{
 				{
 					NameSuffix:  "my_disk",
 					DiskSizeGB:  0,
@@ -325,7 +325,7 @@ func TestAzureMachine_ValidateDataDisks(t *testing.T) {
 		},
 		{
 			name: "empty name",
-			disks: []DataDisk{
+			disks: []infrav1.DataDisk{
 				{
 					NameSuffix:  "",
 					DiskSizeGB:  0,
@@ -337,7 +337,7 @@ func TestAzureMachine_ValidateDataDisks(t *testing.T) {
 		},
 		{
 			name: "invalid disk cachingType",
-			disks: []DataDisk{
+			disks: []infrav1.DataDisk{
 				{
 					NameSuffix:  "my_disk",
 					DiskSizeGB:  64,
@@ -349,7 +349,7 @@ func TestAzureMachine_ValidateDataDisks(t *testing.T) {
 		},
 		{
 			name: "valid disk cachingType",
-			disks: []DataDisk{
+			disks: []infrav1.DataDisk{
 				{
 					NameSuffix:  "my_disk",
 					DiskSizeGB:  64,
@@ -361,11 +361,11 @@ func TestAzureMachine_ValidateDataDisks(t *testing.T) {
 		},
 		{
 			name: "valid managed disk storage account type",
-			disks: []DataDisk{
+			disks: []infrav1.DataDisk{
 				{
 					NameSuffix: "my_disk_1",
 					DiskSizeGB: 64,
-					ManagedDisk: &ManagedDiskParameters{
+					ManagedDisk: &infrav1.ManagedDiskParameters{
 						StorageAccountType: "Premium_LRS",
 					},
 					Lun:         ptr.To[int32](0),
@@ -374,7 +374,7 @@ func TestAzureMachine_ValidateDataDisks(t *testing.T) {
 				{
 					NameSuffix: "my_disk_2",
 					DiskSizeGB: 64,
-					ManagedDisk: &ManagedDiskParameters{
+					ManagedDisk: &infrav1.ManagedDiskParameters{
 						StorageAccountType: "Standard_LRS",
 					},
 					Lun:         ptr.To[int32](1),
@@ -385,11 +385,11 @@ func TestAzureMachine_ValidateDataDisks(t *testing.T) {
 		},
 		{
 			name: "invalid managed disk storage account type",
-			disks: []DataDisk{
+			disks: []infrav1.DataDisk{
 				{
 					NameSuffix: "my_disk_1",
 					DiskSizeGB: 64,
-					ManagedDisk: &ManagedDiskParameters{
+					ManagedDisk: &infrav1.ManagedDiskParameters{
 						StorageAccountType: "invalid storage account",
 					},
 					Lun:         ptr.To[int32](0),
@@ -400,11 +400,11 @@ func TestAzureMachine_ValidateDataDisks(t *testing.T) {
 		},
 		{
 			name: "valid combination of managed disk storage account type UltraSSD_LRS and cachingType None",
-			disks: []DataDisk{
+			disks: []infrav1.DataDisk{
 				{
 					NameSuffix: "my_disk_1",
 					DiskSizeGB: 64,
-					ManagedDisk: &ManagedDiskParameters{
+					ManagedDisk: &infrav1.ManagedDiskParameters{
 						StorageAccountType: string(armcompute.StorageAccountTypesUltraSSDLRS),
 					},
 					Lun:         ptr.To[int32](0),
@@ -415,11 +415,11 @@ func TestAzureMachine_ValidateDataDisks(t *testing.T) {
 		},
 		{
 			name: "invalid combination of managed disk storage account type UltraSSD_LRS and cachingType ReadWrite",
-			disks: []DataDisk{
+			disks: []infrav1.DataDisk{
 				{
 					NameSuffix: "my_disk_1",
 					DiskSizeGB: 64,
-					ManagedDisk: &ManagedDiskParameters{
+					ManagedDisk: &infrav1.ManagedDiskParameters{
 						StorageAccountType: string(armcompute.StorageAccountTypesUltraSSDLRS),
 					},
 					Lun:         ptr.To[int32](0),
@@ -430,11 +430,11 @@ func TestAzureMachine_ValidateDataDisks(t *testing.T) {
 		},
 		{
 			name: "invalid combination of managed disk storage account type UltraSSD_LRS and cachingType ReadOnly",
-			disks: []DataDisk{
+			disks: []infrav1.DataDisk{
 				{
 					NameSuffix: "my_disk_1",
 					DiskSizeGB: 64,
-					ManagedDisk: &ManagedDiskParameters{
+					ManagedDisk: &infrav1.ManagedDiskParameters{
 						StorageAccountType: string(armcompute.StorageAccountTypesUltraSSDLRS),
 					},
 					Lun:         ptr.To[int32](0),
@@ -463,38 +463,38 @@ func TestAzureMachine_ValidateSystemAssignedIdentity(t *testing.T) {
 		name               string
 		roleAssignmentName string
 		old                string
-		Identity           VMIdentity
+		Identity           infrav1.VMIdentity
 		wantErr            bool
 	}{
 		{
 			name:               "valid UUID",
 			roleAssignmentName: uuid.New().String(),
-			Identity:           VMIdentitySystemAssigned,
+			Identity:           infrav1.VMIdentitySystemAssigned,
 			wantErr:            false,
 		},
 		{
 			name:               "wrong Identity type",
 			roleAssignmentName: uuid.New().String(),
-			Identity:           VMIdentityNone,
+			Identity:           infrav1.VMIdentityNone,
 			wantErr:            true,
 		},
 		{
 			name:               "not a valid UUID",
 			roleAssignmentName: "notaguid",
-			Identity:           VMIdentitySystemAssigned,
+			Identity:           infrav1.VMIdentitySystemAssigned,
 			wantErr:            true,
 		},
 		{
 			name:               "empty",
 			roleAssignmentName: "",
-			Identity:           VMIdentitySystemAssigned,
+			Identity:           infrav1.VMIdentitySystemAssigned,
 			wantErr:            true,
 		},
 		{
 			name:               "changed",
 			roleAssignmentName: uuid.New().String(),
 			old:                uuid.New().String(),
-			Identity:           VMIdentitySystemAssigned,
+			Identity:           infrav1.VMIdentitySystemAssigned,
 			wantErr:            true,
 		},
 	}
@@ -515,15 +515,15 @@ func TestAzureMachine_ValidateSystemAssignedIdentity(t *testing.T) {
 func TestAzureMachine_ValidateSystemAssignedIdentityRole(t *testing.T) {
 	tests := []struct {
 		name               string
-		Identity           VMIdentity
+		Identity           infrav1.VMIdentity
 		roleAssignmentName string
-		role               *SystemAssignedIdentityRole
+		role               *infrav1.SystemAssignedIdentityRole
 		wantErr            bool
 	}{
 		{
 			name:     "valid role",
-			Identity: VMIdentitySystemAssigned,
-			role: &SystemAssignedIdentityRole{
+			Identity: infrav1.VMIdentitySystemAssigned,
+			role: &infrav1.SystemAssignedIdentityRole{
 				Name:         uuid.New().String(),
 				Scope:        "fake-scope",
 				DefinitionID: "fake-definition-id",
@@ -531,18 +531,18 @@ func TestAzureMachine_ValidateSystemAssignedIdentityRole(t *testing.T) {
 		},
 		{
 			name:               "valid role using deprecated role assignment name",
-			Identity:           VMIdentitySystemAssigned,
+			Identity:           infrav1.VMIdentitySystemAssigned,
 			roleAssignmentName: uuid.New().String(),
-			role: &SystemAssignedIdentityRole{
+			role: &infrav1.SystemAssignedIdentityRole{
 				Scope:        "fake-scope",
 				DefinitionID: "fake-definition-id",
 			},
 		},
 		{
 			name:               "set both system assigned identity role and role assignment name",
-			Identity:           VMIdentitySystemAssigned,
+			Identity:           infrav1.VMIdentitySystemAssigned,
 			roleAssignmentName: uuid.New().String(),
-			role: &SystemAssignedIdentityRole{
+			role: &infrav1.SystemAssignedIdentityRole{
 				Name:         uuid.New().String(),
 				Scope:        "fake-scope",
 				DefinitionID: "fake-definition-id",
@@ -551,8 +551,8 @@ func TestAzureMachine_ValidateSystemAssignedIdentityRole(t *testing.T) {
 		},
 		{
 			name:     "wrong Identity type",
-			Identity: VMIdentityUserAssigned,
-			role: &SystemAssignedIdentityRole{
+			Identity: infrav1.VMIdentityUserAssigned,
+			role: &infrav1.SystemAssignedIdentityRole{
 				Name:         uuid.New().String(),
 				Scope:        "fake-scope",
 				DefinitionID: "fake-definition-id",
@@ -561,8 +561,8 @@ func TestAzureMachine_ValidateSystemAssignedIdentityRole(t *testing.T) {
 		},
 		{
 			name:     "missing scope",
-			Identity: VMIdentitySystemAssigned,
-			role: &SystemAssignedIdentityRole{
+			Identity: infrav1.VMIdentitySystemAssigned,
+			role: &infrav1.SystemAssignedIdentityRole{
 				Name:         uuid.New().String(),
 				DefinitionID: "fake-definition-id",
 			},
@@ -570,8 +570,8 @@ func TestAzureMachine_ValidateSystemAssignedIdentityRole(t *testing.T) {
 		},
 		{
 			name:     "missing definition id",
-			Identity: VMIdentitySystemAssigned,
-			role: &SystemAssignedIdentityRole{
+			Identity: infrav1.VMIdentitySystemAssigned,
+			role: &infrav1.SystemAssignedIdentityRole{
 				Name:  uuid.New().String(),
 				Scope: "fake-scope",
 			},
@@ -595,20 +595,20 @@ func TestAzureMachine_ValidateSystemAssignedIdentityRole(t *testing.T) {
 func TestAzureMachine_ValidateUserAssignedIdentity(t *testing.T) {
 	tests := []struct {
 		name       string
-		idType     VMIdentity
-		identities []UserAssignedIdentity
+		idType     infrav1.VMIdentity
+		identities []infrav1.UserAssignedIdentity
 		wantErr    bool
 	}{
 		{
 			name:       "empty identity list",
-			idType:     VMIdentityUserAssigned,
-			identities: []UserAssignedIdentity{},
+			idType:     infrav1.VMIdentityUserAssigned,
+			identities: []infrav1.UserAssignedIdentity{},
 			wantErr:    true,
 		},
 		{
 			name:   "invalid: providerID must start with slash",
-			idType: VMIdentityUserAssigned,
-			identities: []UserAssignedIdentity{
+			idType: infrav1.VMIdentityUserAssigned,
+			identities: []infrav1.UserAssignedIdentity{
 				{
 					ProviderID: "subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/my-resource-group/providers/Microsoft.Compute/virtualMachines/default-20202-control-plane-7w265",
 				},
@@ -617,8 +617,8 @@ func TestAzureMachine_ValidateUserAssignedIdentity(t *testing.T) {
 		},
 		{
 			name:   "invalid: providerID must start with subscriptions or providers",
-			idType: VMIdentityUserAssigned,
-			identities: []UserAssignedIdentity{
+			idType: infrav1.VMIdentityUserAssigned,
+			identities: []infrav1.UserAssignedIdentity{
 				{
 					ProviderID: "azure:///prescriptions/00000000-0000-0000-0000-000000000000/resourceGroups/my-resource-group/providers/Microsoft.Compute/virtualMachines/default-20202-control-plane-7w265",
 				},
@@ -627,8 +627,8 @@ func TestAzureMachine_ValidateUserAssignedIdentity(t *testing.T) {
 		},
 		{
 			name:   "valid",
-			idType: VMIdentityUserAssigned,
-			identities: []UserAssignedIdentity{
+			idType: infrav1.VMIdentityUserAssigned,
+			identities: []infrav1.UserAssignedIdentity{
 				{
 					ProviderID: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/my-resource-group/providers/Microsoft.Compute/virtualMachines/default-20202-control-plane-7w265",
 				},
@@ -637,8 +637,8 @@ func TestAzureMachine_ValidateUserAssignedIdentity(t *testing.T) {
 		},
 		{
 			name:   "valid with provider prefix",
-			idType: VMIdentityUserAssigned,
-			identities: []UserAssignedIdentity{
+			idType: infrav1.VMIdentityUserAssigned,
+			identities: []infrav1.UserAssignedIdentity{
 				{
 					ProviderID: "azure:///subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/my-resource-group/providers/Microsoft.Compute/virtualMachines/default-20202-control-plane-7w265",
 				},
@@ -665,7 +665,7 @@ func TestAzureMachine_ValidateNetwork(t *testing.T) {
 		name                  string
 		subnetName            string
 		acceleratedNetworking *bool
-		networkInterfaces     []NetworkInterface
+		networkInterfaces     []infrav1.NetworkInterface
 		wantErr               bool
 	}{
 		{
@@ -679,7 +679,7 @@ func TestAzureMachine_ValidateNetwork(t *testing.T) {
 			name:                  "valid config with networkInterfaces fields",
 			subnetName:            "",
 			acceleratedNetworking: nil,
-			networkInterfaces: []NetworkInterface{{
+			networkInterfaces: []infrav1.NetworkInterface{{
 				SubnetName:            "subnet1",
 				AcceleratedNetworking: ptr.To(true),
 				PrivateIPConfigs:      1,
@@ -690,7 +690,7 @@ func TestAzureMachine_ValidateNetwork(t *testing.T) {
 			name:                  "valid config with multiple networkInterfaces",
 			subnetName:            "",
 			acceleratedNetworking: nil,
-			networkInterfaces: []NetworkInterface{
+			networkInterfaces: []infrav1.NetworkInterface{
 				{
 					SubnetName:            "subnet1",
 					AcceleratedNetworking: ptr.To(true),
@@ -708,7 +708,7 @@ func TestAzureMachine_ValidateNetwork(t *testing.T) {
 			name:                  "invalid config using both deprecated subnetName and networkInterfaces",
 			subnetName:            "subnet1",
 			acceleratedNetworking: nil,
-			networkInterfaces: []NetworkInterface{{
+			networkInterfaces: []infrav1.NetworkInterface{{
 				SubnetName:            "subnet1",
 				AcceleratedNetworking: nil,
 				PrivateIPConfigs:      1,
@@ -719,7 +719,7 @@ func TestAzureMachine_ValidateNetwork(t *testing.T) {
 			name:                  "invalid config using both deprecated acceleratedNetworking and networkInterfaces",
 			subnetName:            "",
 			acceleratedNetworking: ptr.To(true),
-			networkInterfaces: []NetworkInterface{{
+			networkInterfaces: []infrav1.NetworkInterface{{
 				SubnetName:            "subnet1",
 				AcceleratedNetworking: ptr.To(true),
 				PrivateIPConfigs:      1,
@@ -730,7 +730,7 @@ func TestAzureMachine_ValidateNetwork(t *testing.T) {
 			name:                  "invalid config setting privateIPConfigs to less than 1",
 			subnetName:            "",
 			acceleratedNetworking: nil,
-			networkInterfaces: []NetworkInterface{{
+			networkInterfaces: []infrav1.NetworkInterface{{
 				SubnetName:            "subnet1",
 				AcceleratedNetworking: ptr.To(true),
 				PrivateIPConfigs:      0,
@@ -755,14 +755,14 @@ func TestAzureMachine_ValidateNetwork(t *testing.T) {
 func TestAzureMachine_ValidateConfidentialCompute(t *testing.T) {
 	tests := []struct {
 		name            string
-		managedDisk     *ManagedDiskParameters
-		securityProfile *SecurityProfile
+		managedDisk     *infrav1.ManagedDiskParameters
+		securityProfile *infrav1.SecurityProfile
 		wantErr         bool
 	}{
 		{
 			name: "valid configuration without confidential compute",
-			managedDisk: &ManagedDiskParameters{
-				SecurityProfile: &VMDiskSecurityProfile{
+			managedDisk: &infrav1.ManagedDiskParameters{
+				SecurityProfile: &infrav1.VMDiskSecurityProfile{
 					SecurityEncryptionType: "",
 				},
 			},
@@ -771,26 +771,26 @@ func TestAzureMachine_ValidateConfidentialCompute(t *testing.T) {
 		},
 		{
 			name: "valid configuration without confidential compute and host encryption enabled",
-			managedDisk: &ManagedDiskParameters{
-				SecurityProfile: &VMDiskSecurityProfile{
+			managedDisk: &infrav1.ManagedDiskParameters{
+				SecurityProfile: &infrav1.VMDiskSecurityProfile{
 					SecurityEncryptionType: "",
 				},
 			},
-			securityProfile: &SecurityProfile{
+			securityProfile: &infrav1.SecurityProfile{
 				EncryptionAtHost: ptr.To(true),
 			},
 			wantErr: false,
 		},
 		{
 			name: "valid configuration with VMGuestStateOnly encryption and secure boot disabled",
-			managedDisk: &ManagedDiskParameters{
-				SecurityProfile: &VMDiskSecurityProfile{
-					SecurityEncryptionType: SecurityEncryptionTypeVMGuestStateOnly,
+			managedDisk: &infrav1.ManagedDiskParameters{
+				SecurityProfile: &infrav1.VMDiskSecurityProfile{
+					SecurityEncryptionType: infrav1.SecurityEncryptionTypeVMGuestStateOnly,
 				},
 			},
-			securityProfile: &SecurityProfile{
-				SecurityType: SecurityTypesConfidentialVM,
-				UefiSettings: &UefiSettings{
+			securityProfile: &infrav1.SecurityProfile{
+				SecurityType: infrav1.SecurityTypesConfidentialVM,
+				UefiSettings: &infrav1.UefiSettings{
 					VTpmEnabled:       ptr.To(true),
 					SecureBootEnabled: ptr.To(false),
 				},
@@ -799,14 +799,14 @@ func TestAzureMachine_ValidateConfidentialCompute(t *testing.T) {
 		},
 		{
 			name: "valid configuration with VMGuestStateOnly encryption and secure boot enabled",
-			managedDisk: &ManagedDiskParameters{
-				SecurityProfile: &VMDiskSecurityProfile{
-					SecurityEncryptionType: SecurityEncryptionTypeVMGuestStateOnly,
+			managedDisk: &infrav1.ManagedDiskParameters{
+				SecurityProfile: &infrav1.VMDiskSecurityProfile{
+					SecurityEncryptionType: infrav1.SecurityEncryptionTypeVMGuestStateOnly,
 				},
 			},
-			securityProfile: &SecurityProfile{
-				SecurityType: SecurityTypesConfidentialVM,
-				UefiSettings: &UefiSettings{
+			securityProfile: &infrav1.SecurityProfile{
+				SecurityType: infrav1.SecurityTypesConfidentialVM,
+				UefiSettings: &infrav1.UefiSettings{
 					VTpmEnabled:       ptr.To(true),
 					SecureBootEnabled: ptr.To(true),
 				},
@@ -815,15 +815,15 @@ func TestAzureMachine_ValidateConfidentialCompute(t *testing.T) {
 		},
 		{
 			name: "valid configuration with VMGuestStateOnly encryption and EncryptionAtHost enabled",
-			managedDisk: &ManagedDiskParameters{
-				SecurityProfile: &VMDiskSecurityProfile{
-					SecurityEncryptionType: SecurityEncryptionTypeVMGuestStateOnly,
+			managedDisk: &infrav1.ManagedDiskParameters{
+				SecurityProfile: &infrav1.VMDiskSecurityProfile{
+					SecurityEncryptionType: infrav1.SecurityEncryptionTypeVMGuestStateOnly,
 				},
 			},
-			securityProfile: &SecurityProfile{
+			securityProfile: &infrav1.SecurityProfile{
 				EncryptionAtHost: ptr.To(true),
-				SecurityType:     SecurityTypesConfidentialVM,
-				UefiSettings: &UefiSettings{
+				SecurityType:     infrav1.SecurityTypesConfidentialVM,
+				UefiSettings: &infrav1.UefiSettings{
 					VTpmEnabled: ptr.To(true),
 				},
 			},
@@ -831,14 +831,14 @@ func TestAzureMachine_ValidateConfidentialCompute(t *testing.T) {
 		},
 		{
 			name: "valid configuration with DiskWithVMGuestState encryption",
-			managedDisk: &ManagedDiskParameters{
-				SecurityProfile: &VMDiskSecurityProfile{
-					SecurityEncryptionType: SecurityEncryptionTypeDiskWithVMGuestState,
+			managedDisk: &infrav1.ManagedDiskParameters{
+				SecurityProfile: &infrav1.VMDiskSecurityProfile{
+					SecurityEncryptionType: infrav1.SecurityEncryptionTypeDiskWithVMGuestState,
 				},
 			},
-			securityProfile: &SecurityProfile{
-				SecurityType: SecurityTypesConfidentialVM,
-				UefiSettings: &UefiSettings{
+			securityProfile: &infrav1.SecurityProfile{
+				SecurityType: infrav1.SecurityTypesConfidentialVM,
+				UefiSettings: &infrav1.UefiSettings{
 					SecureBootEnabled: ptr.To(true),
 					VTpmEnabled:       ptr.To(true),
 				},
@@ -847,26 +847,26 @@ func TestAzureMachine_ValidateConfidentialCompute(t *testing.T) {
 		},
 		{
 			name: "invalid configuration with DiskWithVMGuestState encryption and EncryptionAtHost enabled",
-			managedDisk: &ManagedDiskParameters{
-				SecurityProfile: &VMDiskSecurityProfile{
-					SecurityEncryptionType: SecurityEncryptionTypeDiskWithVMGuestState,
+			managedDisk: &infrav1.ManagedDiskParameters{
+				SecurityProfile: &infrav1.VMDiskSecurityProfile{
+					SecurityEncryptionType: infrav1.SecurityEncryptionTypeDiskWithVMGuestState,
 				},
 			},
-			securityProfile: &SecurityProfile{
+			securityProfile: &infrav1.SecurityProfile{
 				EncryptionAtHost: ptr.To(true),
 			},
 			wantErr: true,
 		},
 		{
 			name: "invalid configuration with DiskWithVMGuestState encryption and vTPM disabled",
-			managedDisk: &ManagedDiskParameters{
-				SecurityProfile: &VMDiskSecurityProfile{
-					SecurityEncryptionType: SecurityEncryptionTypeDiskWithVMGuestState,
+			managedDisk: &infrav1.ManagedDiskParameters{
+				SecurityProfile: &infrav1.VMDiskSecurityProfile{
+					SecurityEncryptionType: infrav1.SecurityEncryptionTypeDiskWithVMGuestState,
 				},
 			},
-			securityProfile: &SecurityProfile{
-				SecurityType: SecurityTypesConfidentialVM,
-				UefiSettings: &UefiSettings{
+			securityProfile: &infrav1.SecurityProfile{
+				SecurityType: infrav1.SecurityTypesConfidentialVM,
+				UefiSettings: &infrav1.UefiSettings{
 					VTpmEnabled:       ptr.To(false),
 					SecureBootEnabled: ptr.To(false),
 				},
@@ -875,14 +875,14 @@ func TestAzureMachine_ValidateConfidentialCompute(t *testing.T) {
 		},
 		{
 			name: "invalid configuration with DiskWithVMGuestState encryption and secure boot disabled",
-			managedDisk: &ManagedDiskParameters{
-				SecurityProfile: &VMDiskSecurityProfile{
-					SecurityEncryptionType: SecurityEncryptionTypeDiskWithVMGuestState,
+			managedDisk: &infrav1.ManagedDiskParameters{
+				SecurityProfile: &infrav1.VMDiskSecurityProfile{
+					SecurityEncryptionType: infrav1.SecurityEncryptionTypeDiskWithVMGuestState,
 				},
 			},
-			securityProfile: &SecurityProfile{
-				SecurityType: SecurityTypesConfidentialVM,
-				UefiSettings: &UefiSettings{
+			securityProfile: &infrav1.SecurityProfile{
+				SecurityType: infrav1.SecurityTypesConfidentialVM,
+				UefiSettings: &infrav1.UefiSettings{
 					VTpmEnabled:       ptr.To(true),
 					SecureBootEnabled: ptr.To(false),
 				},
@@ -891,13 +891,13 @@ func TestAzureMachine_ValidateConfidentialCompute(t *testing.T) {
 		},
 		{
 			name: "invalid configuration with DiskWithVMGuestState encryption and SecurityType not set to ConfidentialVM",
-			managedDisk: &ManagedDiskParameters{
-				SecurityProfile: &VMDiskSecurityProfile{
-					SecurityEncryptionType: SecurityEncryptionTypeDiskWithVMGuestState,
+			managedDisk: &infrav1.ManagedDiskParameters{
+				SecurityProfile: &infrav1.VMDiskSecurityProfile{
+					SecurityEncryptionType: infrav1.SecurityEncryptionTypeDiskWithVMGuestState,
 				},
 			},
-			securityProfile: &SecurityProfile{
-				UefiSettings: &UefiSettings{
+			securityProfile: &infrav1.SecurityProfile{
+				UefiSettings: &infrav1.UefiSettings{
 					VTpmEnabled:       ptr.To(true),
 					SecureBootEnabled: ptr.To(true),
 				},
@@ -906,13 +906,13 @@ func TestAzureMachine_ValidateConfidentialCompute(t *testing.T) {
 		},
 		{
 			name: "invalid configuration with VMGuestStateOnly encryption and SecurityType not set to ConfidentialVM",
-			managedDisk: &ManagedDiskParameters{
-				SecurityProfile: &VMDiskSecurityProfile{
-					SecurityEncryptionType: SecurityEncryptionTypeVMGuestStateOnly,
+			managedDisk: &infrav1.ManagedDiskParameters{
+				SecurityProfile: &infrav1.VMDiskSecurityProfile{
+					SecurityEncryptionType: infrav1.SecurityEncryptionTypeVMGuestStateOnly,
 				},
 			},
-			securityProfile: &SecurityProfile{
-				UefiSettings: &UefiSettings{
+			securityProfile: &infrav1.SecurityProfile{
+				UefiSettings: &infrav1.UefiSettings{
 					VTpmEnabled:       ptr.To(true),
 					SecureBootEnabled: ptr.To(true),
 				},

--- a/internal/webhooks/azuremachine_webhook.go
+++ b/internal/webhooks/azuremachine_webhook.go
@@ -27,7 +27,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
-	. "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
+	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	apiinternal "sigs.k8s.io/cluster-api-provider-azure/internal/api/v1beta1"
 	webhookutils "sigs.k8s.io/cluster-api-provider-azure/util/webhook"
 )
@@ -37,7 +37,7 @@ func (mw *AzureMachineWebhook) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	mw.client = mgr.GetClient()
 
 	return ctrl.NewWebhookManagedBy(mgr).
-		For(&AzureMachine{}).
+		For(&infrav1.AzureMachine{}).
 		WithDefaulter(mw).
 		WithValidator(mw).
 		Complete()
@@ -53,7 +53,7 @@ type AzureMachineWebhook struct {
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
 func (mw *AzureMachineWebhook) ValidateCreate(_ context.Context, obj runtime.Object) (admission.Warnings, error) {
-	m, ok := obj.(*AzureMachine)
+	m, ok := obj.(*infrav1.AzureMachine)
 	if !ok {
 		return nil, apierrors.NewBadRequest("expected an AzureMachine resource")
 	}
@@ -74,17 +74,17 @@ func (mw *AzureMachineWebhook) ValidateCreate(_ context.Context, obj runtime.Obj
 		return nil, nil
 	}
 
-	return nil, apierrors.NewInvalid(GroupVersion.WithKind(AzureMachineKind).GroupKind(), m.Name, allErrs)
+	return nil, apierrors.NewInvalid(infrav1.GroupVersion.WithKind(infrav1.AzureMachineKind).GroupKind(), m.Name, allErrs)
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
 func (mw *AzureMachineWebhook) ValidateUpdate(_ context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
 	var allErrs field.ErrorList
-	old, ok := oldObj.(*AzureMachine)
+	old, ok := oldObj.(*infrav1.AzureMachine)
 	if !ok {
 		return nil, apierrors.NewBadRequest("expected an AzureMachine resource")
 	}
-	m, ok := newObj.(*AzureMachine)
+	m, ok := newObj.(*infrav1.AzureMachine)
 	if !ok {
 		return nil, apierrors.NewBadRequest("expected an AzureMachine resource")
 	}
@@ -234,7 +234,7 @@ func (mw *AzureMachineWebhook) ValidateUpdate(_ context.Context, oldObj, newObj 
 	if len(allErrs) == 0 {
 		return nil, nil
 	}
-	return nil, apierrors.NewInvalid(GroupVersion.WithKind(AzureMachineKind).GroupKind(), m.Name, allErrs)
+	return nil, apierrors.NewInvalid(infrav1.GroupVersion.WithKind(infrav1.AzureMachineKind).GroupKind(), m.Name, allErrs)
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type.
@@ -244,7 +244,7 @@ func (mw *AzureMachineWebhook) ValidateDelete(_ context.Context, _ runtime.Objec
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type.
 func (mw *AzureMachineWebhook) Default(_ context.Context, obj runtime.Object) error {
-	m, ok := obj.(*AzureMachine)
+	m, ok := obj.(*infrav1.AzureMachine)
 	if !ok {
 		return apierrors.NewBadRequest("expected an AzureMachine resource")
 	}

--- a/internal/webhooks/azuremachine_webhook_test.go
+++ b/internal/webhooks/azuremachine_webhook_test.go
@@ -29,7 +29,7 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	. "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
+	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	apifixtures "sigs.k8s.io/cluster-api-provider-azure/internal/test/apifixtures"
 )
 
@@ -41,7 +41,7 @@ var (
 func TestAzureMachine_ValidateCreate(t *testing.T) {
 	tests := []struct {
 		name    string
-		machine *AzureMachine
+		machine *infrav1.AzureMachine
 		wantErr bool
 	}{
 		{
@@ -91,7 +91,7 @@ func TestAzureMachine_ValidateCreate(t *testing.T) {
 		},
 		{
 			name: "azuremachine with list of user-assigned identities",
-			machine: apifixtures.CreateMachineWithUserAssignedIdentities([]UserAssignedIdentity{
+			machine: apifixtures.CreateMachineWithUserAssignedIdentities([]infrav1.UserAssignedIdentity{
 				{ProviderID: "azure:///subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/my-resource-group/providers/Microsoft.Compute/virtualMachines/default-12345-control-plane-9d5x5"},
 				{ProviderID: "azure:///subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/my-resource-group/providers/Microsoft.Compute/virtualMachines/default-12345-control-plane-a1b2c"},
 			}),
@@ -99,7 +99,7 @@ func TestAzureMachine_ValidateCreate(t *testing.T) {
 		},
 		{
 			name: "azuremachine with list of user-assigned identities with wrong identity type",
-			machine: apifixtures.CreateMachineWithUserAssignedIdentitiesWithBadIdentity([]UserAssignedIdentity{
+			machine: apifixtures.CreateMachineWithUserAssignedIdentitiesWithBadIdentity([]infrav1.UserAssignedIdentity{
 				{ProviderID: "azure:///subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/my-resource-group/providers/Microsoft.Compute/virtualMachines/default-12345-control-plane-9d5x5"},
 				{ProviderID: "azure:///subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/my-resource-group/providers/Microsoft.Compute/virtualMachines/default-12345-control-plane-a1b2c"},
 			}),
@@ -107,7 +107,7 @@ func TestAzureMachine_ValidateCreate(t *testing.T) {
 		},
 		{
 			name:    "azuremachine with empty list of user-assigned identities",
-			machine: apifixtures.CreateMachineWithUserAssignedIdentities([]UserAssignedIdentity{}),
+			machine: apifixtures.CreateMachineWithUserAssignedIdentities([]infrav1.UserAssignedIdentity{}),
 			wantErr: true,
 		},
 		{
@@ -122,17 +122,17 @@ func TestAzureMachine_ValidateCreate(t *testing.T) {
 		},
 		{
 			name:    "azuremachinepool with managed diagnostics profile",
-			machine: createMachineWithDiagnostics(ManagedDiagnosticsStorage, nil),
+			machine: createMachineWithDiagnostics(infrav1.ManagedDiagnosticsStorage, nil),
 			wantErr: false,
 		},
 		{
 			name:    "azuremachine with disabled diagnostics profile",
-			machine: createMachineWithDiagnostics(ManagedDiagnosticsStorage, nil),
+			machine: createMachineWithDiagnostics(infrav1.ManagedDiagnosticsStorage, nil),
 			wantErr: false,
 		},
 		{
 			name:    "azuremachine with user managed diagnostics profile and defined user managed storage account",
-			machine: createMachineWithDiagnostics(UserManagedDiagnosticsStorage, &UserManagedBootDiagnostics{StorageAccountURI: "https://fakeurl"}),
+			machine: createMachineWithDiagnostics(infrav1.UserManagedDiagnosticsStorage, &infrav1.UserManagedBootDiagnostics{StorageAccountURI: "https://fakeurl"}),
 			wantErr: false,
 		},
 		{
@@ -142,22 +142,22 @@ func TestAzureMachine_ValidateCreate(t *testing.T) {
 		},
 		{
 			name:    "azuremachine with user managed diagnostics profile, but empty user managed storage account",
-			machine: createMachineWithDiagnostics(UserManagedDiagnosticsStorage, nil),
+			machine: createMachineWithDiagnostics(infrav1.UserManagedDiagnosticsStorage, nil),
 			wantErr: true,
 		},
 		{
 			name:    "azuremachine with invalid network configuration",
-			machine: createMachineWithNetworkConfig("subnet", nil, []NetworkInterface{{SubnetName: "subnet1"}}),
+			machine: createMachineWithNetworkConfig("subnet", nil, []infrav1.NetworkInterface{{SubnetName: "subnet1"}}),
 			wantErr: true,
 		},
 		{
 			name:    "azuremachine with valid legacy network configuration",
-			machine: createMachineWithNetworkConfig("subnet", nil, []NetworkInterface{}),
+			machine: createMachineWithNetworkConfig("subnet", nil, []infrav1.NetworkInterface{}),
 			wantErr: false,
 		},
 		{
 			name:    "azuremachine with valid network configuration",
-			machine: createMachineWithNetworkConfig("", nil, []NetworkInterface{{SubnetName: "subnet", PrivateIPConfigs: 1}}),
+			machine: createMachineWithNetworkConfig("", nil, []infrav1.NetworkInterface{{SubnetName: "subnet", PrivateIPConfigs: 1}}),
 			wantErr: false,
 		},
 		{
@@ -167,62 +167,62 @@ func TestAzureMachine_ValidateCreate(t *testing.T) {
 		},
 		{
 			name:    "azuremachine with confidential compute VMGuestStateOnly encryption and encryption at host enabled",
-			machine: createMachineWithConfidentialCompute(SecurityEncryptionTypeVMGuestStateOnly, SecurityTypesConfidentialVM, true, false, false),
+			machine: createMachineWithConfidentialCompute(infrav1.SecurityEncryptionTypeVMGuestStateOnly, infrav1.SecurityTypesConfidentialVM, true, false, false),
 			wantErr: true,
 		},
 		{
 			name:    "azuremachine with confidential compute DiskWithVMGuestState encryption and encryption at host enabled",
-			machine: createMachineWithConfidentialCompute(SecurityEncryptionTypeDiskWithVMGuestState, SecurityTypesConfidentialVM, true, true, true),
+			machine: createMachineWithConfidentialCompute(infrav1.SecurityEncryptionTypeDiskWithVMGuestState, infrav1.SecurityTypesConfidentialVM, true, true, true),
 			wantErr: true,
 		},
 		{
 			name:    "azuremachine with confidential compute VMGuestStateOnly encryption, vTPM and SecureBoot enabled",
-			machine: createMachineWithConfidentialCompute(SecurityEncryptionTypeVMGuestStateOnly, SecurityTypesConfidentialVM, false, true, true),
+			machine: createMachineWithConfidentialCompute(infrav1.SecurityEncryptionTypeVMGuestStateOnly, infrav1.SecurityTypesConfidentialVM, false, true, true),
 			wantErr: false,
 		},
 		{
 			name:    "azuremachine with confidential compute VMGuestStateOnly encryption enabled, vTPM enabled and SecureBoot disabled",
-			machine: createMachineWithConfidentialCompute(SecurityEncryptionTypeVMGuestStateOnly, SecurityTypesConfidentialVM, false, true, false),
+			machine: createMachineWithConfidentialCompute(infrav1.SecurityEncryptionTypeVMGuestStateOnly, infrav1.SecurityTypesConfidentialVM, false, true, false),
 			wantErr: false,
 		},
 		{
 			name:    "azuremachine with confidential compute VMGuestStateOnly encryption enabled, vTPM disabled and SecureBoot enabled",
-			machine: createMachineWithConfidentialCompute(SecurityEncryptionTypeVMGuestStateOnly, SecurityTypesConfidentialVM, false, false, true),
+			machine: createMachineWithConfidentialCompute(infrav1.SecurityEncryptionTypeVMGuestStateOnly, infrav1.SecurityTypesConfidentialVM, false, false, true),
 			wantErr: true,
 		},
 		{
 			name:    "azuremachine with confidential compute VMGuestStateOnly encryption enabled, vTPM enabled, SecureBoot disabled and SecurityType empty",
-			machine: createMachineWithConfidentialCompute(SecurityEncryptionTypeVMGuestStateOnly, "", false, true, false),
+			machine: createMachineWithConfidentialCompute(infrav1.SecurityEncryptionTypeVMGuestStateOnly, "", false, true, false),
 			wantErr: true,
 		},
 		{
 			name:    "azuremachine with confidential compute VMGuestStateOnly encryption enabled, vTPM and SecureBoot empty",
-			machine: createMachineWithConfidentialCompute(SecurityEncryptionTypeVMGuestStateOnly, SecurityTypesConfidentialVM, false, false, false),
+			machine: createMachineWithConfidentialCompute(infrav1.SecurityEncryptionTypeVMGuestStateOnly, infrav1.SecurityTypesConfidentialVM, false, false, false),
 			wantErr: true,
 		},
 		{
 			name:    "azuremachine with confidential compute DiskWithVMGuestState encryption, vTPM and SecureBoot enabled",
-			machine: createMachineWithConfidentialCompute(SecurityEncryptionTypeDiskWithVMGuestState, SecurityTypesConfidentialVM, false, true, true),
+			machine: createMachineWithConfidentialCompute(infrav1.SecurityEncryptionTypeDiskWithVMGuestState, infrav1.SecurityTypesConfidentialVM, false, true, true),
 			wantErr: false,
 		},
 		{
 			name:    "azuremachine with confidential compute DiskWithVMGuestState encryption enabled, vTPM enabled and SecureBoot disabled",
-			machine: createMachineWithConfidentialCompute(SecurityEncryptionTypeDiskWithVMGuestState, SecurityTypesConfidentialVM, false, true, false),
+			machine: createMachineWithConfidentialCompute(infrav1.SecurityEncryptionTypeDiskWithVMGuestState, infrav1.SecurityTypesConfidentialVM, false, true, false),
 			wantErr: true,
 		},
 		{
 			name:    "azuremachine with confidential compute DiskWithVMGuestState encryption enabled, vTPM disabled and SecureBoot enabled",
-			machine: createMachineWithConfidentialCompute(SecurityEncryptionTypeDiskWithVMGuestState, SecurityTypesConfidentialVM, false, false, true),
+			machine: createMachineWithConfidentialCompute(infrav1.SecurityEncryptionTypeDiskWithVMGuestState, infrav1.SecurityTypesConfidentialVM, false, false, true),
 			wantErr: true,
 		},
 		{
 			name:    "azuremachine with confidential compute DiskWithVMGuestState encryption enabled, vTPM disabled and SecureBoot disabled",
-			machine: createMachineWithConfidentialCompute(SecurityEncryptionTypeDiskWithVMGuestState, SecurityTypesConfidentialVM, false, false, false),
+			machine: createMachineWithConfidentialCompute(infrav1.SecurityEncryptionTypeDiskWithVMGuestState, infrav1.SecurityTypesConfidentialVM, false, false, false),
 			wantErr: true,
 		},
 		{
 			name:    "azuremachine with confidential compute DiskWithVMGuestState encryption enabled, vTPM enabled, SecureBoot disabled and SecurityType empty",
-			machine: createMachineWithConfidentialCompute(SecurityEncryptionTypeDiskWithVMGuestState, "", false, true, false),
+			machine: createMachineWithConfidentialCompute(infrav1.SecurityEncryptionTypeDiskWithVMGuestState, "", false, true, false),
 			wantErr: true,
 		},
 		{
@@ -268,22 +268,22 @@ func TestAzureMachine_ValidateCreate(t *testing.T) {
 func TestAzureMachine_ValidateUpdate(t *testing.T) {
 	tests := []struct {
 		name       string
-		oldMachine *AzureMachine
-		newMachine *AzureMachine
+		oldMachine *infrav1.AzureMachine
+		newMachine *infrav1.AzureMachine
 		wantErr    bool
 	}{
 		{
 			name: "invalidTest: azuremachine.spec.image is immutable",
-			oldMachine: &AzureMachine{
-				Spec: AzureMachineSpec{
-					Image: &Image{
+			oldMachine: &infrav1.AzureMachine{
+				Spec: infrav1.AzureMachineSpec{
+					Image: &infrav1.Image{
 						ID: ptr.To("imageID-1"),
 					},
 				},
 			},
-			newMachine: &AzureMachine{
-				Spec: AzureMachineSpec{
-					Image: &Image{
+			newMachine: &infrav1.AzureMachine{
+				Spec: infrav1.AzureMachineSpec{
+					Image: &infrav1.Image{
 						ID: ptr.To("imageID-2"),
 					},
 				},
@@ -292,16 +292,16 @@ func TestAzureMachine_ValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "validTest: azuremachine.spec.image is immutable",
-			oldMachine: &AzureMachine{
-				Spec: AzureMachineSpec{
-					Image: &Image{
+			oldMachine: &infrav1.AzureMachine{
+				Spec: infrav1.AzureMachineSpec{
+					Image: &infrav1.Image{
 						ID: ptr.To("imageID-1"),
 					},
 				},
 			},
-			newMachine: &AzureMachine{
-				Spec: AzureMachineSpec{
-					Image: &Image{
+			newMachine: &infrav1.AzureMachine{
+				Spec: infrav1.AzureMachineSpec{
+					Image: &infrav1.Image{
 						ID: ptr.To("imageID-1"),
 					},
 				},
@@ -310,44 +310,44 @@ func TestAzureMachine_ValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "invalidTest: azuremachine.spec.Identity is immutable",
-			oldMachine: &AzureMachine{
-				Spec: AzureMachineSpec{
-					Identity: VMIdentityUserAssigned,
+			oldMachine: &infrav1.AzureMachine{
+				Spec: infrav1.AzureMachineSpec{
+					Identity: infrav1.VMIdentityUserAssigned,
 				},
 			},
-			newMachine: &AzureMachine{
-				Spec: AzureMachineSpec{
-					Identity: VMIdentityNone,
+			newMachine: &infrav1.AzureMachine{
+				Spec: infrav1.AzureMachineSpec{
+					Identity: infrav1.VMIdentityNone,
 				},
 			},
 			wantErr: true,
 		},
 		{
 			name: "validTest: azuremachine.spec.Identity is immutable",
-			oldMachine: &AzureMachine{
-				Spec: AzureMachineSpec{
-					Identity: VMIdentityNone,
+			oldMachine: &infrav1.AzureMachine{
+				Spec: infrav1.AzureMachineSpec{
+					Identity: infrav1.VMIdentityNone,
 				},
 			},
-			newMachine: &AzureMachine{
-				Spec: AzureMachineSpec{
-					Identity: VMIdentityNone,
+			newMachine: &infrav1.AzureMachine{
+				Spec: infrav1.AzureMachineSpec{
+					Identity: infrav1.VMIdentityNone,
 				},
 			},
 			wantErr: false,
 		},
 		{
 			name: "invalidTest: azuremachine.spec.UserAssignedIdentities is immutable",
-			oldMachine: &AzureMachine{
-				Spec: AzureMachineSpec{
-					UserAssignedIdentities: []UserAssignedIdentity{
+			oldMachine: &infrav1.AzureMachine{
+				Spec: infrav1.AzureMachineSpec{
+					UserAssignedIdentities: []infrav1.UserAssignedIdentity{
 						{ProviderID: "providerID-1"},
 					},
 				},
 			},
-			newMachine: &AzureMachine{
-				Spec: AzureMachineSpec{
-					UserAssignedIdentities: []UserAssignedIdentity{
+			newMachine: &infrav1.AzureMachine{
+				Spec: infrav1.AzureMachineSpec{
+					UserAssignedIdentities: []infrav1.UserAssignedIdentity{
 						{ProviderID: "providerID-2"},
 					},
 				},
@@ -356,16 +356,16 @@ func TestAzureMachine_ValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "validTest: azuremachine.spec.UserAssignedIdentities is immutable",
-			oldMachine: &AzureMachine{
-				Spec: AzureMachineSpec{
-					UserAssignedIdentities: []UserAssignedIdentity{
+			oldMachine: &infrav1.AzureMachine{
+				Spec: infrav1.AzureMachineSpec{
+					UserAssignedIdentities: []infrav1.UserAssignedIdentity{
 						{ProviderID: "providerID-1"},
 					},
 				},
 			},
-			newMachine: &AzureMachine{
-				Spec: AzureMachineSpec{
-					UserAssignedIdentities: []UserAssignedIdentity{
+			newMachine: &infrav1.AzureMachine{
+				Spec: infrav1.AzureMachineSpec{
+					UserAssignedIdentities: []infrav1.UserAssignedIdentity{
 						{ProviderID: "providerID-1"},
 					},
 				},
@@ -374,13 +374,13 @@ func TestAzureMachine_ValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "invalidTest: azuremachine.spec.RoleAssignmentName is immutable",
-			oldMachine: &AzureMachine{
-				Spec: AzureMachineSpec{
+			oldMachine: &infrav1.AzureMachine{
+				Spec: infrav1.AzureMachineSpec{
 					RoleAssignmentName: "role",
 				},
 			},
-			newMachine: &AzureMachine{
-				Spec: AzureMachineSpec{
+			newMachine: &infrav1.AzureMachine{
+				Spec: infrav1.AzureMachineSpec{
 					RoleAssignmentName: "not-role",
 				},
 			},
@@ -388,13 +388,13 @@ func TestAzureMachine_ValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "validTest: azuremachine.spec.RoleAssignmentName is immutable",
-			oldMachine: &AzureMachine{
-				Spec: AzureMachineSpec{
+			oldMachine: &infrav1.AzureMachine{
+				Spec: infrav1.AzureMachineSpec{
 					RoleAssignmentName: "role",
 				},
 			},
-			newMachine: &AzureMachine{
-				Spec: AzureMachineSpec{
+			newMachine: &infrav1.AzureMachine{
+				Spec: infrav1.AzureMachineSpec{
 					RoleAssignmentName: "role",
 				},
 			},
@@ -402,18 +402,18 @@ func TestAzureMachine_ValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "invalidTest: azuremachine.spec.RoleAssignmentName is immutable",
-			oldMachine: &AzureMachine{
-				Spec: AzureMachineSpec{
-					SystemAssignedIdentityRole: &SystemAssignedIdentityRole{
+			oldMachine: &infrav1.AzureMachine{
+				Spec: infrav1.AzureMachineSpec{
+					SystemAssignedIdentityRole: &infrav1.SystemAssignedIdentityRole{
 						Name:         "role",
 						Scope:        "scope",
 						DefinitionID: "definitionID",
 					},
 				},
 			},
-			newMachine: &AzureMachine{
-				Spec: AzureMachineSpec{
-					SystemAssignedIdentityRole: &SystemAssignedIdentityRole{
+			newMachine: &infrav1.AzureMachine{
+				Spec: infrav1.AzureMachineSpec{
+					SystemAssignedIdentityRole: &infrav1.SystemAssignedIdentityRole{
 						Name:         "not-role",
 						Scope:        "scope",
 						DefinitionID: "definitionID",
@@ -424,18 +424,18 @@ func TestAzureMachine_ValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "validTest: azuremachine.spec.SystemAssignedIdentityRole is immutable",
-			oldMachine: &AzureMachine{
-				Spec: AzureMachineSpec{
-					SystemAssignedIdentityRole: &SystemAssignedIdentityRole{
+			oldMachine: &infrav1.AzureMachine{
+				Spec: infrav1.AzureMachineSpec{
+					SystemAssignedIdentityRole: &infrav1.SystemAssignedIdentityRole{
 						Name:         "role",
 						Scope:        "scope",
 						DefinitionID: "definitionID",
 					},
 				},
 			},
-			newMachine: &AzureMachine{
-				Spec: AzureMachineSpec{
-					SystemAssignedIdentityRole: &SystemAssignedIdentityRole{
+			newMachine: &infrav1.AzureMachine{
+				Spec: infrav1.AzureMachineSpec{
+					SystemAssignedIdentityRole: &infrav1.SystemAssignedIdentityRole{
 						Name:         "role",
 						Scope:        "scope",
 						DefinitionID: "definitionID",
@@ -446,16 +446,16 @@ func TestAzureMachine_ValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "invalidTest: azuremachine.spec.OSDisk is immutable",
-			oldMachine: &AzureMachine{
-				Spec: AzureMachineSpec{
-					OSDisk: OSDisk{
+			oldMachine: &infrav1.AzureMachine{
+				Spec: infrav1.AzureMachineSpec{
+					OSDisk: infrav1.OSDisk{
 						OSType: "osType-0",
 					},
 				},
 			},
-			newMachine: &AzureMachine{
-				Spec: AzureMachineSpec{
-					OSDisk: OSDisk{
+			newMachine: &infrav1.AzureMachine{
+				Spec: infrav1.AzureMachineSpec{
+					OSDisk: infrav1.OSDisk{
 						OSType: "osType-1",
 					},
 				},
@@ -464,16 +464,16 @@ func TestAzureMachine_ValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "validTest: azuremachine.spec.OSDisk is immutable",
-			oldMachine: &AzureMachine{
-				Spec: AzureMachineSpec{
-					OSDisk: OSDisk{
+			oldMachine: &infrav1.AzureMachine{
+				Spec: infrav1.AzureMachineSpec{
+					OSDisk: infrav1.OSDisk{
 						OSType: "osType-1",
 					},
 				},
 			},
-			newMachine: &AzureMachine{
-				Spec: AzureMachineSpec{
-					OSDisk: OSDisk{
+			newMachine: &infrav1.AzureMachine{
+				Spec: infrav1.AzureMachineSpec{
+					OSDisk: infrav1.OSDisk{
 						OSType: "osType-1",
 					},
 				},
@@ -482,18 +482,18 @@ func TestAzureMachine_ValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "invalidTest: azuremachine.spec.DataDisks is immutable",
-			oldMachine: &AzureMachine{
-				Spec: AzureMachineSpec{
-					DataDisks: []DataDisk{
+			oldMachine: &infrav1.AzureMachine{
+				Spec: infrav1.AzureMachineSpec{
+					DataDisks: []infrav1.DataDisk{
 						{
 							DiskSizeGB: 128,
 						},
 					},
 				},
 			},
-			newMachine: &AzureMachine{
-				Spec: AzureMachineSpec{
-					DataDisks: []DataDisk{
+			newMachine: &infrav1.AzureMachine{
+				Spec: infrav1.AzureMachineSpec{
+					DataDisks: []infrav1.DataDisk{
 						{
 							DiskSizeGB: 64,
 						},
@@ -504,18 +504,18 @@ func TestAzureMachine_ValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "validTest: azuremachine.spec.DataDisks is immutable",
-			oldMachine: &AzureMachine{
-				Spec: AzureMachineSpec{
-					DataDisks: []DataDisk{
+			oldMachine: &infrav1.AzureMachine{
+				Spec: infrav1.AzureMachineSpec{
+					DataDisks: []infrav1.DataDisk{
 						{
 							DiskSizeGB: 128,
 						},
 					},
 				},
 			},
-			newMachine: &AzureMachine{
-				Spec: AzureMachineSpec{
-					DataDisks: []DataDisk{
+			newMachine: &infrav1.AzureMachine{
+				Spec: infrav1.AzureMachineSpec{
+					DataDisks: []infrav1.DataDisk{
 						{
 							DiskSizeGB: 128,
 						},
@@ -526,13 +526,13 @@ func TestAzureMachine_ValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "invalidTest: azuremachine.spec.SSHPublicKey is immutable",
-			oldMachine: &AzureMachine{
-				Spec: AzureMachineSpec{
+			oldMachine: &infrav1.AzureMachine{
+				Spec: infrav1.AzureMachineSpec{
 					SSHPublicKey: "validKey",
 				},
 			},
-			newMachine: &AzureMachine{
-				Spec: AzureMachineSpec{
+			newMachine: &infrav1.AzureMachine{
+				Spec: infrav1.AzureMachineSpec{
 					SSHPublicKey: "invalidKey",
 				},
 			},
@@ -540,13 +540,13 @@ func TestAzureMachine_ValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "validTest: azuremachine.spec.SSHPublicKey is immutable",
-			oldMachine: &AzureMachine{
-				Spec: AzureMachineSpec{
+			oldMachine: &infrav1.AzureMachine{
+				Spec: infrav1.AzureMachineSpec{
 					SSHPublicKey: "validKey",
 				},
 			},
-			newMachine: &AzureMachine{
-				Spec: AzureMachineSpec{
+			newMachine: &infrav1.AzureMachine{
+				Spec: infrav1.AzureMachineSpec{
 					SSHPublicKey: "validKey",
 				},
 			},
@@ -554,13 +554,13 @@ func TestAzureMachine_ValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "invalidTest: azuremachine.spec.AllocatePublicIP is immutable",
-			oldMachine: &AzureMachine{
-				Spec: AzureMachineSpec{
+			oldMachine: &infrav1.AzureMachine{
+				Spec: infrav1.AzureMachineSpec{
 					AllocatePublicIP: true,
 				},
 			},
-			newMachine: &AzureMachine{
-				Spec: AzureMachineSpec{
+			newMachine: &infrav1.AzureMachine{
+				Spec: infrav1.AzureMachineSpec{
 					AllocatePublicIP: false,
 				},
 			},
@@ -568,13 +568,13 @@ func TestAzureMachine_ValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "validTest: azuremachine.spec.AllocatePublicIP is immutable",
-			oldMachine: &AzureMachine{
-				Spec: AzureMachineSpec{
+			oldMachine: &infrav1.AzureMachine{
+				Spec: infrav1.AzureMachineSpec{
 					AllocatePublicIP: true,
 				},
 			},
-			newMachine: &AzureMachine{
-				Spec: AzureMachineSpec{
+			newMachine: &infrav1.AzureMachine{
+				Spec: infrav1.AzureMachineSpec{
 					AllocatePublicIP: true,
 				},
 			},
@@ -582,13 +582,13 @@ func TestAzureMachine_ValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "invalidTest: azuremachine.spec.EnableIPForwarding is immutable",
-			oldMachine: &AzureMachine{
-				Spec: AzureMachineSpec{
+			oldMachine: &infrav1.AzureMachine{
+				Spec: infrav1.AzureMachineSpec{
 					EnableIPForwarding: true,
 				},
 			},
-			newMachine: &AzureMachine{
-				Spec: AzureMachineSpec{
+			newMachine: &infrav1.AzureMachine{
+				Spec: infrav1.AzureMachineSpec{
 					EnableIPForwarding: false,
 				},
 			},
@@ -596,13 +596,13 @@ func TestAzureMachine_ValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "validTest: azuremachine.spec.EnableIPForwarding is immutable",
-			oldMachine: &AzureMachine{
-				Spec: AzureMachineSpec{
+			oldMachine: &infrav1.AzureMachine{
+				Spec: infrav1.AzureMachineSpec{
 					EnableIPForwarding: true,
 				},
 			},
-			newMachine: &AzureMachine{
-				Spec: AzureMachineSpec{
+			newMachine: &infrav1.AzureMachine{
+				Spec: infrav1.AzureMachineSpec{
 					EnableIPForwarding: true,
 				},
 			},
@@ -610,13 +610,13 @@ func TestAzureMachine_ValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "invalidTest: azuremachine.spec.AcceleratedNetworking is immutable",
-			oldMachine: &AzureMachine{
-				Spec: AzureMachineSpec{
+			oldMachine: &infrav1.AzureMachine{
+				Spec: infrav1.AzureMachineSpec{
 					AcceleratedNetworking: ptr.To(true),
 				},
 			},
-			newMachine: &AzureMachine{
-				Spec: AzureMachineSpec{
+			newMachine: &infrav1.AzureMachine{
+				Spec: infrav1.AzureMachineSpec{
 					AcceleratedNetworking: ptr.To(false),
 				},
 			},
@@ -624,13 +624,13 @@ func TestAzureMachine_ValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "validTest: azuremachine.spec.AcceleratedNetworking is immutable",
-			oldMachine: &AzureMachine{
-				Spec: AzureMachineSpec{
+			oldMachine: &infrav1.AzureMachine{
+				Spec: infrav1.AzureMachineSpec{
 					AcceleratedNetworking: ptr.To(true),
 				},
 			},
-			newMachine: &AzureMachine{
-				Spec: AzureMachineSpec{
+			newMachine: &infrav1.AzureMachine{
+				Spec: infrav1.AzureMachineSpec{
 					AcceleratedNetworking: ptr.To(true),
 				},
 			},
@@ -638,13 +638,13 @@ func TestAzureMachine_ValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "validTest: azuremachine.spec.AcceleratedNetworking transition(from true) to nil is acceptable",
-			oldMachine: &AzureMachine{
-				Spec: AzureMachineSpec{
+			oldMachine: &infrav1.AzureMachine{
+				Spec: infrav1.AzureMachineSpec{
 					AcceleratedNetworking: ptr.To(true),
 				},
 			},
-			newMachine: &AzureMachine{
-				Spec: AzureMachineSpec{
+			newMachine: &infrav1.AzureMachine{
+				Spec: infrav1.AzureMachineSpec{
 					AcceleratedNetworking: nil,
 				},
 			},
@@ -652,13 +652,13 @@ func TestAzureMachine_ValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "validTest: azuremachine.spec.AcceleratedNetworking transition(from false) to nil is acceptable",
-			oldMachine: &AzureMachine{
-				Spec: AzureMachineSpec{
+			oldMachine: &infrav1.AzureMachine{
+				Spec: infrav1.AzureMachineSpec{
 					AcceleratedNetworking: ptr.To(false),
 				},
 			},
-			newMachine: &AzureMachine{
-				Spec: AzureMachineSpec{
+			newMachine: &infrav1.AzureMachine{
+				Spec: infrav1.AzureMachineSpec{
 					AcceleratedNetworking: nil,
 				},
 			},
@@ -666,16 +666,16 @@ func TestAzureMachine_ValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "invalidTest: azuremachine.spec.SpotVMOptions is immutable",
-			oldMachine: &AzureMachine{
-				Spec: AzureMachineSpec{
-					SpotVMOptions: &SpotVMOptions{
+			oldMachine: &infrav1.AzureMachine{
+				Spec: infrav1.AzureMachineSpec{
+					SpotVMOptions: &infrav1.SpotVMOptions{
 						MaxPrice: &resource.Quantity{Format: "vmoptions-0"},
 					},
 				},
 			},
-			newMachine: &AzureMachine{
-				Spec: AzureMachineSpec{
-					SpotVMOptions: &SpotVMOptions{
+			newMachine: &infrav1.AzureMachine{
+				Spec: infrav1.AzureMachineSpec{
+					SpotVMOptions: &infrav1.SpotVMOptions{
 						MaxPrice: &resource.Quantity{Format: "vmoptions-1"},
 					},
 				},
@@ -684,16 +684,16 @@ func TestAzureMachine_ValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "validTest: azuremachine.spec.SpotVMOptions is immutable",
-			oldMachine: &AzureMachine{
-				Spec: AzureMachineSpec{
-					SpotVMOptions: &SpotVMOptions{
+			oldMachine: &infrav1.AzureMachine{
+				Spec: infrav1.AzureMachineSpec{
+					SpotVMOptions: &infrav1.SpotVMOptions{
 						MaxPrice: &resource.Quantity{Format: "vmoptions-1"},
 					},
 				},
 			},
-			newMachine: &AzureMachine{
-				Spec: AzureMachineSpec{
-					SpotVMOptions: &SpotVMOptions{
+			newMachine: &infrav1.AzureMachine{
+				Spec: infrav1.AzureMachineSpec{
+					SpotVMOptions: &infrav1.SpotVMOptions{
 						MaxPrice: &resource.Quantity{Format: "vmoptions-1"},
 					},
 				},
@@ -702,111 +702,111 @@ func TestAzureMachine_ValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "invalidTest: azuremachine.spec.SecurityProfile is immutable",
-			oldMachine: &AzureMachine{
-				Spec: AzureMachineSpec{
-					SecurityProfile: &SecurityProfile{EncryptionAtHost: ptr.To(true)},
+			oldMachine: &infrav1.AzureMachine{
+				Spec: infrav1.AzureMachineSpec{
+					SecurityProfile: &infrav1.SecurityProfile{EncryptionAtHost: ptr.To(true)},
 				},
 			},
-			newMachine: &AzureMachine{
-				Spec: AzureMachineSpec{
-					SecurityProfile: &SecurityProfile{EncryptionAtHost: ptr.To(false)},
+			newMachine: &infrav1.AzureMachine{
+				Spec: infrav1.AzureMachineSpec{
+					SecurityProfile: &infrav1.SecurityProfile{EncryptionAtHost: ptr.To(false)},
 				},
 			},
 			wantErr: true,
 		},
 		{
 			name: "validTest: azuremachine.spec.SecurityProfile is immutable",
-			oldMachine: &AzureMachine{
-				Spec: AzureMachineSpec{
-					SecurityProfile: &SecurityProfile{EncryptionAtHost: ptr.To(true)},
+			oldMachine: &infrav1.AzureMachine{
+				Spec: infrav1.AzureMachineSpec{
+					SecurityProfile: &infrav1.SecurityProfile{EncryptionAtHost: ptr.To(true)},
 				},
 			},
-			newMachine: &AzureMachine{
-				Spec: AzureMachineSpec{
-					SecurityProfile: &SecurityProfile{EncryptionAtHost: ptr.To(true)},
+			newMachine: &infrav1.AzureMachine{
+				Spec: infrav1.AzureMachineSpec{
+					SecurityProfile: &infrav1.SecurityProfile{EncryptionAtHost: ptr.To(true)},
 				},
 			},
 			wantErr: false,
 		},
 		{
 			name: "invalidTest: azuremachine.spec.Diagnostics is immutable",
-			oldMachine: &AzureMachine{
-				Spec: AzureMachineSpec{
-					Diagnostics: &Diagnostics{Boot: &BootDiagnostics{StorageAccountType: DisabledDiagnosticsStorage}},
+			oldMachine: &infrav1.AzureMachine{
+				Spec: infrav1.AzureMachineSpec{
+					Diagnostics: &infrav1.Diagnostics{Boot: &infrav1.BootDiagnostics{StorageAccountType: infrav1.DisabledDiagnosticsStorage}},
 				},
 			},
-			newMachine: &AzureMachine{
-				Spec: AzureMachineSpec{
-					Diagnostics: &Diagnostics{Boot: &BootDiagnostics{StorageAccountType: ManagedDiagnosticsStorage}},
+			newMachine: &infrav1.AzureMachine{
+				Spec: infrav1.AzureMachineSpec{
+					Diagnostics: &infrav1.Diagnostics{Boot: &infrav1.BootDiagnostics{StorageAccountType: infrav1.ManagedDiagnosticsStorage}},
 				},
 			},
 			wantErr: true,
 		},
 		{
 			name: "validTest: azuremachine.spec.Diagnostics is immutable",
-			oldMachine: &AzureMachine{
-				Spec: AzureMachineSpec{
-					Diagnostics: &Diagnostics{Boot: &BootDiagnostics{StorageAccountType: DisabledDiagnosticsStorage}},
+			oldMachine: &infrav1.AzureMachine{
+				Spec: infrav1.AzureMachineSpec{
+					Diagnostics: &infrav1.Diagnostics{Boot: &infrav1.BootDiagnostics{StorageAccountType: infrav1.DisabledDiagnosticsStorage}},
 				},
 			},
-			newMachine: &AzureMachine{
-				Spec: AzureMachineSpec{
-					Diagnostics: &Diagnostics{Boot: &BootDiagnostics{StorageAccountType: DisabledDiagnosticsStorage}},
+			newMachine: &infrav1.AzureMachine{
+				Spec: infrav1.AzureMachineSpec{
+					Diagnostics: &infrav1.Diagnostics{Boot: &infrav1.BootDiagnostics{StorageAccountType: infrav1.DisabledDiagnosticsStorage}},
 				},
 			},
 			wantErr: false,
 		},
 		{
 			name: "validTest: azuremachine.spec.Diagnostics should not error on updating nil diagnostics",
-			oldMachine: &AzureMachine{
-				Spec: AzureMachineSpec{},
+			oldMachine: &infrav1.AzureMachine{
+				Spec: infrav1.AzureMachineSpec{},
 			},
-			newMachine: &AzureMachine{
-				Spec: AzureMachineSpec{
-					Diagnostics: &Diagnostics{Boot: &BootDiagnostics{StorageAccountType: ManagedDiagnosticsStorage}},
+			newMachine: &infrav1.AzureMachine{
+				Spec: infrav1.AzureMachineSpec{
+					Diagnostics: &infrav1.Diagnostics{Boot: &infrav1.BootDiagnostics{StorageAccountType: infrav1.ManagedDiagnosticsStorage}},
 				},
 			},
 			wantErr: false,
 		},
 		{
 			name: "invalidTest: azuremachine.spec.Diagnostics is immutable",
-			oldMachine: &AzureMachine{
-				Spec: AzureMachineSpec{
-					Diagnostics: &Diagnostics{},
+			oldMachine: &infrav1.AzureMachine{
+				Spec: infrav1.AzureMachineSpec{
+					Diagnostics: &infrav1.Diagnostics{},
 				},
 			},
-			newMachine: &AzureMachine{
-				Spec: AzureMachineSpec{
-					Diagnostics: &Diagnostics{Boot: &BootDiagnostics{StorageAccountType: ManagedDiagnosticsStorage}},
+			newMachine: &infrav1.AzureMachine{
+				Spec: infrav1.AzureMachineSpec{
+					Diagnostics: &infrav1.Diagnostics{Boot: &infrav1.BootDiagnostics{StorageAccountType: infrav1.ManagedDiagnosticsStorage}},
 				},
 			},
 			wantErr: true,
 		},
 		{
 			name: "invalidTest: azuremachine.spec.Diagnostics is immutable",
-			oldMachine: &AzureMachine{
-				Spec: AzureMachineSpec{
-					Diagnostics: &Diagnostics{
-						Boot: &BootDiagnostics{},
+			oldMachine: &infrav1.AzureMachine{
+				Spec: infrav1.AzureMachineSpec{
+					Diagnostics: &infrav1.Diagnostics{
+						Boot: &infrav1.BootDiagnostics{},
 					},
 				},
 			},
-			newMachine: &AzureMachine{
-				Spec: AzureMachineSpec{
-					Diagnostics: &Diagnostics{Boot: &BootDiagnostics{StorageAccountType: ManagedDiagnosticsStorage}},
+			newMachine: &infrav1.AzureMachine{
+				Spec: infrav1.AzureMachineSpec{
+					Diagnostics: &infrav1.Diagnostics{Boot: &infrav1.BootDiagnostics{StorageAccountType: infrav1.ManagedDiagnosticsStorage}},
 				},
 			},
 			wantErr: true,
 		},
 		{
 			name: "invalidTest: azuremachine.spec.disableExtensionOperations is immutable",
-			oldMachine: &AzureMachine{
-				Spec: AzureMachineSpec{
+			oldMachine: &infrav1.AzureMachine{
+				Spec: infrav1.AzureMachineSpec{
 					DisableExtensionOperations: ptr.To(true),
 				},
 			},
-			newMachine: &AzureMachine{
-				Spec: AzureMachineSpec{
+			newMachine: &infrav1.AzureMachine{
+				Spec: infrav1.AzureMachineSpec{
 					DisableExtensionOperations: ptr.To(false),
 				},
 			},
@@ -814,13 +814,13 @@ func TestAzureMachine_ValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "validTest: azuremachine.spec.disableExtensionOperations is immutable",
-			oldMachine: &AzureMachine{
-				Spec: AzureMachineSpec{
+			oldMachine: &infrav1.AzureMachine{
+				Spec: infrav1.AzureMachineSpec{
 					DisableExtensionOperations: ptr.To(true),
 				},
 			},
-			newMachine: &AzureMachine{
-				Spec: AzureMachineSpec{
+			newMachine: &infrav1.AzureMachine{
+				Spec: infrav1.AzureMachineSpec{
 					DisableExtensionOperations: ptr.To(true),
 				},
 			},
@@ -828,55 +828,55 @@ func TestAzureMachine_ValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "validTest: azuremachine.spec.networkInterfaces is immutable",
-			oldMachine: &AzureMachine{
-				Spec: AzureMachineSpec{
-					NetworkInterfaces: []NetworkInterface{{SubnetName: "subnet"}},
+			oldMachine: &infrav1.AzureMachine{
+				Spec: infrav1.AzureMachineSpec{
+					NetworkInterfaces: []infrav1.NetworkInterface{{SubnetName: "subnet"}},
 				},
 			},
-			newMachine: &AzureMachine{
-				Spec: AzureMachineSpec{
-					NetworkInterfaces: []NetworkInterface{{SubnetName: "subnet"}},
+			newMachine: &infrav1.AzureMachine{
+				Spec: infrav1.AzureMachineSpec{
+					NetworkInterfaces: []infrav1.NetworkInterface{{SubnetName: "subnet"}},
 				},
 			},
 			wantErr: false,
 		},
 		{
 			name: "invalidtest: azuremachine.spec.networkInterfaces is immutable",
-			oldMachine: &AzureMachine{
-				Spec: AzureMachineSpec{
-					NetworkInterfaces: []NetworkInterface{{SubnetName: "subnet1"}},
+			oldMachine: &infrav1.AzureMachine{
+				Spec: infrav1.AzureMachineSpec{
+					NetworkInterfaces: []infrav1.NetworkInterface{{SubnetName: "subnet1"}},
 				},
 			},
-			newMachine: &AzureMachine{
-				Spec: AzureMachineSpec{
-					NetworkInterfaces: []NetworkInterface{{SubnetName: "subnet2"}},
+			newMachine: &infrav1.AzureMachine{
+				Spec: infrav1.AzureMachineSpec{
+					NetworkInterfaces: []infrav1.NetworkInterface{{SubnetName: "subnet2"}},
 				},
 			},
 			wantErr: true,
 		},
 		{
 			name: "invalidtest: updating subnet name from empty to non empty",
-			oldMachine: &AzureMachine{
-				Spec: AzureMachineSpec{
-					NetworkInterfaces: []NetworkInterface{{SubnetName: ""}},
+			oldMachine: &infrav1.AzureMachine{
+				Spec: infrav1.AzureMachineSpec{
+					NetworkInterfaces: []infrav1.NetworkInterface{{SubnetName: ""}},
 				},
 			},
-			newMachine: &AzureMachine{
-				Spec: AzureMachineSpec{
-					NetworkInterfaces: []NetworkInterface{{SubnetName: "subnet1"}},
+			newMachine: &infrav1.AzureMachine{
+				Spec: infrav1.AzureMachineSpec{
+					NetworkInterfaces: []infrav1.NetworkInterface{{SubnetName: "subnet1"}},
 				},
 			},
 			wantErr: true,
 		},
 		{
 			name: "invalidTest: azuremachine.spec.capacityReservationGroupID is immutable",
-			oldMachine: &AzureMachine{
-				Spec: AzureMachineSpec{
+			oldMachine: &infrav1.AzureMachine{
+				Spec: infrav1.AzureMachineSpec{
 					CapacityReservationGroupID: ptr.To("capacityReservationGroupID-1"),
 				},
 			},
-			newMachine: &AzureMachine{
-				Spec: AzureMachineSpec{
+			newMachine: &infrav1.AzureMachine{
+				Spec: infrav1.AzureMachineSpec{
 					CapacityReservationGroupID: ptr.To("capacityReservationGroupID-2"),
 				},
 			},
@@ -884,13 +884,13 @@ func TestAzureMachine_ValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "invalidTest: updating azuremachine.spec.capacityReservationGroupID from empty to non-empty",
-			oldMachine: &AzureMachine{
-				Spec: AzureMachineSpec{
+			oldMachine: &infrav1.AzureMachine{
+				Spec: infrav1.AzureMachineSpec{
 					CapacityReservationGroupID: nil,
 				},
 			},
-			newMachine: &AzureMachine{
-				Spec: AzureMachineSpec{
+			newMachine: &infrav1.AzureMachine{
+				Spec: infrav1.AzureMachineSpec{
 					CapacityReservationGroupID: ptr.To("capacityReservationGroupID-1"),
 				},
 			},
@@ -898,13 +898,13 @@ func TestAzureMachine_ValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "invalidTest: updating azuremachine.spec.capacityReservationGroupID from non-empty to empty",
-			oldMachine: &AzureMachine{
-				Spec: AzureMachineSpec{
+			oldMachine: &infrav1.AzureMachine{
+				Spec: infrav1.AzureMachineSpec{
 					CapacityReservationGroupID: ptr.To("capacityReservationGroupID-1"),
 				},
 			},
-			newMachine: &AzureMachine{
-				Spec: AzureMachineSpec{
+			newMachine: &infrav1.AzureMachine{
+				Spec: infrav1.AzureMachineSpec{
 					CapacityReservationGroupID: nil,
 				},
 			},
@@ -912,13 +912,13 @@ func TestAzureMachine_ValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "validTest: azuremachine.spec.capacityReservationGroupID is immutable",
-			oldMachine: &AzureMachine{
-				Spec: AzureMachineSpec{
+			oldMachine: &infrav1.AzureMachine{
+				Spec: infrav1.AzureMachineSpec{
 					CapacityReservationGroupID: ptr.To("capacityReservationGroupID-1"),
 				},
 			},
-			newMachine: &AzureMachine{
-				Spec: AzureMachineSpec{
+			newMachine: &infrav1.AzureMachine{
+				Spec: infrav1.AzureMachineSpec{
 					CapacityReservationGroupID: ptr.To("capacityReservationGroupID-1"),
 				},
 			},
@@ -947,11 +947,11 @@ type mockDefaultClient struct {
 
 func (m mockDefaultClient) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
 	switch obj := obj.(type) {
-	case *AzureCluster:
+	case *infrav1.AzureCluster:
 		obj.Spec.SubscriptionID = m.SubscriptionID
 	case *clusterv1.Cluster:
 		obj.Spec.InfrastructureRef = clusterv1.ContractVersionedObjectReference{
-			Kind: AzureClusterKind,
+			Kind: infrav1.AzureClusterKind,
 			Name: "test-cluster",
 		}
 	default:
@@ -964,7 +964,7 @@ func TestAzureMachine_Default(t *testing.T) {
 	g := NewWithT(t)
 
 	type test struct {
-		machine *AzureMachine
+		machine *infrav1.AzureMachine
 	}
 
 	testSubscriptionID := "test-subscription-id"
@@ -991,16 +991,16 @@ func TestAzureMachine_Default(t *testing.T) {
 	g.Expect(publicKeyNotExistTest.machine.Spec.SSHPublicKey).To(Not(BeEmpty()))
 
 	for _, possibleCachingType := range armcompute.PossibleCachingTypesValues() {
-		cacheTypeSpecifiedTest := test{machine: &AzureMachine{ObjectMeta: testObjectMeta, Spec: AzureMachineSpec{OSDisk: OSDisk{CachingType: string(possibleCachingType)}}}}
+		cacheTypeSpecifiedTest := test{machine: &infrav1.AzureMachine{ObjectMeta: testObjectMeta, Spec: infrav1.AzureMachineSpec{OSDisk: infrav1.OSDisk{CachingType: string(possibleCachingType)}}}}
 		err = mw.Default(t.Context(), cacheTypeSpecifiedTest.machine)
 		g.Expect(err).NotTo(HaveOccurred())
 		g.Expect(cacheTypeSpecifiedTest.machine.Spec.OSDisk.CachingType).To(Equal(string(possibleCachingType)))
 	}
 }
 
-func createMachineWithNetworkConfig(subnetName string, acceleratedNetworking *bool, interfaces []NetworkInterface) *AzureMachine {
-	return &AzureMachine{
-		Spec: AzureMachineSpec{
+func createMachineWithNetworkConfig(subnetName string, acceleratedNetworking *bool, interfaces []infrav1.NetworkInterface) *infrav1.AzureMachine {
+	return &infrav1.AzureMachine{
+		Spec: infrav1.AzureMachineSpec{
 			SubnetName:            subnetName,
 			NetworkInterfaces:     interfaces,
 			AcceleratedNetworking: acceleratedNetworking,
@@ -1010,9 +1010,9 @@ func createMachineWithNetworkConfig(subnetName string, acceleratedNetworking *bo
 	}
 }
 
-func createMachineWithSharedImage(subscriptionID, resourceGroup, name, gallery, version string) *AzureMachine {
-	image := &Image{
-		SharedGallery: &AzureSharedGalleryImage{
+func createMachineWithSharedImage(subscriptionID, resourceGroup, name, gallery, version string) *infrav1.AzureMachine {
+	image := &infrav1.Image{
+		SharedGallery: &infrav1.AzureSharedGalleryImage{
 			SubscriptionID: subscriptionID,
 			ResourceGroup:  resourceGroup,
 			Name:           name,
@@ -1021,8 +1021,8 @@ func createMachineWithSharedImage(subscriptionID, resourceGroup, name, gallery, 
 		},
 	}
 
-	return &AzureMachine{
-		Spec: AzureMachineSpec{
+	return &infrav1.AzureMachine{
+		Spec: infrav1.AzureMachineSpec{
 			Image:        image,
 			SSHPublicKey: validSSHPublicKey,
 			OSDisk:       validOSDisk,
@@ -1030,10 +1030,10 @@ func createMachineWithSharedImage(subscriptionID, resourceGroup, name, gallery, 
 	}
 }
 
-func createMachineWithMarketPlaceImage(publisher, offer, sku, version string) *AzureMachine {
-	image := &Image{
-		Marketplace: &AzureMarketplaceImage{
-			ImagePlan: ImagePlan{
+func createMachineWithMarketPlaceImage(publisher, offer, sku, version string) *infrav1.AzureMachine {
+	image := &infrav1.Image{
+		Marketplace: &infrav1.AzureMarketplaceImage{
+			ImagePlan: infrav1.ImagePlan{
 				Publisher: publisher,
 				Offer:     offer,
 				SKU:       sku,
@@ -1042,8 +1042,8 @@ func createMachineWithMarketPlaceImage(publisher, offer, sku, version string) *A
 		},
 	}
 
-	return &AzureMachine{
-		Spec: AzureMachineSpec{
+	return &infrav1.AzureMachine{
+		Spec: infrav1.AzureMachineSpec{
 			Image:        image,
 			SSHPublicKey: validSSHPublicKey,
 			OSDisk:       validOSDisk,
@@ -1051,13 +1051,13 @@ func createMachineWithMarketPlaceImage(publisher, offer, sku, version string) *A
 	}
 }
 
-func createMachineWithImageByID(imageID string) *AzureMachine {
-	image := &Image{
+func createMachineWithImageByID(imageID string) *infrav1.AzureMachine {
+	image := &infrav1.Image{
 		ID: &imageID,
 	}
 
-	return &AzureMachine{
-		Spec: AzureMachineSpec{
+	return &infrav1.AzureMachine{
+		Spec: infrav1.AzureMachineSpec{
 			Image:        image,
 			SSHPublicKey: validSSHPublicKey,
 			OSDisk:       validOSDisk,
@@ -1065,9 +1065,9 @@ func createMachineWithImageByID(imageID string) *AzureMachine {
 	}
 }
 
-func createMachineWithOsDiskCacheType(cacheType string) *AzureMachine {
-	machine := &AzureMachine{
-		Spec: AzureMachineSpec{
+func createMachineWithOsDiskCacheType(cacheType string) *infrav1.AzureMachine {
+	machine := &infrav1.AzureMachine{
+		Spec: infrav1.AzureMachineSpec{
 			SSHPublicKey: validSSHPublicKey,
 			OSDisk:       validOSDisk,
 		},
@@ -1076,13 +1076,13 @@ func createMachineWithOsDiskCacheType(cacheType string) *AzureMachine {
 	return machine
 }
 
-func createMachineWithSystemAssignedIdentityRoleName() *AzureMachine {
-	machine := &AzureMachine{
-		Spec: AzureMachineSpec{
+func createMachineWithSystemAssignedIdentityRoleName() *infrav1.AzureMachine {
+	machine := &infrav1.AzureMachine{
+		Spec: infrav1.AzureMachineSpec{
 			SSHPublicKey: validSSHPublicKey,
 			OSDisk:       validOSDisk,
-			Identity:     VMIdentitySystemAssigned,
-			SystemAssignedIdentityRole: &SystemAssignedIdentityRole{
+			Identity:     infrav1.VMIdentitySystemAssigned,
+			SystemAssignedIdentityRole: &infrav1.SystemAssignedIdentityRole{
 				Name:         "c6e3443d-bc11-4335-8819-ab6637b10586",
 				Scope:        "test-scope",
 				DefinitionID: "test-definition-id",
@@ -1092,13 +1092,13 @@ func createMachineWithSystemAssignedIdentityRoleName() *AzureMachine {
 	return machine
 }
 
-func createMachineWithoutSystemAssignedIdentityRoleName() *AzureMachine {
-	machine := &AzureMachine{
-		Spec: AzureMachineSpec{
+func createMachineWithoutSystemAssignedIdentityRoleName() *infrav1.AzureMachine {
+	machine := &infrav1.AzureMachine{
+		Spec: infrav1.AzureMachineSpec{
 			SSHPublicKey: validSSHPublicKey,
 			OSDisk:       validOSDisk,
-			Identity:     VMIdentitySystemAssigned,
-			SystemAssignedIdentityRole: &SystemAssignedIdentityRole{
+			Identity:     infrav1.VMIdentitySystemAssigned,
+			SystemAssignedIdentityRole: &infrav1.SystemAssignedIdentityRole{
 				Scope:        "test-scope",
 				DefinitionID: "test-definition-id",
 			},
@@ -1107,9 +1107,9 @@ func createMachineWithoutSystemAssignedIdentityRoleName() *AzureMachine {
 	return machine
 }
 
-func createMachineWithoutRoleAssignmentName() *AzureMachine {
-	machine := &AzureMachine{
-		Spec: AzureMachineSpec{
+func createMachineWithoutRoleAssignmentName() *infrav1.AzureMachine {
+	machine := &infrav1.AzureMachine{
+		Spec: infrav1.AzureMachineSpec{
 			SSHPublicKey: validSSHPublicKey,
 			OSDisk:       validOSDisk,
 		},
@@ -1117,9 +1117,9 @@ func createMachineWithoutRoleAssignmentName() *AzureMachine {
 	return machine
 }
 
-func createMachineWithRoleAssignmentName() *AzureMachine {
-	machine := &AzureMachine{
-		Spec: AzureMachineSpec{
+func createMachineWithRoleAssignmentName() *infrav1.AzureMachine {
+	machine := &infrav1.AzureMachine{
+		Spec: infrav1.AzureMachineSpec{
 			SSHPublicKey:       validSSHPublicKey,
 			OSDisk:             validOSDisk,
 			RoleAssignmentName: "test-role-assignment",
@@ -1128,12 +1128,12 @@ func createMachineWithRoleAssignmentName() *AzureMachine {
 	return machine
 }
 
-func createMachineWithDiagnostics(diagnosticsType BootDiagnosticsStorageAccountType, userManaged *UserManagedBootDiagnostics) *AzureMachine {
-	var diagnostics *Diagnostics
+func createMachineWithDiagnostics(diagnosticsType infrav1.BootDiagnosticsStorageAccountType, userManaged *infrav1.UserManagedBootDiagnostics) *infrav1.AzureMachine {
+	var diagnostics *infrav1.Diagnostics
 
 	if diagnosticsType != "" {
-		diagnostics = &Diagnostics{
-			Boot: &BootDiagnostics{
+		diagnostics = &infrav1.Diagnostics{
+			Boot: &infrav1.BootDiagnostics{
 				StorageAccountType: diagnosticsType,
 			},
 		}
@@ -1143,8 +1143,8 @@ func createMachineWithDiagnostics(diagnosticsType BootDiagnosticsStorageAccountT
 		diagnostics.Boot.UserManaged = userManaged
 	}
 
-	return &AzureMachine{
-		Spec: AzureMachineSpec{
+	return &infrav1.AzureMachine{
+		Spec: infrav1.AzureMachineSpec{
 			SSHPublicKey: validSSHPublicKey,
 			OSDisk:       validOSDisk,
 			Diagnostics:  diagnostics,
@@ -1152,30 +1152,30 @@ func createMachineWithDiagnostics(diagnosticsType BootDiagnosticsStorageAccountT
 	}
 }
 
-func createMachineWithConfidentialCompute(securityEncryptionType SecurityEncryptionType, securityType SecurityTypes, encryptionAtHost, vTpmEnabled, secureBootEnabled bool) *AzureMachine {
-	securityProfile := &SecurityProfile{
+func createMachineWithConfidentialCompute(securityEncryptionType infrav1.SecurityEncryptionType, securityType infrav1.SecurityTypes, encryptionAtHost, vTpmEnabled, secureBootEnabled bool) *infrav1.AzureMachine {
+	securityProfile := &infrav1.SecurityProfile{
 		EncryptionAtHost: &encryptionAtHost,
 		SecurityType:     securityType,
-		UefiSettings: &UefiSettings{
+		UefiSettings: &infrav1.UefiSettings{
 			VTpmEnabled:       &vTpmEnabled,
 			SecureBootEnabled: &secureBootEnabled,
 		},
 	}
 
-	osDisk := OSDisk{
+	osDisk := infrav1.OSDisk{
 		DiskSizeGB: ptr.To[int32](30),
-		OSType:     LinuxOS,
-		ManagedDisk: &ManagedDiskParameters{
+		OSType:     infrav1.LinuxOS,
+		ManagedDisk: &infrav1.ManagedDiskParameters{
 			StorageAccountType: "Premium_LRS",
-			SecurityProfile: &VMDiskSecurityProfile{
+			SecurityProfile: &infrav1.VMDiskSecurityProfile{
 				SecurityEncryptionType: securityEncryptionType,
 			},
 		},
 		CachingType: string(armcompute.PossibleCachingTypesValues()[0]),
 	}
 
-	return &AzureMachine{
-		Spec: AzureMachineSpec{
+	return &infrav1.AzureMachine{
+		Spec: infrav1.AzureMachineSpec{
 			SSHPublicKey:    validSSHPublicKey,
 			OSDisk:          osDisk,
 			SecurityProfile: securityProfile,
@@ -1183,14 +1183,14 @@ func createMachineWithConfidentialCompute(securityEncryptionType SecurityEncrypt
 	}
 }
 
-func createMachineWithCapacityReservaionGroupID(capacityReservationGroupID string) *AzureMachine {
+func createMachineWithCapacityReservaionGroupID(capacityReservationGroupID string) *infrav1.AzureMachine {
 	var strPtr *string
 	if capacityReservationGroupID != "" {
 		strPtr = ptr.To(capacityReservationGroupID)
 	}
 
-	return &AzureMachine{
-		Spec: AzureMachineSpec{
+	return &infrav1.AzureMachine{
+		Spec: infrav1.AzureMachineSpec{
 			SSHPublicKey:               validSSHPublicKey,
 			OSDisk:                     validOSDisk,
 			CapacityReservationGroupID: strPtr,
@@ -1198,13 +1198,13 @@ func createMachineWithCapacityReservaionGroupID(capacityReservationGroupID strin
 	}
 }
 
-func createMachineWithDisableExtenionOperationsAndHasExtension() *AzureMachine {
-	return &AzureMachine{
-		Spec: AzureMachineSpec{
+func createMachineWithDisableExtenionOperationsAndHasExtension() *infrav1.AzureMachine {
+	return &infrav1.AzureMachine{
+		Spec: infrav1.AzureMachineSpec{
 			SSHPublicKey:               validSSHPublicKey,
 			OSDisk:                     validOSDisk,
 			DisableExtensionOperations: ptr.To(true),
-			VMExtensions: []VMExtension{{
+			VMExtensions: []infrav1.VMExtension{{
 				Name:      "test-extension",
 				Publisher: "test-publiher",
 				Version:   "v0.0.1-test",
@@ -1213,9 +1213,9 @@ func createMachineWithDisableExtenionOperationsAndHasExtension() *AzureMachine {
 	}
 }
 
-func createMachineWithDisableExtenionOperations() *AzureMachine {
-	return &AzureMachine{
-		Spec: AzureMachineSpec{
+func createMachineWithDisableExtenionOperations() *infrav1.AzureMachine {
+	return &infrav1.AzureMachine{
+		Spec: infrav1.AzureMachineSpec{
 			SSHPublicKey:               validSSHPublicKey,
 			OSDisk:                     validOSDisk,
 			DisableExtensionOperations: ptr.To(true),

--- a/internal/webhooks/azuremachinetemplate_webhook.go
+++ b/internal/webhooks/azuremachinetemplate_webhook.go
@@ -30,7 +30,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
-	. "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
+	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	apiinternal "sigs.k8s.io/cluster-api-provider-azure/internal/api/v1beta1"
 )
 
@@ -44,7 +44,7 @@ const (
 // SetupWebhookWithManager sets up and registers the webhook with the manager.
 func (w *AzureMachineTemplateWebhook) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
-		For(&AzureMachineTemplate{}).
+		For(&infrav1.AzureMachineTemplate{}).
 		WithValidator(w).
 		WithDefaulter(w).
 		Complete()
@@ -61,7 +61,7 @@ var _ webhook.CustomValidator = &AzureMachineTemplateWebhook{}
 
 // ValidateCreate implements webhook.CustomValidator so a webhook will be registered for the type.
 func (*AzureMachineTemplateWebhook) ValidateCreate(_ context.Context, obj runtime.Object) (admission.Warnings, error) {
-	r := obj.(*AzureMachineTemplate)
+	r := obj.(*infrav1.AzureMachineTemplate)
 	spec := r.Spec.Template.Spec
 
 	allErrs := validateAzureMachineSpec(spec)
@@ -100,14 +100,14 @@ func (*AzureMachineTemplateWebhook) ValidateCreate(_ context.Context, obj runtim
 		return nil, nil
 	}
 
-	return nil, apierrors.NewInvalid(GroupVersion.WithKind(AzureMachineTemplateKind).GroupKind(), r.Name, allErrs)
+	return nil, apierrors.NewInvalid(infrav1.GroupVersion.WithKind(infrav1.AzureMachineTemplateKind).GroupKind(), r.Name, allErrs)
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
 func (w *AzureMachineTemplateWebhook) ValidateUpdate(ctx context.Context, oldRaw runtime.Object, newRaw runtime.Object) (admission.Warnings, error) {
 	var allErrs field.ErrorList
-	old := oldRaw.(*AzureMachineTemplate)
-	t := newRaw.(*AzureMachineTemplate)
+	old := oldRaw.(*infrav1.AzureMachineTemplate)
+	t := newRaw.(*infrav1.AzureMachineTemplate)
 
 	req, err := admission.RequestFromContext(ctx)
 	if err != nil {
@@ -144,7 +144,7 @@ func (w *AzureMachineTemplateWebhook) ValidateUpdate(ctx context.Context, oldRaw
 	if len(allErrs) == 0 {
 		return nil, nil
 	}
-	return nil, apierrors.NewInvalid(GroupVersion.WithKind(AzureMachineTemplateKind).GroupKind(), t.Name, allErrs)
+	return nil, apierrors.NewInvalid(infrav1.GroupVersion.WithKind(infrav1.AzureMachineTemplateKind).GroupKind(), t.Name, allErrs)
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type.
@@ -154,7 +154,7 @@ func (*AzureMachineTemplateWebhook) ValidateDelete(_ context.Context, _ runtime.
 
 // Default implements webhookutil.defaulter so a webhook will be registered for the type.
 func (*AzureMachineTemplateWebhook) Default(_ context.Context, obj runtime.Object) error {
-	t := obj.(*AzureMachineTemplate)
+	t := obj.(*infrav1.AzureMachineTemplate)
 	if err := apiinternal.SetDefaultAzureMachineSpecSSHPublicKey(&t.Spec.Template.Spec); err != nil {
 		ctrl.Log.WithName("SetDefault").Error(err, "SetDefaultSSHPublicKey failed")
 	}

--- a/internal/webhooks/azuremachinetemplate_webhook_test.go
+++ b/internal/webhooks/azuremachinetemplate_webhook_test.go
@@ -26,14 +26,14 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
-	. "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
+	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	apifixtures "sigs.k8s.io/cluster-api-provider-azure/internal/test/apifixtures"
 )
 
 func TestAzureMachineTemplate_ValidateCreate(t *testing.T) {
 	tests := []struct {
 		name            string
-		machineTemplate *AzureMachineTemplate
+		machineTemplate *infrav1.AzureMachineTemplate
 		wantErr         bool
 	}{
 		{
@@ -102,7 +102,7 @@ func TestAzureMachineTemplate_ValidateCreate(t *testing.T) {
 		{
 			name: "azuremachinetemplate with list of user-assigned identities",
 			machineTemplate: createAzureMachineTemplateFromMachine(
-				apifixtures.CreateMachineWithUserAssignedIdentities([]UserAssignedIdentity{
+				apifixtures.CreateMachineWithUserAssignedIdentities([]infrav1.UserAssignedIdentity{
 					{ProviderID: "azure:///subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/my-resource-group/providers/Microsoft.Compute/virtualMachines/default-09091-control-plane-f1b2c"},
 					{ProviderID: "azure:///subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/my-resource-group/providers/Microsoft.Compute/virtualMachines/default-09091-control-plane-9a8b7"},
 				}),
@@ -112,7 +112,7 @@ func TestAzureMachineTemplate_ValidateCreate(t *testing.T) {
 		{
 			name: "azuremachinetemplate with empty list of user-assigned identities",
 			machineTemplate: createAzureMachineTemplateFromMachine(
-				apifixtures.CreateMachineWithUserAssignedIdentities([]UserAssignedIdentity{}),
+				apifixtures.CreateMachineWithUserAssignedIdentities([]infrav1.UserAssignedIdentity{}),
 			),
 			wantErr: true,
 		},
@@ -166,7 +166,7 @@ func TestAzureMachineTemplate_ValidateCreate(t *testing.T) {
 				createMachineWithNetworkConfig(
 					"test-subnet",
 					nil,
-					[]NetworkInterface{
+					[]infrav1.NetworkInterface{
 						{SubnetName: "subnet1", PrivateIPConfigs: 1},
 						{SubnetName: "subnet2", PrivateIPConfigs: 1},
 					},
@@ -180,7 +180,7 @@ func TestAzureMachineTemplate_ValidateCreate(t *testing.T) {
 				createMachineWithNetworkConfig(
 					"",
 					nil,
-					[]NetworkInterface{
+					[]infrav1.NetworkInterface{
 						{SubnetName: "subnet1", PrivateIPConfigs: 1},
 						{SubnetName: "subnet2", PrivateIPConfigs: 1},
 					},
@@ -194,7 +194,7 @@ func TestAzureMachineTemplate_ValidateCreate(t *testing.T) {
 				createMachineWithNetworkConfig(
 					"",
 					ptr.To(true),
-					[]NetworkInterface{
+					[]infrav1.NetworkInterface{
 						{SubnetName: "subnet1", PrivateIPConfigs: 1},
 						{SubnetName: "subnet2", PrivateIPConfigs: 1},
 					},
@@ -208,7 +208,7 @@ func TestAzureMachineTemplate_ValidateCreate(t *testing.T) {
 				createMachineWithNetworkConfig(
 					"",
 					nil,
-					[]NetworkInterface{
+					[]infrav1.NetworkInterface{
 						{SubnetName: "subnet1", PrivateIPConfigs: 1},
 						{SubnetName: "subnet2", PrivateIPConfigs: 1},
 					},
@@ -222,7 +222,7 @@ func TestAzureMachineTemplate_ValidateCreate(t *testing.T) {
 				createMachineWithNetworkConfig(
 					"",
 					nil,
-					[]NetworkInterface{
+					[]infrav1.NetworkInterface{
 						{SubnetName: "subnet1", PrivateIPConfigs: 0},
 						{SubnetName: "subnet2", PrivateIPConfigs: -1},
 					},
@@ -236,7 +236,7 @@ func TestAzureMachineTemplate_ValidateCreate(t *testing.T) {
 				createMachineWithNetworkConfig(
 					"",
 					nil,
-					[]NetworkInterface{
+					[]infrav1.NetworkInterface{
 						{SubnetName: "subnet1", PrivateIPConfigs: 1},
 						{SubnetName: "subnet2", PrivateIPConfigs: 2},
 					},
@@ -266,39 +266,39 @@ func TestAzureMachineTemplate_ValidateUpdate(t *testing.T) {
 
 	tests := []struct {
 		name        string
-		oldTemplate *AzureMachineTemplate
-		template    *AzureMachineTemplate
+		oldTemplate *infrav1.AzureMachineTemplate
+		template    *infrav1.AzureMachineTemplate
 		wantErr     bool
 	}{
 		{
 			name: "AzureMachineTemplate with immutable spec",
-			oldTemplate: &AzureMachineTemplate{
-				Spec: AzureMachineTemplateSpec{
-					Template: AzureMachineTemplateResource{
-						Spec: AzureMachineSpec{
+			oldTemplate: &infrav1.AzureMachineTemplate{
+				Spec: infrav1.AzureMachineTemplateSpec{
+					Template: infrav1.AzureMachineTemplateResource{
+						Spec: infrav1.AzureMachineSpec{
 							VMSize:        "size",
 							FailureDomain: &failureDomain,
-							OSDisk: OSDisk{
+							OSDisk: infrav1.OSDisk{
 								OSType:     "type",
 								DiskSizeGB: ptr.To[int32](11),
 							},
-							DataDisks:    []DataDisk{},
+							DataDisks:    []infrav1.DataDisk{},
 							SSHPublicKey: "",
 						},
 					},
 				},
 			},
-			template: &AzureMachineTemplate{
-				Spec: AzureMachineTemplateSpec{
-					Template: AzureMachineTemplateResource{
-						Spec: AzureMachineSpec{
+			template: &infrav1.AzureMachineTemplate{
+				Spec: infrav1.AzureMachineTemplateSpec{
+					Template: infrav1.AzureMachineTemplateResource{
+						Spec: infrav1.AzureMachineSpec{
 							VMSize:        "size1",
 							FailureDomain: &failureDomain,
-							OSDisk: OSDisk{
+							OSDisk: infrav1.OSDisk{
 								OSType:     "type",
 								DiskSizeGB: ptr.To[int32](11),
 							},
-							DataDisks:    []DataDisk{},
+							DataDisks:    []infrav1.DataDisk{},
 							SSHPublicKey: "fake ssh key",
 						},
 					},
@@ -308,17 +308,17 @@ func TestAzureMachineTemplate_ValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "AzureMachineTemplate with mutable metadata",
-			oldTemplate: &AzureMachineTemplate{
-				Spec: AzureMachineTemplateSpec{
-					Template: AzureMachineTemplateResource{
-						Spec: AzureMachineSpec{
+			oldTemplate: &infrav1.AzureMachineTemplate{
+				Spec: infrav1.AzureMachineTemplateSpec{
+					Template: infrav1.AzureMachineTemplateResource{
+						Spec: infrav1.AzureMachineSpec{
 							VMSize:        "size",
 							FailureDomain: &failureDomain,
-							OSDisk: OSDisk{
+							OSDisk: infrav1.OSDisk{
 								OSType:     "type",
 								DiskSizeGB: ptr.To[int32](11),
 							},
-							DataDisks:    []DataDisk{},
+							DataDisks:    []infrav1.DataDisk{},
 							SSHPublicKey: "fake ssh key",
 						},
 					},
@@ -327,17 +327,17 @@ func TestAzureMachineTemplate_ValidateUpdate(t *testing.T) {
 					Name: "OldTemplate",
 				},
 			},
-			template: &AzureMachineTemplate{
-				Spec: AzureMachineTemplateSpec{
-					Template: AzureMachineTemplateResource{
-						Spec: AzureMachineSpec{
+			template: &infrav1.AzureMachineTemplate{
+				Spec: infrav1.AzureMachineTemplateSpec{
+					Template: infrav1.AzureMachineTemplateResource{
+						Spec: infrav1.AzureMachineSpec{
 							VMSize:        "size",
 							FailureDomain: &failureDomain,
-							OSDisk: OSDisk{
+							OSDisk: infrav1.OSDisk{
 								OSType:     "type",
 								DiskSizeGB: ptr.To[int32](11),
 							},
-							DataDisks:    []DataDisk{},
+							DataDisks:    []infrav1.DataDisk{},
 							SSHPublicKey: "fake ssh key",
 						},
 					},
@@ -350,18 +350,18 @@ func TestAzureMachineTemplate_ValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "AzureMachineTemplate ssh key removed",
-			oldTemplate: &AzureMachineTemplate{
-				Spec: AzureMachineTemplateSpec{
-					Template: AzureMachineTemplateResource{
-						Spec: AzureMachineSpec{
+			oldTemplate: &infrav1.AzureMachineTemplate{
+				Spec: infrav1.AzureMachineTemplateSpec{
+					Template: infrav1.AzureMachineTemplateResource{
+						Spec: infrav1.AzureMachineSpec{
 							VMSize:        "size",
 							FailureDomain: &failureDomain,
-							OSDisk: OSDisk{
+							OSDisk: infrav1.OSDisk{
 								OSType:      "type",
 								DiskSizeGB:  ptr.To[int32](11),
 								CachingType: "None",
 							},
-							DataDisks:    []DataDisk{},
+							DataDisks:    []infrav1.DataDisk{},
 							SSHPublicKey: "some key",
 						},
 					},
@@ -370,18 +370,18 @@ func TestAzureMachineTemplate_ValidateUpdate(t *testing.T) {
 					Name: "OldTemplate",
 				},
 			},
-			template: &AzureMachineTemplate{
-				Spec: AzureMachineTemplateSpec{
-					Template: AzureMachineTemplateResource{
-						Spec: AzureMachineSpec{
+			template: &infrav1.AzureMachineTemplate{
+				Spec: infrav1.AzureMachineTemplateSpec{
+					Template: infrav1.AzureMachineTemplateResource{
+						Spec: infrav1.AzureMachineSpec{
 							VMSize:        "size",
 							FailureDomain: &failureDomain,
-							OSDisk: OSDisk{
+							OSDisk: infrav1.OSDisk{
 								OSType:      "type",
 								DiskSizeGB:  ptr.To[int32](11),
 								CachingType: "None",
 							},
-							DataDisks:    []DataDisk{},
+							DataDisks:    []infrav1.DataDisk{},
 							SSHPublicKey: "",
 						},
 					},
@@ -394,18 +394,18 @@ func TestAzureMachineTemplate_ValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "AzureMachineTemplate with legacy subnetName updated to new networkInterfaces",
-			oldTemplate: &AzureMachineTemplate{
-				Spec: AzureMachineTemplateSpec{
-					Template: AzureMachineTemplateResource{
-						Spec: AzureMachineSpec{
+			oldTemplate: &infrav1.AzureMachineTemplate{
+				Spec: infrav1.AzureMachineTemplateSpec{
+					Template: infrav1.AzureMachineTemplateResource{
+						Spec: infrav1.AzureMachineSpec{
 							VMSize:        "size",
 							FailureDomain: &failureDomain,
-							OSDisk: OSDisk{
+							OSDisk: infrav1.OSDisk{
 								OSType:      "type",
 								DiskSizeGB:  ptr.To[int32](11),
 								CachingType: "None",
 							},
-							DataDisks:             []DataDisk{},
+							DataDisks:             []infrav1.DataDisk{},
 							SSHPublicKey:          "fake ssh key",
 							SubnetName:            "subnet1",
 							AcceleratedNetworking: ptr.To(true),
@@ -413,22 +413,22 @@ func TestAzureMachineTemplate_ValidateUpdate(t *testing.T) {
 					},
 				},
 			},
-			template: &AzureMachineTemplate{
-				Spec: AzureMachineTemplateSpec{
-					Template: AzureMachineTemplateResource{
-						Spec: AzureMachineSpec{
+			template: &infrav1.AzureMachineTemplate{
+				Spec: infrav1.AzureMachineTemplateSpec{
+					Template: infrav1.AzureMachineTemplateResource{
+						Spec: infrav1.AzureMachineSpec{
 							VMSize:        "size",
 							FailureDomain: &failureDomain,
-							OSDisk: OSDisk{
+							OSDisk: infrav1.OSDisk{
 								OSType:      "type",
 								DiskSizeGB:  ptr.To[int32](11),
 								CachingType: "None",
 							},
-							DataDisks:             []DataDisk{},
+							DataDisks:             []infrav1.DataDisk{},
 							SSHPublicKey:          "fake ssh key",
 							SubnetName:            "",
 							AcceleratedNetworking: nil,
-							NetworkInterfaces: []NetworkInterface{
+							NetworkInterfaces: []infrav1.NetworkInterface{
 								{
 									SubnetName:            "subnet1",
 									AcceleratedNetworking: ptr.To(true),
@@ -443,42 +443,42 @@ func TestAzureMachineTemplate_ValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "AzureMachineTemplate with legacy AcceleratedNetworking updated to new networkInterfaces",
-			oldTemplate: &AzureMachineTemplate{
-				Spec: AzureMachineTemplateSpec{
-					Template: AzureMachineTemplateResource{
-						Spec: AzureMachineSpec{
+			oldTemplate: &infrav1.AzureMachineTemplate{
+				Spec: infrav1.AzureMachineTemplateSpec{
+					Template: infrav1.AzureMachineTemplateResource{
+						Spec: infrav1.AzureMachineSpec{
 							VMSize:        "size",
 							FailureDomain: &failureDomain,
-							OSDisk: OSDisk{
+							OSDisk: infrav1.OSDisk{
 								OSType:      "type",
 								DiskSizeGB:  ptr.To[int32](11),
 								CachingType: "None",
 							},
-							DataDisks:             []DataDisk{},
+							DataDisks:             []infrav1.DataDisk{},
 							SSHPublicKey:          "fake ssh key",
 							SubnetName:            "",
 							AcceleratedNetworking: ptr.To(true),
-							NetworkInterfaces:     []NetworkInterface{},
+							NetworkInterfaces:     []infrav1.NetworkInterface{},
 						},
 					},
 				},
 			},
-			template: &AzureMachineTemplate{
-				Spec: AzureMachineTemplateSpec{
-					Template: AzureMachineTemplateResource{
-						Spec: AzureMachineSpec{
+			template: &infrav1.AzureMachineTemplate{
+				Spec: infrav1.AzureMachineTemplateSpec{
+					Template: infrav1.AzureMachineTemplateResource{
+						Spec: infrav1.AzureMachineSpec{
 							VMSize:        "size",
 							FailureDomain: &failureDomain,
-							OSDisk: OSDisk{
+							OSDisk: infrav1.OSDisk{
 								OSType:      "type",
 								DiskSizeGB:  ptr.To[int32](11),
 								CachingType: "None",
 							},
-							DataDisks:             []DataDisk{},
+							DataDisks:             []infrav1.DataDisk{},
 							SSHPublicKey:          "fake ssh key",
 							SubnetName:            "",
 							AcceleratedNetworking: nil,
-							NetworkInterfaces: []NetworkInterface{
+							NetworkInterfaces: []infrav1.NetworkInterface{
 								{
 									SubnetName:            "",
 									AcceleratedNetworking: ptr.To(true),
@@ -493,20 +493,20 @@ func TestAzureMachineTemplate_ValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "AzureMachineTemplate with modified networkInterfaces is immutable",
-			oldTemplate: &AzureMachineTemplate{
-				Spec: AzureMachineTemplateSpec{
-					Template: AzureMachineTemplateResource{
-						Spec: AzureMachineSpec{
+			oldTemplate: &infrav1.AzureMachineTemplate{
+				Spec: infrav1.AzureMachineTemplateSpec{
+					Template: infrav1.AzureMachineTemplateResource{
+						Spec: infrav1.AzureMachineSpec{
 							VMSize:        "size",
 							FailureDomain: &failureDomain,
-							OSDisk: OSDisk{
+							OSDisk: infrav1.OSDisk{
 								OSType:      "type",
 								DiskSizeGB:  ptr.To[int32](11),
 								CachingType: "None",
 							},
-							DataDisks:    []DataDisk{},
+							DataDisks:    []infrav1.DataDisk{},
 							SSHPublicKey: "fake ssh key",
-							NetworkInterfaces: []NetworkInterface{
+							NetworkInterfaces: []infrav1.NetworkInterface{
 								{
 									SubnetName:            "subnet1",
 									AcceleratedNetworking: ptr.To(true),
@@ -517,20 +517,20 @@ func TestAzureMachineTemplate_ValidateUpdate(t *testing.T) {
 					},
 				},
 			},
-			template: &AzureMachineTemplate{
-				Spec: AzureMachineTemplateSpec{
-					Template: AzureMachineTemplateResource{
-						Spec: AzureMachineSpec{
+			template: &infrav1.AzureMachineTemplate{
+				Spec: infrav1.AzureMachineTemplateSpec{
+					Template: infrav1.AzureMachineTemplateResource{
+						Spec: infrav1.AzureMachineSpec{
 							VMSize:        "size",
 							FailureDomain: &failureDomain,
-							OSDisk: OSDisk{
+							OSDisk: infrav1.OSDisk{
 								OSType:      "type",
 								DiskSizeGB:  ptr.To[int32](11),
 								CachingType: "None",
 							},
-							DataDisks:    []DataDisk{},
+							DataDisks:    []infrav1.DataDisk{},
 							SSHPublicKey: "fake ssh key",
-							NetworkInterfaces: []NetworkInterface{
+							NetworkInterfaces: []infrav1.NetworkInterface{
 								{
 									SubnetName:            "subnet2",
 									AcceleratedNetworking: ptr.To(true),
@@ -574,10 +574,10 @@ func TestAzureMachineTemplate_ValidateUpdate(t *testing.T) {
 	}
 }
 
-func createAzureMachineTemplateFromMachine(machine *AzureMachine) *AzureMachineTemplate {
-	return &AzureMachineTemplate{
-		Spec: AzureMachineTemplateSpec{
-			Template: AzureMachineTemplateResource{
+func createAzureMachineTemplateFromMachine(machine *infrav1.AzureMachine) *infrav1.AzureMachineTemplate {
+	return &infrav1.AzureMachineTemplate{
+		Spec: infrav1.AzureMachineTemplateSpec{
+			Template: infrav1.AzureMachineTemplateResource{
 				Spec: machine.Spec,
 			},
 		},

--- a/internal/webhooks/azuremanagedcluster_webhook.go
+++ b/internal/webhooks/azuremanagedcluster_webhook.go
@@ -24,13 +24,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
-	. "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
+	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 )
 
 // SetupWebhookWithManager sets up and registers the webhook with the manager.
 func (w *AzureManagedClusterWebhook) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
-		For(&AzureManagedCluster{}).
+		For(&infrav1.AzureManagedCluster{}).
 		WithValidator(w).
 		Complete()
 }

--- a/internal/webhooks/azuremanagedcluster_webhook_test.go
+++ b/internal/webhooks/azuremanagedcluster_webhook_test.go
@@ -25,30 +25,30 @@ import (
 	clusterv1beta1 "sigs.k8s.io/cluster-api/api/core/v1beta1"
 	capifeature "sigs.k8s.io/cluster-api/feature"
 
-	. "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
+	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/feature"
 )
 
 func TestAzureManagedCluster_ValidateUpdate(t *testing.T) {
 	tests := []struct {
 		name    string
-		oldAMC  *AzureManagedCluster
-		amc     *AzureManagedCluster
+		oldAMC  *infrav1.AzureManagedCluster
+		amc     *infrav1.AzureManagedCluster
 		wantErr bool
 	}{
 		{
 			name: "ControlPlaneEndpoint.Port update (AKS API-derived update scenario)",
-			oldAMC: &AzureManagedCluster{
+			oldAMC: &infrav1.AzureManagedCluster{
 				ObjectMeta: metav1.ObjectMeta{},
-				Spec: AzureManagedClusterSpec{
+				Spec: infrav1.AzureManagedClusterSpec{
 					ControlPlaneEndpoint: clusterv1beta1.APIEndpoint{
 						Host: "aks-8622-h4h26c44.hcp.eastus.azmk8s.io",
 					},
 				},
 			},
-			amc: &AzureManagedCluster{
+			amc: &infrav1.AzureManagedCluster{
 				ObjectMeta: metav1.ObjectMeta{},
-				Spec: AzureManagedClusterSpec{
+				Spec: infrav1.AzureManagedClusterSpec{
 					ControlPlaneEndpoint: clusterv1beta1.APIEndpoint{
 						Host: "aks-8622-h4h26c44.hcp.eastus.azmk8s.io",
 						Port: 443,
@@ -59,17 +59,17 @@ func TestAzureManagedCluster_ValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "ControlPlaneEndpoint.Host update (AKS API-derived update scenario)",
-			oldAMC: &AzureManagedCluster{
+			oldAMC: &infrav1.AzureManagedCluster{
 				ObjectMeta: metav1.ObjectMeta{},
-				Spec: AzureManagedClusterSpec{
+				Spec: infrav1.AzureManagedClusterSpec{
 					ControlPlaneEndpoint: clusterv1beta1.APIEndpoint{
 						Port: 443,
 					},
 				},
 			},
-			amc: &AzureManagedCluster{
+			amc: &infrav1.AzureManagedCluster{
 				ObjectMeta: metav1.ObjectMeta{},
-				Spec: AzureManagedClusterSpec{
+				Spec: infrav1.AzureManagedClusterSpec{
 					ControlPlaneEndpoint: clusterv1beta1.APIEndpoint{
 						Host: "aks-8622-h4h26c44.hcp.eastus.azmk8s.io",
 						Port: 443,
@@ -95,14 +95,14 @@ func TestAzureManagedCluster_ValidateUpdate(t *testing.T) {
 func TestAzureManagedCluster_ValidateCreate(t *testing.T) {
 	tests := []struct {
 		name    string
-		oldAMC  *AzureManagedCluster
-		amc     *AzureManagedCluster
+		oldAMC  *infrav1.AzureManagedCluster
+		amc     *infrav1.AzureManagedCluster
 		wantErr bool
 	}{
 		{
 			name: "can set Spec.ControlPlaneEndpoint.Host during create (clusterctl move scenario)",
-			amc: &AzureManagedCluster{
-				Spec: AzureManagedClusterSpec{
+			amc: &infrav1.AzureManagedCluster{
+				Spec: infrav1.AzureManagedClusterSpec{
 					ControlPlaneEndpoint: clusterv1beta1.APIEndpoint{
 						Host: "my-host",
 					},
@@ -112,8 +112,8 @@ func TestAzureManagedCluster_ValidateCreate(t *testing.T) {
 		},
 		{
 			name: "can set Spec.ControlPlaneEndpoint.Port during create (clusterctl move scenario)",
-			amc: &AzureManagedCluster{
-				Spec: AzureManagedClusterSpec{
+			amc: &infrav1.AzureManagedCluster{
+				Spec: infrav1.AzureManagedClusterSpec{
 					ControlPlaneEndpoint: clusterv1beta1.APIEndpoint{
 						Port: 4443,
 					},
@@ -138,7 +138,7 @@ func TestAzureManagedCluster_ValidateCreate(t *testing.T) {
 func TestAzureManagedCluster_ValidateCreateFailure(t *testing.T) {
 	tests := []struct {
 		name               string
-		amc                *AzureManagedCluster
+		amc                *infrav1.AzureManagedCluster
 		featureGateEnabled *bool
 		expectError        bool
 	}{
@@ -165,6 +165,6 @@ func TestAzureManagedCluster_ValidateCreateFailure(t *testing.T) {
 	}
 }
 
-func getKnownValidAzureManagedCluster() *AzureManagedCluster {
-	return &AzureManagedCluster{}
+func getKnownValidAzureManagedCluster() *infrav1.AzureManagedCluster {
+	return &infrav1.AzureManagedCluster{}
 }

--- a/internal/webhooks/azuremanagedclustertemplate_webhook.go
+++ b/internal/webhooks/azuremanagedclustertemplate_webhook.go
@@ -24,13 +24,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
-	. "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
+	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 )
 
 // SetupWebhookWithManager sets up and registers the webhook with the manager.
 func (w *AzureManagedClusterTemplateWebhook) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
-		For(&AzureManagedClusterTemplate{}).
+		For(&infrav1.AzureManagedClusterTemplate{}).
 		WithValidator(w).
 		Complete()
 }

--- a/internal/webhooks/azuremanagedcontrolplane_validation.go
+++ b/internal/webhooks/azuremanagedcontrolplane_validation.go
@@ -31,15 +31,15 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	. "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
+	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/util/versions"
 	webhookutils "sigs.k8s.io/cluster-api-provider-azure/util/webhook"
 )
 
 // Validate the Azure Managed Control Plane and return an aggregate error.
-func validateAzureManagedControlPlane(m *AzureManagedControlPlane, cli client.Client) error {
+func validateAzureManagedControlPlane(m *infrav1.AzureManagedControlPlane, cli client.Client) error {
 	var allErrs field.ErrorList
-	validators := []func(m *AzureManagedControlPlane, client client.Client) field.ErrorList{
+	validators := []func(m *infrav1.AzureManagedControlPlane, client client.Client) field.ErrorList{
 		validateAzureManagedControlPlaneSSHKey,
 		validateAzureManagedControlPlaneIdentity,
 		validateAzureManagedControlPlaneNetworkPluginMode,
@@ -89,7 +89,7 @@ func validateAzureManagedControlPlane(m *AzureManagedControlPlane, cli client.Cl
 	return allErrs.ToAggregate()
 }
 
-func validateAzureManagedControlPlaneDNSPrefix(m *AzureManagedControlPlane, _ client.Client) field.ErrorList {
+func validateAzureManagedControlPlaneDNSPrefix(m *infrav1.AzureManagedControlPlane, _ client.Client) field.ErrorList {
 	if m.Spec.DNSPrefix == nil {
 		return nil
 	}
@@ -110,7 +110,7 @@ func validateAzureManagedControlPlaneDNSPrefix(m *AzureManagedControlPlane, _ cl
 }
 
 // validateSecurityProfile validates SecurityProfile.
-func validateAzureManagedControlPlaneClassSpecSecurityProfile(m *AzureManagedControlPlaneClassSpec) field.ErrorList {
+func validateAzureManagedControlPlaneClassSpecSecurityProfile(m *infrav1.AzureManagedControlPlaneClassSpec) field.ErrorList {
 	allErrs := field.ErrorList{}
 	if err := validateAzureManagedControlPlaneClassSpecAzureKeyVaultKms(m); err != nil {
 		allErrs = append(allErrs, err...)
@@ -122,7 +122,7 @@ func validateAzureManagedControlPlaneClassSpecSecurityProfile(m *AzureManagedCon
 }
 
 // validateAzureKeyVaultKms validates AzureKeyVaultKms.
-func validateAzureManagedControlPlaneClassSpecAzureKeyVaultKms(m *AzureManagedControlPlaneClassSpec) field.ErrorList {
+func validateAzureManagedControlPlaneClassSpecAzureKeyVaultKms(m *infrav1.AzureManagedControlPlaneClassSpec) field.ErrorList {
 	if m.SecurityProfile != nil && m.SecurityProfile.AzureKeyVaultKms != nil {
 		if !azureManagedControlPlaneClassSpecIsUserManagedIdentityEnabled(m) {
 			allErrs := field.ErrorList{
@@ -132,9 +132,9 @@ func validateAzureManagedControlPlaneClassSpecAzureKeyVaultKms(m *AzureManagedCo
 			}
 			return allErrs
 		}
-		keyVaultNetworkAccess := ptr.Deref(m.SecurityProfile.AzureKeyVaultKms.KeyVaultNetworkAccess, KeyVaultNetworkAccessTypesPublic)
+		keyVaultNetworkAccess := ptr.Deref(m.SecurityProfile.AzureKeyVaultKms.KeyVaultNetworkAccess, infrav1.KeyVaultNetworkAccessTypesPublic)
 		keyVaultResourceID := ptr.Deref(m.SecurityProfile.AzureKeyVaultKms.KeyVaultResourceID, "")
-		if keyVaultNetworkAccess == KeyVaultNetworkAccessTypesPrivate && keyVaultResourceID == "" {
+		if keyVaultNetworkAccess == infrav1.KeyVaultNetworkAccessTypesPrivate && keyVaultResourceID == "" {
 			allErrs := field.ErrorList{
 				field.Invalid(field.NewPath("spec", "securityProfile", "azureKeyVaultKms", "keyVaultResourceID"),
 					m.SecurityProfile.AzureKeyVaultKms.KeyVaultResourceID,
@@ -142,7 +142,7 @@ func validateAzureManagedControlPlaneClassSpecAzureKeyVaultKms(m *AzureManagedCo
 			}
 			return allErrs
 		}
-		if keyVaultNetworkAccess == KeyVaultNetworkAccessTypesPublic && keyVaultResourceID != "" {
+		if keyVaultNetworkAccess == infrav1.KeyVaultNetworkAccessTypesPublic && keyVaultResourceID != "" {
 			allErrs := field.ErrorList{
 				field.Invalid(field.NewPath("spec", "securityProfile", "azureKeyVaultKms", "keyVaultResourceID"), m.SecurityProfile.AzureKeyVaultKms.KeyVaultResourceID,
 					"Spec.SecurityProfile.AzureKeyVaultKms.KeyVaultResourceID should be empty when Spec.SecurityProfile.AzureKeyVaultKms.KeyVaultNetworkAccess is Public"),
@@ -154,7 +154,7 @@ func validateAzureManagedControlPlaneClassSpecAzureKeyVaultKms(m *AzureManagedCo
 }
 
 // validateWorkloadIdentity validates WorkloadIdentity.
-func validateAzureManagedControlPlaneClassSpecWorkloadIdentity(m *AzureManagedControlPlaneClassSpec) field.ErrorList {
+func validateAzureManagedControlPlaneClassSpecWorkloadIdentity(m *infrav1.AzureManagedControlPlaneClassSpec) field.ErrorList {
 	if m.SecurityProfile != nil && m.SecurityProfile.WorkloadIdentity != nil && !azureManagedControlPlaneClassSpecIsOIDCEnabled(m) {
 		allErrs := field.ErrorList{
 			field.Invalid(field.NewPath("spec", "securityProfile", "workloadIdentity"), m.SecurityProfile.WorkloadIdentity,
@@ -166,7 +166,7 @@ func validateAzureManagedControlPlaneClassSpecWorkloadIdentity(m *AzureManagedCo
 }
 
 // validateDisableLocalAccounts disabling local accounts for AAD based clusters.
-func validateAzureManagedControlPlaneDisableLocalAccounts(m *AzureManagedControlPlane, _ client.Client) field.ErrorList {
+func validateAzureManagedControlPlaneDisableLocalAccounts(m *infrav1.AzureManagedControlPlane, _ client.Client) field.ErrorList {
 	if m.Spec.DisableLocalAccounts != nil && m.Spec.AADProfile == nil {
 		return field.ErrorList{
 			field.Invalid(field.NewPath("spec", "disableLocalAccounts"), *m.Spec.DisableLocalAccounts, "DisableLocalAccounts should be set only for AAD enabled clusters"),
@@ -186,7 +186,7 @@ func validateVersion(version string, fldPath *field.Path) field.ErrorList {
 }
 
 // validateSSHKey validates an SSHKey.
-func validateAzureManagedControlPlaneSSHKey(m *AzureManagedControlPlane, _ client.Client) field.ErrorList {
+func validateAzureManagedControlPlaneSSHKey(m *infrav1.AzureManagedControlPlane, _ client.Client) field.ErrorList {
 	if sshKey := m.Spec.SSHPublicKey; sshKey != nil && *sshKey != "" {
 		if errs := ValidateSSHKey(*sshKey, field.NewPath("sshKey")); len(errs) > 0 {
 			return errs
@@ -197,7 +197,7 @@ func validateAzureManagedControlPlaneSSHKey(m *AzureManagedControlPlane, _ clien
 }
 
 // validateLoadBalancerProfile validates a LoadBalancerProfile.
-func validateLoadBalancerProfile(loadBalancerProfile *LoadBalancerProfile, fldPath *field.Path) field.ErrorList {
+func validateLoadBalancerProfile(loadBalancerProfile *infrav1.LoadBalancerProfile, fldPath *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
 	if loadBalancerProfile != nil {
 		numOutboundIPTypes := 0
@@ -237,11 +237,11 @@ func validateLoadBalancerProfile(loadBalancerProfile *LoadBalancerProfile, fldPa
 	return allErrs
 }
 
-func validateAMCPVirtualNetwork(virtualNetwork ManagedControlPlaneVirtualNetwork, fldPath *field.Path) field.ErrorList {
+func validateAMCPVirtualNetwork(virtualNetwork infrav1.ManagedControlPlaneVirtualNetwork, fldPath *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
 
 	// VirtualNetwork and the CIDR blocks get defaulted in the defaulting webhook, so we can assume they are always set.
-	if !reflect.DeepEqual(virtualNetwork, ManagedControlPlaneVirtualNetwork{}) {
+	if !reflect.DeepEqual(virtualNetwork, infrav1.ManagedControlPlaneVirtualNetwork{}) {
 		_, parentNet, vnetErr := net.ParseCIDR(virtualNetwork.CIDRBlock)
 		if vnetErr != nil {
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("CIDRBlock"), virtualNetwork.CIDRBlock, "pre-existing virtual networks CIDR block is invalid"))
@@ -257,7 +257,7 @@ func validateAMCPVirtualNetwork(virtualNetwork ManagedControlPlaneVirtualNetwork
 	return allErrs
 }
 
-func validateFleetsMember(fleetsMember *FleetsMember, fldPath *field.Path) field.ErrorList {
+func validateFleetsMember(fleetsMember *infrav1.FleetsMember, fldPath *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
 
 	if fleetsMember != nil && fleetsMember.Name != "" {
@@ -277,7 +277,7 @@ func validateFleetsMember(fleetsMember *FleetsMember, fldPath *field.Path) field
 }
 
 // validateAPIServerAccessProfile validates an APIServerAccessProfile.
-func validateAPIServerAccessProfile(apiServerAccessProfile *APIServerAccessProfile, fldPath *field.Path) field.ErrorList {
+func validateAPIServerAccessProfile(apiServerAccessProfile *infrav1.APIServerAccessProfile, fldPath *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
 	if apiServerAccessProfile != nil {
 		for _, ipRange := range apiServerAccessProfile.AuthorizedIPRanges {
@@ -326,7 +326,7 @@ func validateAPIServerAccessProfile(apiServerAccessProfile *APIServerAccessProfi
 }
 
 // validateManagedClusterNetwork validates the Cluster network values.
-func validateManagedClusterNetwork(cli client.Client, labels map[string]string, namespace string, dnsServiceIP *string, subnet ManagedControlPlaneSubnet, fldPath *field.Path) field.ErrorList {
+func validateManagedClusterNetwork(cli client.Client, labels map[string]string, namespace string, dnsServiceIP *string, subnet infrav1.ManagedControlPlaneSubnet, fldPath *field.Path) field.ErrorList {
 	var (
 		allErrs     field.ErrorList
 		serviceCIDR string
@@ -400,7 +400,7 @@ func validateManagedClusterNetwork(cli client.Client, labels map[string]string, 
 }
 
 // validateAutoUpgradeProfile validates auto upgrade profile.
-func validateAzureManagedControlPlaneAutoUpgradeProfile(m *AzureManagedControlPlane, old *AzureManagedControlPlane) field.ErrorList {
+func validateAzureManagedControlPlaneAutoUpgradeProfile(m *infrav1.AzureManagedControlPlane, old *infrav1.AzureManagedControlPlane) field.ErrorList {
 	var allErrs field.ErrorList
 	if old.Spec.AutoUpgradeProfile != nil {
 		if old.Spec.AutoUpgradeProfile.UpgradeChannel != nil && (m.Spec.AutoUpgradeProfile == nil || m.Spec.AutoUpgradeProfile.UpgradeChannel == nil) {
@@ -417,7 +417,7 @@ func validateAzureManagedControlPlaneAutoUpgradeProfile(m *AzureManagedControlPl
 }
 
 // validateK8sVersionUpdate validates K8s version.
-func validateAzureManagedControlPlaneK8sVersionUpdate(m *AzureManagedControlPlane, old *AzureManagedControlPlane) field.ErrorList {
+func validateAzureManagedControlPlaneK8sVersionUpdate(m *infrav1.AzureManagedControlPlane, old *infrav1.AzureManagedControlPlane) field.ErrorList {
 	var allErrs field.ErrorList
 	if hv := versions.GetHigherK8sVersion(m.Spec.Version, old.Spec.Version); hv != m.Spec.Version {
 		allErrs = append(allErrs, field.Invalid(field.NewPath("spec", "version"),
@@ -436,14 +436,14 @@ func validateAzureManagedControlPlaneK8sVersionUpdate(m *AzureManagedControlPlan
 }
 
 // validateAPIServerAccessProfileUpdate validates update to APIServerAccessProfile.
-func validateAzureManagedControlPlaneAPIServerAccessProfileUpdate(m *AzureManagedControlPlane, old *AzureManagedControlPlane) field.ErrorList {
+func validateAzureManagedControlPlaneAPIServerAccessProfileUpdate(m *infrav1.AzureManagedControlPlane, old *infrav1.AzureManagedControlPlane) field.ErrorList {
 	var allErrs field.ErrorList
 
-	newAPIServerAccessProfileNormalized := &APIServerAccessProfile{}
-	oldAPIServerAccessProfileNormalized := &APIServerAccessProfile{}
+	newAPIServerAccessProfileNormalized := &infrav1.APIServerAccessProfile{}
+	oldAPIServerAccessProfileNormalized := &infrav1.APIServerAccessProfile{}
 	if m.Spec.APIServerAccessProfile != nil {
-		newAPIServerAccessProfileNormalized = &APIServerAccessProfile{
-			APIServerAccessProfileClassSpec: APIServerAccessProfileClassSpec{
+		newAPIServerAccessProfileNormalized = &infrav1.APIServerAccessProfile{
+			APIServerAccessProfileClassSpec: infrav1.APIServerAccessProfileClassSpec{
 				EnablePrivateCluster:           m.Spec.APIServerAccessProfile.EnablePrivateCluster,
 				PrivateDNSZone:                 m.Spec.APIServerAccessProfile.PrivateDNSZone,
 				EnablePrivateClusterPublicFQDN: m.Spec.APIServerAccessProfile.EnablePrivateClusterPublicFQDN,
@@ -451,8 +451,8 @@ func validateAzureManagedControlPlaneAPIServerAccessProfileUpdate(m *AzureManage
 		}
 	}
 	if old.Spec.APIServerAccessProfile != nil {
-		oldAPIServerAccessProfileNormalized = &APIServerAccessProfile{
-			APIServerAccessProfileClassSpec: APIServerAccessProfileClassSpec{
+		oldAPIServerAccessProfileNormalized = &infrav1.APIServerAccessProfile{
+			APIServerAccessProfileClassSpec: infrav1.APIServerAccessProfileClassSpec{
 				EnablePrivateCluster:           old.Spec.APIServerAccessProfile.EnablePrivateCluster,
 				PrivateDNSZone:                 old.Spec.APIServerAccessProfile.PrivateDNSZone,
 				EnablePrivateClusterPublicFQDN: old.Spec.APIServerAccessProfile.EnablePrivateClusterPublicFQDN,
@@ -471,7 +471,7 @@ func validateAzureManagedControlPlaneAPIServerAccessProfileUpdate(m *AzureManage
 }
 
 // validateAddonProfilesUpdate validates update to AddonProfiles.
-func validateAzureManagedControlPlaneAddonProfilesUpdate(m *AzureManagedControlPlane, old *AzureManagedControlPlane) field.ErrorList {
+func validateAzureManagedControlPlaneAddonProfilesUpdate(m *infrav1.AzureManagedControlPlane, old *infrav1.AzureManagedControlPlane) field.ErrorList {
 	var allErrs field.ErrorList
 	newAddonProfileMap := map[string]struct{}{}
 	if len(old.Spec.AddonProfiles) != 0 {
@@ -491,7 +491,7 @@ func validateAzureManagedControlPlaneAddonProfilesUpdate(m *AzureManagedControlP
 }
 
 // validateVirtualNetworkUpdate validates update to VirtualNetwork.
-func validateAzureManagedControlPlaneVirtualNetworkUpdate(m *AzureManagedControlPlane, old *AzureManagedControlPlane) field.ErrorList {
+func validateAzureManagedControlPlaneVirtualNetworkUpdate(m *infrav1.AzureManagedControlPlane, old *infrav1.AzureManagedControlPlane) field.ErrorList {
 	var allErrs field.ErrorList
 	if old.Spec.VirtualNetwork.Name != m.Spec.VirtualNetwork.Name {
 		allErrs = append(allErrs,
@@ -540,20 +540,20 @@ func validateAzureManagedControlPlaneVirtualNetworkUpdate(m *AzureManagedControl
 }
 
 // validateNetworkPluginModeUpdate validates update to NetworkPluginMode.
-func validateAzureManagedControlPlaneNetworkPluginModeUpdate(m *AzureManagedControlPlane, old *AzureManagedControlPlane) field.ErrorList {
+func validateAzureManagedControlPlaneNetworkPluginModeUpdate(m *infrav1.AzureManagedControlPlane, old *infrav1.AzureManagedControlPlane) field.ErrorList {
 	var allErrs field.ErrorList
 
-	if ptr.Deref(old.Spec.NetworkPluginMode, "") != NetworkPluginModeOverlay &&
-		ptr.Deref(m.Spec.NetworkPluginMode, "") == NetworkPluginModeOverlay &&
+	if ptr.Deref(old.Spec.NetworkPluginMode, "") != infrav1.NetworkPluginModeOverlay &&
+		ptr.Deref(m.Spec.NetworkPluginMode, "") == infrav1.NetworkPluginModeOverlay &&
 		old.Spec.NetworkPolicy != nil {
-		allErrs = append(allErrs, field.Forbidden(field.NewPath("spec", "networkPluginMode"), fmt.Sprintf("%q NetworkPluginMode cannot be enabled when NetworkPolicy is set", NetworkPluginModeOverlay)))
+		allErrs = append(allErrs, field.Forbidden(field.NewPath("spec", "networkPluginMode"), fmt.Sprintf("%q NetworkPluginMode cannot be enabled when NetworkPolicy is set", infrav1.NetworkPluginModeOverlay)))
 	}
 
 	return allErrs
 }
 
 // validateAADProfileUpdateAndLocalAccounts validates updates for AADProfile.
-func validateAzureManagedControlPlaneAADProfileUpdateAndLocalAccounts(m *AzureManagedControlPlane, old *AzureManagedControlPlane) field.ErrorList {
+func validateAzureManagedControlPlaneAADProfileUpdateAndLocalAccounts(m *infrav1.AzureManagedControlPlane, old *infrav1.AzureManagedControlPlane) field.ErrorList {
 	var allErrs field.ErrorList
 	if old.Spec.AADProfile != nil {
 		if m.Spec.AADProfile == nil {
@@ -605,7 +605,7 @@ func validateAzureManagedControlPlaneAADProfileUpdateAndLocalAccounts(m *AzureMa
 }
 
 // validateSecurityProfileUpdate validates a SecurityProfile update.
-func validateAzureManagedControlPlaneClassSpecSecurityProfileUpdate(m *AzureManagedControlPlaneClassSpec, old *AzureManagedControlPlaneClassSpec) field.ErrorList {
+func validateAzureManagedControlPlaneClassSpecSecurityProfileUpdate(m *infrav1.AzureManagedControlPlaneClassSpec, old *infrav1.AzureManagedControlPlaneClassSpec) field.ErrorList {
 	var allErrs field.ErrorList
 	if old.SecurityProfile != nil {
 		if errAzureKeyVaultKms := validateAzureManagedControlPlaneClassSpecAzureKeyVaultKmsUpdate(m, old); errAzureKeyVaultKms != nil {
@@ -625,7 +625,7 @@ func validateAzureManagedControlPlaneClassSpecSecurityProfileUpdate(m *AzureMana
 }
 
 // validateAzureKeyVaultKmsUpdate validates AzureKeyVaultKmsUpdate profile.
-func validateAzureManagedControlPlaneClassSpecAzureKeyVaultKmsUpdate(m *AzureManagedControlPlaneClassSpec, old *AzureManagedControlPlaneClassSpec) field.ErrorList {
+func validateAzureManagedControlPlaneClassSpecAzureKeyVaultKmsUpdate(m *infrav1.AzureManagedControlPlaneClassSpec, old *infrav1.AzureManagedControlPlaneClassSpec) field.ErrorList {
 	var allErrs field.ErrorList
 	if old.SecurityProfile.AzureKeyVaultKms != nil {
 		if m.SecurityProfile == nil || m.SecurityProfile.AzureKeyVaultKms == nil {
@@ -638,7 +638,7 @@ func validateAzureManagedControlPlaneClassSpecAzureKeyVaultKmsUpdate(m *AzureMan
 }
 
 // validateWorkloadIdentityUpdate validates WorkloadIdentityUpdate profile.
-func validateAzureManagedControlPlaneClassSpecWorkloadIdentityUpdate(m *AzureManagedControlPlaneClassSpec, old *AzureManagedControlPlaneClassSpec) field.ErrorList {
+func validateAzureManagedControlPlaneClassSpecWorkloadIdentityUpdate(m *infrav1.AzureManagedControlPlaneClassSpec, old *infrav1.AzureManagedControlPlaneClassSpec) field.ErrorList {
 	var allErrs field.ErrorList
 	if old.SecurityProfile.WorkloadIdentity != nil {
 		if m.SecurityProfile == nil || m.SecurityProfile.WorkloadIdentity == nil {
@@ -650,7 +650,7 @@ func validateAzureManagedControlPlaneClassSpecWorkloadIdentityUpdate(m *AzureMan
 }
 
 // validateImageCleanerUpdate validates ImageCleanerUpdate profile.
-func validateAzureManagedControlPlaneClassSpecImageCleanerUpdate(m *AzureManagedControlPlaneClassSpec, old *AzureManagedControlPlaneClassSpec) field.ErrorList {
+func validateAzureManagedControlPlaneClassSpecImageCleanerUpdate(m *infrav1.AzureManagedControlPlaneClassSpec, old *infrav1.AzureManagedControlPlaneClassSpec) field.ErrorList {
 	var allErrs field.ErrorList
 	if old.SecurityProfile.ImageCleaner != nil {
 		if m.SecurityProfile == nil || m.SecurityProfile.ImageCleaner == nil {
@@ -662,7 +662,7 @@ func validateAzureManagedControlPlaneClassSpecImageCleanerUpdate(m *AzureManaged
 }
 
 // validateDefender validates defender profile.
-func validateAzureManagedControlPlaneClassSpecDefender(m *AzureManagedControlPlaneClassSpec, old *AzureManagedControlPlaneClassSpec) field.ErrorList {
+func validateAzureManagedControlPlaneClassSpecDefender(m *infrav1.AzureManagedControlPlaneClassSpec, old *infrav1.AzureManagedControlPlaneClassSpec) field.ErrorList {
 	var allErrs field.ErrorList
 	if old.SecurityProfile.Defender != nil {
 		if m.SecurityProfile == nil || m.SecurityProfile.Defender == nil {
@@ -674,7 +674,7 @@ func validateAzureManagedControlPlaneClassSpecDefender(m *AzureManagedControlPla
 }
 
 // validateOIDCIssuerProfile validates an OIDCIssuerProfile.
-func validateAzureManagedControlPlaneOIDCIssuerProfileUpdate(m *AzureManagedControlPlane, old *AzureManagedControlPlane) field.ErrorList {
+func validateAzureManagedControlPlaneOIDCIssuerProfileUpdate(m *infrav1.AzureManagedControlPlane, old *infrav1.AzureManagedControlPlane) field.ErrorList {
 	var allErrs field.ErrorList
 	if m.Spec.OIDCIssuerProfile != nil && old.Spec.OIDCIssuerProfile != nil {
 		if m.Spec.OIDCIssuerProfile.Enabled != nil && old.Spec.OIDCIssuerProfile.Enabled != nil &&
@@ -691,7 +691,7 @@ func validateAzureManagedControlPlaneOIDCIssuerProfileUpdate(m *AzureManagedCont
 }
 
 // validateFleetsMemberUpdate validates a FleetsMember.
-func validateAzureManagedControlPlaneFleetsMemberUpdate(m *AzureManagedControlPlane, old *AzureManagedControlPlane) field.ErrorList {
+func validateAzureManagedControlPlaneFleetsMemberUpdate(m *infrav1.AzureManagedControlPlane, old *infrav1.AzureManagedControlPlane) field.ErrorList {
 	var allErrs field.ErrorList
 
 	if old.Spec.FleetsMember == nil || m.Spec.FleetsMember == nil {
@@ -710,10 +710,10 @@ func validateAzureManagedControlPlaneFleetsMemberUpdate(m *AzureManagedControlPl
 }
 
 // validateAKSExtensionsUpdate validates update to AKS extensions.
-func validateAKSExtensionsUpdate(old []AKSExtension, current []AKSExtension) field.ErrorList {
+func validateAKSExtensionsUpdate(old []infrav1.AKSExtension, current []infrav1.AKSExtension) field.ErrorList {
 	var allErrs field.ErrorList
 
-	oldAKSExtensionsMap := make(map[string]AKSExtension, len(old))
+	oldAKSExtensionsMap := make(map[string]infrav1.AKSExtension, len(old))
 	oldAKSExtensionsIndex := make(map[string]int, len(old))
 	for i, extension := range old {
 		oldAKSExtensionsMap[extension.Name] = extension
@@ -804,7 +804,7 @@ func validateName(name string, fldPath *field.Path) field.ErrorList {
 }
 
 // validateAKSExtensions validates the AKS extensions.
-func validateAKSExtensions(extensions []AKSExtension, fldPath *field.Path) field.ErrorList {
+func validateAKSExtensions(extensions []infrav1.AKSExtension, fldPath *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
 	for _, extension := range extensions {
 		if extension.Version != nil && (extension.AutoUpgradeMinorVersion == nil || (extension.AutoUpgradeMinorVersion != nil && *extension.AutoUpgradeMinorVersion)) {
@@ -815,14 +815,14 @@ func validateAKSExtensions(extensions []AKSExtension, fldPath *field.Path) field
 		}
 		if extension.Scope != nil {
 			switch extension.Scope.ScopeType {
-			case ExtensionScopeCluster:
+			case infrav1.ExtensionScopeCluster:
 				if extension.Scope.ReleaseNamespace == "" {
 					allErrs = append(allErrs, field.Required(fldPath.Child("Scope", "ReleaseNamespace"), "ReleaseNamespace must be provided if Scope is Cluster"))
 				}
 				if extension.Scope.TargetNamespace != "" {
 					allErrs = append(allErrs, field.Forbidden(fldPath.Child("Scope", "TargetNamespace"), "TargetNamespace can only be given if Scope is Namespace"))
 				}
-			case ExtensionScopeNamespace:
+			case infrav1.ExtensionScopeNamespace:
 				if extension.Scope.TargetNamespace == "" {
 					allErrs = append(allErrs, field.Required(fldPath.Child("Scope", "TargetNamespace"), "TargetNamespace must be provided if Scope is Namespace"))
 				}
@@ -837,14 +837,14 @@ func validateAKSExtensions(extensions []AKSExtension, fldPath *field.Path) field
 }
 
 // validateNetworkPolicy validates the networkPolicy.
-func validateNetworkPolicy(networkPolicy *string, networkDataplane *NetworkDataplaneType, fldPath *field.Path) field.ErrorList {
+func validateNetworkPolicy(networkPolicy *string, networkDataplane *infrav1.NetworkDataplaneType, fldPath *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
 
 	if networkPolicy == nil {
 		return nil
 	}
 
-	if *networkPolicy == "cilium" && networkDataplane != nil && *networkDataplane != NetworkDataplaneTypeCilium {
+	if *networkPolicy == "cilium" && networkDataplane != nil && *networkDataplane != infrav1.NetworkDataplaneTypeCilium {
 		allErrs = append(allErrs, field.Invalid(fldPath, networkPolicy, "cilium network policy can only be used with cilium network dataplane"))
 	}
 
@@ -852,17 +852,17 @@ func validateNetworkPolicy(networkPolicy *string, networkDataplane *NetworkDatap
 }
 
 // validateNetworkDataplane validates the NetworkDataplane.
-func validateNetworkDataplane(networkDataplane *NetworkDataplaneType, networkPolicy *string, networkPluginMode *NetworkPluginMode, fldPath *field.Path) field.ErrorList {
+func validateNetworkDataplane(networkDataplane *infrav1.NetworkDataplaneType, networkPolicy *string, networkPluginMode *infrav1.NetworkPluginMode, fldPath *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
 
 	if networkDataplane == nil {
 		return nil
 	}
 
-	if *networkDataplane == NetworkDataplaneTypeCilium && (networkPluginMode == nil || *networkPluginMode != NetworkPluginModeOverlay) {
+	if *networkDataplane == infrav1.NetworkDataplaneTypeCilium && (networkPluginMode == nil || *networkPluginMode != infrav1.NetworkPluginModeOverlay) {
 		allErrs = append(allErrs, field.Invalid(fldPath, networkDataplane, "cilium network dataplane can only be used with overlay network plugin mode"))
 	}
-	if *networkDataplane == NetworkDataplaneTypeCilium && (networkPolicy == nil || *networkPolicy != "cilium") {
+	if *networkDataplane == infrav1.NetworkDataplaneTypeCilium && (networkPolicy == nil || *networkPolicy != "cilium") {
 		allErrs = append(allErrs, field.Invalid(fldPath, networkDataplane, "cilium dataplane requires network policy cilium."))
 	}
 
@@ -870,7 +870,7 @@ func validateNetworkDataplane(networkDataplane *NetworkDataplaneType, networkPol
 }
 
 // validateAutoScalerProfile validates an AutoScalerProfile.
-func validateAutoScalerProfile(autoScalerProfile *AutoScalerProfile, fldPath *field.Path) field.ErrorList {
+func validateAutoScalerProfile(autoScalerProfile *infrav1.AutoScalerProfile, fldPath *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
 
 	if autoScalerProfile == nil {
@@ -1009,11 +1009,11 @@ func validateIntegerStringGreaterThanZero(input *string, fldPath *field.Path, fi
 }
 
 // validateIdentity validates an Identity.
-func validateAzureManagedControlPlaneIdentity(m *AzureManagedControlPlane, _ client.Client) field.ErrorList {
+func validateAzureManagedControlPlaneIdentity(m *infrav1.AzureManagedControlPlane, _ client.Client) field.ErrorList {
 	var allErrs field.ErrorList
 
 	if m.Spec.Identity != nil {
-		if m.Spec.Identity.Type == ManagedControlPlaneIdentityTypeUserAssigned {
+		if m.Spec.Identity.Type == infrav1.ManagedControlPlaneIdentityTypeUserAssigned {
 			if m.Spec.Identity.UserAssignedIdentityResourceID == "" {
 				allErrs = append(allErrs, field.Invalid(field.NewPath("spec", "identity", "userAssignedIdentityResourceID"), m.Spec.Identity.UserAssignedIdentityResourceID, "cannot be empty if Identity.Type is UserAssigned"))
 			}
@@ -1032,13 +1032,13 @@ func validateAzureManagedControlPlaneIdentity(m *AzureManagedControlPlane, _ cli
 }
 
 // validateNetworkPluginMode validates a NetworkPluginMode.
-func validateAzureManagedControlPlaneNetworkPluginMode(m *AzureManagedControlPlane, _ client.Client) field.ErrorList {
+func validateAzureManagedControlPlaneNetworkPluginMode(m *infrav1.AzureManagedControlPlane, _ client.Client) field.ErrorList {
 	var allErrs field.ErrorList
 
 	const kubenet = "kubenet"
-	if ptr.Deref(m.Spec.NetworkPluginMode, "") == NetworkPluginModeOverlay &&
+	if ptr.Deref(m.Spec.NetworkPluginMode, "") == infrav1.NetworkPluginModeOverlay &&
 		ptr.Deref(m.Spec.NetworkPlugin, "") == kubenet {
-		allErrs = append(allErrs, field.Invalid(field.NewPath("spec", "networkPluginMode"), m.Spec.NetworkPluginMode, fmt.Sprintf("cannot be set to %q when NetworkPlugin is %q", NetworkPluginModeOverlay, kubenet)))
+		allErrs = append(allErrs, field.Invalid(field.NewPath("spec", "networkPluginMode"), m.Spec.NetworkPluginMode, fmt.Sprintf("cannot be set to %q when NetworkPlugin is %q", infrav1.NetworkPluginModeOverlay, kubenet)))
 	}
 
 	if len(allErrs) > 0 {
@@ -1049,7 +1049,7 @@ func validateAzureManagedControlPlaneNetworkPluginMode(m *AzureManagedControlPla
 }
 
 // isOIDCEnabled return true if OIDC issuer is enabled.
-func azureManagedControlPlaneClassSpecIsOIDCEnabled(m *AzureManagedControlPlaneClassSpec) bool {
+func azureManagedControlPlaneClassSpecIsOIDCEnabled(m *infrav1.AzureManagedControlPlaneClassSpec) bool {
 	if m.OIDCIssuerProfile == nil {
 		return false
 	}
@@ -1060,11 +1060,11 @@ func azureManagedControlPlaneClassSpecIsOIDCEnabled(m *AzureManagedControlPlaneC
 }
 
 // isUserManagedIdentityEnabled checks if user assigned identity is set.
-func azureManagedControlPlaneClassSpecIsUserManagedIdentityEnabled(m *AzureManagedControlPlaneClassSpec) bool {
+func azureManagedControlPlaneClassSpecIsUserManagedIdentityEnabled(m *infrav1.AzureManagedControlPlaneClassSpec) bool {
 	if m.Identity == nil {
 		return false
 	}
-	if m.Identity.Type != ManagedControlPlaneIdentityTypeUserAssigned {
+	if m.Identity.Type != infrav1.ManagedControlPlaneIdentityTypeUserAssigned {
 		return false
 	}
 	return true

--- a/internal/webhooks/azuremanagedcontrolplane_webhook.go
+++ b/internal/webhooks/azuremanagedcontrolplane_webhook.go
@@ -29,7 +29,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
-	. "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
+	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	apiinternal "sigs.k8s.io/cluster-api-provider-azure/internal/api/v1beta1"
 	webhookutils "sigs.k8s.io/cluster-api-provider-azure/util/webhook"
 )
@@ -48,7 +48,7 @@ func (mw *AzureManagedControlPlaneWebhook) SetupWebhookWithManager(mgr ctrl.Mana
 	mw.logger = mgr.GetLogger().WithName("AzureManagedControlPlane")
 
 	return ctrl.NewWebhookManagedBy(mgr).
-		For(&AzureManagedControlPlane{}).
+		For(&infrav1.AzureManagedControlPlane{}).
 		WithDefaulter(mw).
 		WithValidator(mw).
 		Complete()
@@ -64,7 +64,7 @@ type AzureManagedControlPlaneWebhook struct {
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type.
 func (mw *AzureManagedControlPlaneWebhook) Default(_ context.Context, obj runtime.Object) error {
-	m, ok := obj.(*AzureManagedControlPlane)
+	m, ok := obj.(*infrav1.AzureManagedControlPlane)
 	if !ok {
 		return apierrors.NewBadRequest("expected an AzureManagedControlPlane")
 	}
@@ -92,7 +92,7 @@ func (mw *AzureManagedControlPlaneWebhook) Default(_ context.Context, obj runtim
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
 func (mw *AzureManagedControlPlaneWebhook) ValidateCreate(_ context.Context, obj runtime.Object) (admission.Warnings, error) {
-	m, ok := obj.(*AzureManagedControlPlane)
+	m, ok := obj.(*infrav1.AzureManagedControlPlane)
 	if !ok {
 		return nil, apierrors.NewBadRequest("expected an AzureManagedControlPlane")
 	}
@@ -103,11 +103,11 @@ func (mw *AzureManagedControlPlaneWebhook) ValidateCreate(_ context.Context, obj
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
 func (mw *AzureManagedControlPlaneWebhook) ValidateUpdate(_ context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
 	var allErrs field.ErrorList
-	old, ok := oldObj.(*AzureManagedControlPlane)
+	old, ok := oldObj.(*infrav1.AzureManagedControlPlane)
 	if !ok {
 		return nil, apierrors.NewBadRequest("expected an AzureManagedControlPlane")
 	}
-	m, ok := newObj.(*AzureManagedControlPlane)
+	m, ok := newObj.(*infrav1.AzureManagedControlPlane)
 	if !ok {
 		return nil, apierrors.NewBadRequest("expected an AzureManagedControlPlane")
 	}
@@ -214,7 +214,7 @@ func (mw *AzureManagedControlPlaneWebhook) ValidateUpdate(_ context.Context, old
 		return nil, validateAzureManagedControlPlane(m, mw.client)
 	}
 
-	return nil, apierrors.NewInvalid(GroupVersion.WithKind(AzureManagedControlPlaneKind).GroupKind(), m.Name, allErrs)
+	return nil, apierrors.NewInvalid(infrav1.GroupVersion.WithKind(infrav1.AzureManagedControlPlaneKind).GroupKind(), m.Name, allErrs)
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type.

--- a/internal/webhooks/azuremanagedcontrolplane_webhook_test.go
+++ b/internal/webhooks/azuremanagedcontrolplane_webhook_test.go
@@ -32,7 +32,7 @@ import (
 	capifeature "sigs.k8s.io/cluster-api/feature"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	. "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
+	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/feature"
 	apiinternal "sigs.k8s.io/cluster-api-provider-azure/internal/api/v1beta1"
 )
@@ -46,27 +46,27 @@ func TestDefaultingWebhook(t *testing.T) {
 	g := NewWithT(t)
 
 	t.Logf("Testing amcp defaulting webhook with no baseline")
-	amcp := &AzureManagedControlPlane{
+	amcp := &infrav1.AzureManagedControlPlane{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "fooName",
 			Labels: map[string]string{
 				clusterv1.ClusterNameLabel: "fooCluster",
 			},
 		},
-		Spec: AzureManagedControlPlaneSpec{
-			AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+		Spec: infrav1.AzureManagedControlPlaneSpec{
+			AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 				Location: "fooLocation",
 				Version:  "1.17.5",
-				Extensions: []AKSExtension{
+				Extensions: []infrav1.AKSExtension{
 					{
 						Name: "test-extension",
-						Plan: &ExtensionPlan{
+						Plan: &infrav1.ExtensionPlan{
 							Product:   "test-product",
 							Publisher: "test-publisher",
 						},
 					},
 				},
-				SKU: &AKSSku{},
+				SKU: &infrav1.AKSSku{},
 			},
 			SSHPublicKey: ptr.To(""),
 		},
@@ -95,20 +95,20 @@ func TestDefaultingWebhook(t *testing.T) {
 	amcp.Spec.NodeResourceGroupName = "fooNodeRg"
 	amcp.Spec.VirtualNetwork.Name = "fooVnetName"
 	amcp.Spec.VirtualNetwork.Subnet.Name = "fooSubnetName"
-	amcp.Spec.SKU.Tier = PaidManagedControlPlaneTier
-	amcp.Spec.OIDCIssuerProfile = &OIDCIssuerProfile{
+	amcp.Spec.SKU.Tier = infrav1.PaidManagedControlPlaneTier
+	amcp.Spec.OIDCIssuerProfile = &infrav1.OIDCIssuerProfile{
 		Enabled: ptr.To(true),
 	}
 	amcp.Spec.DNSPrefix = ptr.To("test-prefix")
-	amcp.Spec.FleetsMember = &FleetsMember{}
-	amcp.Spec.AutoUpgradeProfile = &ManagedClusterAutoUpgradeProfile{
-		UpgradeChannel: ptr.To(UpgradeChannelPatch),
+	amcp.Spec.FleetsMember = &infrav1.FleetsMember{}
+	amcp.Spec.AutoUpgradeProfile = &infrav1.ManagedClusterAutoUpgradeProfile{
+		UpgradeChannel: ptr.To(infrav1.UpgradeChannelPatch),
 	}
-	amcp.Spec.SecurityProfile = &ManagedClusterSecurityProfile{
-		AzureKeyVaultKms: &AzureKeyVaultKms{
+	amcp.Spec.SecurityProfile = &infrav1.ManagedClusterSecurityProfile{
+		AzureKeyVaultKms: &infrav1.AzureKeyVaultKms{
 			Enabled: true,
 		},
-		ImageCleaner: &ManagedClusterSecurityProfileImageCleaner{
+		ImageCleaner: &infrav1.ManagedClusterSecurityProfileImageCleaner{
 			Enabled:       true,
 			IntervalHours: ptr.To(48),
 		},
@@ -125,14 +125,14 @@ func TestDefaultingWebhook(t *testing.T) {
 	g.Expect(amcp.Spec.NodeResourceGroupName).To(Equal("fooNodeRg"))
 	g.Expect(amcp.Spec.VirtualNetwork.Name).To(Equal("fooVnetName"))
 	g.Expect(amcp.Spec.VirtualNetwork.Subnet.Name).To(Equal("fooSubnetName"))
-	g.Expect(amcp.Spec.SKU.Tier).To(Equal(StandardManagedControlPlaneTier))
+	g.Expect(amcp.Spec.SKU.Tier).To(Equal(infrav1.StandardManagedControlPlaneTier))
 	g.Expect(*amcp.Spec.OIDCIssuerProfile.Enabled).To(BeTrue())
 	g.Expect(amcp.Spec.DNSPrefix).NotTo(BeNil())
 	g.Expect(*amcp.Spec.DNSPrefix).To(Equal("test-prefix"))
 	g.Expect(amcp.Spec.FleetsMember.Name).To(Equal("fooCluster"))
 	g.Expect(amcp.Spec.AutoUpgradeProfile).NotTo(BeNil())
 	g.Expect(amcp.Spec.AutoUpgradeProfile.UpgradeChannel).NotTo(BeNil())
-	g.Expect(*amcp.Spec.AutoUpgradeProfile.UpgradeChannel).To(Equal(UpgradeChannelPatch))
+	g.Expect(*amcp.Spec.AutoUpgradeProfile.UpgradeChannel).To(Equal(infrav1.UpgradeChannelPatch))
 	g.Expect(amcp.Spec.SecurityProfile).NotTo(BeNil())
 	g.Expect(amcp.Spec.SecurityProfile.AzureKeyVaultKms).NotTo(BeNil())
 	g.Expect(amcp.Spec.SecurityProfile.ImageCleaner).NotTo(BeNil())
@@ -142,31 +142,31 @@ func TestDefaultingWebhook(t *testing.T) {
 	g.Expect(*amcp.Spec.EnablePreviewFeatures).To(BeTrue())
 
 	t.Logf("Testing amcp defaulting webhook with overlay")
-	amcp = &AzureManagedControlPlane{
+	amcp = &infrav1.AzureManagedControlPlane{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "fooName",
 		},
-		Spec: AzureManagedControlPlaneSpec{
-			AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+		Spec: infrav1.AzureManagedControlPlaneSpec{
+			AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 				ResourceGroupName: "fooRg",
 				Location:          "fooLocation",
 				Version:           "1.17.5",
-				NetworkPluginMode: ptr.To(NetworkPluginModeOverlay),
-				AutoUpgradeProfile: &ManagedClusterAutoUpgradeProfile{
-					UpgradeChannel: ptr.To(UpgradeChannelRapid),
+				NetworkPluginMode: ptr.To(infrav1.NetworkPluginModeOverlay),
+				AutoUpgradeProfile: &infrav1.ManagedClusterAutoUpgradeProfile{
+					UpgradeChannel: ptr.To(infrav1.UpgradeChannelRapid),
 				},
-				SecurityProfile: &ManagedClusterSecurityProfile{
-					Defender: &ManagedClusterSecurityProfileDefender{
+				SecurityProfile: &infrav1.ManagedClusterSecurityProfile{
+					Defender: &infrav1.ManagedClusterSecurityProfileDefender{
 						LogAnalyticsWorkspaceResourceID: "not empty",
-						SecurityMonitoring: ManagedClusterSecurityProfileDefenderSecurityMonitoring{
+						SecurityMonitoring: infrav1.ManagedClusterSecurityProfileDefenderSecurityMonitoring{
 							Enabled: true,
 						},
 					},
-					WorkloadIdentity: &ManagedClusterSecurityProfileWorkloadIdentity{
+					WorkloadIdentity: &infrav1.ManagedClusterSecurityProfileWorkloadIdentity{
 						Enabled: true,
 					},
 				},
-				SKU: &AKSSku{},
+				SKU: &infrav1.AKSSku{},
 			},
 			SSHPublicKey: ptr.To(""),
 		},
@@ -177,7 +177,7 @@ func TestDefaultingWebhook(t *testing.T) {
 	g.Expect(amcp.Spec.VirtualNetwork.Subnet.CIDRBlock).To(Equal(apiinternal.DefaultAKSNodeSubnetCIDRForOverlay))
 	g.Expect(amcp.Spec.AutoUpgradeProfile).NotTo(BeNil())
 	g.Expect(amcp.Spec.AutoUpgradeProfile.UpgradeChannel).NotTo(BeNil())
-	g.Expect(*amcp.Spec.AutoUpgradeProfile.UpgradeChannel).To(Equal(UpgradeChannelRapid))
+	g.Expect(*amcp.Spec.AutoUpgradeProfile.UpgradeChannel).To(Equal(infrav1.UpgradeChannelRapid))
 }
 
 func TestValidateVersion(t *testing.T) {
@@ -224,12 +224,12 @@ func TestValidateVersion(t *testing.T) {
 func TestValidateLoadBalancerProfile(t *testing.T) {
 	tests := []struct {
 		name        string
-		profile     *LoadBalancerProfile
+		profile     *infrav1.LoadBalancerProfile
 		expectedErr field.Error
 	}{
 		{
 			name: "Valid LoadBalancerProfile",
-			profile: &LoadBalancerProfile{
+			profile: &infrav1.LoadBalancerProfile{
 				ManagedOutboundIPs:     ptr.To(10),
 				AllocatedOutboundPorts: ptr.To(1000),
 				IdleTimeoutInMinutes:   ptr.To(60),
@@ -237,7 +237,7 @@ func TestValidateLoadBalancerProfile(t *testing.T) {
 		},
 		{
 			name: "Invalid LoadBalancerProfile.ManagedOutboundIPs",
-			profile: &LoadBalancerProfile{
+			profile: &infrav1.LoadBalancerProfile{
 				ManagedOutboundIPs: ptr.To(200),
 			},
 			expectedErr: field.Error{
@@ -249,7 +249,7 @@ func TestValidateLoadBalancerProfile(t *testing.T) {
 		},
 		{
 			name: "Invalid LoadBalancerProfile.IdleTimeoutInMinutes",
-			profile: &LoadBalancerProfile{
+			profile: &infrav1.LoadBalancerProfile{
 				IdleTimeoutInMinutes: ptr.To(600),
 			},
 			expectedErr: field.Error{
@@ -261,7 +261,7 @@ func TestValidateLoadBalancerProfile(t *testing.T) {
 		},
 		{
 			name: "LoadBalancerProfile must specify at most one of ManagedOutboundIPs, OutboundIPPrefixes and OutboundIPs",
-			profile: &LoadBalancerProfile{
+			profile: &infrav1.LoadBalancerProfile{
 				ManagedOutboundIPs: ptr.To(1),
 				OutboundIPs: []string{
 					"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/foo-bar/providers/Microsoft.Network/publicIPAddresses/my-public-ip",
@@ -291,14 +291,14 @@ func TestValidateLoadBalancerProfile(t *testing.T) {
 func TestValidateAutoScalerProfile(t *testing.T) {
 	tests := []struct {
 		name      string
-		profile   *AutoScalerProfile
+		profile   *infrav1.AutoScalerProfile
 		expectErr bool
 	}{
 		{
 			name: "Valid AutoScalerProfile",
-			profile: &AutoScalerProfile{
-				BalanceSimilarNodeGroups:      (*BalanceSimilarNodeGroups)(ptr.To(string(BalanceSimilarNodeGroupsFalse))),
-				Expander:                      (*Expander)(ptr.To(string(ExpanderRandom))),
+			profile: &infrav1.AutoScalerProfile{
+				BalanceSimilarNodeGroups:      (*infrav1.BalanceSimilarNodeGroups)(ptr.To(string(infrav1.BalanceSimilarNodeGroupsFalse))),
+				Expander:                      (*infrav1.Expander)(ptr.To(string(infrav1.ExpanderRandom))),
 				MaxEmptyBulkDelete:            ptr.To("10"),
 				MaxGracefulTerminationSec:     ptr.To("600"),
 				MaxNodeProvisionTime:          ptr.To("10m"),
@@ -312,155 +312,155 @@ func TestValidateAutoScalerProfile(t *testing.T) {
 				ScaleDownUnneededTime:         ptr.To("10m"),
 				ScaleDownUnreadyTime:          ptr.To("10m"),
 				ScaleDownUtilizationThreshold: ptr.To("0.5"),
-				SkipNodesWithLocalStorage:     (*SkipNodesWithLocalStorage)(ptr.To(string(SkipNodesWithLocalStorageTrue))),
-				SkipNodesWithSystemPods:       (*SkipNodesWithSystemPods)(ptr.To(string(SkipNodesWithSystemPodsTrue))),
+				SkipNodesWithLocalStorage:     (*infrav1.SkipNodesWithLocalStorage)(ptr.To(string(infrav1.SkipNodesWithLocalStorageTrue))),
+				SkipNodesWithSystemPods:       (*infrav1.SkipNodesWithSystemPods)(ptr.To(string(infrav1.SkipNodesWithSystemPodsTrue))),
 			},
 			expectErr: false,
 		},
 		{
 			name: "Testing valid AutoScalerProfile.ExpanderRandom",
-			profile: &AutoScalerProfile{
-				Expander: (*Expander)(ptr.To(string(ExpanderRandom))),
+			profile: &infrav1.AutoScalerProfile{
+				Expander: (*infrav1.Expander)(ptr.To(string(infrav1.ExpanderRandom))),
 			},
 			expectErr: false,
 		},
 		{
 			name: "Testing valid AutoScalerProfile.ExpanderLeastWaste",
-			profile: &AutoScalerProfile{
-				Expander: (*Expander)(ptr.To(string(ExpanderLeastWaste))),
+			profile: &infrav1.AutoScalerProfile{
+				Expander: (*infrav1.Expander)(ptr.To(string(infrav1.ExpanderLeastWaste))),
 			},
 			expectErr: false,
 		},
 		{
 			name: "Testing valid AutoScalerProfile.ExpanderMostPods",
-			profile: &AutoScalerProfile{
-				Expander: (*Expander)(ptr.To(string(ExpanderMostPods))),
+			profile: &infrav1.AutoScalerProfile{
+				Expander: (*infrav1.Expander)(ptr.To(string(infrav1.ExpanderMostPods))),
 			},
 			expectErr: false,
 		},
 		{
 			name: "Testing valid AutoScalerProfile.ExpanderPriority",
-			profile: &AutoScalerProfile{
-				Expander: (*Expander)(ptr.To(string(ExpanderPriority))),
+			profile: &infrav1.AutoScalerProfile{
+				Expander: (*infrav1.Expander)(ptr.To(string(infrav1.ExpanderPriority))),
 			},
 			expectErr: false,
 		},
 		{
 			name: "Testing valid AutoScalerProfile.BalanceSimilarNodeGroupsTrue",
-			profile: &AutoScalerProfile{
-				BalanceSimilarNodeGroups: (*BalanceSimilarNodeGroups)(ptr.To(string(BalanceSimilarNodeGroupsTrue))),
+			profile: &infrav1.AutoScalerProfile{
+				BalanceSimilarNodeGroups: (*infrav1.BalanceSimilarNodeGroups)(ptr.To(string(infrav1.BalanceSimilarNodeGroupsTrue))),
 			},
 			expectErr: false,
 		},
 		{
 			name: "Testing valid AutoScalerProfile.BalanceSimilarNodeGroupsFalse",
-			profile: &AutoScalerProfile{
-				BalanceSimilarNodeGroups: (*BalanceSimilarNodeGroups)(ptr.To(string(BalanceSimilarNodeGroupsFalse))),
+			profile: &infrav1.AutoScalerProfile{
+				BalanceSimilarNodeGroups: (*infrav1.BalanceSimilarNodeGroups)(ptr.To(string(infrav1.BalanceSimilarNodeGroupsFalse))),
 			},
 			expectErr: false,
 		},
 		{
 			name: "Testing invalid AutoScalerProfile.MaxEmptyBulkDelete",
-			profile: &AutoScalerProfile{
+			profile: &infrav1.AutoScalerProfile{
 				MaxEmptyBulkDelete: ptr.To("invalid"),
 			},
 			expectErr: true,
 		},
 		{
 			name: "Testing invalid AutoScalerProfile.MaxGracefulTerminationSec",
-			profile: &AutoScalerProfile{
+			profile: &infrav1.AutoScalerProfile{
 				MaxGracefulTerminationSec: ptr.To("invalid"),
 			},
 			expectErr: true,
 		},
 		{
 			name: "Testing invalid AutoScalerProfile.MaxNodeProvisionTime",
-			profile: &AutoScalerProfile{
+			profile: &infrav1.AutoScalerProfile{
 				MaxNodeProvisionTime: ptr.To("invalid"),
 			},
 			expectErr: true,
 		},
 		{
 			name: "Testing invalid AutoScalerProfile.MaxTotalUnreadyPercentage",
-			profile: &AutoScalerProfile{
+			profile: &infrav1.AutoScalerProfile{
 				MaxTotalUnreadyPercentage: ptr.To("invalid"),
 			},
 			expectErr: true,
 		},
 		{
 			name: "Testing invalid AutoScalerProfile.NewPodScaleUpDelay",
-			profile: &AutoScalerProfile{
+			profile: &infrav1.AutoScalerProfile{
 				NewPodScaleUpDelay: ptr.To("invalid"),
 			},
 			expectErr: true,
 		},
 		{
 			name: "Testing invalid AutoScalerProfile.OkTotalUnreadyCount",
-			profile: &AutoScalerProfile{
+			profile: &infrav1.AutoScalerProfile{
 				OkTotalUnreadyCount: ptr.To("invalid"),
 			},
 			expectErr: true,
 		},
 		{
 			name: "Testing invalid AutoScalerProfile.ScanInterval",
-			profile: &AutoScalerProfile{
+			profile: &infrav1.AutoScalerProfile{
 				ScanInterval: ptr.To("invalid"),
 			},
 			expectErr: true,
 		},
 		{
 			name: "Testing invalid AutoScalerProfile.ScaleDownDelayAfterAdd",
-			profile: &AutoScalerProfile{
+			profile: &infrav1.AutoScalerProfile{
 				ScaleDownDelayAfterAdd: ptr.To("invalid"),
 			},
 			expectErr: true,
 		},
 		{
 			name: "Testing invalid AutoScalerProfile.ScaleDownDelayAfterDelete",
-			profile: &AutoScalerProfile{
+			profile: &infrav1.AutoScalerProfile{
 				ScaleDownDelayAfterDelete: ptr.To("invalid"),
 			},
 			expectErr: true,
 		},
 		{
 			name: "Testing invalid AutoScalerProfile.ScaleDownDelayAfterFailure",
-			profile: &AutoScalerProfile{
+			profile: &infrav1.AutoScalerProfile{
 				ScaleDownDelayAfterFailure: ptr.To("invalid"),
 			},
 			expectErr: true,
 		},
 		{
 			name: "Testing invalid AutoScalerProfile.ScaleDownUnneededTime",
-			profile: &AutoScalerProfile{
+			profile: &infrav1.AutoScalerProfile{
 				ScaleDownUnneededTime: ptr.To("invalid"),
 			},
 			expectErr: true,
 		},
 		{
 			name: "Testing invalid AutoScalerProfile.ScaleDownUnreadyTime",
-			profile: &AutoScalerProfile{
+			profile: &infrav1.AutoScalerProfile{
 				ScaleDownUnreadyTime: ptr.To("invalid"),
 			},
 			expectErr: true,
 		},
 		{
 			name: "Testing invalid AutoScalerProfile.ScaleDownUtilizationThreshold",
-			profile: &AutoScalerProfile{
+			profile: &infrav1.AutoScalerProfile{
 				ScaleDownUtilizationThreshold: ptr.To("invalid"),
 			},
 			expectErr: true,
 		},
 		{
 			name: "Testing valid AutoScalerProfile.SkipNodesWithLocalStorageTrue",
-			profile: &AutoScalerProfile{
-				SkipNodesWithLocalStorage: (*SkipNodesWithLocalStorage)(ptr.To(string(SkipNodesWithLocalStorageTrue))),
+			profile: &infrav1.AutoScalerProfile{
+				SkipNodesWithLocalStorage: (*infrav1.SkipNodesWithLocalStorage)(ptr.To(string(infrav1.SkipNodesWithLocalStorageTrue))),
 			},
 			expectErr: false,
 		},
 		{
 			name: "Testing valid AutoScalerProfile.SkipNodesWithLocalStorageFalse",
-			profile: &AutoScalerProfile{
-				SkipNodesWithSystemPods: (*SkipNodesWithSystemPods)(ptr.To(string(SkipNodesWithSystemPodsFalse))),
+			profile: &infrav1.AutoScalerProfile{
+				SkipNodesWithSystemPods: (*infrav1.SkipNodesWithSystemPods)(ptr.To(string(infrav1.SkipNodesWithSystemPodsFalse))),
 			},
 			expectErr: false,
 		},
@@ -482,15 +482,15 @@ func TestValidateAutoScalerProfile(t *testing.T) {
 func TestValidatingWebhook(t *testing.T) {
 	tests := []struct {
 		name      string
-		amcp      AzureManagedControlPlane
+		amcp      infrav1.AzureManagedControlPlane
 		expectErr bool
 	}{
 		{
 			name: "Testing valid DNSServiceIP",
-			amcp: AzureManagedControlPlane{
+			amcp: infrav1.AzureManagedControlPlane{
 				ObjectMeta: getAMCPMetaData(),
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						DNSServiceIP: ptr.To("192.168.0.10"),
 						Version:      "v1.17.8",
 					},
@@ -500,10 +500,10 @@ func TestValidatingWebhook(t *testing.T) {
 		},
 		{
 			name: "Testing invalid DNSServiceIP",
-			amcp: AzureManagedControlPlane{
+			amcp: infrav1.AzureManagedControlPlane{
 				ObjectMeta: getAMCPMetaData(),
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						DNSServiceIP: ptr.To("192.168.0.10.3"),
 						Version:      "v1.17.8",
 					},
@@ -513,10 +513,10 @@ func TestValidatingWebhook(t *testing.T) {
 		},
 		{
 			name: "Testing invalid DNSServiceIP",
-			amcp: AzureManagedControlPlane{
+			amcp: infrav1.AzureManagedControlPlane{
 				ObjectMeta: getAMCPMetaData(),
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						DNSServiceIP: ptr.To("192.168.0.11"),
 						Version:      "v1.17.8",
 					},
@@ -526,10 +526,10 @@ func TestValidatingWebhook(t *testing.T) {
 		},
 		{
 			name: "Testing empty DNSServiceIP",
-			amcp: AzureManagedControlPlane{
+			amcp: infrav1.AzureManagedControlPlane{
 				ObjectMeta: getAMCPMetaData(),
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.17.8",
 					},
 				},
@@ -538,10 +538,10 @@ func TestValidatingWebhook(t *testing.T) {
 		},
 		{
 			name: "Invalid Version",
-			amcp: AzureManagedControlPlane{
+			amcp: infrav1.AzureManagedControlPlane{
 				ObjectMeta: getAMCPMetaData(),
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						DNSServiceIP: ptr.To("192.168.0.10"),
 						Version:      "honk",
 					},
@@ -551,10 +551,10 @@ func TestValidatingWebhook(t *testing.T) {
 		},
 		{
 			name: "not following the Kubernetes Version pattern",
-			amcp: AzureManagedControlPlane{
+			amcp: infrav1.AzureManagedControlPlane{
 				ObjectMeta: getAMCPMetaData(),
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						DNSServiceIP: ptr.To("192.168.0.10"),
 						Version:      "1.19.0",
 					},
@@ -564,10 +564,10 @@ func TestValidatingWebhook(t *testing.T) {
 		},
 		{
 			name: "Version not set",
-			amcp: AzureManagedControlPlane{
+			amcp: infrav1.AzureManagedControlPlane{
 				ObjectMeta: getAMCPMetaData(),
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						DNSServiceIP: ptr.To("192.168.0.10"),
 						Version:      "",
 					},
@@ -577,10 +577,10 @@ func TestValidatingWebhook(t *testing.T) {
 		},
 		{
 			name: "Valid Version",
-			amcp: AzureManagedControlPlane{
+			amcp: infrav1.AzureManagedControlPlane{
 				ObjectMeta: getAMCPMetaData(),
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						DNSServiceIP: ptr.To("192.168.0.10"),
 						Version:      "v1.17.8",
 					},
@@ -590,12 +590,12 @@ func TestValidatingWebhook(t *testing.T) {
 		},
 		{
 			name: "Valid Managed AADProfile",
-			amcp: AzureManagedControlPlane{
+			amcp: infrav1.AzureManagedControlPlane{
 				ObjectMeta: getAMCPMetaData(),
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.21.2",
-						AADProfile: &AADProfile{
+						AADProfile: &infrav1.AADProfile{
 							Managed: true,
 							AdminGroupObjectIDs: []string{
 								"616077a8-5db7-4c98-b856-b34619afg75h",
@@ -608,12 +608,12 @@ func TestValidatingWebhook(t *testing.T) {
 		},
 		{
 			name: "Valid LoadBalancerProfile",
-			amcp: AzureManagedControlPlane{
+			amcp: infrav1.AzureManagedControlPlane{
 				ObjectMeta: getAMCPMetaData(),
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.21.2",
-						LoadBalancerProfile: &LoadBalancerProfile{
+						LoadBalancerProfile: &infrav1.LoadBalancerProfile{
 							ManagedOutboundIPs:     ptr.To(10),
 							AllocatedOutboundPorts: ptr.To(1000),
 							IdleTimeoutInMinutes:   ptr.To(60),
@@ -625,12 +625,12 @@ func TestValidatingWebhook(t *testing.T) {
 		},
 		{
 			name: "Invalid LoadBalancerProfile.ManagedOutboundIPs",
-			amcp: AzureManagedControlPlane{
+			amcp: infrav1.AzureManagedControlPlane{
 				ObjectMeta: getAMCPMetaData(),
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.21.2",
-						LoadBalancerProfile: &LoadBalancerProfile{
+						LoadBalancerProfile: &infrav1.LoadBalancerProfile{
 							ManagedOutboundIPs: ptr.To(200),
 						},
 					},
@@ -640,12 +640,12 @@ func TestValidatingWebhook(t *testing.T) {
 		},
 		{
 			name: "Invalid LoadBalancerProfile.AllocatedOutboundPorts",
-			amcp: AzureManagedControlPlane{
+			amcp: infrav1.AzureManagedControlPlane{
 				ObjectMeta: getAMCPMetaData(),
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.21.2",
-						LoadBalancerProfile: &LoadBalancerProfile{
+						LoadBalancerProfile: &infrav1.LoadBalancerProfile{
 							AllocatedOutboundPorts: ptr.To(80000),
 						},
 					},
@@ -655,12 +655,12 @@ func TestValidatingWebhook(t *testing.T) {
 		},
 		{
 			name: "Invalid LoadBalancerProfile.IdleTimeoutInMinutes",
-			amcp: AzureManagedControlPlane{
+			amcp: infrav1.AzureManagedControlPlane{
 				ObjectMeta: getAMCPMetaData(),
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.21.2",
-						LoadBalancerProfile: &LoadBalancerProfile{
+						LoadBalancerProfile: &infrav1.LoadBalancerProfile{
 							IdleTimeoutInMinutes: ptr.To(600),
 						},
 					},
@@ -670,12 +670,12 @@ func TestValidatingWebhook(t *testing.T) {
 		},
 		{
 			name: "LoadBalancerProfile must specify at most one of ManagedOutboundIPs, OutboundIPPrefixes and OutboundIPs",
-			amcp: AzureManagedControlPlane{
+			amcp: infrav1.AzureManagedControlPlane{
 				ObjectMeta: getAMCPMetaData(),
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.21.2",
-						LoadBalancerProfile: &LoadBalancerProfile{
+						LoadBalancerProfile: &infrav1.LoadBalancerProfile{
 							ManagedOutboundIPs: ptr.To(1),
 							OutboundIPs: []string{
 								"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/foo-bar/providers/Microsoft.Network/publicIPAddresses/my-public-ip",
@@ -688,12 +688,12 @@ func TestValidatingWebhook(t *testing.T) {
 		},
 		{
 			name: "Invalid CIDR for AuthorizedIPRanges",
-			amcp: AzureManagedControlPlane{
+			amcp: infrav1.AzureManagedControlPlane{
 				ObjectMeta: getAMCPMetaData(),
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.21.2",
-						APIServerAccessProfile: &APIServerAccessProfile{
+						APIServerAccessProfile: &infrav1.APIServerAccessProfile{
 							AuthorizedIPRanges: []string{"1.2.3.400/32"},
 						},
 					},
@@ -703,14 +703,14 @@ func TestValidatingWebhook(t *testing.T) {
 		},
 		{
 			name: "Testing valid AutoScalerProfile",
-			amcp: AzureManagedControlPlane{
+			amcp: infrav1.AzureManagedControlPlane{
 				ObjectMeta: getAMCPMetaData(),
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.24.1",
-						AutoScalerProfile: &AutoScalerProfile{
-							BalanceSimilarNodeGroups:      (*BalanceSimilarNodeGroups)(ptr.To(string(BalanceSimilarNodeGroupsFalse))),
-							Expander:                      (*Expander)(ptr.To(string(ExpanderRandom))),
+						AutoScalerProfile: &infrav1.AutoScalerProfile{
+							BalanceSimilarNodeGroups:      (*infrav1.BalanceSimilarNodeGroups)(ptr.To(string(infrav1.BalanceSimilarNodeGroupsFalse))),
+							Expander:                      (*infrav1.Expander)(ptr.To(string(infrav1.ExpanderRandom))),
 							MaxEmptyBulkDelete:            ptr.To("10"),
 							MaxGracefulTerminationSec:     ptr.To("600"),
 							MaxNodeProvisionTime:          ptr.To("10m"),
@@ -724,8 +724,8 @@ func TestValidatingWebhook(t *testing.T) {
 							ScaleDownUnneededTime:         ptr.To("10m"),
 							ScaleDownUnreadyTime:          ptr.To("10m"),
 							ScaleDownUtilizationThreshold: ptr.To("0.5"),
-							SkipNodesWithLocalStorage:     (*SkipNodesWithLocalStorage)(ptr.To(string(SkipNodesWithLocalStorageTrue))),
-							SkipNodesWithSystemPods:       (*SkipNodesWithSystemPods)(ptr.To(string(SkipNodesWithSystemPodsTrue))),
+							SkipNodesWithLocalStorage:     (*infrav1.SkipNodesWithLocalStorage)(ptr.To(string(infrav1.SkipNodesWithLocalStorageTrue))),
+							SkipNodesWithSystemPods:       (*infrav1.SkipNodesWithSystemPods)(ptr.To(string(infrav1.SkipNodesWithSystemPodsTrue))),
 						},
 					},
 				},
@@ -734,13 +734,13 @@ func TestValidatingWebhook(t *testing.T) {
 		},
 		{
 			name: "Testing valid AutoScalerProfile.ExpanderRandom",
-			amcp: AzureManagedControlPlane{
+			amcp: infrav1.AzureManagedControlPlane{
 				ObjectMeta: getAMCPMetaData(),
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.24.1",
-						AutoScalerProfile: &AutoScalerProfile{
-							Expander: (*Expander)(ptr.To(string(ExpanderRandom))),
+						AutoScalerProfile: &infrav1.AutoScalerProfile{
+							Expander: (*infrav1.Expander)(ptr.To(string(infrav1.ExpanderRandom))),
 						},
 					},
 				},
@@ -749,13 +749,13 @@ func TestValidatingWebhook(t *testing.T) {
 		},
 		{
 			name: "Testing valid AutoScalerProfile.ExpanderLeastWaste",
-			amcp: AzureManagedControlPlane{
+			amcp: infrav1.AzureManagedControlPlane{
 				ObjectMeta: getAMCPMetaData(),
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.24.1",
-						AutoScalerProfile: &AutoScalerProfile{
-							Expander: (*Expander)(ptr.To(string(ExpanderLeastWaste))),
+						AutoScalerProfile: &infrav1.AutoScalerProfile{
+							Expander: (*infrav1.Expander)(ptr.To(string(infrav1.ExpanderLeastWaste))),
 						},
 					},
 				},
@@ -764,13 +764,13 @@ func TestValidatingWebhook(t *testing.T) {
 		},
 		{
 			name: "Testing valid AutoScalerProfile.ExpanderMostPods",
-			amcp: AzureManagedControlPlane{
+			amcp: infrav1.AzureManagedControlPlane{
 				ObjectMeta: getAMCPMetaData(),
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.24.1",
-						AutoScalerProfile: &AutoScalerProfile{
-							Expander: (*Expander)(ptr.To(string(ExpanderMostPods))),
+						AutoScalerProfile: &infrav1.AutoScalerProfile{
+							Expander: (*infrav1.Expander)(ptr.To(string(infrav1.ExpanderMostPods))),
 						},
 					},
 				},
@@ -779,13 +779,13 @@ func TestValidatingWebhook(t *testing.T) {
 		},
 		{
 			name: "Testing valid AutoScalerProfile.ExpanderPriority",
-			amcp: AzureManagedControlPlane{
+			amcp: infrav1.AzureManagedControlPlane{
 				ObjectMeta: getAMCPMetaData(),
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.24.1",
-						AutoScalerProfile: &AutoScalerProfile{
-							Expander: (*Expander)(ptr.To(string(ExpanderPriority))),
+						AutoScalerProfile: &infrav1.AutoScalerProfile{
+							Expander: (*infrav1.Expander)(ptr.To(string(infrav1.ExpanderPriority))),
 						},
 					},
 				},
@@ -794,13 +794,13 @@ func TestValidatingWebhook(t *testing.T) {
 		},
 		{
 			name: "Testing valid AutoScalerProfile.BalanceSimilarNodeGroupsTrue",
-			amcp: AzureManagedControlPlane{
+			amcp: infrav1.AzureManagedControlPlane{
 				ObjectMeta: getAMCPMetaData(),
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.24.1",
-						AutoScalerProfile: &AutoScalerProfile{
-							BalanceSimilarNodeGroups: (*BalanceSimilarNodeGroups)(ptr.To(string(BalanceSimilarNodeGroupsTrue))),
+						AutoScalerProfile: &infrav1.AutoScalerProfile{
+							BalanceSimilarNodeGroups: (*infrav1.BalanceSimilarNodeGroups)(ptr.To(string(infrav1.BalanceSimilarNodeGroupsTrue))),
 						},
 					},
 				},
@@ -809,13 +809,13 @@ func TestValidatingWebhook(t *testing.T) {
 		},
 		{
 			name: "Testing valid AutoScalerProfile.BalanceSimilarNodeGroupsFalse",
-			amcp: AzureManagedControlPlane{
+			amcp: infrav1.AzureManagedControlPlane{
 				ObjectMeta: getAMCPMetaData(),
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.24.1",
-						AutoScalerProfile: &AutoScalerProfile{
-							BalanceSimilarNodeGroups: (*BalanceSimilarNodeGroups)(ptr.To(string(BalanceSimilarNodeGroupsFalse))),
+						AutoScalerProfile: &infrav1.AutoScalerProfile{
+							BalanceSimilarNodeGroups: (*infrav1.BalanceSimilarNodeGroups)(ptr.To(string(infrav1.BalanceSimilarNodeGroupsFalse))),
 						},
 					},
 				},
@@ -824,12 +824,12 @@ func TestValidatingWebhook(t *testing.T) {
 		},
 		{
 			name: "Testing invalid AutoScalerProfile.MaxEmptyBulkDelete",
-			amcp: AzureManagedControlPlane{
+			amcp: infrav1.AzureManagedControlPlane{
 				ObjectMeta: getAMCPMetaData(),
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.24.1",
-						AutoScalerProfile: &AutoScalerProfile{
+						AutoScalerProfile: &infrav1.AutoScalerProfile{
 							MaxEmptyBulkDelete: ptr.To("invalid"),
 						},
 					},
@@ -839,12 +839,12 @@ func TestValidatingWebhook(t *testing.T) {
 		},
 		{
 			name: "Testing invalid AutoScalerProfile.MaxGracefulTerminationSec",
-			amcp: AzureManagedControlPlane{
+			amcp: infrav1.AzureManagedControlPlane{
 				ObjectMeta: getAMCPMetaData(),
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.24.1",
-						AutoScalerProfile: &AutoScalerProfile{
+						AutoScalerProfile: &infrav1.AutoScalerProfile{
 							MaxGracefulTerminationSec: ptr.To("invalid"),
 						},
 					},
@@ -854,12 +854,12 @@ func TestValidatingWebhook(t *testing.T) {
 		},
 		{
 			name: "Testing invalid AutoScalerProfile.MaxNodeProvisionTime",
-			amcp: AzureManagedControlPlane{
+			amcp: infrav1.AzureManagedControlPlane{
 				ObjectMeta: getAMCPMetaData(),
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.24.1",
-						AutoScalerProfile: &AutoScalerProfile{
+						AutoScalerProfile: &infrav1.AutoScalerProfile{
 							MaxNodeProvisionTime: ptr.To("invalid"),
 						},
 					},
@@ -869,12 +869,12 @@ func TestValidatingWebhook(t *testing.T) {
 		},
 		{
 			name: "Testing invalid AutoScalerProfile.MaxTotalUnreadyPercentage",
-			amcp: AzureManagedControlPlane{
+			amcp: infrav1.AzureManagedControlPlane{
 				ObjectMeta: getAMCPMetaData(),
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.24.1",
-						AutoScalerProfile: &AutoScalerProfile{
+						AutoScalerProfile: &infrav1.AutoScalerProfile{
 							MaxTotalUnreadyPercentage: ptr.To("invalid"),
 						},
 					},
@@ -884,12 +884,12 @@ func TestValidatingWebhook(t *testing.T) {
 		},
 		{
 			name: "Testing invalid AutoScalerProfile.NewPodScaleUpDelay",
-			amcp: AzureManagedControlPlane{
+			amcp: infrav1.AzureManagedControlPlane{
 				ObjectMeta: getAMCPMetaData(),
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.24.1",
-						AutoScalerProfile: &AutoScalerProfile{
+						AutoScalerProfile: &infrav1.AutoScalerProfile{
 							NewPodScaleUpDelay: ptr.To("invalid"),
 						},
 					},
@@ -899,12 +899,12 @@ func TestValidatingWebhook(t *testing.T) {
 		},
 		{
 			name: "Testing invalid AutoScalerProfile.OkTotalUnreadyCount",
-			amcp: AzureManagedControlPlane{
+			amcp: infrav1.AzureManagedControlPlane{
 				ObjectMeta: getAMCPMetaData(),
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.24.1",
-						AutoScalerProfile: &AutoScalerProfile{
+						AutoScalerProfile: &infrav1.AutoScalerProfile{
 							OkTotalUnreadyCount: ptr.To("invalid"),
 						},
 					},
@@ -914,12 +914,12 @@ func TestValidatingWebhook(t *testing.T) {
 		},
 		{
 			name: "Testing invalid AutoScalerProfile.ScanInterval",
-			amcp: AzureManagedControlPlane{
+			amcp: infrav1.AzureManagedControlPlane{
 				ObjectMeta: getAMCPMetaData(),
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.24.1",
-						AutoScalerProfile: &AutoScalerProfile{
+						AutoScalerProfile: &infrav1.AutoScalerProfile{
 							ScanInterval: ptr.To("invalid"),
 						},
 					},
@@ -929,12 +929,12 @@ func TestValidatingWebhook(t *testing.T) {
 		},
 		{
 			name: "Testing invalid AutoScalerProfile.ScaleDownDelayAfterAdd",
-			amcp: AzureManagedControlPlane{
+			amcp: infrav1.AzureManagedControlPlane{
 				ObjectMeta: getAMCPMetaData(),
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.24.1",
-						AutoScalerProfile: &AutoScalerProfile{
+						AutoScalerProfile: &infrav1.AutoScalerProfile{
 							ScaleDownDelayAfterAdd: ptr.To("invalid"),
 						},
 					},
@@ -944,12 +944,12 @@ func TestValidatingWebhook(t *testing.T) {
 		},
 		{
 			name: "Testing invalid AutoScalerProfile.ScaleDownDelayAfterDelete",
-			amcp: AzureManagedControlPlane{
+			amcp: infrav1.AzureManagedControlPlane{
 				ObjectMeta: getAMCPMetaData(),
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.24.1",
-						AutoScalerProfile: &AutoScalerProfile{
+						AutoScalerProfile: &infrav1.AutoScalerProfile{
 							ScaleDownDelayAfterDelete: ptr.To("invalid"),
 						},
 					},
@@ -959,12 +959,12 @@ func TestValidatingWebhook(t *testing.T) {
 		},
 		{
 			name: "Testing invalid AutoScalerProfile.ScaleDownDelayAfterFailure",
-			amcp: AzureManagedControlPlane{
+			amcp: infrav1.AzureManagedControlPlane{
 				ObjectMeta: getAMCPMetaData(),
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.24.1",
-						AutoScalerProfile: &AutoScalerProfile{
+						AutoScalerProfile: &infrav1.AutoScalerProfile{
 							ScaleDownDelayAfterFailure: ptr.To("invalid"),
 						},
 					},
@@ -974,12 +974,12 @@ func TestValidatingWebhook(t *testing.T) {
 		},
 		{
 			name: "Testing invalid AutoScalerProfile.ScaleDownUnneededTime",
-			amcp: AzureManagedControlPlane{
+			amcp: infrav1.AzureManagedControlPlane{
 				ObjectMeta: getAMCPMetaData(),
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.24.1",
-						AutoScalerProfile: &AutoScalerProfile{
+						AutoScalerProfile: &infrav1.AutoScalerProfile{
 							ScaleDownUnneededTime: ptr.To("invalid"),
 						},
 					},
@@ -989,12 +989,12 @@ func TestValidatingWebhook(t *testing.T) {
 		},
 		{
 			name: "Testing invalid AutoScalerProfile.ScaleDownUnreadyTime",
-			amcp: AzureManagedControlPlane{
+			amcp: infrav1.AzureManagedControlPlane{
 				ObjectMeta: getAMCPMetaData(),
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.24.1",
-						AutoScalerProfile: &AutoScalerProfile{
+						AutoScalerProfile: &infrav1.AutoScalerProfile{
 							ScaleDownUnreadyTime: ptr.To("invalid"),
 						},
 					},
@@ -1004,12 +1004,12 @@ func TestValidatingWebhook(t *testing.T) {
 		},
 		{
 			name: "Testing invalid AutoScalerProfile.ScaleDownUtilizationThreshold",
-			amcp: AzureManagedControlPlane{
+			amcp: infrav1.AzureManagedControlPlane{
 				ObjectMeta: getAMCPMetaData(),
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.24.1",
-						AutoScalerProfile: &AutoScalerProfile{
+						AutoScalerProfile: &infrav1.AutoScalerProfile{
 							ScaleDownUtilizationThreshold: ptr.To("invalid"),
 						},
 					},
@@ -1019,13 +1019,13 @@ func TestValidatingWebhook(t *testing.T) {
 		},
 		{
 			name: "Testing valid AutoScalerProfile.SkipNodesWithLocalStorageTrue",
-			amcp: AzureManagedControlPlane{
+			amcp: infrav1.AzureManagedControlPlane{
 				ObjectMeta: getAMCPMetaData(),
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.24.1",
-						AutoScalerProfile: &AutoScalerProfile{
-							SkipNodesWithLocalStorage: (*SkipNodesWithLocalStorage)(ptr.To(string(SkipNodesWithLocalStorageTrue))),
+						AutoScalerProfile: &infrav1.AutoScalerProfile{
+							SkipNodesWithLocalStorage: (*infrav1.SkipNodesWithLocalStorage)(ptr.To(string(infrav1.SkipNodesWithLocalStorageTrue))),
 						},
 					},
 				},
@@ -1034,13 +1034,13 @@ func TestValidatingWebhook(t *testing.T) {
 		},
 		{
 			name: "Testing valid AutoScalerProfile.SkipNodesWithLocalStorageFalse",
-			amcp: AzureManagedControlPlane{
+			amcp: infrav1.AzureManagedControlPlane{
 				ObjectMeta: getAMCPMetaData(),
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.24.1",
-						AutoScalerProfile: &AutoScalerProfile{
-							SkipNodesWithLocalStorage: (*SkipNodesWithLocalStorage)(ptr.To(string(SkipNodesWithLocalStorageFalse))),
+						AutoScalerProfile: &infrav1.AutoScalerProfile{
+							SkipNodesWithLocalStorage: (*infrav1.SkipNodesWithLocalStorage)(ptr.To(string(infrav1.SkipNodesWithLocalStorageFalse))),
 						},
 					},
 				},
@@ -1049,13 +1049,13 @@ func TestValidatingWebhook(t *testing.T) {
 		},
 		{
 			name: "Testing valid AutoScalerProfile.SkipNodesWithSystemPodsTrue",
-			amcp: AzureManagedControlPlane{
+			amcp: infrav1.AzureManagedControlPlane{
 				ObjectMeta: getAMCPMetaData(),
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.24.1",
-						AutoScalerProfile: &AutoScalerProfile{
-							SkipNodesWithSystemPods: (*SkipNodesWithSystemPods)(ptr.To(string(SkipNodesWithSystemPodsTrue))),
+						AutoScalerProfile: &infrav1.AutoScalerProfile{
+							SkipNodesWithSystemPods: (*infrav1.SkipNodesWithSystemPods)(ptr.To(string(infrav1.SkipNodesWithSystemPodsTrue))),
 						},
 					},
 				},
@@ -1064,13 +1064,13 @@ func TestValidatingWebhook(t *testing.T) {
 		},
 		{
 			name: "Testing valid AutoScalerProfile.SkipNodesWithSystemPodsFalse",
-			amcp: AzureManagedControlPlane{
+			amcp: infrav1.AzureManagedControlPlane{
 				ObjectMeta: getAMCPMetaData(),
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.24.1",
-						AutoScalerProfile: &AutoScalerProfile{
-							SkipNodesWithSystemPods: (*SkipNodesWithSystemPods)(ptr.To(string(SkipNodesWithSystemPodsFalse))),
+						AutoScalerProfile: &infrav1.AutoScalerProfile{
+							SkipNodesWithSystemPods: (*infrav1.SkipNodesWithSystemPods)(ptr.To(string(infrav1.SkipNodesWithSystemPodsFalse))),
 						},
 					},
 				},
@@ -1079,13 +1079,13 @@ func TestValidatingWebhook(t *testing.T) {
 		},
 		{
 			name: "Testing valid Identity: SystemAssigned",
-			amcp: AzureManagedControlPlane{
+			amcp: infrav1.AzureManagedControlPlane{
 				ObjectMeta: getAMCPMetaData(),
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.24.1",
-						Identity: &Identity{
-							Type: ManagedControlPlaneIdentityTypeSystemAssigned,
+						Identity: &infrav1.Identity{
+							Type: infrav1.ManagedControlPlaneIdentityTypeSystemAssigned,
 						},
 					},
 				},
@@ -1094,13 +1094,13 @@ func TestValidatingWebhook(t *testing.T) {
 		},
 		{
 			name: "Testing valid Identity: UserAssigned",
-			amcp: AzureManagedControlPlane{
+			amcp: infrav1.AzureManagedControlPlane{
 				ObjectMeta: getAMCPMetaData(),
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.24.1",
-						Identity: &Identity{
-							Type:                           ManagedControlPlaneIdentityTypeUserAssigned,
+						Identity: &infrav1.Identity{
+							Type:                           infrav1.ManagedControlPlaneIdentityTypeUserAssigned,
 							UserAssignedIdentityResourceID: "/resource/id",
 						},
 					},
@@ -1110,13 +1110,13 @@ func TestValidatingWebhook(t *testing.T) {
 		},
 		{
 			name: "Testing invalid Identity: SystemAssigned with UserAssigned values",
-			amcp: AzureManagedControlPlane{
+			amcp: infrav1.AzureManagedControlPlane{
 				ObjectMeta: getAMCPMetaData(),
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.24.1",
-						Identity: &Identity{
-							Type:                           ManagedControlPlaneIdentityTypeSystemAssigned,
+						Identity: &infrav1.Identity{
+							Type:                           infrav1.ManagedControlPlaneIdentityTypeSystemAssigned,
 							UserAssignedIdentityResourceID: "/resource/id",
 						},
 					},
@@ -1126,13 +1126,13 @@ func TestValidatingWebhook(t *testing.T) {
 		},
 		{
 			name: "Testing invalid Identity: UserAssigned with missing properties",
-			amcp: AzureManagedControlPlane{
+			amcp: infrav1.AzureManagedControlPlane{
 				ObjectMeta: getAMCPMetaData(),
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.24.1",
-						Identity: &Identity{
-							Type: ManagedControlPlaneIdentityTypeUserAssigned,
+						Identity: &infrav1.Identity{
+							Type: infrav1.ManagedControlPlaneIdentityTypeUserAssigned,
 						},
 					},
 				},
@@ -1141,13 +1141,13 @@ func TestValidatingWebhook(t *testing.T) {
 		},
 		{
 			name: "overlay cannot be used with kubenet",
-			amcp: AzureManagedControlPlane{
+			amcp: infrav1.AzureManagedControlPlane{
 				ObjectMeta: getAMCPMetaData(),
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version:           "v1.24.1",
 						NetworkPlugin:     ptr.To("kubenet"),
-						NetworkPluginMode: ptr.To(NetworkPluginModeOverlay),
+						NetworkPluginMode: ptr.To(infrav1.NetworkPluginModeOverlay),
 					},
 				},
 			},
@@ -1155,13 +1155,13 @@ func TestValidatingWebhook(t *testing.T) {
 		},
 		{
 			name: "overlay can be used with azure",
-			amcp: AzureManagedControlPlane{
+			amcp: infrav1.AzureManagedControlPlane{
 				ObjectMeta: getAMCPMetaData(),
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version:           "v1.24.1",
 						NetworkPlugin:     ptr.To("azure"),
-						NetworkPluginMode: ptr.To(NetworkPluginModeOverlay),
+						NetworkPluginMode: ptr.To(infrav1.NetworkPluginModeOverlay),
 					},
 				},
 			},
@@ -1169,16 +1169,16 @@ func TestValidatingWebhook(t *testing.T) {
 		},
 		{
 			name: "Testing valid AKS Extension",
-			amcp: AzureManagedControlPlane{
+			amcp: infrav1.AzureManagedControlPlane{
 				ObjectMeta: getAMCPMetaData(),
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.17.8",
-						Extensions: []AKSExtension{
+						Extensions: []infrav1.AKSExtension{
 							{
 								Name:          "extension1",
 								ExtensionType: ptr.To("test-type"),
-								Plan: &ExtensionPlan{
+								Plan: &infrav1.ExtensionPlan{
 									Name:      "test-plan",
 									Product:   "test-product",
 									Publisher: "test-publisher",
@@ -1192,18 +1192,18 @@ func TestValidatingWebhook(t *testing.T) {
 		},
 		{
 			name: "Testing invalid AKS Extension: version given when AutoUpgradeMinorVersion is true",
-			amcp: AzureManagedControlPlane{
+			amcp: infrav1.AzureManagedControlPlane{
 				ObjectMeta: getAMCPMetaData(),
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.17.8",
-						Extensions: []AKSExtension{
+						Extensions: []infrav1.AKSExtension{
 							{
 								Name:                    "extension1",
 								ExtensionType:           ptr.To("test-type"),
 								Version:                 ptr.To("1.0.0"),
 								AutoUpgradeMinorVersion: ptr.To(true),
-								Plan: &ExtensionPlan{
+								Plan: &infrav1.ExtensionPlan{
 									Name:      "test-plan",
 									Product:   "test-product",
 									Publisher: "test-publisher",
@@ -1217,18 +1217,18 @@ func TestValidatingWebhook(t *testing.T) {
 		},
 		{
 			name: "Testing invalid AKS Extension: missing plan.product and plan.publisher",
-			amcp: AzureManagedControlPlane{
+			amcp: infrav1.AzureManagedControlPlane{
 				ObjectMeta: getAMCPMetaData(),
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.17.8",
-						Extensions: []AKSExtension{
+						Extensions: []infrav1.AKSExtension{
 							{
 								Name:                    "extension1",
 								ExtensionType:           ptr.To("test-type"),
 								Version:                 ptr.To("1.0.0"),
 								AutoUpgradeMinorVersion: ptr.To(true),
-								Plan: &ExtensionPlan{
+								Plan: &infrav1.ExtensionPlan{
 									Name: "test-plan",
 								},
 							},
@@ -1240,14 +1240,14 @@ func TestValidatingWebhook(t *testing.T) {
 		},
 		{
 			name: "Test invalid AzureKeyVaultKms",
-			amcp: AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+			amcp: infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.17.8",
-						SecurityProfile: &ManagedClusterSecurityProfile{
-							AzureKeyVaultKms: &AzureKeyVaultKms{
+						SecurityProfile: &infrav1.ManagedClusterSecurityProfile{
+							AzureKeyVaultKms: &infrav1.AzureKeyVaultKms{
 								Enabled:               true,
-								KeyVaultNetworkAccess: ptr.To(KeyVaultNetworkAccessTypesPrivate),
+								KeyVaultNetworkAccess: ptr.To(infrav1.KeyVaultNetworkAccessTypesPrivate),
 							},
 						},
 					},
@@ -1257,13 +1257,13 @@ func TestValidatingWebhook(t *testing.T) {
 		},
 		{
 			name: "Valid NetworkDataplane: cilium",
-			amcp: AzureManagedControlPlane{
+			amcp: infrav1.AzureManagedControlPlane{
 				ObjectMeta: getAMCPMetaData(),
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version:           "v1.17.8",
-						NetworkPluginMode: ptr.To(NetworkPluginModeOverlay),
-						NetworkDataplane:  ptr.To(NetworkDataplaneTypeCilium),
+						NetworkPluginMode: ptr.To(infrav1.NetworkPluginModeOverlay),
+						NetworkDataplane:  ptr.To(infrav1.NetworkDataplaneTypeCilium),
 						NetworkPolicy:     ptr.To("cilium"),
 					},
 				},
@@ -1272,13 +1272,13 @@ func TestValidatingWebhook(t *testing.T) {
 		},
 		{
 			name: "Testing invalid NetworkDataplane: cilium dataplane requires overlay network plugin mode",
-			amcp: AzureManagedControlPlane{
+			amcp: infrav1.AzureManagedControlPlane{
 				ObjectMeta: getAMCPMetaData(),
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version:           "v1.17.8",
 						NetworkPluginMode: nil,
-						NetworkDataplane:  ptr.To(NetworkDataplaneTypeCilium),
+						NetworkDataplane:  ptr.To(infrav1.NetworkDataplaneTypeCilium),
 						NetworkPolicy:     ptr.To("cilium"),
 					},
 				},
@@ -1287,18 +1287,18 @@ func TestValidatingWebhook(t *testing.T) {
 		},
 		{
 			name: "Test valid AzureKeyVaultKms",
-			amcp: AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+			amcp: infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.17.8",
-						Identity: &Identity{
-							Type:                           ManagedControlPlaneIdentityTypeUserAssigned,
+						Identity: &infrav1.Identity{
+							Type:                           infrav1.ManagedControlPlaneIdentityTypeUserAssigned,
 							UserAssignedIdentityResourceID: "not empty",
 						},
-						SecurityProfile: &ManagedClusterSecurityProfile{
-							AzureKeyVaultKms: &AzureKeyVaultKms{
+						SecurityProfile: &infrav1.ManagedClusterSecurityProfile{
+							AzureKeyVaultKms: &infrav1.AzureKeyVaultKms{
 								Enabled:               true,
-								KeyVaultNetworkAccess: ptr.To(KeyVaultNetworkAccessTypesPrivate),
+								KeyVaultNetworkAccess: ptr.To(infrav1.KeyVaultNetworkAccessTypesPrivate),
 								KeyVaultResourceID:    ptr.To("0000-0000-0000-000"),
 							},
 						},
@@ -1309,18 +1309,18 @@ func TestValidatingWebhook(t *testing.T) {
 		},
 		{
 			name: "Test valid AzureKeyVaultKms",
-			amcp: AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+			amcp: infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.17.8",
-						Identity: &Identity{
-							Type:                           ManagedControlPlaneIdentityTypeUserAssigned,
+						Identity: &infrav1.Identity{
+							Type:                           infrav1.ManagedControlPlaneIdentityTypeUserAssigned,
 							UserAssignedIdentityResourceID: "not empty",
 						},
-						SecurityProfile: &ManagedClusterSecurityProfile{
-							AzureKeyVaultKms: &AzureKeyVaultKms{
+						SecurityProfile: &infrav1.ManagedClusterSecurityProfile{
+							AzureKeyVaultKms: &infrav1.AzureKeyVaultKms{
 								Enabled:               true,
-								KeyVaultNetworkAccess: ptr.To(KeyVaultNetworkAccessTypesPublic),
+								KeyVaultNetworkAccess: ptr.To(infrav1.KeyVaultNetworkAccessTypesPublic),
 							},
 						},
 					},
@@ -1330,13 +1330,13 @@ func TestValidatingWebhook(t *testing.T) {
 		},
 		{
 			name: "Testing invalid NetworkDataplane: cilium dataplane requires network policy to be cilium",
-			amcp: AzureManagedControlPlane{
+			amcp: infrav1.AzureManagedControlPlane{
 				ObjectMeta: getAMCPMetaData(),
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version:           "v1.17.8",
 						NetworkPluginMode: nil,
-						NetworkDataplane:  ptr.To(NetworkDataplaneTypeCilium),
+						NetworkDataplane:  ptr.To(infrav1.NetworkDataplaneTypeCilium),
 						NetworkPolicy:     ptr.To("azure"),
 					},
 				},
@@ -1345,13 +1345,13 @@ func TestValidatingWebhook(t *testing.T) {
 		},
 		{
 			name: "Testing invalid NetworkPolicy: cilium network policy can only be used with cilium network dataplane",
-			amcp: AzureManagedControlPlane{
+			amcp: infrav1.AzureManagedControlPlane{
 				ObjectMeta: getAMCPMetaData(),
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version:           "v1.17.8",
 						NetworkPluginMode: nil,
-						NetworkDataplane:  ptr.To(NetworkDataplaneTypeAzure),
+						NetworkDataplane:  ptr.To(infrav1.NetworkDataplaneTypeAzure),
 						NetworkPolicy:     ptr.To("cilium"),
 					},
 				},
@@ -1360,13 +1360,13 @@ func TestValidatingWebhook(t *testing.T) {
 		},
 		{
 			name: "Testing valid FleetsMember",
-			amcp: AzureManagedControlPlane{
+			amcp: infrav1.AzureManagedControlPlane{
 				ObjectMeta: getAMCPMetaData(),
-				Spec: AzureManagedControlPlaneSpec{
-					FleetsMember: &FleetsMember{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					FleetsMember: &infrav1.FleetsMember{
 						Name: "fleetmember1",
 					},
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.17.8",
 					},
 				},
@@ -1375,13 +1375,13 @@ func TestValidatingWebhook(t *testing.T) {
 		},
 		{
 			name: "Testing invalid FleetsMember: Fleets member name cannot contain capital letters",
-			amcp: AzureManagedControlPlane{
+			amcp: infrav1.AzureManagedControlPlane{
 				ObjectMeta: getAMCPMetaData(),
-				Spec: AzureManagedControlPlaneSpec{
-					FleetsMember: &FleetsMember{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					FleetsMember: &infrav1.FleetsMember{
 						Name: "FleetMember1",
 					},
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.17.8",
 					},
 				},
@@ -1411,7 +1411,7 @@ func TestValidatingWebhook(t *testing.T) {
 func TestAzureManagedControlPlane_ValidateCreate(t *testing.T) {
 	tests := []struct {
 		name     string
-		amcp     *AzureManagedControlPlane
+		amcp     *infrav1.AzureManagedControlPlane
 		wantErr  bool
 		errorLen int
 	}{
@@ -1452,10 +1452,10 @@ func TestAzureManagedControlPlane_ValidateCreate(t *testing.T) {
 		},
 		{
 			name: "Testing inValid DNSPrefix for starting with invalid characters",
-			amcp: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
+			amcp: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
 					DNSPrefix: ptr.To("-thisi$"),
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.17.8",
 					},
 				},
@@ -1464,10 +1464,10 @@ func TestAzureManagedControlPlane_ValidateCreate(t *testing.T) {
 		},
 		{
 			name: "Testing inValid DNSPrefix with more then 54 characters",
-			amcp: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
+			amcp: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
 					DNSPrefix: ptr.To("thisisaverylong$^clusternameconsistingofmorethan54characterswhichshouldbeinvalid"),
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.17.8",
 					},
 				},
@@ -1476,10 +1476,10 @@ func TestAzureManagedControlPlane_ValidateCreate(t *testing.T) {
 		},
 		{
 			name: "Testing inValid DNSPrefix with underscore",
-			amcp: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
+			amcp: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
 					DNSPrefix: ptr.To("no_underscore"),
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.17.8",
 					},
 				},
@@ -1488,10 +1488,10 @@ func TestAzureManagedControlPlane_ValidateCreate(t *testing.T) {
 		},
 		{
 			name: "Testing inValid DNSPrefix with special characters",
-			amcp: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
+			amcp: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
 					DNSPrefix: ptr.To("no-dollar$@%"),
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.17.8",
 					},
 				},
@@ -1500,10 +1500,10 @@ func TestAzureManagedControlPlane_ValidateCreate(t *testing.T) {
 		},
 		{
 			name: "Testing Valid DNSPrefix with hyphen characters",
-			amcp: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
+			amcp: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
 					DNSPrefix: ptr.To("hyphen-allowed"),
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.17.8",
 					},
 				},
@@ -1512,10 +1512,10 @@ func TestAzureManagedControlPlane_ValidateCreate(t *testing.T) {
 		},
 		{
 			name: "Testing Valid DNSPrefix with hyphen characters",
-			amcp: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
+			amcp: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
 					DNSPrefix: ptr.To("palette-test07"),
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.17.8",
 					},
 				},
@@ -1524,10 +1524,10 @@ func TestAzureManagedControlPlane_ValidateCreate(t *testing.T) {
 		},
 		{
 			name: "Testing valid DNSPrefix ",
-			amcp: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
+			amcp: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
 					DNSPrefix: ptr.To("thisisavlerylongclu7l0sternam3leconsistingofmorethan54"),
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.17.8",
 					},
 				},
@@ -1536,13 +1536,13 @@ func TestAzureManagedControlPlane_ValidateCreate(t *testing.T) {
 		},
 		{
 			name: "invalid name with microsoft",
-			amcp: &AzureManagedControlPlane{
+			amcp: &infrav1.AzureManagedControlPlane{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "microsoft-cluster",
 				},
-				Spec: AzureManagedControlPlaneSpec{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
 					SSHPublicKey: ptr.To(generateSSHPublicKey(true)),
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						DNSServiceIP: ptr.To("192.168.0.10"),
 						Version:      "v1.23.5",
 					},
@@ -1553,13 +1553,13 @@ func TestAzureManagedControlPlane_ValidateCreate(t *testing.T) {
 		},
 		{
 			name: "invalid name with windows",
-			amcp: &AzureManagedControlPlane{
+			amcp: &infrav1.AzureManagedControlPlane{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "a-windows-cluster",
 				},
-				Spec: AzureManagedControlPlaneSpec{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
 					SSHPublicKey: ptr.To(generateSSHPublicKey(true)),
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						DNSServiceIP: ptr.To("192.168.0.10"),
 						Version:      "v1.23.5",
 					},
@@ -1570,16 +1570,16 @@ func TestAzureManagedControlPlane_ValidateCreate(t *testing.T) {
 		},
 		{
 			name: "set Spec.ControlPlaneEndpoint.Host during create (clusterctl move scenario)",
-			amcp: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
+			amcp: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
 					ControlPlaneEndpoint: clusterv1beta1.APIEndpoint{
 						Host: "my-host",
 					},
 					SSHPublicKey: ptr.To(generateSSHPublicKey(true)),
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						DNSServiceIP: ptr.To("192.168.0.10"),
 						Version:      "v1.18.0",
-						AADProfile: &AADProfile{
+						AADProfile: &infrav1.AADProfile{
 							Managed: true,
 							AdminGroupObjectIDs: []string{
 								"616077a8-5db7-4c98-b856-b34619afg75h",
@@ -1592,16 +1592,16 @@ func TestAzureManagedControlPlane_ValidateCreate(t *testing.T) {
 		},
 		{
 			name: "can set Spec.ControlPlaneEndpoint.Port during create (clusterctl move scenario)",
-			amcp: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
+			amcp: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
 					ControlPlaneEndpoint: clusterv1beta1.APIEndpoint{
 						Port: 444,
 					},
 					SSHPublicKey: ptr.To(generateSSHPublicKey(true)),
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						DNSServiceIP: ptr.To("192.168.0.10"),
 						Version:      "v1.18.0",
-						AADProfile: &AADProfile{
+						AADProfile: &infrav1.AADProfile{
 							Managed: true,
 							AdminGroupObjectIDs: []string{
 								"616077a8-5db7-4c98-b856-b34619afg75h",
@@ -1614,9 +1614,9 @@ func TestAzureManagedControlPlane_ValidateCreate(t *testing.T) {
 		},
 		{
 			name: "DisableLocalAccounts cannot be set for non AAD clusters",
-			amcp: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+			amcp: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version:              "v1.21.2",
 						DisableLocalAccounts: ptr.To[bool](true),
 					},
@@ -1626,11 +1626,11 @@ func TestAzureManagedControlPlane_ValidateCreate(t *testing.T) {
 		},
 		{
 			name: "DisableLocalAccounts can be set for AAD clusters",
-			amcp: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+			amcp: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.21.2",
-						AADProfile: &AADProfile{
+						AADProfile: &infrav1.AADProfile{
 							Managed:             true,
 							AdminGroupObjectIDs: []string{"00000000-0000-0000-0000-000000000000"},
 						},
@@ -1664,7 +1664,7 @@ func TestAzureManagedControlPlane_ValidateCreate(t *testing.T) {
 func TestAzureManagedControlPlane_ValidateCreateFailure(t *testing.T) {
 	tests := []struct {
 		name               string
-		amcp               *AzureManagedControlPlane
+		amcp               *infrav1.AzureManagedControlPlane
 		featureGateEnabled *bool
 		expectError        bool
 	}{
@@ -1699,8 +1699,8 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 	commonSSHKey := generateSSHPublicKey(true)
 	tests := []struct {
 		name    string
-		oldAMCP *AzureManagedControlPlane
-		amcp    *AzureManagedControlPlane
+		oldAMCP *infrav1.AzureManagedControlPlane
+		amcp    *infrav1.AzureManagedControlPlane
 		wantErr bool
 	}{
 		{
@@ -1735,18 +1735,18 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "AzureManagedControlPlane AddonProfiles is mutable",
-			oldAMCP: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+			oldAMCP: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.18.0",
 					},
 				},
 			},
-			amcp: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+			amcp: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.18.0",
-						AddonProfiles: []AddonProfile{
+						AddonProfiles: []infrav1.AddonProfile{
 							{
 								Name:    "first-addon-profile",
 								Enabled: true,
@@ -1759,10 +1759,10 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "AzureManagedControlPlane AddonProfiles can be disabled",
-			oldAMCP: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
-						AddonProfiles: []AddonProfile{
+			oldAMCP: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
+						AddonProfiles: []infrav1.AddonProfile{
 							{
 								Name:    "first-addon-profile",
 								Enabled: true,
@@ -1772,11 +1772,11 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 					},
 				},
 			},
-			amcp: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+			amcp: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.18.0",
-						AddonProfiles: []AddonProfile{
+						AddonProfiles: []infrav1.AddonProfile{
 							{
 								Name:    "first-addon-profile",
 								Enabled: false,
@@ -1789,10 +1789,10 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "AzureManagedControlPlane AddonProfiles cannot update to empty array",
-			oldAMCP: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
-						AddonProfiles: []AddonProfile{
+			oldAMCP: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
+						AddonProfiles: []infrav1.AddonProfile{
 							{
 								Name:    "first-addon-profile",
 								Enabled: true,
@@ -1802,9 +1802,9 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 					},
 				},
 			},
-			amcp: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+			amcp: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.18.0",
 					},
 				},
@@ -1813,10 +1813,10 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "AzureManagedControlPlane AddonProfiles cannot be completely removed",
-			oldAMCP: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
-						AddonProfiles: []AddonProfile{
+			oldAMCP: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
+						AddonProfiles: []infrav1.AddonProfile{
 							{
 								Name:    "first-addon-profile",
 								Enabled: true,
@@ -1830,10 +1830,10 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 					},
 				},
 			},
-			amcp: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
-						AddonProfiles: []AddonProfile{
+			amcp: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
+						AddonProfiles: []infrav1.AddonProfile{
 							{
 								Name:    "first-addon-profile",
 								Enabled: true,
@@ -1847,16 +1847,16 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "AzureManagedControlPlane invalid version downgrade change",
-			oldAMCP: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+			oldAMCP: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.18.0",
 					},
 				},
 			},
-			amcp: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+			amcp: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.17.0",
 					},
 				},
@@ -1865,19 +1865,19 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "AzureManagedControlPlane invalid version downgrade change",
-			oldAMCP: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+			oldAMCP: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.18.0",
 					},
 				},
-				Status: AzureManagedControlPlaneStatus{
+				Status: infrav1.AzureManagedControlPlaneStatus{
 					AutoUpgradeVersion: "v1.18.3",
 				},
 			},
-			amcp: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+			amcp: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.18.1",
 					},
 				},
@@ -1886,21 +1886,21 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "AzureManagedControlPlane Autoupgrade cannot be set to nil",
-			oldAMCP: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+			oldAMCP: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						DNSServiceIP:   ptr.To("192.168.0.10"),
 						SubscriptionID: "212ec1q8",
 						Version:        "v1.18.0",
-						AutoUpgradeProfile: &ManagedClusterAutoUpgradeProfile{
-							UpgradeChannel: ptr.To(UpgradeChannelStable),
+						AutoUpgradeProfile: &infrav1.ManagedClusterAutoUpgradeProfile{
+							UpgradeChannel: ptr.To(infrav1.UpgradeChannelStable),
 						},
 					},
 				},
 			},
-			amcp: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+			amcp: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						DNSServiceIP:   ptr.To("192.168.0.10"),
 						SubscriptionID: "212ec1q8",
 						Version:        "v1.18.0",
@@ -1911,25 +1911,25 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "AzureManagedControlPlane Autoupgrade cannot be set to nil",
-			oldAMCP: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+			oldAMCP: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						DNSServiceIP:   ptr.To("192.168.0.10"),
 						SubscriptionID: "212ec1q8",
 						Version:        "v1.18.0",
-						AutoUpgradeProfile: &ManagedClusterAutoUpgradeProfile{
-							UpgradeChannel: ptr.To(UpgradeChannelStable),
+						AutoUpgradeProfile: &infrav1.ManagedClusterAutoUpgradeProfile{
+							UpgradeChannel: ptr.To(infrav1.UpgradeChannelStable),
 						},
 					},
 				},
 			},
-			amcp: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+			amcp: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						DNSServiceIP:       ptr.To("192.168.0.10"),
 						SubscriptionID:     "212ec1q8",
 						Version:            "v1.18.0",
-						AutoUpgradeProfile: &ManagedClusterAutoUpgradeProfile{},
+						AutoUpgradeProfile: &infrav1.ManagedClusterAutoUpgradeProfile{},
 					},
 				},
 			},
@@ -1937,26 +1937,26 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "AzureManagedControlPlane Autoupgrade is mutable",
-			oldAMCP: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+			oldAMCP: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						DNSServiceIP:   ptr.To("192.168.0.10"),
 						SubscriptionID: "212ec1q8",
 						Version:        "v1.18.0",
-						AutoUpgradeProfile: &ManagedClusterAutoUpgradeProfile{
-							UpgradeChannel: ptr.To(UpgradeChannelStable),
+						AutoUpgradeProfile: &infrav1.ManagedClusterAutoUpgradeProfile{
+							UpgradeChannel: ptr.To(infrav1.UpgradeChannelStable),
 						},
 					},
 				},
 			},
-			amcp: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+			amcp: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						DNSServiceIP:   ptr.To("192.168.0.10"),
 						SubscriptionID: "212ec1q8",
 						Version:        "v1.18.0",
-						AutoUpgradeProfile: &ManagedClusterAutoUpgradeProfile{
-							UpgradeChannel: ptr.To(UpgradeChannelNone),
+						AutoUpgradeProfile: &infrav1.ManagedClusterAutoUpgradeProfile{
+							UpgradeChannel: ptr.To(infrav1.UpgradeChannelNone),
 						},
 					},
 				},
@@ -1965,18 +1965,18 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "AzureManagedControlPlane SubscriptionID is immutable",
-			oldAMCP: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+			oldAMCP: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						DNSServiceIP:   ptr.To("192.168.0.10"),
 						SubscriptionID: "212ec1q8",
 						Version:        "v1.18.0",
 					},
 				},
 			},
-			amcp: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+			amcp: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						DNSServiceIP:   ptr.To("192.168.0.10"),
 						SubscriptionID: "212ec1q9",
 						Version:        "v1.18.0",
@@ -1987,18 +1987,18 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "AzureManagedControlPlane ResourceGroupName is immutable",
-			oldAMCP: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+			oldAMCP: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						DNSServiceIP:      ptr.To("192.168.0.10"),
 						Version:           "v1.18.0",
 						ResourceGroupName: "hello-1",
 					},
 				},
 			},
-			amcp: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+			amcp: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						DNSServiceIP:      ptr.To("192.168.0.10"),
 						Version:           "v1.18.0",
 						ResourceGroupName: "hello-2",
@@ -2009,18 +2009,18 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "AzureManagedControlPlane NodeResourceGroupName is immutable",
-			oldAMCP: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+			oldAMCP: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						DNSServiceIP: ptr.To("192.168.0.10"),
 						Version:      "v1.18.0",
 					},
 					NodeResourceGroupName: "hello-1",
 				},
 			},
-			amcp: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+			amcp: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						DNSServiceIP: ptr.To("192.168.0.10"),
 						Version:      "v1.18.0",
 					},
@@ -2031,18 +2031,18 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "AzureManagedControlPlane Location is immutable",
-			oldAMCP: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+			oldAMCP: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						DNSServiceIP: ptr.To("192.168.0.10"),
 						Location:     "westeurope",
 						Version:      "v1.18.0",
 					},
 				},
 			},
-			amcp: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+			amcp: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						DNSServiceIP: ptr.To("192.168.0.10"),
 						Location:     "eastus",
 						Version:      "v1.18.0",
@@ -2053,18 +2053,18 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "AzureManagedControlPlane SSHPublicKey is immutable",
-			oldAMCP: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+			oldAMCP: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						DNSServiceIP: ptr.To("192.168.0.10"),
 						Version:      "v1.18.0",
 					},
 					SSHPublicKey: ptr.To(generateSSHPublicKey(true)),
 				},
 			},
-			amcp: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+			amcp: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						DNSServiceIP: ptr.To("192.168.0.10"),
 						Version:      "v1.18.0",
 					},
@@ -2075,17 +2075,17 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "AzureManagedControlPlane DNSServiceIP is immutable",
-			oldAMCP: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+			oldAMCP: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						DNSServiceIP: ptr.To("192.168.0.10"),
 						Version:      "v1.18.0",
 					},
 				},
 			},
-			amcp: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+			amcp: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						DNSServiceIP: ptr.To("192.168.1.1"),
 						Version:      "v1.18.0",
 					},
@@ -2095,17 +2095,17 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "AzureManagedControlPlane DNSServiceIP is immutable, unsetting is not allowed",
-			oldAMCP: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+			oldAMCP: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						DNSServiceIP: ptr.To("192.168.0.10"),
 						Version:      "v1.18.0",
 					},
 				},
 			},
-			amcp: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+			amcp: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.18.0",
 					},
 				},
@@ -2114,18 +2114,18 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "AzureManagedControlPlane NetworkPlugin is immutable",
-			oldAMCP: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+			oldAMCP: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						DNSServiceIP:  ptr.To("192.168.0.10"),
 						NetworkPlugin: ptr.To("azure"),
 						Version:       "v1.18.0",
 					},
 				},
 			},
-			amcp: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+			amcp: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						DNSServiceIP:  ptr.To("192.168.0.10"),
 						NetworkPlugin: ptr.To("kubenet"),
 						Version:       "v1.18.0",
@@ -2136,18 +2136,18 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "AzureManagedControlPlane NetworkPlugin is immutable, unsetting is not allowed",
-			oldAMCP: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+			oldAMCP: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						DNSServiceIP:  ptr.To("192.168.0.10"),
 						NetworkPlugin: ptr.To("azure"),
 						Version:       "v1.18.0",
 					},
 				},
 			},
-			amcp: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+			amcp: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						DNSServiceIP: ptr.To("192.168.0.10"),
 						Version:      "v1.18.0",
 					},
@@ -2157,18 +2157,18 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "AzureManagedControlPlane NetworkPolicy is immutable",
-			oldAMCP: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+			oldAMCP: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						DNSServiceIP:  ptr.To("192.168.0.10"),
 						NetworkPolicy: ptr.To("azure"),
 						Version:       "v1.18.0",
 					},
 				},
 			},
-			amcp: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+			amcp: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						DNSServiceIP:  ptr.To("192.168.0.10"),
 						NetworkPolicy: ptr.To("calico"),
 						Version:       "v1.18.0",
@@ -2179,18 +2179,18 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "AzureManagedControlPlane NetworkPolicy is immutable, unsetting is not allowed",
-			oldAMCP: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+			oldAMCP: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						DNSServiceIP:  ptr.To("192.168.0.10"),
 						NetworkPolicy: ptr.To("azure"),
 						Version:       "v1.18.0",
 					},
 				},
 			},
-			amcp: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+			amcp: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						DNSServiceIP: ptr.To("192.168.0.10"),
 						Version:      "v1.18.0",
 					},
@@ -2200,20 +2200,20 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "AzureManagedControlPlane NetworkPolicy is immutable",
-			oldAMCP: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+			oldAMCP: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						DNSServiceIP:     ptr.To("192.168.0.10"),
-						NetworkDataplane: ptr.To(NetworkDataplaneTypeCilium),
+						NetworkDataplane: ptr.To(infrav1.NetworkDataplaneTypeCilium),
 						Version:          "v1.18.0",
 					},
 				},
 			},
-			amcp: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+			amcp: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						DNSServiceIP:     ptr.To("192.168.0.10"),
-						NetworkDataplane: ptr.To(NetworkDataplaneTypeAzure),
+						NetworkDataplane: ptr.To(infrav1.NetworkDataplaneTypeAzure),
 						Version:          "v1.18.0",
 					},
 				},
@@ -2222,18 +2222,18 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "AzureManagedControlPlane NetworkDataplane is immutable, unsetting is not allowed",
-			oldAMCP: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+			oldAMCP: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						DNSServiceIP:     ptr.To("192.168.0.10"),
-						NetworkDataplane: ptr.To(NetworkDataplaneTypeCilium),
+						NetworkDataplane: ptr.To(infrav1.NetworkDataplaneTypeCilium),
 						Version:          "v1.18.0",
 					},
 				},
 			},
-			amcp: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+			amcp: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						DNSServiceIP: ptr.To("192.168.0.10"),
 						Version:      "v1.18.0",
 					},
@@ -2243,20 +2243,20 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "AzureManagedControlPlane LoadBalancerSKU is immutable",
-			oldAMCP: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+			oldAMCP: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						DNSServiceIP:    ptr.To("192.168.0.10"),
 						LoadBalancerSKU: ptr.To("Standard"),
 						Version:         "v1.18.0",
 					},
 				},
 			},
-			amcp: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+			amcp: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						DNSServiceIP:    ptr.To("192.168.0.10"),
-						LoadBalancerSKU: ptr.To(LoadBalancerSKUBasic),
+						LoadBalancerSKU: ptr.To(infrav1.LoadBalancerSKUBasic),
 						Version:         "v1.18.0",
 					},
 				},
@@ -2265,18 +2265,18 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "AzureManagedControlPlane LoadBalancerSKU is immutable, unsetting is not allowed",
-			oldAMCP: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+			oldAMCP: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						DNSServiceIP:    ptr.To("192.168.0.10"),
-						LoadBalancerSKU: ptr.To(LoadBalancerSKUStandard),
+						LoadBalancerSKU: ptr.To(infrav1.LoadBalancerSKUStandard),
 						Version:         "v1.18.0",
 					},
 				},
 			},
-			amcp: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+			amcp: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						DNSServiceIP: ptr.To("192.168.0.10"),
 						Version:      "v1.18.0",
 					},
@@ -2286,18 +2286,18 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "AzureManagedControlPlane ManagedAad can be set after cluster creation",
-			oldAMCP: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+			oldAMCP: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.18.0",
 					},
 				},
 			},
-			amcp: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+			amcp: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.18.0",
-						AADProfile: &AADProfile{
+						AADProfile: &infrav1.AADProfile{
 							Managed: true,
 							AdminGroupObjectIDs: []string{
 								"616077a8-5db7-4c98-b856-b34619afg75h",
@@ -2310,11 +2310,11 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "AzureManagedControlPlane ManagedAad cannot be disabled",
-			oldAMCP: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+			oldAMCP: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.18.0",
-						AADProfile: &AADProfile{
+						AADProfile: &infrav1.AADProfile{
 							Managed: true,
 							AdminGroupObjectIDs: []string{
 								"616077a8-5db7-4c98-b856-b34619afg75h",
@@ -2323,11 +2323,11 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 					},
 				},
 			},
-			amcp: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+			amcp: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version:    "v1.18.0",
-						AADProfile: &AADProfile{},
+						AADProfile: &infrav1.AADProfile{},
 					},
 				},
 			},
@@ -2335,11 +2335,11 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "AzureManagedControlPlane managed field cannot set to false",
-			oldAMCP: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+			oldAMCP: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.18.0",
-						AADProfile: &AADProfile{
+						AADProfile: &infrav1.AADProfile{
 							Managed: true,
 							AdminGroupObjectIDs: []string{
 								"616077a8-5db7-4c98-b856-b34619afg75h",
@@ -2348,11 +2348,11 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 					},
 				},
 			},
-			amcp: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+			amcp: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.18.0",
-						AADProfile: &AADProfile{
+						AADProfile: &infrav1.AADProfile{
 							Managed: false,
 							AdminGroupObjectIDs: []string{
 								"616077a8-5db7-4c98-b856-b34619afg75h",
@@ -2365,11 +2365,11 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "AzureManagedControlPlane adminGroupObjectIDs cannot set to empty",
-			oldAMCP: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+			oldAMCP: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.18.0",
-						AADProfile: &AADProfile{
+						AADProfile: &infrav1.AADProfile{
 							Managed: true,
 							AdminGroupObjectIDs: []string{
 								"616077a8-5db7-4c98-b856-b34619afg75h",
@@ -2378,11 +2378,11 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 					},
 				},
 			},
-			amcp: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+			amcp: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.18.0",
-						AADProfile: &AADProfile{
+						AADProfile: &infrav1.AADProfile{
 							Managed:             true,
 							AdminGroupObjectIDs: []string{},
 						},
@@ -2393,11 +2393,11 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "AzureManagedControlPlane ManagedAad cannot be disabled",
-			oldAMCP: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+			oldAMCP: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.18.0",
-						AADProfile: &AADProfile{
+						AADProfile: &infrav1.AADProfile{
 							Managed: true,
 							AdminGroupObjectIDs: []string{
 								"616077a8-5db7-4c98-b856-b34619afg75h",
@@ -2406,9 +2406,9 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 					},
 				},
 			},
-			amcp: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+			amcp: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.18.0",
 					},
 				},
@@ -2417,21 +2417,21 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "AzureManagedControlPlane EnablePrivateCluster is immutable",
-			oldAMCP: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+			oldAMCP: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						DNSServiceIP: ptr.To("192.168.0.10"),
 						Version:      "v1.18.0",
 					},
 				},
 			},
-			amcp: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+			amcp: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						DNSServiceIP: ptr.To("192.168.0.10"),
 						Version:      "v1.18.0",
-						APIServerAccessProfile: &APIServerAccessProfile{
-							APIServerAccessProfileClassSpec: APIServerAccessProfileClassSpec{
+						APIServerAccessProfile: &infrav1.APIServerAccessProfile{
+							APIServerAccessProfileClassSpec: infrav1.APIServerAccessProfileClassSpec{
 								EnablePrivateCluster: ptr.To(true),
 							},
 						},
@@ -2442,20 +2442,20 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "AzureManagedControlPlane AuthorizedIPRanges is mutable",
-			oldAMCP: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+			oldAMCP: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						DNSServiceIP: ptr.To("192.168.0.10"),
 						Version:      "v1.18.0",
 					},
 				},
 			},
-			amcp: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+			amcp: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						DNSServiceIP: ptr.To("192.168.0.10"),
 						Version:      "v1.18.0",
-						APIServerAccessProfile: &APIServerAccessProfile{
+						APIServerAccessProfile: &infrav1.APIServerAccessProfile{
 							AuthorizedIPRanges: []string{"192.168.0.1/32"},
 						},
 					},
@@ -2465,19 +2465,19 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "AzureManagedControlPlane.VirtualNetwork Name is mutable",
-			oldAMCP: &AzureManagedControlPlane{
+			oldAMCP: &infrav1.AzureManagedControlPlane{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster",
 				},
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						DNSServiceIP: ptr.To("192.168.0.10"),
 						Version:      "v1.18.0",
-						VirtualNetwork: ManagedControlPlaneVirtualNetwork{
+						VirtualNetwork: infrav1.ManagedControlPlaneVirtualNetwork{
 							Name: "test-network",
-							ManagedControlPlaneVirtualNetworkClassSpec: ManagedControlPlaneVirtualNetworkClassSpec{
+							ManagedControlPlaneVirtualNetworkClassSpec: infrav1.ManagedControlPlaneVirtualNetworkClassSpec{
 								CIDRBlock: "10.0.0.0/8",
-								Subnet: ManagedControlPlaneSubnet{
+								Subnet: infrav1.ManagedControlPlaneSubnet{
 									Name:      "test-subnet",
 									CIDRBlock: "10.0.2.0/24",
 								},
@@ -2487,12 +2487,12 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 					},
 				},
 			},
-			amcp: &AzureManagedControlPlane{
+			amcp: &infrav1.AzureManagedControlPlane{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster",
 				},
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						DNSServiceIP: ptr.To("192.168.0.10"),
 						Version:      "v1.18.0",
 					},
@@ -2502,30 +2502,30 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "AzureManagedControlPlane.VirtualNetwork Name is mutable",
-			oldAMCP: &AzureManagedControlPlane{
+			oldAMCP: &infrav1.AzureManagedControlPlane{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster",
 				},
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						DNSServiceIP: ptr.To("192.168.0.10"),
 						Version:      "v1.18.0",
 					},
 				},
 			},
-			amcp: &AzureManagedControlPlane{
+			amcp: &infrav1.AzureManagedControlPlane{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster",
 				},
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						DNSServiceIP: ptr.To("192.168.0.10"),
 						Version:      "v1.18.0",
-						VirtualNetwork: ManagedControlPlaneVirtualNetwork{
+						VirtualNetwork: infrav1.ManagedControlPlaneVirtualNetwork{
 							Name: "test-network",
-							ManagedControlPlaneVirtualNetworkClassSpec: ManagedControlPlaneVirtualNetworkClassSpec{
+							ManagedControlPlaneVirtualNetworkClassSpec: infrav1.ManagedControlPlaneVirtualNetworkClassSpec{
 								CIDRBlock: "10.0.0.0/8",
-								Subnet: ManagedControlPlaneSubnet{
+								Subnet: infrav1.ManagedControlPlaneSubnet{
 									Name:      "test-subnet",
 									CIDRBlock: "10.0.2.0/24",
 								},
@@ -2539,19 +2539,19 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "AzureManagedControlPlane.VirtualNetwork Name is mutable",
-			oldAMCP: &AzureManagedControlPlane{
+			oldAMCP: &infrav1.AzureManagedControlPlane{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster",
 				},
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						DNSServiceIP: ptr.To("192.168.0.10"),
 						Version:      "v1.18.0",
-						VirtualNetwork: ManagedControlPlaneVirtualNetwork{
+						VirtualNetwork: infrav1.ManagedControlPlaneVirtualNetwork{
 							Name: "test-network",
-							ManagedControlPlaneVirtualNetworkClassSpec: ManagedControlPlaneVirtualNetworkClassSpec{
+							ManagedControlPlaneVirtualNetworkClassSpec: infrav1.ManagedControlPlaneVirtualNetworkClassSpec{
 								CIDRBlock: "10.0.0.0/8",
-								Subnet: ManagedControlPlaneSubnet{
+								Subnet: infrav1.ManagedControlPlaneSubnet{
 									Name:      "test-subnet",
 									CIDRBlock: "10.0.2.0/24",
 								},
@@ -2561,19 +2561,19 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 					},
 				},
 			},
-			amcp: &AzureManagedControlPlane{
+			amcp: &infrav1.AzureManagedControlPlane{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster",
 				},
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						DNSServiceIP: ptr.To("192.168.0.10"),
 						Version:      "v1.18.0",
-						VirtualNetwork: ManagedControlPlaneVirtualNetwork{
+						VirtualNetwork: infrav1.ManagedControlPlaneVirtualNetwork{
 							Name: "test-network",
-							ManagedControlPlaneVirtualNetworkClassSpec: ManagedControlPlaneVirtualNetworkClassSpec{
+							ManagedControlPlaneVirtualNetworkClassSpec: infrav1.ManagedControlPlaneVirtualNetworkClassSpec{
 								CIDRBlock: "10.0.0.0/8",
-								Subnet: ManagedControlPlaneSubnet{
+								Subnet: infrav1.ManagedControlPlaneSubnet{
 									Name:      "test-subnet",
 									CIDRBlock: "10.0.2.0/24",
 								},
@@ -2587,23 +2587,23 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "OutboundType update",
-			oldAMCP: &AzureManagedControlPlane{
+			oldAMCP: &infrav1.AzureManagedControlPlane{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster",
 				},
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
-						OutboundType: (*ManagedControlPlaneOutboundType)(ptr.To(string(ManagedControlPlaneOutboundTypeUserDefinedRouting))),
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
+						OutboundType: (*infrav1.ManagedControlPlaneOutboundType)(ptr.To(string(infrav1.ManagedControlPlaneOutboundTypeUserDefinedRouting))),
 					},
 				},
 			},
-			amcp: &AzureManagedControlPlane{
+			amcp: &infrav1.AzureManagedControlPlane{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster",
 				},
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
-						OutboundType: (*ManagedControlPlaneOutboundType)(ptr.To(string(ManagedControlPlaneOutboundTypeLoadBalancer))),
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
+						OutboundType: (*infrav1.ManagedControlPlaneOutboundType)(ptr.To(string(infrav1.ManagedControlPlaneOutboundTypeLoadBalancer))),
 					},
 				},
 			},
@@ -2611,13 +2611,13 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "AzureManagedControlPlane HTTPProxyConfig is immutable",
-			oldAMCP: &AzureManagedControlPlane{
+			oldAMCP: &infrav1.AzureManagedControlPlane{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster",
 				},
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
-						HTTPProxyConfig: &HTTPProxyConfig{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
+						HTTPProxyConfig: &infrav1.HTTPProxyConfig{
 							HTTPProxy:  ptr.To("http://1.2.3.4:8080"),
 							HTTPSProxy: ptr.To("https://5.6.7.8:8443"),
 							NoProxy:    []string{"endpoint1", "endpoint2"},
@@ -2626,13 +2626,13 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 					},
 				},
 			},
-			amcp: &AzureManagedControlPlane{
+			amcp: &infrav1.AzureManagedControlPlane{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster",
 				},
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
-						HTTPProxyConfig: &HTTPProxyConfig{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
+						HTTPProxyConfig: &infrav1.HTTPProxyConfig{
 							HTTPProxy:  ptr.To("http://10.20.3.4:8080"),
 							HTTPSProxy: ptr.To("https://5.6.7.8:8443"),
 							NoProxy:    []string{"endpoint1", "endpoint2"},
@@ -2645,25 +2645,25 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "NetworkPluginMode cannot change to \"overlay\" when NetworkPolicy is set",
-			oldAMCP: &AzureManagedControlPlane{
+			oldAMCP: &infrav1.AzureManagedControlPlane{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster",
 				},
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						NetworkPolicy:     ptr.To("anything"),
 						NetworkPluginMode: nil,
 					},
 				},
 			},
-			amcp: &AzureManagedControlPlane{
+			amcp: &infrav1.AzureManagedControlPlane{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster",
 				},
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						NetworkPolicy:     ptr.To("anything"),
-						NetworkPluginMode: ptr.To(NetworkPluginModeOverlay),
+						NetworkPluginMode: ptr.To(infrav1.NetworkPluginModeOverlay),
 					},
 				},
 			},
@@ -2671,25 +2671,25 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "NetworkPluginMode can change to \"overlay\" when NetworkPolicy is not set",
-			oldAMCP: &AzureManagedControlPlane{
+			oldAMCP: &infrav1.AzureManagedControlPlane{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster",
 				},
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						NetworkPolicy:     nil,
 						NetworkPluginMode: nil,
 					},
 				},
 			},
-			amcp: &AzureManagedControlPlane{
+			amcp: &infrav1.AzureManagedControlPlane{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster",
 				},
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version:           "v0.0.0",
-						NetworkPluginMode: ptr.To(NetworkPluginModeOverlay),
+						NetworkPluginMode: ptr.To(infrav1.NetworkPluginModeOverlay),
 					},
 				},
 			},
@@ -2697,26 +2697,26 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "NetworkPolicy is allowed when NetworkPluginMode is not changed",
-			oldAMCP: &AzureManagedControlPlane{
+			oldAMCP: &infrav1.AzureManagedControlPlane{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster",
 				},
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						NetworkPolicy:     ptr.To("anything"),
-						NetworkPluginMode: ptr.To(NetworkPluginModeOverlay),
+						NetworkPluginMode: ptr.To(infrav1.NetworkPluginModeOverlay),
 					},
 				},
 			},
-			amcp: &AzureManagedControlPlane{
+			amcp: &infrav1.AzureManagedControlPlane{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster",
 				},
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						NetworkPolicy:     ptr.To("anything"),
 						Version:           "v0.0.0",
-						NetworkPluginMode: ptr.To(NetworkPluginModeOverlay),
+						NetworkPluginMode: ptr.To(infrav1.NetworkPluginModeOverlay),
 					},
 				},
 			},
@@ -2724,26 +2724,26 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "AzureManagedControlPlane OIDCIssuerProfile.Enabled false -> false OK",
-			oldAMCP: &AzureManagedControlPlane{
+			oldAMCP: &infrav1.AzureManagedControlPlane{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster",
 				},
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
-						OIDCIssuerProfile: &OIDCIssuerProfile{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
+						OIDCIssuerProfile: &infrav1.OIDCIssuerProfile{
 							Enabled: ptr.To(false),
 						},
 					},
 				},
 			},
-			amcp: &AzureManagedControlPlane{
+			amcp: &infrav1.AzureManagedControlPlane{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster",
 				},
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v0.0.0",
-						OIDCIssuerProfile: &OIDCIssuerProfile{
+						OIDCIssuerProfile: &infrav1.OIDCIssuerProfile{
 							Enabled: ptr.To(false),
 						},
 					},
@@ -2753,26 +2753,26 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "AzureManagedControlPlane OIDCIssuerProfile.Enabled false -> true OK",
-			oldAMCP: &AzureManagedControlPlane{
+			oldAMCP: &infrav1.AzureManagedControlPlane{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster",
 				},
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
-						OIDCIssuerProfile: &OIDCIssuerProfile{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
+						OIDCIssuerProfile: &infrav1.OIDCIssuerProfile{
 							Enabled: ptr.To(false),
 						},
 					},
 				},
 			},
-			amcp: &AzureManagedControlPlane{
+			amcp: &infrav1.AzureManagedControlPlane{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster",
 				},
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v0.0.0",
-						OIDCIssuerProfile: &OIDCIssuerProfile{
+						OIDCIssuerProfile: &infrav1.OIDCIssuerProfile{
 							Enabled: ptr.To(true),
 						},
 					},
@@ -2782,26 +2782,26 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "AzureManagedControlPlane OIDCIssuerProfile.Enabled true -> false err",
-			oldAMCP: &AzureManagedControlPlane{
+			oldAMCP: &infrav1.AzureManagedControlPlane{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster",
 				},
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
-						OIDCIssuerProfile: &OIDCIssuerProfile{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
+						OIDCIssuerProfile: &infrav1.OIDCIssuerProfile{
 							Enabled: ptr.To(true),
 						},
 					},
 				},
 			},
-			amcp: &AzureManagedControlPlane{
+			amcp: &infrav1.AzureManagedControlPlane{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster",
 				},
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v0.0.0",
-						OIDCIssuerProfile: &OIDCIssuerProfile{
+						OIDCIssuerProfile: &infrav1.OIDCIssuerProfile{
 							Enabled: ptr.To(false),
 						},
 					},
@@ -2811,26 +2811,26 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "AzureManagedControlPlane OIDCIssuerProfile.Enabled true -> true OK",
-			oldAMCP: &AzureManagedControlPlane{
+			oldAMCP: &infrav1.AzureManagedControlPlane{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster",
 				},
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
-						OIDCIssuerProfile: &OIDCIssuerProfile{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
+						OIDCIssuerProfile: &infrav1.OIDCIssuerProfile{
 							Enabled: ptr.To(true),
 						},
 					},
 				},
 			},
-			amcp: &AzureManagedControlPlane{
+			amcp: &infrav1.AzureManagedControlPlane{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster",
 				},
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v0.0.0",
-						OIDCIssuerProfile: &OIDCIssuerProfile{
+						OIDCIssuerProfile: &infrav1.OIDCIssuerProfile{
 							Enabled: ptr.To(true),
 						},
 					},
@@ -2840,18 +2840,18 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "AzureManagedControlPlane DNSPrefix is immutable error",
-			oldAMCP: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
+			oldAMCP: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
 					DNSPrefix: ptr.To("capz-aks-1"),
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.18.0",
 					},
 				},
 			},
-			amcp: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
+			amcp: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
 					DNSPrefix: ptr.To("capz-aks"),
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.18.0",
 					},
 				},
@@ -2860,18 +2860,18 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "AzureManagedControlPlane DNSPrefix is immutable no error",
-			oldAMCP: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
+			oldAMCP: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
 					DNSPrefix: ptr.To("capz-aks"),
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.18.0",
 					},
 				},
 			},
-			amcp: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
+			amcp: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
 					DNSPrefix: ptr.To("capz-aks"),
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.18.0",
 					},
 				},
@@ -2880,28 +2880,28 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "DisableLocalAccounts can be set only for AAD enabled clusters",
-			oldAMCP: &AzureManagedControlPlane{
+			oldAMCP: &infrav1.AzureManagedControlPlane{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster",
 				},
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.18.0",
-						AADProfile: &AADProfile{
+						AADProfile: &infrav1.AADProfile{
 							Managed:             true,
 							AdminGroupObjectIDs: []string{"00000000-0000-0000-0000-000000000000"},
 						},
 					},
 				},
 			},
-			amcp: &AzureManagedControlPlane{
+			amcp: &infrav1.AzureManagedControlPlane{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster",
 				},
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.18.0",
-						AADProfile: &AADProfile{
+						AADProfile: &infrav1.AADProfile{
 							Managed:             true,
 							AdminGroupObjectIDs: []string{"00000000-0000-0000-0000-000000000000"},
 						},
@@ -2913,14 +2913,14 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "DisableLocalAccounts cannot be disabled",
-			oldAMCP: &AzureManagedControlPlane{
+			oldAMCP: &infrav1.AzureManagedControlPlane{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster",
 				},
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.18.0",
-						AADProfile: &AADProfile{
+						AADProfile: &infrav1.AADProfile{
 							Managed:             true,
 							AdminGroupObjectIDs: []string{"00000000-0000-0000-0000-000000000000"},
 						},
@@ -2928,14 +2928,14 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 					},
 				},
 			},
-			amcp: &AzureManagedControlPlane{
+			amcp: &infrav1.AzureManagedControlPlane{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster",
 				},
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.18.0",
-						AADProfile: &AADProfile{
+						AADProfile: &infrav1.AADProfile{
 							Managed:             true,
 							AdminGroupObjectIDs: []string{"00000000-0000-0000-0000-000000000000"},
 						},
@@ -2946,14 +2946,14 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "DisableLocalAccounts cannot be disabled",
-			oldAMCP: &AzureManagedControlPlane{
+			oldAMCP: &infrav1.AzureManagedControlPlane{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster",
 				},
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.18.0",
-						AADProfile: &AADProfile{
+						AADProfile: &infrav1.AADProfile{
 							Managed:             true,
 							AdminGroupObjectIDs: []string{"00000000-0000-0000-0000-000000000000"},
 						},
@@ -2961,14 +2961,14 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 					},
 				},
 			},
-			amcp: &AzureManagedControlPlane{
+			amcp: &infrav1.AzureManagedControlPlane{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster",
 				},
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.18.0",
-						AADProfile: &AADProfile{
+						AADProfile: &infrav1.AADProfile{
 							Managed:             true,
 							AdminGroupObjectIDs: []string{"00000000-0000-0000-0000-000000000000"},
 						},
@@ -2980,18 +2980,18 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "AzureManagedControlPlane DNSPrefix is immutable error nil -> capz-aks",
-			oldAMCP: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
+			oldAMCP: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
 					DNSPrefix: nil,
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.18.0",
 					},
 				},
 			},
-			amcp: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
+			amcp: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
 					DNSPrefix: ptr.To("capz-aks"),
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.18.0",
 					},
 				},
@@ -3000,21 +3000,21 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "AzureManagedControlPlane DNSPrefix can be updated from nil when resource name matches",
-			oldAMCP: &AzureManagedControlPlane{
+			oldAMCP: &infrav1.AzureManagedControlPlane{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "capz-aks",
 				},
-				Spec: AzureManagedControlPlaneSpec{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
 					DNSPrefix: nil,
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.18.0",
 					},
 				},
 			},
-			amcp: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
+			amcp: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
 					DNSPrefix: ptr.To("capz-aks"),
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.18.0",
 					},
 				},
@@ -3023,22 +3023,22 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "DisableLocalAccounts cannot be set for non AAD clusters",
-			oldAMCP: &AzureManagedControlPlane{
+			oldAMCP: &infrav1.AzureManagedControlPlane{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster",
 				},
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.18.0",
 					},
 				},
 			},
-			amcp: &AzureManagedControlPlane{
+			amcp: &infrav1.AzureManagedControlPlane{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster",
 				},
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version:              "v1.18.0",
 						DisableLocalAccounts: ptr.To[bool](true),
 					},
@@ -3048,18 +3048,18 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "AzureManagedControlPlane DNSPrefix is immutable error nil -> empty",
-			oldAMCP: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
+			oldAMCP: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
 					DNSPrefix: nil,
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.18.0",
 					},
 				},
 			},
-			amcp: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
+			amcp: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
 					DNSPrefix: ptr.To(""),
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.18.0",
 					},
 				},
@@ -3068,18 +3068,18 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "AzureManagedControlPlane DNSPrefix is immutable no error nil -> nil",
-			oldAMCP: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
+			oldAMCP: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
 					DNSPrefix: nil,
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.18.0",
 					},
 				},
 			},
-			amcp: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
+			amcp: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
 					DNSPrefix: nil,
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.18.0",
 					},
 				},
@@ -3088,18 +3088,18 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "AzureManagedControlPlane AKSExtensions ConfigurationSettings and AutoUpgradeMinorVersion are mutable",
-			oldAMCP: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+			oldAMCP: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.18.0",
-						Extensions: []AKSExtension{
+						Extensions: []infrav1.AKSExtension{
 							{
 								Name:                    "extension1",
 								AutoUpgradeMinorVersion: ptr.To(false),
 								ConfigurationSettings: map[string]string{
 									"key1": "value1",
 								},
-								Plan: &ExtensionPlan{
+								Plan: &infrav1.ExtensionPlan{
 									Name:      "planName",
 									Product:   "planProduct",
 									Publisher: "planPublisher",
@@ -3109,11 +3109,11 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 					},
 				},
 			},
-			amcp: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+			amcp: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.18.0",
-						Extensions: []AKSExtension{
+						Extensions: []infrav1.AKSExtension{
 							{
 								Name:                    "extension1",
 								AutoUpgradeMinorVersion: ptr.To(true),
@@ -3121,7 +3121,7 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 									"key1": "value1",
 									"key2": "value2",
 								},
-								Plan: &ExtensionPlan{
+								Plan: &infrav1.ExtensionPlan{
 									Name:      "planName",
 									Product:   "planProduct",
 									Publisher: "planPublisher",
@@ -3135,21 +3135,21 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "AzureManagedControlPlane all other fields are immutable",
-			oldAMCP: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+			oldAMCP: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.18.0",
-						Extensions: []AKSExtension{
+						Extensions: []infrav1.AKSExtension{
 							{
 								Name:                    "extension1",
-								AKSAssignedIdentityType: AKSAssignedIdentitySystemAssigned,
+								AKSAssignedIdentityType: infrav1.AKSAssignedIdentitySystemAssigned,
 								ExtensionType:           ptr.To("extensionType"),
-								Plan: &ExtensionPlan{
+								Plan: &infrav1.ExtensionPlan{
 									Name:      "planName",
 									Product:   "planProduct",
 									Publisher: "planPublisher",
 								},
-								Scope: &ExtensionScope{
+								Scope: &infrav1.ExtensionScope{
 									ScopeType:        "Cluster",
 									ReleaseNamespace: "default",
 								},
@@ -3160,21 +3160,21 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 					},
 				},
 			},
-			amcp: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+			amcp: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.18.0",
-						Extensions: []AKSExtension{
+						Extensions: []infrav1.AKSExtension{
 							{
 								Name:                    "extension2",
-								AKSAssignedIdentityType: AKSAssignedIdentityUserAssigned,
+								AKSAssignedIdentityType: infrav1.AKSAssignedIdentityUserAssigned,
 								ExtensionType:           ptr.To("extensionType1"),
-								Plan: &ExtensionPlan{
+								Plan: &infrav1.ExtensionPlan{
 									Name:      "planName1",
 									Product:   "planProduct1",
 									Publisher: "planPublisher1",
 								},
-								Scope: &ExtensionScope{
+								Scope: &infrav1.ExtensionScope{
 									ScopeType:        "Namespace",
 									ReleaseNamespace: "default",
 								},
@@ -3205,12 +3205,12 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 	}
 }
 
-func createAzureManagedControlPlane(serviceIP, version, sshKey string) *AzureManagedControlPlane {
-	return &AzureManagedControlPlane{
+func createAzureManagedControlPlane(serviceIP, version, sshKey string) *infrav1.AzureManagedControlPlane {
+	return &infrav1.AzureManagedControlPlane{
 		ObjectMeta: getAMCPMetaData(),
-		Spec: AzureManagedControlPlaneSpec{
+		Spec: infrav1.AzureManagedControlPlaneSpec{
 			SSHPublicKey: &sshKey,
-			AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+			AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 				DNSServiceIP: ptr.To(serviceIP),
 				Version:      version,
 			},
@@ -3218,14 +3218,14 @@ func createAzureManagedControlPlane(serviceIP, version, sshKey string) *AzureMan
 	}
 }
 
-func getKnownValidAzureManagedControlPlane() *AzureManagedControlPlane {
-	return &AzureManagedControlPlane{
+func getKnownValidAzureManagedControlPlane() *infrav1.AzureManagedControlPlane {
+	return &infrav1.AzureManagedControlPlane{
 		ObjectMeta: getAMCPMetaData(),
-		Spec: AzureManagedControlPlaneSpec{
-			AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+		Spec: infrav1.AzureManagedControlPlaneSpec{
+			AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 				DNSServiceIP: ptr.To("192.168.0.10"),
 				Version:      "v1.18.0",
-				AADProfile: &AADProfile{
+				AADProfile: &infrav1.AADProfile{
 					Managed: true,
 					AdminGroupObjectIDs: []string{
 						"616077a8-5db7-4c98-b856-b34619afg75h",
@@ -3250,17 +3250,17 @@ func getAMCPMetaData() metav1.ObjectMeta {
 func TestAzureManagedClusterSecurityProfileValidateCreate(t *testing.T) {
 	testsCreate := []struct {
 		name    string
-		amcp    *AzureManagedControlPlane
+		amcp    *infrav1.AzureManagedControlPlane
 		wantErr string
 	}{
 		{
 			name: "Cannot enable Workload Identity without enabling OIDC issuer",
-			amcp: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+			amcp: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.17.8",
-						SecurityProfile: &ManagedClusterSecurityProfile{
-							WorkloadIdentity: &ManagedClusterSecurityProfileWorkloadIdentity{
+						SecurityProfile: &infrav1.ManagedClusterSecurityProfile{
+							WorkloadIdentity: &infrav1.ManagedClusterSecurityProfileWorkloadIdentity{
 								Enabled: true,
 							},
 						},
@@ -3271,12 +3271,12 @@ func TestAzureManagedClusterSecurityProfileValidateCreate(t *testing.T) {
 		},
 		{
 			name: "Cannot enable AzureKms without user assigned identity",
-			amcp: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+			amcp: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.17.8",
-						SecurityProfile: &ManagedClusterSecurityProfile{
-							AzureKeyVaultKms: &AzureKeyVaultKms{
+						SecurityProfile: &infrav1.ManagedClusterSecurityProfile{
+							AzureKeyVaultKms: &infrav1.AzureKeyVaultKms{
 								Enabled: true,
 							},
 						},
@@ -3287,19 +3287,19 @@ func TestAzureManagedClusterSecurityProfileValidateCreate(t *testing.T) {
 		},
 		{
 			name: "When AzureKms.KeyVaultNetworkAccess is private AzureKeyVaultKms.KeyVaultResourceID cannot be empty",
-			amcp: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
-						Identity: &Identity{
-							Type:                           ManagedControlPlaneIdentityTypeUserAssigned,
+			amcp: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
+						Identity: &infrav1.Identity{
+							Type:                           infrav1.ManagedControlPlaneIdentityTypeUserAssigned,
 							UserAssignedIdentityResourceID: "not empty",
 						},
 						Version: "v1.17.8",
-						SecurityProfile: &ManagedClusterSecurityProfile{
-							AzureKeyVaultKms: &AzureKeyVaultKms{
+						SecurityProfile: &infrav1.ManagedClusterSecurityProfile{
+							AzureKeyVaultKms: &infrav1.AzureKeyVaultKms{
 								Enabled:               true,
 								KeyID:                 "not empty",
-								KeyVaultNetworkAccess: ptr.To(KeyVaultNetworkAccessTypesPrivate),
+								KeyVaultNetworkAccess: ptr.To(infrav1.KeyVaultNetworkAccessTypesPrivate),
 							},
 						},
 					},
@@ -3309,19 +3309,19 @@ func TestAzureManagedClusterSecurityProfileValidateCreate(t *testing.T) {
 		},
 		{
 			name: "When AzureKms.KeyVaultNetworkAccess is public AzureKeyVaultKms.KeyVaultResourceID should be empty",
-			amcp: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+			amcp: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.17.8",
-						Identity: &Identity{
-							Type:                           ManagedControlPlaneIdentityTypeUserAssigned,
+						Identity: &infrav1.Identity{
+							Type:                           infrav1.ManagedControlPlaneIdentityTypeUserAssigned,
 							UserAssignedIdentityResourceID: "not empty",
 						},
-						SecurityProfile: &ManagedClusterSecurityProfile{
-							AzureKeyVaultKms: &AzureKeyVaultKms{
+						SecurityProfile: &infrav1.ManagedClusterSecurityProfile{
+							AzureKeyVaultKms: &infrav1.AzureKeyVaultKms{
 								Enabled:               true,
 								KeyID:                 "not empty",
-								KeyVaultNetworkAccess: ptr.To(KeyVaultNetworkAccessTypesPublic),
+								KeyVaultNetworkAccess: ptr.To(infrav1.KeyVaultNetworkAccessTypesPublic),
 								KeyVaultResourceID:    ptr.To("not empty"),
 							},
 						},
@@ -3332,33 +3332,33 @@ func TestAzureManagedClusterSecurityProfileValidateCreate(t *testing.T) {
 		},
 		{
 			name: "Valid profile",
-			amcp: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+			amcp: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.17.8",
-						Identity: &Identity{
-							Type:                           ManagedControlPlaneIdentityTypeUserAssigned,
+						Identity: &infrav1.Identity{
+							Type:                           infrav1.ManagedControlPlaneIdentityTypeUserAssigned,
 							UserAssignedIdentityResourceID: "not empty",
 						},
-						OIDCIssuerProfile: &OIDCIssuerProfile{
+						OIDCIssuerProfile: &infrav1.OIDCIssuerProfile{
 							Enabled: ptr.To(true),
 						},
-						SecurityProfile: &ManagedClusterSecurityProfile{
-							AzureKeyVaultKms: &AzureKeyVaultKms{
+						SecurityProfile: &infrav1.ManagedClusterSecurityProfile{
+							AzureKeyVaultKms: &infrav1.AzureKeyVaultKms{
 								Enabled:               true,
 								KeyID:                 "not empty",
-								KeyVaultNetworkAccess: ptr.To(KeyVaultNetworkAccessTypesPublic),
+								KeyVaultNetworkAccess: ptr.To(infrav1.KeyVaultNetworkAccessTypesPublic),
 							},
-							Defender: &ManagedClusterSecurityProfileDefender{
+							Defender: &infrav1.ManagedClusterSecurityProfileDefender{
 								LogAnalyticsWorkspaceResourceID: "not empty",
-								SecurityMonitoring: ManagedClusterSecurityProfileDefenderSecurityMonitoring{
+								SecurityMonitoring: infrav1.ManagedClusterSecurityProfileDefenderSecurityMonitoring{
 									Enabled: true,
 								},
 							},
-							WorkloadIdentity: &ManagedClusterSecurityProfileWorkloadIdentity{
+							WorkloadIdentity: &infrav1.ManagedClusterSecurityProfileWorkloadIdentity{
 								Enabled: true,
 							},
-							ImageCleaner: &ManagedClusterSecurityProfileImageCleaner{
+							ImageCleaner: &infrav1.ManagedClusterSecurityProfileImageCleaner{
 								Enabled:       true,
 								IntervalHours: ptr.To(24),
 							},
@@ -3390,27 +3390,27 @@ func TestAzureManagedClusterSecurityProfileValidateCreate(t *testing.T) {
 func TestAzureClusterSecurityProfileValidateUpdate(t *testing.T) {
 	tests := []struct {
 		name    string
-		oldAMCP *AzureManagedControlPlane
-		amcp    *AzureManagedControlPlane
+		oldAMCP *infrav1.AzureManagedControlPlane
+		amcp    *infrav1.AzureManagedControlPlane
 		wantErr string
 	}{
 		{
 			name: "AzureManagedControlPlane SecurityProfile.Defender is mutable",
-			oldAMCP: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+			oldAMCP: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.18.0",
 					},
 				},
 			},
-			amcp: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+			amcp: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.18.0",
-						SecurityProfile: &ManagedClusterSecurityProfile{
-							Defender: &ManagedClusterSecurityProfileDefender{
+						SecurityProfile: &infrav1.ManagedClusterSecurityProfile{
+							Defender: &infrav1.ManagedClusterSecurityProfileDefender{
 								LogAnalyticsWorkspaceResourceID: "0000-0000-0000-0000",
-								SecurityMonitoring: ManagedClusterSecurityProfileDefenderSecurityMonitoring{
+								SecurityMonitoring: infrav1.ManagedClusterSecurityProfileDefenderSecurityMonitoring{
 									Enabled: true,
 								},
 							},
@@ -3422,14 +3422,14 @@ func TestAzureClusterSecurityProfileValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "AzureManagedControlPlane SecurityProfile.Defender is mutable and cannot be unset",
-			oldAMCP: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+			oldAMCP: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.18.0",
-						SecurityProfile: &ManagedClusterSecurityProfile{
-							Defender: &ManagedClusterSecurityProfileDefender{
+						SecurityProfile: &infrav1.ManagedClusterSecurityProfile{
+							Defender: &infrav1.ManagedClusterSecurityProfileDefender{
 								LogAnalyticsWorkspaceResourceID: "0000-0000-0000-0000",
-								SecurityMonitoring: ManagedClusterSecurityProfileDefenderSecurityMonitoring{
+								SecurityMonitoring: infrav1.ManagedClusterSecurityProfileDefenderSecurityMonitoring{
 									Enabled: true,
 								},
 							},
@@ -3437,9 +3437,9 @@ func TestAzureClusterSecurityProfileValidateUpdate(t *testing.T) {
 					},
 				},
 			},
-			amcp: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+			amcp: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.18.0",
 					},
 				},
@@ -3448,14 +3448,14 @@ func TestAzureClusterSecurityProfileValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "AzureManagedControlPlane SecurityProfile.Defender is mutable and can be disabled",
-			oldAMCP: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+			oldAMCP: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.18.0",
-						SecurityProfile: &ManagedClusterSecurityProfile{
-							Defender: &ManagedClusterSecurityProfileDefender{
+						SecurityProfile: &infrav1.ManagedClusterSecurityProfile{
+							Defender: &infrav1.ManagedClusterSecurityProfileDefender{
 								LogAnalyticsWorkspaceResourceID: "0000-0000-0000-0000",
-								SecurityMonitoring: ManagedClusterSecurityProfileDefenderSecurityMonitoring{
+								SecurityMonitoring: infrav1.ManagedClusterSecurityProfileDefenderSecurityMonitoring{
 									Enabled: true,
 								},
 							},
@@ -3463,14 +3463,14 @@ func TestAzureClusterSecurityProfileValidateUpdate(t *testing.T) {
 					},
 				},
 			},
-			amcp: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+			amcp: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.18.0",
-						SecurityProfile: &ManagedClusterSecurityProfile{
-							Defender: &ManagedClusterSecurityProfileDefender{
+						SecurityProfile: &infrav1.ManagedClusterSecurityProfile{
+							Defender: &infrav1.ManagedClusterSecurityProfileDefender{
 								LogAnalyticsWorkspaceResourceID: "0000-0000-0000-0000",
-								SecurityMonitoring: ManagedClusterSecurityProfileDefenderSecurityMonitoring{
+								SecurityMonitoring: infrav1.ManagedClusterSecurityProfileDefenderSecurityMonitoring{
 									Enabled: false,
 								},
 							},
@@ -3482,22 +3482,22 @@ func TestAzureClusterSecurityProfileValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "AzureManagedControlPlane SecurityProfile.WorkloadIdentity is mutable",
-			oldAMCP: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+			oldAMCP: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.18.0",
 					},
 				},
 			},
-			amcp: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+			amcp: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.18.0",
-						OIDCIssuerProfile: &OIDCIssuerProfile{
+						OIDCIssuerProfile: &infrav1.OIDCIssuerProfile{
 							Enabled: ptr.To(true),
 						},
-						SecurityProfile: &ManagedClusterSecurityProfile{
-							WorkloadIdentity: &ManagedClusterSecurityProfileWorkloadIdentity{
+						SecurityProfile: &infrav1.ManagedClusterSecurityProfile{
+							WorkloadIdentity: &infrav1.ManagedClusterSecurityProfileWorkloadIdentity{
 								Enabled: true,
 							},
 						},
@@ -3508,19 +3508,19 @@ func TestAzureClusterSecurityProfileValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "AzureManagedControlPlane SecurityProfile.WorkloadIdentity cannot be enabled without OIDC issuer",
-			oldAMCP: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+			oldAMCP: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.18.0",
 					},
 				},
 			},
-			amcp: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+			amcp: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.18.0",
-						SecurityProfile: &ManagedClusterSecurityProfile{
-							WorkloadIdentity: &ManagedClusterSecurityProfileWorkloadIdentity{
+						SecurityProfile: &infrav1.ManagedClusterSecurityProfile{
+							WorkloadIdentity: &infrav1.ManagedClusterSecurityProfileWorkloadIdentity{
 								Enabled: true,
 							},
 						},
@@ -3531,26 +3531,26 @@ func TestAzureClusterSecurityProfileValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "AzureManagedControlPlane SecurityProfile.WorkloadIdentity cannot unset values",
-			oldAMCP: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+			oldAMCP: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.18.0",
-						OIDCIssuerProfile: &OIDCIssuerProfile{
+						OIDCIssuerProfile: &infrav1.OIDCIssuerProfile{
 							Enabled: ptr.To(true),
 						},
-						SecurityProfile: &ManagedClusterSecurityProfile{
-							WorkloadIdentity: &ManagedClusterSecurityProfileWorkloadIdentity{
+						SecurityProfile: &infrav1.ManagedClusterSecurityProfile{
+							WorkloadIdentity: &infrav1.ManagedClusterSecurityProfileWorkloadIdentity{
 								Enabled: true,
 							},
 						},
 					},
 				},
 			},
-			amcp: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+			amcp: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.18.0",
-						OIDCIssuerProfile: &OIDCIssuerProfile{
+						OIDCIssuerProfile: &infrav1.OIDCIssuerProfile{
 							Enabled: ptr.To(true),
 						},
 					},
@@ -3560,30 +3560,30 @@ func TestAzureClusterSecurityProfileValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "AzureManagedControlPlane SecurityProfile.WorkloadIdentity can be disabled",
-			oldAMCP: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+			oldAMCP: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.18.0",
-						OIDCIssuerProfile: &OIDCIssuerProfile{
+						OIDCIssuerProfile: &infrav1.OIDCIssuerProfile{
 							Enabled: ptr.To(true),
 						},
-						SecurityProfile: &ManagedClusterSecurityProfile{
-							WorkloadIdentity: &ManagedClusterSecurityProfileWorkloadIdentity{
+						SecurityProfile: &infrav1.ManagedClusterSecurityProfile{
+							WorkloadIdentity: &infrav1.ManagedClusterSecurityProfileWorkloadIdentity{
 								Enabled: true,
 							},
 						},
 					},
 				},
 			},
-			amcp: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+			amcp: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.18.0",
-						OIDCIssuerProfile: &OIDCIssuerProfile{
+						OIDCIssuerProfile: &infrav1.OIDCIssuerProfile{
 							Enabled: ptr.To(true),
 						},
-						SecurityProfile: &ManagedClusterSecurityProfile{
-							WorkloadIdentity: &ManagedClusterSecurityProfileWorkloadIdentity{
+						SecurityProfile: &infrav1.ManagedClusterSecurityProfile{
+							WorkloadIdentity: &infrav1.ManagedClusterSecurityProfileWorkloadIdentity{
 								Enabled: false,
 							},
 						},
@@ -3594,26 +3594,26 @@ func TestAzureClusterSecurityProfileValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "AzureManagedControlPlane SecurityProfile.AzureKeyVaultKms is mutable",
-			oldAMCP: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+			oldAMCP: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.18.0",
 					},
 				},
 			},
-			amcp: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+			amcp: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.18.0",
-						Identity: &Identity{
-							Type:                           ManagedControlPlaneIdentityTypeUserAssigned,
+						Identity: &infrav1.Identity{
+							Type:                           infrav1.ManagedControlPlaneIdentityTypeUserAssigned,
 							UserAssignedIdentityResourceID: "not empty",
 						},
-						SecurityProfile: &ManagedClusterSecurityProfile{
-							AzureKeyVaultKms: &AzureKeyVaultKms{
+						SecurityProfile: &infrav1.ManagedClusterSecurityProfile{
+							AzureKeyVaultKms: &infrav1.AzureKeyVaultKms{
 								Enabled:               true,
 								KeyID:                 "0000-0000-0000-0000",
-								KeyVaultNetworkAccess: ptr.To(KeyVaultNetworkAccessTypesPrivate),
+								KeyVaultNetworkAccess: ptr.To(infrav1.KeyVaultNetworkAccessTypesPrivate),
 								KeyVaultResourceID:    ptr.To("0000-0000-0000-0000"),
 							},
 						},
@@ -3624,37 +3624,37 @@ func TestAzureClusterSecurityProfileValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "AzureManagedControlPlane SecurityProfile.AzureKeyVaultKms.KeyVaultNetworkAccess can be updated when KMS is enabled",
-			oldAMCP: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+			oldAMCP: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.18.0",
-						Identity: &Identity{
-							Type:                           ManagedControlPlaneIdentityTypeUserAssigned,
+						Identity: &infrav1.Identity{
+							Type:                           infrav1.ManagedControlPlaneIdentityTypeUserAssigned,
 							UserAssignedIdentityResourceID: "not empty",
 						},
-						SecurityProfile: &ManagedClusterSecurityProfile{
-							AzureKeyVaultKms: &AzureKeyVaultKms{
+						SecurityProfile: &infrav1.ManagedClusterSecurityProfile{
+							AzureKeyVaultKms: &infrav1.AzureKeyVaultKms{
 								Enabled:               true,
 								KeyID:                 "0000-0000-0000-0000",
-								KeyVaultNetworkAccess: ptr.To(KeyVaultNetworkAccessTypesPublic),
+								KeyVaultNetworkAccess: ptr.To(infrav1.KeyVaultNetworkAccessTypesPublic),
 							},
 						},
 					},
 				},
 			},
-			amcp: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+			amcp: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.18.0",
-						Identity: &Identity{
-							Type:                           ManagedControlPlaneIdentityTypeUserAssigned,
+						Identity: &infrav1.Identity{
+							Type:                           infrav1.ManagedControlPlaneIdentityTypeUserAssigned,
 							UserAssignedIdentityResourceID: "not empty",
 						},
-						SecurityProfile: &ManagedClusterSecurityProfile{
-							AzureKeyVaultKms: &AzureKeyVaultKms{
+						SecurityProfile: &infrav1.ManagedClusterSecurityProfile{
+							AzureKeyVaultKms: &infrav1.AzureKeyVaultKms{
 								Enabled:               true,
 								KeyID:                 "0000-0000-0000-0000",
-								KeyVaultNetworkAccess: ptr.To(KeyVaultNetworkAccessTypesPrivate),
+								KeyVaultNetworkAccess: ptr.To(infrav1.KeyVaultNetworkAccessTypesPrivate),
 								KeyVaultResourceID:    ptr.To("0000-0000-0000-0000"),
 							},
 						},
@@ -3665,37 +3665,37 @@ func TestAzureClusterSecurityProfileValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "AzureManagedControlPlane SecurityProfile.AzureKeyVaultKms.Enabled can be disabled",
-			oldAMCP: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+			oldAMCP: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.18.0",
-						Identity: &Identity{
-							Type:                           ManagedControlPlaneIdentityTypeUserAssigned,
+						Identity: &infrav1.Identity{
+							Type:                           infrav1.ManagedControlPlaneIdentityTypeUserAssigned,
 							UserAssignedIdentityResourceID: "not empty",
 						},
-						SecurityProfile: &ManagedClusterSecurityProfile{
-							AzureKeyVaultKms: &AzureKeyVaultKms{
+						SecurityProfile: &infrav1.ManagedClusterSecurityProfile{
+							AzureKeyVaultKms: &infrav1.AzureKeyVaultKms{
 								Enabled:               true,
 								KeyID:                 "0000-0000-0000-0000",
-								KeyVaultNetworkAccess: ptr.To(KeyVaultNetworkAccessTypesPublic),
+								KeyVaultNetworkAccess: ptr.To(infrav1.KeyVaultNetworkAccessTypesPublic),
 							},
 						},
 					},
 				},
 			},
-			amcp: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+			amcp: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.18.0",
-						Identity: &Identity{
-							Type:                           ManagedControlPlaneIdentityTypeUserAssigned,
+						Identity: &infrav1.Identity{
+							Type:                           infrav1.ManagedControlPlaneIdentityTypeUserAssigned,
 							UserAssignedIdentityResourceID: "not empty",
 						},
-						SecurityProfile: &ManagedClusterSecurityProfile{
-							AzureKeyVaultKms: &AzureKeyVaultKms{
+						SecurityProfile: &infrav1.ManagedClusterSecurityProfile{
+							AzureKeyVaultKms: &infrav1.AzureKeyVaultKms{
 								Enabled:               false,
 								KeyID:                 "0000-0000-0000-0000",
-								KeyVaultNetworkAccess: ptr.To(KeyVaultNetworkAccessTypesPublic),
+								KeyVaultNetworkAccess: ptr.To(infrav1.KeyVaultNetworkAccessTypesPublic),
 							},
 						},
 					},
@@ -3705,30 +3705,30 @@ func TestAzureClusterSecurityProfileValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "AzureManagedControlPlane SecurityProfile.AzureKeyVaultKms cannot unset",
-			oldAMCP: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+			oldAMCP: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.18.0",
-						Identity: &Identity{
-							Type:                           ManagedControlPlaneIdentityTypeUserAssigned,
+						Identity: &infrav1.Identity{
+							Type:                           infrav1.ManagedControlPlaneIdentityTypeUserAssigned,
 							UserAssignedIdentityResourceID: "not empty",
 						},
-						SecurityProfile: &ManagedClusterSecurityProfile{
-							AzureKeyVaultKms: &AzureKeyVaultKms{
+						SecurityProfile: &infrav1.ManagedClusterSecurityProfile{
+							AzureKeyVaultKms: &infrav1.AzureKeyVaultKms{
 								Enabled:               true,
 								KeyID:                 "0000-0000-0000-0000",
-								KeyVaultNetworkAccess: ptr.To(KeyVaultNetworkAccessTypesPublic),
+								KeyVaultNetworkAccess: ptr.To(infrav1.KeyVaultNetworkAccessTypesPublic),
 							},
 						},
 					},
 				},
 			},
-			amcp: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+			amcp: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.18.0",
-						Identity: &Identity{
-							Type:                           ManagedControlPlaneIdentityTypeUserAssigned,
+						Identity: &infrav1.Identity{
+							Type:                           infrav1.ManagedControlPlaneIdentityTypeUserAssigned,
 							UserAssignedIdentityResourceID: "not empty",
 						},
 					},
@@ -3738,22 +3738,22 @@ func TestAzureClusterSecurityProfileValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "AzureManagedControlPlane SecurityProfile.AzureKeyVaultKms cannot be enabled without UserAssigned Identity",
-			oldAMCP: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+			oldAMCP: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.18.0",
 					},
 				},
 			},
-			amcp: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+			amcp: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.18.0",
-						SecurityProfile: &ManagedClusterSecurityProfile{
-							AzureKeyVaultKms: &AzureKeyVaultKms{
+						SecurityProfile: &infrav1.ManagedClusterSecurityProfile{
+							AzureKeyVaultKms: &infrav1.AzureKeyVaultKms{
 								Enabled:               true,
 								KeyID:                 "0000-0000-0000-0000",
-								KeyVaultNetworkAccess: ptr.To(KeyVaultNetworkAccessTypesPrivate),
+								KeyVaultNetworkAccess: ptr.To(infrav1.KeyVaultNetworkAccessTypesPrivate),
 								KeyVaultResourceID:    ptr.To("0000-0000-0000-0000"),
 							},
 						},
@@ -3764,19 +3764,19 @@ func TestAzureClusterSecurityProfileValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "AzureManagedControlPlane SecurityProfile.ImageCleaner is mutable",
-			oldAMCP: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+			oldAMCP: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.18.0",
 					},
 				},
 			},
-			amcp: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+			amcp: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.18.0",
-						SecurityProfile: &ManagedClusterSecurityProfile{
-							ImageCleaner: &ManagedClusterSecurityProfileImageCleaner{
+						SecurityProfile: &infrav1.ManagedClusterSecurityProfile{
+							ImageCleaner: &infrav1.ManagedClusterSecurityProfileImageCleaner{
 								Enabled:       true,
 								IntervalHours: ptr.To(28),
 							},
@@ -3788,12 +3788,12 @@ func TestAzureClusterSecurityProfileValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "AzureManagedControlPlane SecurityProfile.ImageCleaner cannot be unset",
-			oldAMCP: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+			oldAMCP: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.18.0",
-						SecurityProfile: &ManagedClusterSecurityProfile{
-							ImageCleaner: &ManagedClusterSecurityProfileImageCleaner{
+						SecurityProfile: &infrav1.ManagedClusterSecurityProfile{
+							ImageCleaner: &infrav1.ManagedClusterSecurityProfileImageCleaner{
 								Enabled:       true,
 								IntervalHours: ptr.To(48),
 							},
@@ -3801,11 +3801,11 @@ func TestAzureClusterSecurityProfileValidateUpdate(t *testing.T) {
 					},
 				},
 			},
-			amcp: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+			amcp: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version:         "v1.18.0",
-						SecurityProfile: &ManagedClusterSecurityProfile{},
+						SecurityProfile: &infrav1.ManagedClusterSecurityProfile{},
 					},
 				},
 			},
@@ -3813,24 +3813,24 @@ func TestAzureClusterSecurityProfileValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "AzureManagedControlPlane SecurityProfile.ImageCleaner is mutable",
-			oldAMCP: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+			oldAMCP: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.18.0",
-						SecurityProfile: &ManagedClusterSecurityProfile{
-							ImageCleaner: &ManagedClusterSecurityProfileImageCleaner{
+						SecurityProfile: &infrav1.ManagedClusterSecurityProfile{
+							ImageCleaner: &infrav1.ManagedClusterSecurityProfileImageCleaner{
 								Enabled: true,
 							},
 						},
 					},
 				},
 			},
-			amcp: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+			amcp: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.18.0",
-						SecurityProfile: &ManagedClusterSecurityProfile{
-							ImageCleaner: &ManagedClusterSecurityProfileImageCleaner{
+						SecurityProfile: &infrav1.ManagedClusterSecurityProfile{
+							ImageCleaner: &infrav1.ManagedClusterSecurityProfileImageCleaner{
 								IntervalHours: ptr.To(48),
 							},
 						},
@@ -3841,12 +3841,12 @@ func TestAzureClusterSecurityProfileValidateUpdate(t *testing.T) {
 		},
 		{
 			name: "AzureManagedControlPlane SecurityProfile.ImageCleaner can be disabled",
-			oldAMCP: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+			oldAMCP: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.18.0",
-						SecurityProfile: &ManagedClusterSecurityProfile{
-							ImageCleaner: &ManagedClusterSecurityProfileImageCleaner{
+						SecurityProfile: &infrav1.ManagedClusterSecurityProfile{
+							ImageCleaner: &infrav1.ManagedClusterSecurityProfileImageCleaner{
 								Enabled:       true,
 								IntervalHours: ptr.To(48),
 							},
@@ -3854,12 +3854,12 @@ func TestAzureClusterSecurityProfileValidateUpdate(t *testing.T) {
 					},
 				},
 			},
-			amcp: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+			amcp: &infrav1.AzureManagedControlPlane{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Version: "v1.18.0",
-						SecurityProfile: &ManagedClusterSecurityProfile{
-							ImageCleaner: &ManagedClusterSecurityProfileImageCleaner{
+						SecurityProfile: &infrav1.ManagedClusterSecurityProfile{
+							ImageCleaner: &infrav1.ManagedClusterSecurityProfileImageCleaner{
 								Enabled:       false,
 								IntervalHours: ptr.To(36),
 							},
@@ -3891,13 +3891,13 @@ func TestAzureClusterSecurityProfileValidateUpdate(t *testing.T) {
 func TestValidateAPIServerAccessProfile(t *testing.T) {
 	tests := []struct {
 		name      string
-		profile   *APIServerAccessProfile
+		profile   *infrav1.APIServerAccessProfile
 		expectErr bool
 	}{
 		{
 			name: "Testing valid PrivateDNSZone:System",
-			profile: &APIServerAccessProfile{
-				APIServerAccessProfileClassSpec: APIServerAccessProfileClassSpec{
+			profile: &infrav1.APIServerAccessProfile{
+				APIServerAccessProfileClassSpec: infrav1.APIServerAccessProfileClassSpec{
 					PrivateDNSZone: ptr.To("System"),
 				},
 			},
@@ -3905,8 +3905,8 @@ func TestValidateAPIServerAccessProfile(t *testing.T) {
 		},
 		{
 			name: "Testing valid PrivateDNSZone:None",
-			profile: &APIServerAccessProfile{
-				APIServerAccessProfileClassSpec: APIServerAccessProfileClassSpec{
+			profile: &infrav1.APIServerAccessProfile{
+				APIServerAccessProfileClassSpec: infrav1.APIServerAccessProfileClassSpec{
 					PrivateDNSZone: ptr.To("None"),
 				},
 			},
@@ -3914,8 +3914,8 @@ func TestValidateAPIServerAccessProfile(t *testing.T) {
 		},
 		{
 			name: "Testing valid PrivateDNSZone:With privatelink region",
-			profile: &APIServerAccessProfile{
-				APIServerAccessProfileClassSpec: APIServerAccessProfileClassSpec{
+			profile: &infrav1.APIServerAccessProfile{
+				APIServerAccessProfileClassSpec: infrav1.APIServerAccessProfileClassSpec{
 					EnablePrivateCluster: ptr.To(true),
 					PrivateDNSZone:       ptr.To("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/privateDnsZones/privatelink.eastus.azmk8s.io"),
 				},
@@ -3924,8 +3924,8 @@ func TestValidateAPIServerAccessProfile(t *testing.T) {
 		},
 		{
 			name: "Testing valid PrivateDNSZone:With private region",
-			profile: &APIServerAccessProfile{
-				APIServerAccessProfileClassSpec: APIServerAccessProfileClassSpec{
+			profile: &infrav1.APIServerAccessProfile{
+				APIServerAccessProfileClassSpec: infrav1.APIServerAccessProfileClassSpec{
 					EnablePrivateCluster: ptr.To(true),
 					PrivateDNSZone:       ptr.To("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/privateDnsZones/private.eastus.azmk8s.io"),
 				},
@@ -3934,8 +3934,8 @@ func TestValidateAPIServerAccessProfile(t *testing.T) {
 		},
 		{
 			name: "Testing invalid EnablePrivateCluster and valid PrivateDNSZone",
-			profile: &APIServerAccessProfile{
-				APIServerAccessProfileClassSpec: APIServerAccessProfileClassSpec{
+			profile: &infrav1.APIServerAccessProfile{
+				APIServerAccessProfileClassSpec: infrav1.APIServerAccessProfileClassSpec{
 					EnablePrivateCluster: ptr.To(false),
 					PrivateDNSZone:       ptr.To("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/privateDnsZones/private.eastus.azmk8s.io"),
 				},
@@ -3944,8 +3944,8 @@ func TestValidateAPIServerAccessProfile(t *testing.T) {
 		},
 		{
 			name: "Testing valid PrivateDNSZone:With privatelink region and sub-region",
-			profile: &APIServerAccessProfile{
-				APIServerAccessProfileClassSpec: APIServerAccessProfileClassSpec{
+			profile: &infrav1.APIServerAccessProfile{
+				APIServerAccessProfileClassSpec: infrav1.APIServerAccessProfileClassSpec{
 					EnablePrivateCluster: ptr.To(true),
 					PrivateDNSZone:       ptr.To("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/privateDnsZones/sublocation2.privatelink.eastus.azmk8s.io"),
 				},
@@ -3954,8 +3954,8 @@ func TestValidateAPIServerAccessProfile(t *testing.T) {
 		},
 		{
 			name: "Testing valid PrivateDNSZone:With private region and sub-region",
-			profile: &APIServerAccessProfile{
-				APIServerAccessProfileClassSpec: APIServerAccessProfileClassSpec{
+			profile: &infrav1.APIServerAccessProfile{
+				APIServerAccessProfileClassSpec: infrav1.APIServerAccessProfileClassSpec{
 					EnablePrivateCluster: ptr.To(true),
 					PrivateDNSZone:       ptr.To("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/privateDnsZones/sublocation2.private.eastus.azmk8s.io"),
 				},
@@ -3964,8 +3964,8 @@ func TestValidateAPIServerAccessProfile(t *testing.T) {
 		},
 		{
 			name: "Testing invalid PrivateDNSZone: privatelink region: len(sub-region) > 32 characters",
-			profile: &APIServerAccessProfile{
-				APIServerAccessProfileClassSpec: APIServerAccessProfileClassSpec{
+			profile: &infrav1.APIServerAccessProfile{
+				APIServerAccessProfileClassSpec: infrav1.APIServerAccessProfileClassSpec{
 					EnablePrivateCluster: ptr.To(true),
 					PrivateDNSZone:       ptr.To("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/privateDnsZones/thissublocationismorethan32characters.privatelink.eastus.azmk8s.io"),
 				},
@@ -3974,8 +3974,8 @@ func TestValidateAPIServerAccessProfile(t *testing.T) {
 		},
 		{
 			name: "Testing invalid PrivateDNSZone: private region: len(sub-region) > 32 characters",
-			profile: &APIServerAccessProfile{
-				APIServerAccessProfileClassSpec: APIServerAccessProfileClassSpec{
+			profile: &infrav1.APIServerAccessProfile{
+				APIServerAccessProfileClassSpec: infrav1.APIServerAccessProfileClassSpec{
 					EnablePrivateCluster: ptr.To(true),
 					PrivateDNSZone:       ptr.To("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/privateDnsZones/thissublocationismorethan32characters.private.eastus.azmk8s.io"),
 				},
@@ -3984,8 +3984,8 @@ func TestValidateAPIServerAccessProfile(t *testing.T) {
 		},
 		{
 			name: "Testing invalid PrivateDNSZone: random string",
-			profile: &APIServerAccessProfile{
-				APIServerAccessProfileClassSpec: APIServerAccessProfileClassSpec{
+			profile: &infrav1.APIServerAccessProfile{
+				APIServerAccessProfileClassSpec: infrav1.APIServerAccessProfileClassSpec{
 					EnablePrivateCluster: ptr.To(true),
 					PrivateDNSZone:       ptr.To("WrongPrivateDNSZone"),
 				},
@@ -3994,8 +3994,8 @@ func TestValidateAPIServerAccessProfile(t *testing.T) {
 		},
 		{
 			name: "Testing invalid PrivateDNSZone: subzone has an invalid char %",
-			profile: &APIServerAccessProfile{
-				APIServerAccessProfileClassSpec: APIServerAccessProfileClassSpec{
+			profile: &infrav1.APIServerAccessProfile{
+				APIServerAccessProfileClassSpec: infrav1.APIServerAccessProfileClassSpec{
 					EnablePrivateCluster: ptr.To(true),
 					PrivateDNSZone:       ptr.To("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/privateDnsZones/subzone%1.privatelink.eastus.azmk8s.io"),
 				},
@@ -4004,8 +4004,8 @@ func TestValidateAPIServerAccessProfile(t *testing.T) {
 		},
 		{
 			name: "Testing invalid PrivateDNSZone: subzone has an invalid char _",
-			profile: &APIServerAccessProfile{
-				APIServerAccessProfileClassSpec: APIServerAccessProfileClassSpec{
+			profile: &infrav1.APIServerAccessProfile{
+				APIServerAccessProfileClassSpec: infrav1.APIServerAccessProfileClassSpec{
 					EnablePrivateCluster: ptr.To(true),
 					PrivateDNSZone:       ptr.To("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/privateDnsZones/subzone_1.privatelink.eastus.azmk8s.io"),
 				},
@@ -4014,8 +4014,8 @@ func TestValidateAPIServerAccessProfile(t *testing.T) {
 		},
 		{
 			name: "Testing invalid PrivateDNSZone: region has invalid char",
-			profile: &APIServerAccessProfile{
-				APIServerAccessProfileClassSpec: APIServerAccessProfileClassSpec{
+			profile: &infrav1.APIServerAccessProfile{
+				APIServerAccessProfileClassSpec: infrav1.APIServerAccessProfileClassSpec{
 					EnablePrivateCluster: ptr.To(true),
 					PrivateDNSZone:       ptr.To("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/privateDnsZones/subzone1.privatelink.location@1.azmk8s.io"),
 				},
@@ -4040,33 +4040,33 @@ func TestValidateAPIServerAccessProfile(t *testing.T) {
 func TestValidateAMCPVirtualNetwork(t *testing.T) {
 	tests := []struct {
 		name    string
-		amcp    *AzureManagedControlPlane
+		amcp    *infrav1.AzureManagedControlPlane
 		wantErr string
 	}{
 		{
 			name: "Testing valid VirtualNetwork in same resource group",
-			amcp: &AzureManagedControlPlane{
+			amcp: &infrav1.AzureManagedControlPlane{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "fooName",
 					Labels: map[string]string{
 						clusterv1.ClusterNameLabel: "fooCluster",
 					},
 				},
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						ResourceGroupName: "rg1",
-						VirtualNetwork: ManagedControlPlaneVirtualNetwork{
+						VirtualNetwork: infrav1.ManagedControlPlaneVirtualNetwork{
 							ResourceGroup: "rg1",
 							Name:          "vnet1",
-							ManagedControlPlaneVirtualNetworkClassSpec: ManagedControlPlaneVirtualNetworkClassSpec{
+							ManagedControlPlaneVirtualNetworkClassSpec: infrav1.ManagedControlPlaneVirtualNetworkClassSpec{
 								CIDRBlock: apiinternal.DefaultAKSVnetCIDR,
-								Subnet: ManagedControlPlaneSubnet{
+								Subnet: infrav1.ManagedControlPlaneSubnet{
 									Name:      "subnet1",
 									CIDRBlock: apiinternal.DefaultAKSNodeSubnetCIDR,
 								},
 							},
 						},
-						SKU: &AKSSku{},
+						SKU: &infrav1.AKSSku{},
 					},
 				},
 			},
@@ -4074,28 +4074,28 @@ func TestValidateAMCPVirtualNetwork(t *testing.T) {
 		},
 		{
 			name: "Testing valid VirtualNetwork in different resource group",
-			amcp: &AzureManagedControlPlane{
+			amcp: &infrav1.AzureManagedControlPlane{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "fooName",
 					Labels: map[string]string{
 						clusterv1.ClusterNameLabel: "fooCluster",
 					},
 				},
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						ResourceGroupName: "rg1",
-						VirtualNetwork: ManagedControlPlaneVirtualNetwork{
+						VirtualNetwork: infrav1.ManagedControlPlaneVirtualNetwork{
 							ResourceGroup: "rg2",
 							Name:          "vnet1",
-							ManagedControlPlaneVirtualNetworkClassSpec: ManagedControlPlaneVirtualNetworkClassSpec{
+							ManagedControlPlaneVirtualNetworkClassSpec: infrav1.ManagedControlPlaneVirtualNetworkClassSpec{
 								CIDRBlock: apiinternal.DefaultAKSVnetCIDR,
-								Subnet: ManagedControlPlaneSubnet{
+								Subnet: infrav1.ManagedControlPlaneSubnet{
 									Name:      "subnet1",
 									CIDRBlock: apiinternal.DefaultAKSNodeSubnetCIDR,
 								},
 							},
 						},
-						SKU: &AKSSku{},
+						SKU: &infrav1.AKSSku{},
 					},
 				},
 			},
@@ -4103,28 +4103,28 @@ func TestValidateAMCPVirtualNetwork(t *testing.T) {
 		},
 		{
 			name: "Testing invalid VirtualNetwork in different resource group: invalid subnet CIDR",
-			amcp: &AzureManagedControlPlane{
+			amcp: &infrav1.AzureManagedControlPlane{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "fooName",
 					Labels: map[string]string{
 						clusterv1.ClusterNameLabel: "fooCluster",
 					},
 				},
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						ResourceGroupName: "rg1",
-						VirtualNetwork: ManagedControlPlaneVirtualNetwork{
+						VirtualNetwork: infrav1.ManagedControlPlaneVirtualNetwork{
 							ResourceGroup: "rg2",
 							Name:          "vnet1",
-							ManagedControlPlaneVirtualNetworkClassSpec: ManagedControlPlaneVirtualNetworkClassSpec{
+							ManagedControlPlaneVirtualNetworkClassSpec: infrav1.ManagedControlPlaneVirtualNetworkClassSpec{
 								CIDRBlock: "10.1.0.0/16",
-								Subnet: ManagedControlPlaneSubnet{
+								Subnet: infrav1.ManagedControlPlaneSubnet{
 									Name:      "subnet1",
 									CIDRBlock: "10.0.0.0/24",
 								},
 							},
 						},
-						SKU: &AKSSku{},
+						SKU: &infrav1.AKSSku{},
 					},
 				},
 			},
@@ -4132,28 +4132,28 @@ func TestValidateAMCPVirtualNetwork(t *testing.T) {
 		},
 		{
 			name: "Testing invalid VirtualNetwork in different resource group: invalid VNet CIDR",
-			amcp: &AzureManagedControlPlane{
+			amcp: &infrav1.AzureManagedControlPlane{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "fooName",
 					Labels: map[string]string{
 						clusterv1.ClusterNameLabel: "fooCluster",
 					},
 				},
-				Spec: AzureManagedControlPlaneSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+				Spec: infrav1.AzureManagedControlPlaneSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						ResourceGroupName: "rg1",
-						VirtualNetwork: ManagedControlPlaneVirtualNetwork{
+						VirtualNetwork: infrav1.ManagedControlPlaneVirtualNetwork{
 							ResourceGroup: "rg2",
 							Name:          "vnet1",
-							ManagedControlPlaneVirtualNetworkClassSpec: ManagedControlPlaneVirtualNetworkClassSpec{
+							ManagedControlPlaneVirtualNetworkClassSpec: infrav1.ManagedControlPlaneVirtualNetworkClassSpec{
 								CIDRBlock: "invalid_vnet_CIDR",
-								Subnet: ManagedControlPlaneSubnet{
+								Subnet: infrav1.ManagedControlPlaneSubnet{
 									Name:      "subnet1",
 									CIDRBlock: "11.0.0.0/24",
 								},
 							},
 						},
-						SKU: &AKSSku{},
+						SKU: &infrav1.AKSSku{},
 					},
 				},
 			},
@@ -4190,13 +4190,13 @@ func (m mockClient) Get(ctx context.Context, key client.ObjectKey, obj client.Ob
 	}
 	// Check if we're calling Get on an AzureCluster or a Cluster
 	switch obj := obj.(type) {
-	case *AzureCluster:
+	case *infrav1.AzureCluster:
 		obj.Spec.SubscriptionID = "test-subscription-id"
 	case *clusterv1.Cluster:
 		obj.Namespace = "default"
 		obj.Spec = clusterv1.ClusterSpec{
 			InfrastructureRef: clusterv1.ContractVersionedObjectReference{
-				Kind: AzureClusterKind,
+				Kind: infrav1.AzureClusterKind,
 				Name: "test-cluster",
 			},
 			ClusterNetwork: clusterv1.ClusterNetwork{

--- a/internal/webhooks/azuremanagedcontrolplanetemplate_validation.go
+++ b/internal/webhooks/azuremanagedcontrolplanetemplate_validation.go
@@ -22,12 +22,12 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	. "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
+	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/util/versions"
 )
 
 // Validate the Azure Managed Control Plane Template and return an aggregate error.
-func validateAzureManagedControlPlaneTemplate(mcp *AzureManagedControlPlaneTemplate, cli client.Client) error {
+func validateAzureManagedControlPlaneTemplate(mcp *infrav1.AzureManagedControlPlaneTemplate, cli client.Client) error {
 	var allErrs field.ErrorList
 
 	allErrs = append(allErrs, validateVersion(
@@ -66,7 +66,7 @@ func validateAzureManagedControlPlaneTemplate(mcp *AzureManagedControlPlaneTempl
 }
 
 // validateK8sVersionUpdate validates K8s version.
-func validateAzureManagedControlPlaneTemplateK8sVersionUpdate(mcp *AzureManagedControlPlaneTemplate, old *AzureManagedControlPlaneTemplate) field.ErrorList {
+func validateAzureManagedControlPlaneTemplateK8sVersionUpdate(mcp *infrav1.AzureManagedControlPlaneTemplate, old *infrav1.AzureManagedControlPlaneTemplate) field.ErrorList {
 	var allErrs field.ErrorList
 	if hv := versions.GetHigherK8sVersion(mcp.Spec.Template.Spec.Version, old.Spec.Template.Spec.Version); hv != mcp.Spec.Template.Spec.Version {
 		allErrs = append(allErrs, field.Invalid(field.NewPath("spec", "template", "spec", "version"),
@@ -77,7 +77,7 @@ func validateAzureManagedControlPlaneTemplateK8sVersionUpdate(mcp *AzureManagedC
 }
 
 // validateVirtualNetworkTemplateUpdate validates update to VirtualNetworkTemplate.
-func validateAzureManagedControlPlaneTemplateVirtualNetworkTemplateUpdate(mcp *AzureManagedControlPlaneTemplate, old *AzureManagedControlPlaneTemplate) field.ErrorList {
+func validateAzureManagedControlPlaneTemplateVirtualNetworkTemplateUpdate(mcp *infrav1.AzureManagedControlPlaneTemplate, old *infrav1.AzureManagedControlPlaneTemplate) field.ErrorList {
 	var allErrs field.ErrorList
 
 	if old.Spec.Template.Spec.VirtualNetwork.CIDRBlock != mcp.Spec.Template.Spec.VirtualNetwork.CIDRBlock {
@@ -116,14 +116,14 @@ func validateAzureManagedControlPlaneTemplateVirtualNetworkTemplateUpdate(mcp *A
 }
 
 // validateAPIServerAccessProfileTemplateUpdate validates update to APIServerAccessProfileTemplate.
-func validateAzureManagedControlPlaneTemplateAPIServerAccessProfileTemplateUpdate(mcp *AzureManagedControlPlaneTemplate, old *AzureManagedControlPlaneTemplate) field.ErrorList {
+func validateAzureManagedControlPlaneTemplateAPIServerAccessProfileTemplateUpdate(mcp *infrav1.AzureManagedControlPlaneTemplate, old *infrav1.AzureManagedControlPlaneTemplate) field.ErrorList {
 	var allErrs field.ErrorList
 
-	newAPIServerAccessProfileNormalized := &APIServerAccessProfile{}
-	oldAPIServerAccessProfileNormalized := &APIServerAccessProfile{}
+	newAPIServerAccessProfileNormalized := &infrav1.APIServerAccessProfile{}
+	oldAPIServerAccessProfileNormalized := &infrav1.APIServerAccessProfile{}
 	if mcp.Spec.Template.Spec.APIServerAccessProfile != nil {
-		newAPIServerAccessProfileNormalized = &APIServerAccessProfile{
-			APIServerAccessProfileClassSpec: APIServerAccessProfileClassSpec{
+		newAPIServerAccessProfileNormalized = &infrav1.APIServerAccessProfile{
+			APIServerAccessProfileClassSpec: infrav1.APIServerAccessProfileClassSpec{
 				EnablePrivateCluster:           mcp.Spec.Template.Spec.APIServerAccessProfile.EnablePrivateCluster,
 				PrivateDNSZone:                 mcp.Spec.Template.Spec.APIServerAccessProfile.PrivateDNSZone,
 				EnablePrivateClusterPublicFQDN: mcp.Spec.Template.Spec.APIServerAccessProfile.EnablePrivateClusterPublicFQDN,
@@ -131,8 +131,8 @@ func validateAzureManagedControlPlaneTemplateAPIServerAccessProfileTemplateUpdat
 		}
 	}
 	if old.Spec.Template.Spec.APIServerAccessProfile != nil {
-		oldAPIServerAccessProfileNormalized = &APIServerAccessProfile{
-			APIServerAccessProfileClassSpec: APIServerAccessProfileClassSpec{
+		oldAPIServerAccessProfileNormalized = &infrav1.APIServerAccessProfile{
+			APIServerAccessProfileClassSpec: infrav1.APIServerAccessProfileClassSpec{
 				EnablePrivateCluster:           old.Spec.Template.Spec.APIServerAccessProfile.EnablePrivateCluster,
 				PrivateDNSZone:                 old.Spec.Template.Spec.APIServerAccessProfile.PrivateDNSZone,
 				EnablePrivateClusterPublicFQDN: old.Spec.Template.Spec.APIServerAccessProfile.EnablePrivateClusterPublicFQDN,

--- a/internal/webhooks/azuremanagedcontrolplanetemplate_webhook.go
+++ b/internal/webhooks/azuremanagedcontrolplanetemplate_webhook.go
@@ -27,7 +27,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
-	. "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
+	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	apiinternal "sigs.k8s.io/cluster-api-provider-azure/internal/api/v1beta1"
 	webhookutils "sigs.k8s.io/cluster-api-provider-azure/util/webhook"
 )
@@ -38,7 +38,7 @@ func (mcpw *AzureManagedControlPlaneTemplateWebhook) SetupWebhookWithManager(mgr
 	mcpw.logger = mgr.GetLogger().WithName("AzureManagedControlPlaneTemplate")
 
 	return ctrl.NewWebhookManagedBy(mgr).
-		For(&AzureManagedControlPlaneTemplate{}).
+		For(&infrav1.AzureManagedControlPlaneTemplate{}).
 		WithDefaulter(mcpw).
 		WithValidator(mcpw).
 		Complete()
@@ -55,7 +55,7 @@ type AzureManagedControlPlaneTemplateWebhook struct {
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type.
 func (mcpw *AzureManagedControlPlaneTemplateWebhook) Default(_ context.Context, obj runtime.Object) error {
-	mcp, ok := obj.(*AzureManagedControlPlaneTemplate)
+	mcp, ok := obj.(*infrav1.AzureManagedControlPlaneTemplate)
 	if !ok {
 		return apierrors.NewBadRequest("expected an AzureManagedControlPlaneTemplate")
 	}
@@ -65,7 +65,7 @@ func (mcpw *AzureManagedControlPlaneTemplateWebhook) Default(_ context.Context, 
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
 func (mcpw *AzureManagedControlPlaneTemplateWebhook) ValidateCreate(_ context.Context, obj runtime.Object) (admission.Warnings, error) {
-	mcp, ok := obj.(*AzureManagedControlPlaneTemplate)
+	mcp, ok := obj.(*infrav1.AzureManagedControlPlaneTemplate)
 	if !ok {
 		return nil, apierrors.NewBadRequest("expected an AzureManagedControlPlaneTemplate")
 	}
@@ -76,11 +76,11 @@ func (mcpw *AzureManagedControlPlaneTemplateWebhook) ValidateCreate(_ context.Co
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
 func (mcpw *AzureManagedControlPlaneTemplateWebhook) ValidateUpdate(_ context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
 	var allErrs field.ErrorList
-	old, ok := oldObj.(*AzureManagedControlPlaneTemplate)
+	old, ok := oldObj.(*infrav1.AzureManagedControlPlaneTemplate)
 	if !ok {
 		return nil, apierrors.NewBadRequest("expected an AzureManagedControlPlaneTemplate")
 	}
-	mcp, ok := newObj.(*AzureManagedControlPlaneTemplate)
+	mcp, ok := newObj.(*infrav1.AzureManagedControlPlaneTemplate)
 	if !ok {
 		return nil, apierrors.NewBadRequest("expected an AzureManagedControlPlaneTemplate")
 	}
@@ -187,7 +187,7 @@ func (mcpw *AzureManagedControlPlaneTemplateWebhook) ValidateUpdate(_ context.Co
 		return nil, validateAzureManagedControlPlaneTemplate(mcp, mcpw.client)
 	}
 
-	return nil, apierrors.NewInvalid(GroupVersion.WithKind(AzureManagedControlPlaneTemplateKind).GroupKind(), mcp.Name, allErrs)
+	return nil, apierrors.NewInvalid(infrav1.GroupVersion.WithKind(infrav1.AzureManagedControlPlaneTemplateKind).GroupKind(), mcp.Name, allErrs)
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type.

--- a/internal/webhooks/azuremanagedcontrolplanetemplate_webhook_test.go
+++ b/internal/webhooks/azuremanagedcontrolplanetemplate_webhook_test.go
@@ -23,7 +23,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 
-	. "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
+	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	apiinternal "sigs.k8s.io/cluster-api-provider-azure/internal/api/v1beta1"
 )
 
@@ -53,7 +53,7 @@ func TestControlPlaneTemplateDefaultingWebhook(t *testing.T) {
 	amcpt.Spec.Template.Spec.Version = "9.99.99"
 	amcpt.Spec.Template.Spec.VirtualNetwork.Name = "fooVnetName"
 	amcpt.Spec.Template.Spec.VirtualNetwork.Subnet.Name = "fooSubnetName"
-	amcpt.Spec.Template.Spec.SKU.Tier = PaidManagedControlPlaneTier
+	amcpt.Spec.Template.Spec.SKU.Tier = infrav1.PaidManagedControlPlaneTier
 	amcpt.Spec.Template.Spec.EnablePreviewFeatures = ptr.To(true)
 
 	err = mcptw.Default(t.Context(), amcpt)
@@ -64,15 +64,15 @@ func TestControlPlaneTemplateDefaultingWebhook(t *testing.T) {
 	g.Expect(amcpt.Spec.Template.Spec.Version).To(Equal("v9.99.99"))
 	g.Expect(amcpt.Spec.Template.Spec.VirtualNetwork.Name).To(Equal("fooVnetName"))
 	g.Expect(amcpt.Spec.Template.Spec.VirtualNetwork.Subnet.Name).To(Equal("fooSubnetName"))
-	g.Expect(amcpt.Spec.Template.Spec.SKU.Tier).To(Equal(StandardManagedControlPlaneTier))
+	g.Expect(amcpt.Spec.Template.Spec.SKU.Tier).To(Equal(infrav1.StandardManagedControlPlaneTier))
 	g.Expect(*amcpt.Spec.Template.Spec.EnablePreviewFeatures).To(BeTrue())
 }
 
 func TestControlPlaneTemplateUpdateWebhook(t *testing.T) {
 	tests := []struct {
 		name                    string
-		oldControlPlaneTemplate *AzureManagedControlPlaneTemplate
-		controlPlaneTemplate    *AzureManagedControlPlaneTemplate
+		oldControlPlaneTemplate *infrav1.AzureManagedControlPlaneTemplate
+		controlPlaneTemplate    *infrav1.AzureManagedControlPlaneTemplate
 		wantErr                 bool
 	}{
 		{
@@ -83,68 +83,68 @@ func TestControlPlaneTemplateUpdateWebhook(t *testing.T) {
 		},
 		{
 			name: "azuremanagedcontrolplanetemplate subscriptionID is immutable",
-			oldControlPlaneTemplate: getAzureManagedControlPlaneTemplate(func(cpt *AzureManagedControlPlaneTemplate) {
+			oldControlPlaneTemplate: getAzureManagedControlPlaneTemplate(func(cpt *infrav1.AzureManagedControlPlaneTemplate) {
 				cpt.Spec.Template.Spec.SubscriptionID = "foo"
 			}),
-			controlPlaneTemplate: getAzureManagedControlPlaneTemplate(func(cpt *AzureManagedControlPlaneTemplate) {
+			controlPlaneTemplate: getAzureManagedControlPlaneTemplate(func(cpt *infrav1.AzureManagedControlPlaneTemplate) {
 				cpt.Spec.Template.Spec.SubscriptionID = "bar"
 			}),
 			wantErr: true,
 		},
 		{
 			name: "azuremanagedcontrolplanetemplate location is immutable",
-			oldControlPlaneTemplate: getAzureManagedControlPlaneTemplate(func(cpt *AzureManagedControlPlaneTemplate) {
+			oldControlPlaneTemplate: getAzureManagedControlPlaneTemplate(func(cpt *infrav1.AzureManagedControlPlaneTemplate) {
 				cpt.Spec.Template.Spec.Location = "foo"
 			}),
-			controlPlaneTemplate: getAzureManagedControlPlaneTemplate(func(cpt *AzureManagedControlPlaneTemplate) {
+			controlPlaneTemplate: getAzureManagedControlPlaneTemplate(func(cpt *infrav1.AzureManagedControlPlaneTemplate) {
 				cpt.Spec.Template.Spec.Location = "bar"
 			}),
 			wantErr: true,
 		},
 		{
 			name: "azuremanagedcontrolplanetemplate DNSServiceIP is immutable",
-			oldControlPlaneTemplate: getAzureManagedControlPlaneTemplate(func(cpt *AzureManagedControlPlaneTemplate) {
+			oldControlPlaneTemplate: getAzureManagedControlPlaneTemplate(func(cpt *infrav1.AzureManagedControlPlaneTemplate) {
 				cpt.Spec.Template.Spec.DNSServiceIP = ptr.To("foo")
 			}),
-			controlPlaneTemplate: getAzureManagedControlPlaneTemplate(func(cpt *AzureManagedControlPlaneTemplate) {
+			controlPlaneTemplate: getAzureManagedControlPlaneTemplate(func(cpt *infrav1.AzureManagedControlPlaneTemplate) {
 				cpt.Spec.Template.Spec.DNSServiceIP = ptr.To("bar")
 			}),
 			wantErr: true,
 		},
 		{
 			name: "azuremanagedcontrolplanetemplate NetworkPlugin is immutable",
-			oldControlPlaneTemplate: getAzureManagedControlPlaneTemplate(func(cpt *AzureManagedControlPlaneTemplate) {
+			oldControlPlaneTemplate: getAzureManagedControlPlaneTemplate(func(cpt *infrav1.AzureManagedControlPlaneTemplate) {
 				cpt.Spec.Template.Spec.NetworkPlugin = ptr.To("foo")
 			}),
-			controlPlaneTemplate: getAzureManagedControlPlaneTemplate(func(cpt *AzureManagedControlPlaneTemplate) {
+			controlPlaneTemplate: getAzureManagedControlPlaneTemplate(func(cpt *infrav1.AzureManagedControlPlaneTemplate) {
 				cpt.Spec.Template.Spec.NetworkPlugin = ptr.To("bar")
 			}),
 			wantErr: true,
 		},
 		{
 			name: "azuremanagedcontrolplanetemplate NetworkPolicy is immutable",
-			oldControlPlaneTemplate: getAzureManagedControlPlaneTemplate(func(cpt *AzureManagedControlPlaneTemplate) {
+			oldControlPlaneTemplate: getAzureManagedControlPlaneTemplate(func(cpt *infrav1.AzureManagedControlPlaneTemplate) {
 				cpt.Spec.Template.Spec.NetworkPolicy = ptr.To("foo")
 			}),
-			controlPlaneTemplate: getAzureManagedControlPlaneTemplate(func(cpt *AzureManagedControlPlaneTemplate) {
+			controlPlaneTemplate: getAzureManagedControlPlaneTemplate(func(cpt *infrav1.AzureManagedControlPlaneTemplate) {
 				cpt.Spec.Template.Spec.NetworkPolicy = ptr.To("bar")
 			}),
 			wantErr: true,
 		},
 		{
 			name: "azuremanagedcontrolplanetemplate LoadBalancerSKU is immutable",
-			oldControlPlaneTemplate: getAzureManagedControlPlaneTemplate(func(cpt *AzureManagedControlPlaneTemplate) {
+			oldControlPlaneTemplate: getAzureManagedControlPlaneTemplate(func(cpt *infrav1.AzureManagedControlPlaneTemplate) {
 				cpt.Spec.Template.Spec.LoadBalancerSKU = ptr.To("foo")
 			}),
-			controlPlaneTemplate: getAzureManagedControlPlaneTemplate(func(cpt *AzureManagedControlPlaneTemplate) {
+			controlPlaneTemplate: getAzureManagedControlPlaneTemplate(func(cpt *infrav1.AzureManagedControlPlaneTemplate) {
 				cpt.Spec.Template.Spec.LoadBalancerSKU = ptr.To("bar")
 			}),
 			wantErr: true,
 		},
 		{
 			name: "cannot disable AADProfile",
-			oldControlPlaneTemplate: getAzureManagedControlPlaneTemplate(func(cpt *AzureManagedControlPlaneTemplate) {
-				cpt.Spec.Template.Spec.AADProfile = &AADProfile{
+			oldControlPlaneTemplate: getAzureManagedControlPlaneTemplate(func(cpt *infrav1.AzureManagedControlPlaneTemplate) {
+				cpt.Spec.Template.Spec.AADProfile = &infrav1.AADProfile{
 					Managed: true,
 				}
 			}),
@@ -153,13 +153,13 @@ func TestControlPlaneTemplateUpdateWebhook(t *testing.T) {
 		},
 		{
 			name: "cannot set AADProfile.Managed to false",
-			oldControlPlaneTemplate: getAzureManagedControlPlaneTemplate(func(cpt *AzureManagedControlPlaneTemplate) {
-				cpt.Spec.Template.Spec.AADProfile = &AADProfile{
+			oldControlPlaneTemplate: getAzureManagedControlPlaneTemplate(func(cpt *infrav1.AzureManagedControlPlaneTemplate) {
+				cpt.Spec.Template.Spec.AADProfile = &infrav1.AADProfile{
 					Managed: true,
 				}
 			}),
-			controlPlaneTemplate: getAzureManagedControlPlaneTemplate(func(cpt *AzureManagedControlPlaneTemplate) {
-				cpt.Spec.Template.Spec.AADProfile = &AADProfile{
+			controlPlaneTemplate: getAzureManagedControlPlaneTemplate(func(cpt *infrav1.AzureManagedControlPlaneTemplate) {
+				cpt.Spec.Template.Spec.AADProfile = &infrav1.AADProfile{
 					Managed: false,
 				}
 			}),
@@ -167,13 +167,13 @@ func TestControlPlaneTemplateUpdateWebhook(t *testing.T) {
 		},
 		{
 			name: "length of AADProfile.AdminGroupObjectIDs cannot be zero",
-			oldControlPlaneTemplate: getAzureManagedControlPlaneTemplate(func(cpt *AzureManagedControlPlaneTemplate) {
-				cpt.Spec.Template.Spec.AADProfile = &AADProfile{
+			oldControlPlaneTemplate: getAzureManagedControlPlaneTemplate(func(cpt *infrav1.AzureManagedControlPlaneTemplate) {
+				cpt.Spec.Template.Spec.AADProfile = &infrav1.AADProfile{
 					AdminGroupObjectIDs: []string{"foo"},
 				}
 			}),
-			controlPlaneTemplate: getAzureManagedControlPlaneTemplate(func(cpt *AzureManagedControlPlaneTemplate) {
-				cpt.Spec.Template.Spec.AADProfile = &AADProfile{
+			controlPlaneTemplate: getAzureManagedControlPlaneTemplate(func(cpt *infrav1.AzureManagedControlPlaneTemplate) {
+				cpt.Spec.Template.Spec.AADProfile = &infrav1.AADProfile{
 					AdminGroupObjectIDs: []string{},
 				}
 			}),
@@ -181,22 +181,22 @@ func TestControlPlaneTemplateUpdateWebhook(t *testing.T) {
 		},
 		{
 			name: "azuremanagedcontrolplanetemplate OutboundType is immutable",
-			oldControlPlaneTemplate: getAzureManagedControlPlaneTemplate(func(cpt *AzureManagedControlPlaneTemplate) {
-				cpt.Spec.Template.Spec.OutboundType = (*ManagedControlPlaneOutboundType)(ptr.To(string(ManagedControlPlaneOutboundTypeLoadBalancer)))
+			oldControlPlaneTemplate: getAzureManagedControlPlaneTemplate(func(cpt *infrav1.AzureManagedControlPlaneTemplate) {
+				cpt.Spec.Template.Spec.OutboundType = (*infrav1.ManagedControlPlaneOutboundType)(ptr.To(string(infrav1.ManagedControlPlaneOutboundTypeLoadBalancer)))
 			}),
-			controlPlaneTemplate: getAzureManagedControlPlaneTemplate(func(cpt *AzureManagedControlPlaneTemplate) {
-				cpt.Spec.Template.Spec.OutboundType = (*ManagedControlPlaneOutboundType)(ptr.To(string(ManagedControlPlaneOutboundTypeManagedNATGateway)))
+			controlPlaneTemplate: getAzureManagedControlPlaneTemplate(func(cpt *infrav1.AzureManagedControlPlaneTemplate) {
+				cpt.Spec.Template.Spec.OutboundType = (*infrav1.ManagedControlPlaneOutboundType)(ptr.To(string(infrav1.ManagedControlPlaneOutboundTypeManagedNATGateway)))
 			}),
 			wantErr: true,
 		},
 		{
 			name: "azuremanagedcontrolplanetemplate AKSExtension type and plan are immutable",
-			oldControlPlaneTemplate: getAzureManagedControlPlaneTemplate(func(cpt *AzureManagedControlPlaneTemplate) {
-				cpt.Spec.Template.Spec.Extensions = []AKSExtension{
+			oldControlPlaneTemplate: getAzureManagedControlPlaneTemplate(func(cpt *infrav1.AzureManagedControlPlaneTemplate) {
+				cpt.Spec.Template.Spec.Extensions = []infrav1.AKSExtension{
 					{
 						Name:          "foo",
 						ExtensionType: ptr.To("foo-type"),
-						Plan: &ExtensionPlan{
+						Plan: &infrav1.ExtensionPlan{
 							Name:      "foo-name",
 							Product:   "foo-product",
 							Publisher: "foo-publisher",
@@ -204,12 +204,12 @@ func TestControlPlaneTemplateUpdateWebhook(t *testing.T) {
 					},
 				}
 			}),
-			controlPlaneTemplate: getAzureManagedControlPlaneTemplate(func(cpt *AzureManagedControlPlaneTemplate) {
-				cpt.Spec.Template.Spec.Extensions = []AKSExtension{
+			controlPlaneTemplate: getAzureManagedControlPlaneTemplate(func(cpt *infrav1.AzureManagedControlPlaneTemplate) {
+				cpt.Spec.Template.Spec.Extensions = []infrav1.AKSExtension{
 					{
 						Name:          "foo",
 						ExtensionType: ptr.To("bar"),
-						Plan: &ExtensionPlan{
+						Plan: &infrav1.ExtensionPlan{
 							Name:      "bar-name",
 							Product:   "bar-product",
 							Publisher: "bar-publisher",
@@ -221,13 +221,13 @@ func TestControlPlaneTemplateUpdateWebhook(t *testing.T) {
 		},
 		{
 			name: "azuremanagedcontrolplanetemplate AKSExtension autoUpgradeMinorVersion is mutable",
-			oldControlPlaneTemplate: getAzureManagedControlPlaneTemplate(func(cpt *AzureManagedControlPlaneTemplate) {
-				cpt.Spec.Template.Spec.Extensions = []AKSExtension{
+			oldControlPlaneTemplate: getAzureManagedControlPlaneTemplate(func(cpt *infrav1.AzureManagedControlPlaneTemplate) {
+				cpt.Spec.Template.Spec.Extensions = []infrav1.AKSExtension{
 					{
 						Name:                    "foo",
 						ExtensionType:           ptr.To("foo"),
 						AutoUpgradeMinorVersion: ptr.To(true),
-						Plan: &ExtensionPlan{
+						Plan: &infrav1.ExtensionPlan{
 							Name:      "bar-name",
 							Product:   "bar-product",
 							Publisher: "bar-publisher",
@@ -235,13 +235,13 @@ func TestControlPlaneTemplateUpdateWebhook(t *testing.T) {
 					},
 				}
 			}),
-			controlPlaneTemplate: getAzureManagedControlPlaneTemplate(func(cpt *AzureManagedControlPlaneTemplate) {
-				cpt.Spec.Template.Spec.Extensions = []AKSExtension{
+			controlPlaneTemplate: getAzureManagedControlPlaneTemplate(func(cpt *infrav1.AzureManagedControlPlaneTemplate) {
+				cpt.Spec.Template.Spec.Extensions = []infrav1.AKSExtension{
 					{
 						Name:                    "foo",
 						ExtensionType:           ptr.To("foo"),
 						AutoUpgradeMinorVersion: ptr.To(false),
-						Plan: &ExtensionPlan{
+						Plan: &infrav1.ExtensionPlan{
 							Name:      "bar-name",
 							Product:   "bar-product",
 							Publisher: "bar-publisher",
@@ -253,20 +253,20 @@ func TestControlPlaneTemplateUpdateWebhook(t *testing.T) {
 		},
 		{
 			name: "azuremanagedcontrolplanetemplate networkDataplane is immutable",
-			oldControlPlaneTemplate: getAzureManagedControlPlaneTemplate(func(cpt *AzureManagedControlPlaneTemplate) {
-				cpt.Spec.Template.Spec.NetworkDataplane = ptr.To(NetworkDataplaneTypeAzure)
+			oldControlPlaneTemplate: getAzureManagedControlPlaneTemplate(func(cpt *infrav1.AzureManagedControlPlaneTemplate) {
+				cpt.Spec.Template.Spec.NetworkDataplane = ptr.To(infrav1.NetworkDataplaneTypeAzure)
 			}),
-			controlPlaneTemplate: getAzureManagedControlPlaneTemplate(func(cpt *AzureManagedControlPlaneTemplate) {
-				cpt.Spec.Template.Spec.NetworkDataplane = ptr.To(NetworkDataplaneTypeCilium)
+			controlPlaneTemplate: getAzureManagedControlPlaneTemplate(func(cpt *infrav1.AzureManagedControlPlaneTemplate) {
+				cpt.Spec.Template.Spec.NetworkDataplane = ptr.To(infrav1.NetworkDataplaneTypeCilium)
 			}),
 			wantErr: true,
 		},
 		{
 			name: "AzureManagedControlPlane invalid version downgrade change",
-			oldControlPlaneTemplate: getAzureManagedControlPlaneTemplate(func(cpt *AzureManagedControlPlaneTemplate) {
+			oldControlPlaneTemplate: getAzureManagedControlPlaneTemplate(func(cpt *infrav1.AzureManagedControlPlaneTemplate) {
 				cpt.Spec.Template.Spec.Version = "v1.18.0"
 			}),
-			controlPlaneTemplate: getAzureManagedControlPlaneTemplate(func(cpt *AzureManagedControlPlaneTemplate) {
+			controlPlaneTemplate: getAzureManagedControlPlaneTemplate(func(cpt *infrav1.AzureManagedControlPlaneTemplate) {
 				cpt.Spec.Template.Spec.Version = "v1.17.0"
 			}),
 			wantErr: true,
@@ -289,8 +289,8 @@ func TestControlPlaneTemplateUpdateWebhook(t *testing.T) {
 func TestValidateVirtualNetworkTemplateUpdate(t *testing.T) {
 	tests := []struct {
 		name                    string
-		oldControlPlaneTemplate *AzureManagedControlPlaneTemplate
-		controlPlaneTemplate    *AzureManagedControlPlaneTemplate
+		oldControlPlaneTemplate *infrav1.AzureManagedControlPlaneTemplate
+		controlPlaneTemplate    *infrav1.AzureManagedControlPlaneTemplate
 		wantErr                 bool
 	}{
 		{
@@ -301,16 +301,16 @@ func TestValidateVirtualNetworkTemplateUpdate(t *testing.T) {
 		},
 		{
 			name: "azuremanagedcontrolplanetemplate vnet is immutable",
-			oldControlPlaneTemplate: getAzureManagedControlPlaneTemplate(func(cpt *AzureManagedControlPlaneTemplate) {
-				cpt.Spec.Template.Spec.VirtualNetwork = ManagedControlPlaneVirtualNetwork{
-					ManagedControlPlaneVirtualNetworkClassSpec: ManagedControlPlaneVirtualNetworkClassSpec{
+			oldControlPlaneTemplate: getAzureManagedControlPlaneTemplate(func(cpt *infrav1.AzureManagedControlPlaneTemplate) {
+				cpt.Spec.Template.Spec.VirtualNetwork = infrav1.ManagedControlPlaneVirtualNetwork{
+					ManagedControlPlaneVirtualNetworkClassSpec: infrav1.ManagedControlPlaneVirtualNetworkClassSpec{
 						CIDRBlock: "fooCIDRBlock",
 					},
 				}
 			}),
-			controlPlaneTemplate: getAzureManagedControlPlaneTemplate(func(cpt *AzureManagedControlPlaneTemplate) {
-				cpt.Spec.Template.Spec.VirtualNetwork = ManagedControlPlaneVirtualNetwork{
-					ManagedControlPlaneVirtualNetworkClassSpec: ManagedControlPlaneVirtualNetworkClassSpec{
+			controlPlaneTemplate: getAzureManagedControlPlaneTemplate(func(cpt *infrav1.AzureManagedControlPlaneTemplate) {
+				cpt.Spec.Template.Spec.VirtualNetwork = infrav1.ManagedControlPlaneVirtualNetwork{
+					ManagedControlPlaneVirtualNetworkClassSpec: infrav1.ManagedControlPlaneVirtualNetworkClassSpec{
 						CIDRBlock: "barCIDRBlock",
 					},
 				}
@@ -319,16 +319,16 @@ func TestValidateVirtualNetworkTemplateUpdate(t *testing.T) {
 		},
 		{
 			name: "azuremanagedcontrolplanetemplate networkCIDRBlock is immutable",
-			oldControlPlaneTemplate: getAzureManagedControlPlaneTemplate(func(cpt *AzureManagedControlPlaneTemplate) {
-				cpt.Spec.Template.Spec.VirtualNetwork = ManagedControlPlaneVirtualNetwork{
-					ManagedControlPlaneVirtualNetworkClassSpec: ManagedControlPlaneVirtualNetworkClassSpec{
+			oldControlPlaneTemplate: getAzureManagedControlPlaneTemplate(func(cpt *infrav1.AzureManagedControlPlaneTemplate) {
+				cpt.Spec.Template.Spec.VirtualNetwork = infrav1.ManagedControlPlaneVirtualNetwork{
+					ManagedControlPlaneVirtualNetworkClassSpec: infrav1.ManagedControlPlaneVirtualNetworkClassSpec{
 						CIDRBlock: "fooCIDRBlock",
 					},
 				}
 			}),
-			controlPlaneTemplate: getAzureManagedControlPlaneTemplate(func(cpt *AzureManagedControlPlaneTemplate) {
-				cpt.Spec.Template.Spec.VirtualNetwork = ManagedControlPlaneVirtualNetwork{
-					ManagedControlPlaneVirtualNetworkClassSpec: ManagedControlPlaneVirtualNetworkClassSpec{
+			controlPlaneTemplate: getAzureManagedControlPlaneTemplate(func(cpt *infrav1.AzureManagedControlPlaneTemplate) {
+				cpt.Spec.Template.Spec.VirtualNetwork = infrav1.ManagedControlPlaneVirtualNetwork{
+					ManagedControlPlaneVirtualNetworkClassSpec: infrav1.ManagedControlPlaneVirtualNetworkClassSpec{
 						CIDRBlock: "barCIDRBlock",
 					},
 				}
@@ -352,8 +352,8 @@ func TestValidateVirtualNetworkTemplateUpdate(t *testing.T) {
 func TestValidateAPIServerAccessProfileUpdate(t *testing.T) {
 	tests := []struct {
 		name                    string
-		oldControlPlaneTemplate *AzureManagedControlPlaneTemplate
-		controlPlaneTemplate    *AzureManagedControlPlaneTemplate
+		oldControlPlaneTemplate *infrav1.AzureManagedControlPlaneTemplate
+		controlPlaneTemplate    *infrav1.AzureManagedControlPlaneTemplate
 		wantErr                 bool
 	}{
 		{
@@ -364,16 +364,16 @@ func TestValidateAPIServerAccessProfileUpdate(t *testing.T) {
 		},
 		{
 			name: "azuremanagedcontrolplanetemplate enablePrivateCluster is immutable",
-			oldControlPlaneTemplate: getAzureManagedControlPlaneTemplate(func(cpt *AzureManagedControlPlaneTemplate) {
-				cpt.Spec.Template.Spec.APIServerAccessProfile = &APIServerAccessProfile{
-					APIServerAccessProfileClassSpec: APIServerAccessProfileClassSpec{
+			oldControlPlaneTemplate: getAzureManagedControlPlaneTemplate(func(cpt *infrav1.AzureManagedControlPlaneTemplate) {
+				cpt.Spec.Template.Spec.APIServerAccessProfile = &infrav1.APIServerAccessProfile{
+					APIServerAccessProfileClassSpec: infrav1.APIServerAccessProfileClassSpec{
 						EnablePrivateCluster: ptr.To(true),
 					},
 				}
 			}),
-			controlPlaneTemplate: getAzureManagedControlPlaneTemplate(func(cpt *AzureManagedControlPlaneTemplate) {
-				cpt.Spec.Template.Spec.APIServerAccessProfile = &APIServerAccessProfile{
-					APIServerAccessProfileClassSpec: APIServerAccessProfileClassSpec{
+			controlPlaneTemplate: getAzureManagedControlPlaneTemplate(func(cpt *infrav1.AzureManagedControlPlaneTemplate) {
+				cpt.Spec.Template.Spec.APIServerAccessProfile = &infrav1.APIServerAccessProfile{
+					APIServerAccessProfileClassSpec: infrav1.APIServerAccessProfileClassSpec{
 						EnablePrivateCluster: ptr.To(false),
 					},
 				}
@@ -382,16 +382,16 @@ func TestValidateAPIServerAccessProfileUpdate(t *testing.T) {
 		},
 		{
 			name: "azuremanagedcontrolplanetemplate privateDNSZone is immutable",
-			oldControlPlaneTemplate: getAzureManagedControlPlaneTemplate(func(cpt *AzureManagedControlPlaneTemplate) {
-				cpt.Spec.Template.Spec.APIServerAccessProfile = &APIServerAccessProfile{
-					APIServerAccessProfileClassSpec: APIServerAccessProfileClassSpec{
+			oldControlPlaneTemplate: getAzureManagedControlPlaneTemplate(func(cpt *infrav1.AzureManagedControlPlaneTemplate) {
+				cpt.Spec.Template.Spec.APIServerAccessProfile = &infrav1.APIServerAccessProfile{
+					APIServerAccessProfileClassSpec: infrav1.APIServerAccessProfileClassSpec{
 						PrivateDNSZone: ptr.To("foo"),
 					},
 				}
 			}),
-			controlPlaneTemplate: getAzureManagedControlPlaneTemplate(func(cpt *AzureManagedControlPlaneTemplate) {
-				cpt.Spec.Template.Spec.APIServerAccessProfile = &APIServerAccessProfile{
-					APIServerAccessProfileClassSpec: APIServerAccessProfileClassSpec{
+			controlPlaneTemplate: getAzureManagedControlPlaneTemplate(func(cpt *infrav1.AzureManagedControlPlaneTemplate) {
+				cpt.Spec.Template.Spec.APIServerAccessProfile = &infrav1.APIServerAccessProfile{
+					APIServerAccessProfileClassSpec: infrav1.APIServerAccessProfileClassSpec{
 						PrivateDNSZone: ptr.To("bar"),
 					},
 				}
@@ -400,16 +400,16 @@ func TestValidateAPIServerAccessProfileUpdate(t *testing.T) {
 		},
 		{
 			name: "azuremanagedcontrolplanetemplate enablePrivateClusterPublicFQDN is immutable",
-			oldControlPlaneTemplate: getAzureManagedControlPlaneTemplate(func(cpt *AzureManagedControlPlaneTemplate) {
-				cpt.Spec.Template.Spec.APIServerAccessProfile = &APIServerAccessProfile{
-					APIServerAccessProfileClassSpec: APIServerAccessProfileClassSpec{
+			oldControlPlaneTemplate: getAzureManagedControlPlaneTemplate(func(cpt *infrav1.AzureManagedControlPlaneTemplate) {
+				cpt.Spec.Template.Spec.APIServerAccessProfile = &infrav1.APIServerAccessProfile{
+					APIServerAccessProfileClassSpec: infrav1.APIServerAccessProfileClassSpec{
 						EnablePrivateClusterPublicFQDN: ptr.To(true),
 					},
 				}
 			}),
-			controlPlaneTemplate: getAzureManagedControlPlaneTemplate(func(cpt *AzureManagedControlPlaneTemplate) {
-				cpt.Spec.Template.Spec.APIServerAccessProfile = &APIServerAccessProfile{
-					APIServerAccessProfileClassSpec: APIServerAccessProfileClassSpec{
+			controlPlaneTemplate: getAzureManagedControlPlaneTemplate(func(cpt *infrav1.AzureManagedControlPlaneTemplate) {
+				cpt.Spec.Template.Spec.APIServerAccessProfile = &infrav1.APIServerAccessProfile{
+					APIServerAccessProfileClassSpec: infrav1.APIServerAccessProfileClassSpec{
 						EnablePrivateClusterPublicFQDN: ptr.To(false),
 					},
 				}
@@ -430,18 +430,18 @@ func TestValidateAPIServerAccessProfileUpdate(t *testing.T) {
 	}
 }
 
-func getAzureManagedControlPlaneTemplate(changes ...func(*AzureManagedControlPlaneTemplate)) *AzureManagedControlPlaneTemplate {
-	input := &AzureManagedControlPlaneTemplate{
+func getAzureManagedControlPlaneTemplate(changes ...func(*infrav1.AzureManagedControlPlaneTemplate)) *infrav1.AzureManagedControlPlaneTemplate {
+	input := &infrav1.AzureManagedControlPlaneTemplate{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "fooName",
 		},
-		Spec: AzureManagedControlPlaneTemplateSpec{
-			Template: AzureManagedControlPlaneTemplateResource{
-				Spec: AzureManagedControlPlaneTemplateResourceSpec{
-					AzureManagedControlPlaneClassSpec: AzureManagedControlPlaneClassSpec{
+		Spec: infrav1.AzureManagedControlPlaneTemplateSpec{
+			Template: infrav1.AzureManagedControlPlaneTemplateResource{
+				Spec: infrav1.AzureManagedControlPlaneTemplateResourceSpec{
+					AzureManagedControlPlaneClassSpec: infrav1.AzureManagedControlPlaneClassSpec{
 						Location: "fooLocation",
 						Version:  "v1.17.5",
-						SKU:      &AKSSku{},
+						SKU:      &infrav1.AKSSku{},
 					},
 				},
 			},

--- a/internal/webhooks/azuremanagedmachinepool_validation.go
+++ b/internal/webhooks/azuremanagedmachinepool_validation.go
@@ -32,7 +32,7 @@ import (
 	clusterctlv1alpha3 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	. "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
+	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	azureutil "sigs.k8s.io/cluster-api-provider-azure/util/azure"
 )
 
@@ -69,10 +69,10 @@ func validateLastSystemNodePool(cli client.Client, labels map[string]string, nam
 	opt1 := client.InNamespace(namespace)
 	opt2 := client.MatchingLabels(map[string]string{
 		clusterv1.ClusterNameLabel: clusterName,
-		LabelAgentPoolMode:         string(NodePoolModeSystem),
+		infrav1.LabelAgentPoolMode: string(infrav1.NodePoolModeSystem),
 	})
 
-	ammpList := &AzureManagedMachinePoolList{}
+	ammpList := &infrav1.AzureManagedMachinePoolList{}
 	if err := cli.List(ctx, ammpList, opt1, opt2); err != nil {
 		return err
 	}
@@ -97,8 +97,8 @@ func validateMaxPods(maxPods *int, fldPath *field.Path) error {
 }
 
 func validateOSType(mode string, osType *string, fldPath *field.Path) error {
-	if mode == string(NodePoolModeSystem) {
-		if osType != nil && *osType != LinuxOS {
+	if mode == string(infrav1.NodePoolModeSystem) {
+		if osType != nil && *osType != infrav1.LinuxOS {
 			return field.Forbidden(
 				fldPath,
 				"System node pooll must have OSType 'Linux'")
@@ -126,13 +126,13 @@ func validateMPName(mpName string, specName *string, osType *string, fldPath *fi
 }
 
 func validateNameLength(osType *string, name *string, fieldNameMessage string, fldPath *field.Path) error {
-	if osType != nil && *osType == WindowsOS &&
+	if osType != nil && *osType == infrav1.WindowsOS &&
 		name != nil && len(*name) > 6 {
 		return field.Invalid(
 			fldPath,
 			name,
 			fmt.Sprintf("For OSType Windows, %s can not be longer than 6 characters.", fieldNameMessage))
-	} else if (osType == nil || *osType == LinuxOS) &&
+	} else if (osType == nil || *osType == infrav1.LinuxOS) &&
 		(name != nil && len(*name) > 12) {
 		return field.Invalid(
 			fldPath,
@@ -213,7 +213,7 @@ func validateMPSubnetName(subnetName *string, fldPath *field.Path) error {
 
 // validateKubeletConfig enforces the AKS API configuration for KubeletConfig.
 // See:  https://learn.microsoft.com/en-us/azure/aks/custom-node-configuration.
-func validateKubeletConfig(kubeletConfig *KubeletConfig, fldPath *field.Path) error {
+func validateKubeletConfig(kubeletConfig *infrav1.KubeletConfig, fldPath *field.Path) error {
 	var allowedUnsafeSysctlsPatterns = []string{
 		`^kernel\.shm.+$`,
 		`^kernel\.msg.+$`,
@@ -260,7 +260,7 @@ func validateKubeletConfig(kubeletConfig *KubeletConfig, fldPath *field.Path) er
 
 // validateLinuxOSConfig enforces AKS API configuration for Linux OS custom configuration
 // See: https://learn.microsoft.com/en-us/azure/aks/custom-node-configuration#linux-os-custom-configuration for detailed information.
-func validateLinuxOSConfig(linuxOSConfig *LinuxOSConfig, kubeletConfig *KubeletConfig, fldPath *field.Path) error {
+func validateLinuxOSConfig(linuxOSConfig *infrav1.LinuxOSConfig, kubeletConfig *infrav1.KubeletConfig, fldPath *field.Path) error {
 	var errs []error
 	if linuxOSConfig == nil {
 		return nil

--- a/internal/webhooks/azuremanagedmachinepool_webhook.go
+++ b/internal/webhooks/azuremanagedmachinepool_webhook.go
@@ -30,7 +30,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
-	. "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
+	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	webhookutils "sigs.k8s.io/cluster-api-provider-azure/util/webhook"
 )
 
@@ -41,7 +41,7 @@ func (mw *AzureManagedMachinePoolWebhook) SetupWebhookWithManager(mgr ctrl.Manag
 	mw.client = mgr.GetClient()
 
 	return ctrl.NewWebhookManagedBy(mgr).
-		For(&AzureManagedMachinePool{}).
+		For(&infrav1.AzureManagedMachinePool{}).
 		WithDefaulter(mw).
 		WithValidator(mw).
 		Complete()
@@ -56,21 +56,21 @@ type AzureManagedMachinePoolWebhook struct {
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type.
 func (mw *AzureManagedMachinePoolWebhook) Default(_ context.Context, obj runtime.Object) error {
-	m, ok := obj.(*AzureManagedMachinePool)
+	m, ok := obj.(*infrav1.AzureManagedMachinePool)
 	if !ok {
 		return apierrors.NewBadRequest("expected an AzureManagedMachinePool")
 	}
 	if m.Labels == nil {
 		m.Labels = make(map[string]string)
 	}
-	m.Labels[LabelAgentPoolMode] = m.Spec.Mode
+	m.Labels[infrav1.LabelAgentPoolMode] = m.Spec.Mode
 
 	if m.Spec.Name == nil || *m.Spec.Name == "" {
 		m.Spec.Name = &m.Name
 	}
 
 	if m.Spec.OSType == nil {
-		m.Spec.OSType = ptr.To(DefaultOSType)
+		m.Spec.OSType = ptr.To(infrav1.DefaultOSType)
 	}
 
 	return nil
@@ -80,7 +80,7 @@ func (mw *AzureManagedMachinePoolWebhook) Default(_ context.Context, obj runtime
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
 func (mw *AzureManagedMachinePoolWebhook) ValidateCreate(_ context.Context, obj runtime.Object) (admission.Warnings, error) {
-	m, ok := obj.(*AzureManagedMachinePool)
+	m, ok := obj.(*infrav1.AzureManagedMachinePool)
 	if !ok {
 		return nil, apierrors.NewBadRequest("expected an AzureManagedMachinePool")
 	}
@@ -133,11 +133,11 @@ func (mw *AzureManagedMachinePoolWebhook) ValidateCreate(_ context.Context, obj 
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
 func (mw *AzureManagedMachinePoolWebhook) ValidateUpdate(_ context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
-	old, ok := oldObj.(*AzureManagedMachinePool)
+	old, ok := oldObj.(*infrav1.AzureManagedMachinePool)
 	if !ok {
 		return nil, apierrors.NewBadRequest("expected an AzureManagedMachinePool")
 	}
-	m, ok := newObj.(*AzureManagedMachinePool)
+	m, ok := newObj.(*infrav1.AzureManagedMachinePool)
 	if !ok {
 		return nil, apierrors.NewBadRequest("expected an AzureManagedMachinePool")
 	}
@@ -208,7 +208,7 @@ func (mw *AzureManagedMachinePoolWebhook) ValidateUpdate(_ context.Context, oldO
 				"field is immutable"))
 	}
 
-	if m.Spec.Mode != string(NodePoolModeSystem) && old.Spec.Mode == string(NodePoolModeSystem) {
+	if m.Spec.Mode != string(infrav1.NodePoolModeSystem) && old.Spec.Mode == string(infrav1.NodePoolModeSystem) {
 		// validate for last system node pool
 		if err := validateLastSystemNodePool(mw.client, m.Labels, m.Namespace, m.Annotations); err != nil {
 			allErrs = append(allErrs, field.Forbidden(
@@ -279,7 +279,7 @@ func (mw *AzureManagedMachinePoolWebhook) ValidateUpdate(_ context.Context, oldO
 	}
 
 	if len(allErrs) != 0 {
-		return nil, apierrors.NewInvalid(GroupVersion.WithKind(AzureManagedMachinePoolKind).GroupKind(), m.Name, allErrs)
+		return nil, apierrors.NewInvalid(infrav1.GroupVersion.WithKind(infrav1.AzureManagedMachinePoolKind).GroupKind(), m.Name, allErrs)
 	}
 
 	return nil, nil
@@ -287,11 +287,11 @@ func (mw *AzureManagedMachinePoolWebhook) ValidateUpdate(_ context.Context, oldO
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type.
 func (mw *AzureManagedMachinePoolWebhook) ValidateDelete(_ context.Context, obj runtime.Object) (admission.Warnings, error) {
-	m, ok := obj.(*AzureManagedMachinePool)
+	m, ok := obj.(*infrav1.AzureManagedMachinePool)
 	if !ok {
 		return nil, apierrors.NewBadRequest("expected an AzureManagedMachinePool")
 	}
-	if m.Spec.Mode != string(NodePoolModeSystem) {
+	if m.Spec.Mode != string(infrav1.NodePoolModeSystem) {
 		return nil, nil
 	}
 

--- a/internal/webhooks/azuremanagedmachinepool_webhook_test.go
+++ b/internal/webhooks/azuremanagedmachinepool_webhook_test.go
@@ -31,7 +31,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	. "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
+	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/feature"
 )
 
@@ -39,12 +39,12 @@ func TestAzureManagedMachinePoolDefaultingWebhook(t *testing.T) {
 	g := NewWithT(t)
 
 	t.Logf("Testing ammp defaulting webhook with mode system")
-	ammp := &AzureManagedMachinePool{
+	ammp := &infrav1.AzureManagedMachinePool{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "fooname",
 		},
-		Spec: AzureManagedMachinePoolSpec{
-			AzureManagedMachinePoolClassSpec: AzureManagedMachinePoolClassSpec{
+		Spec: infrav1.AzureManagedMachinePoolSpec{
+			AzureManagedMachinePoolClassSpec: infrav1.AzureManagedMachinePoolClassSpec{
 				Mode:         "System",
 				SKU:          "StandardD2S_V3",
 				OSDiskSizeGB: ptr.To(512),
@@ -58,7 +58,7 @@ func TestAzureManagedMachinePoolDefaultingWebhook(t *testing.T) {
 	err := mw.Default(t.Context(), ammp)
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(ammp.Labels).NotTo(BeNil())
-	val, ok := ammp.Labels[LabelAgentPoolMode]
+	val, ok := ammp.Labels[infrav1.LabelAgentPoolMode]
 	g.Expect(ok).To(BeTrue())
 	g.Expect(val).To(Equal("System"))
 	g.Expect(*ammp.Spec.Name).To(Equal("fooname"))
@@ -90,22 +90,22 @@ func TestAzureManagedMachinePoolUpdatingWebhook(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		new     *AzureManagedMachinePool
-		old     *AzureManagedMachinePool
+		new     *infrav1.AzureManagedMachinePool
+		old     *infrav1.AzureManagedMachinePool
 		wantErr bool
 	}{
 		{
 			name: "Cannot change Name of the agentpool",
-			new: &AzureManagedMachinePool{
-				Spec: AzureManagedMachinePoolSpec{
-					AzureManagedMachinePoolClassSpec: AzureManagedMachinePoolClassSpec{
+			new: &infrav1.AzureManagedMachinePool{
+				Spec: infrav1.AzureManagedMachinePoolSpec{
+					AzureManagedMachinePoolClassSpec: infrav1.AzureManagedMachinePoolClassSpec{
 						Name: ptr.To("pool-new"),
 					},
 				},
 			},
-			old: &AzureManagedMachinePool{
-				Spec: AzureManagedMachinePoolSpec{
-					AzureManagedMachinePoolClassSpec: AzureManagedMachinePoolClassSpec{
+			old: &infrav1.AzureManagedMachinePool{
+				Spec: infrav1.AzureManagedMachinePoolSpec{
+					AzureManagedMachinePoolClassSpec: infrav1.AzureManagedMachinePoolClassSpec{
 						Name: ptr.To("pool-old"),
 					},
 				},
@@ -114,18 +114,18 @@ func TestAzureManagedMachinePoolUpdatingWebhook(t *testing.T) {
 		},
 		{
 			name: "Cannot change SKU of the agentpool",
-			new: &AzureManagedMachinePool{
-				Spec: AzureManagedMachinePoolSpec{
-					AzureManagedMachinePoolClassSpec: AzureManagedMachinePoolClassSpec{
+			new: &infrav1.AzureManagedMachinePool{
+				Spec: infrav1.AzureManagedMachinePoolSpec{
+					AzureManagedMachinePoolClassSpec: infrav1.AzureManagedMachinePoolClassSpec{
 						Mode:         "System",
 						SKU:          "StandardD2S_V3",
 						OSDiskSizeGB: ptr.To(512),
 					},
 				},
 			},
-			old: &AzureManagedMachinePool{
-				Spec: AzureManagedMachinePoolSpec{
-					AzureManagedMachinePoolClassSpec: AzureManagedMachinePoolClassSpec{
+			old: &infrav1.AzureManagedMachinePool{
+				Spec: infrav1.AzureManagedMachinePoolSpec{
+					AzureManagedMachinePoolClassSpec: infrav1.AzureManagedMachinePoolClassSpec{
 						Mode:         "System",
 						SKU:          "StandardD2S_V4",
 						OSDiskSizeGB: ptr.To(512),
@@ -136,20 +136,20 @@ func TestAzureManagedMachinePoolUpdatingWebhook(t *testing.T) {
 		},
 		{
 			name: "Cannot change OSType of the agentpool",
-			new: &AzureManagedMachinePool{
-				Spec: AzureManagedMachinePoolSpec{
-					AzureManagedMachinePoolClassSpec: AzureManagedMachinePoolClassSpec{
-						OSType:       ptr.To(LinuxOS),
+			new: &infrav1.AzureManagedMachinePool{
+				Spec: infrav1.AzureManagedMachinePoolSpec{
+					AzureManagedMachinePoolClassSpec: infrav1.AzureManagedMachinePoolClassSpec{
+						OSType:       ptr.To(infrav1.LinuxOS),
 						Mode:         "System",
 						SKU:          "StandardD2S_V3",
 						OSDiskSizeGB: ptr.To(512),
 					},
 				},
 			},
-			old: &AzureManagedMachinePool{
-				Spec: AzureManagedMachinePoolSpec{
-					AzureManagedMachinePoolClassSpec: AzureManagedMachinePoolClassSpec{
-						OSType:       ptr.To(WindowsOS),
+			old: &infrav1.AzureManagedMachinePool{
+				Spec: infrav1.AzureManagedMachinePoolSpec{
+					AzureManagedMachinePoolClassSpec: infrav1.AzureManagedMachinePoolClassSpec{
+						OSType:       ptr.To(infrav1.WindowsOS),
 						Mode:         "System",
 						SKU:          "StandardD2S_V4",
 						OSDiskSizeGB: ptr.To(512),
@@ -160,18 +160,18 @@ func TestAzureManagedMachinePoolUpdatingWebhook(t *testing.T) {
 		},
 		{
 			name: "Cannot change OSDiskSizeGB of the agentpool",
-			new: &AzureManagedMachinePool{
-				Spec: AzureManagedMachinePoolSpec{
-					AzureManagedMachinePoolClassSpec: AzureManagedMachinePoolClassSpec{
+			new: &infrav1.AzureManagedMachinePool{
+				Spec: infrav1.AzureManagedMachinePoolSpec{
+					AzureManagedMachinePoolClassSpec: infrav1.AzureManagedMachinePoolClassSpec{
 						Mode:         "System",
 						SKU:          "StandardD2S_V3",
 						OSDiskSizeGB: ptr.To(512),
 					},
 				},
 			},
-			old: &AzureManagedMachinePool{
-				Spec: AzureManagedMachinePoolSpec{
-					AzureManagedMachinePoolClassSpec: AzureManagedMachinePoolClassSpec{
+			old: &infrav1.AzureManagedMachinePool{
+				Spec: infrav1.AzureManagedMachinePoolSpec{
+					AzureManagedMachinePoolClassSpec: infrav1.AzureManagedMachinePoolClassSpec{
 						Mode:         "System",
 						SKU:          "StandardD2S_V3",
 						OSDiskSizeGB: ptr.To(1024),
@@ -182,9 +182,9 @@ func TestAzureManagedMachinePoolUpdatingWebhook(t *testing.T) {
 		},
 		{
 			name: "Cannot add AvailabilityZones after creating agentpool",
-			new: &AzureManagedMachinePool{
-				Spec: AzureManagedMachinePoolSpec{
-					AzureManagedMachinePoolClassSpec: AzureManagedMachinePoolClassSpec{
+			new: &infrav1.AzureManagedMachinePool{
+				Spec: infrav1.AzureManagedMachinePoolSpec{
+					AzureManagedMachinePoolClassSpec: infrav1.AzureManagedMachinePoolClassSpec{
 						Mode:              "System",
 						SKU:               "StandardD2S_V3",
 						OSDiskSizeGB:      ptr.To(512),
@@ -192,9 +192,9 @@ func TestAzureManagedMachinePoolUpdatingWebhook(t *testing.T) {
 					},
 				},
 			},
-			old: &AzureManagedMachinePool{
-				Spec: AzureManagedMachinePoolSpec{
-					AzureManagedMachinePoolClassSpec: AzureManagedMachinePoolClassSpec{
+			old: &infrav1.AzureManagedMachinePool{
+				Spec: infrav1.AzureManagedMachinePoolSpec{
+					AzureManagedMachinePoolClassSpec: infrav1.AzureManagedMachinePoolClassSpec{
 						Mode:         "System",
 						SKU:          "StandardD2S_V3",
 						OSDiskSizeGB: ptr.To(512),
@@ -205,18 +205,18 @@ func TestAzureManagedMachinePoolUpdatingWebhook(t *testing.T) {
 		},
 		{
 			name: "Cannot remove AvailabilityZones after creating agentpool",
-			new: &AzureManagedMachinePool{
-				Spec: AzureManagedMachinePoolSpec{
-					AzureManagedMachinePoolClassSpec: AzureManagedMachinePoolClassSpec{
+			new: &infrav1.AzureManagedMachinePool{
+				Spec: infrav1.AzureManagedMachinePoolSpec{
+					AzureManagedMachinePoolClassSpec: infrav1.AzureManagedMachinePoolClassSpec{
 						Mode:         "System",
 						SKU:          "StandardD2S_V3",
 						OSDiskSizeGB: ptr.To(512),
 					},
 				},
 			},
-			old: &AzureManagedMachinePool{
-				Spec: AzureManagedMachinePoolSpec{
-					AzureManagedMachinePoolClassSpec: AzureManagedMachinePoolClassSpec{
+			old: &infrav1.AzureManagedMachinePool{
+				Spec: infrav1.AzureManagedMachinePoolSpec{
+					AzureManagedMachinePoolClassSpec: infrav1.AzureManagedMachinePoolClassSpec{
 						Mode:              "System",
 						SKU:               "StandardD2S_V3",
 						OSDiskSizeGB:      ptr.To(512),
@@ -228,9 +228,9 @@ func TestAzureManagedMachinePoolUpdatingWebhook(t *testing.T) {
 		},
 		{
 			name: "Cannot change AvailabilityZones of the agentpool",
-			new: &AzureManagedMachinePool{
-				Spec: AzureManagedMachinePoolSpec{
-					AzureManagedMachinePoolClassSpec: AzureManagedMachinePoolClassSpec{
+			new: &infrav1.AzureManagedMachinePool{
+				Spec: infrav1.AzureManagedMachinePoolSpec{
+					AzureManagedMachinePoolClassSpec: infrav1.AzureManagedMachinePoolClassSpec{
 						Mode:              "System",
 						SKU:               "StandardD2S_V3",
 						OSDiskSizeGB:      ptr.To(512),
@@ -238,9 +238,9 @@ func TestAzureManagedMachinePoolUpdatingWebhook(t *testing.T) {
 					},
 				},
 			},
-			old: &AzureManagedMachinePool{
-				Spec: AzureManagedMachinePoolSpec{
-					AzureManagedMachinePoolClassSpec: AzureManagedMachinePoolClassSpec{
+			old: &infrav1.AzureManagedMachinePool{
+				Spec: infrav1.AzureManagedMachinePoolSpec{
+					AzureManagedMachinePoolClassSpec: infrav1.AzureManagedMachinePoolClassSpec{
 						Mode:              "System",
 						SKU:               "StandardD2S_V3",
 						OSDiskSizeGB:      ptr.To(512),
@@ -252,9 +252,9 @@ func TestAzureManagedMachinePoolUpdatingWebhook(t *testing.T) {
 		},
 		{
 			name: "AvailabilityZones order can be different",
-			new: &AzureManagedMachinePool{
-				Spec: AzureManagedMachinePoolSpec{
-					AzureManagedMachinePoolClassSpec: AzureManagedMachinePoolClassSpec{
+			new: &infrav1.AzureManagedMachinePool{
+				Spec: infrav1.AzureManagedMachinePoolSpec{
+					AzureManagedMachinePoolClassSpec: infrav1.AzureManagedMachinePoolClassSpec{
 						Mode:              "System",
 						SKU:               "StandardD2S_V3",
 						OSDiskSizeGB:      ptr.To(512),
@@ -262,9 +262,9 @@ func TestAzureManagedMachinePoolUpdatingWebhook(t *testing.T) {
 					},
 				},
 			},
-			old: &AzureManagedMachinePool{
-				Spec: AzureManagedMachinePoolSpec{
-					AzureManagedMachinePoolClassSpec: AzureManagedMachinePoolClassSpec{
+			old: &infrav1.AzureManagedMachinePool{
+				Spec: infrav1.AzureManagedMachinePoolSpec{
+					AzureManagedMachinePoolClassSpec: infrav1.AzureManagedMachinePoolClassSpec{
 						Mode:              "System",
 						SKU:               "StandardD2S_V3",
 						OSDiskSizeGB:      ptr.To(512),
@@ -276,9 +276,9 @@ func TestAzureManagedMachinePoolUpdatingWebhook(t *testing.T) {
 		},
 		{
 			name: "Cannot change MaxPods of the agentpool",
-			new: &AzureManagedMachinePool{
-				Spec: AzureManagedMachinePoolSpec{
-					AzureManagedMachinePoolClassSpec: AzureManagedMachinePoolClassSpec{
+			new: &infrav1.AzureManagedMachinePool{
+				Spec: infrav1.AzureManagedMachinePoolSpec{
+					AzureManagedMachinePoolClassSpec: infrav1.AzureManagedMachinePoolClassSpec{
 						Mode:         "System",
 						SKU:          "StandardD2S_V3",
 						OSDiskSizeGB: ptr.To(512),
@@ -286,9 +286,9 @@ func TestAzureManagedMachinePoolUpdatingWebhook(t *testing.T) {
 					},
 				},
 			},
-			old: &AzureManagedMachinePool{
-				Spec: AzureManagedMachinePoolSpec{
-					AzureManagedMachinePoolClassSpec: AzureManagedMachinePoolClassSpec{
+			old: &infrav1.AzureManagedMachinePool{
+				Spec: infrav1.AzureManagedMachinePoolSpec{
+					AzureManagedMachinePoolClassSpec: infrav1.AzureManagedMachinePoolClassSpec{
 						Mode:         "System",
 						SKU:          "StandardD2S_V3",
 						OSDiskSizeGB: ptr.To(512),
@@ -300,9 +300,9 @@ func TestAzureManagedMachinePoolUpdatingWebhook(t *testing.T) {
 		},
 		{
 			name: "Unchanged MaxPods in an agentpool should not result in an error",
-			new: &AzureManagedMachinePool{
-				Spec: AzureManagedMachinePoolSpec{
-					AzureManagedMachinePoolClassSpec: AzureManagedMachinePoolClassSpec{
+			new: &infrav1.AzureManagedMachinePool{
+				Spec: infrav1.AzureManagedMachinePoolSpec{
+					AzureManagedMachinePoolClassSpec: infrav1.AzureManagedMachinePoolClassSpec{
 						Mode:         "System",
 						SKU:          "StandardD2S_V3",
 						OSDiskSizeGB: ptr.To(512),
@@ -310,9 +310,9 @@ func TestAzureManagedMachinePoolUpdatingWebhook(t *testing.T) {
 					},
 				},
 			},
-			old: &AzureManagedMachinePool{
-				Spec: AzureManagedMachinePoolSpec{
-					AzureManagedMachinePoolClassSpec: AzureManagedMachinePoolClassSpec{
+			old: &infrav1.AzureManagedMachinePool{
+				Spec: infrav1.AzureManagedMachinePoolSpec{
+					AzureManagedMachinePoolClassSpec: infrav1.AzureManagedMachinePoolClassSpec{
 						Mode:         "System",
 						SKU:          "StandardD2S_V3",
 						OSDiskSizeGB: ptr.To(512),
@@ -324,9 +324,9 @@ func TestAzureManagedMachinePoolUpdatingWebhook(t *testing.T) {
 		},
 		{
 			name: "Cannot change OSDiskType of the agentpool",
-			new: &AzureManagedMachinePool{
-				Spec: AzureManagedMachinePoolSpec{
-					AzureManagedMachinePoolClassSpec: AzureManagedMachinePoolClassSpec{
+			new: &infrav1.AzureManagedMachinePool{
+				Spec: infrav1.AzureManagedMachinePoolSpec{
+					AzureManagedMachinePoolClassSpec: infrav1.AzureManagedMachinePoolClassSpec{
 						Mode:         "System",
 						SKU:          "StandardD2S_V3",
 						OSDiskSizeGB: ptr.To(512),
@@ -335,9 +335,9 @@ func TestAzureManagedMachinePoolUpdatingWebhook(t *testing.T) {
 					},
 				},
 			},
-			old: &AzureManagedMachinePool{
-				Spec: AzureManagedMachinePoolSpec{
-					AzureManagedMachinePoolClassSpec: AzureManagedMachinePoolClassSpec{
+			old: &infrav1.AzureManagedMachinePool{
+				Spec: infrav1.AzureManagedMachinePoolSpec{
+					AzureManagedMachinePoolClassSpec: infrav1.AzureManagedMachinePoolClassSpec{
 						Mode:         "System",
 						SKU:          "StandardD2S_V3",
 						OSDiskSizeGB: ptr.To(512),
@@ -350,9 +350,9 @@ func TestAzureManagedMachinePoolUpdatingWebhook(t *testing.T) {
 		},
 		{
 			name: "Unchanged OSDiskType in an agentpool should not result in an error",
-			new: &AzureManagedMachinePool{
-				Spec: AzureManagedMachinePoolSpec{
-					AzureManagedMachinePoolClassSpec: AzureManagedMachinePoolClassSpec{
+			new: &infrav1.AzureManagedMachinePool{
+				Spec: infrav1.AzureManagedMachinePoolSpec{
+					AzureManagedMachinePoolClassSpec: infrav1.AzureManagedMachinePoolClassSpec{
 						Mode:         "System",
 						SKU:          "StandardD2S_V3",
 						OSDiskSizeGB: ptr.To(512),
@@ -361,9 +361,9 @@ func TestAzureManagedMachinePoolUpdatingWebhook(t *testing.T) {
 					},
 				},
 			},
-			old: &AzureManagedMachinePool{
-				Spec: AzureManagedMachinePoolSpec{
-					AzureManagedMachinePoolClassSpec: AzureManagedMachinePoolClassSpec{
+			old: &infrav1.AzureManagedMachinePool{
+				Spec: infrav1.AzureManagedMachinePoolSpec{
+					AzureManagedMachinePoolClassSpec: infrav1.AzureManagedMachinePoolClassSpec{
 						Mode:         "System",
 						SKU:          "StandardD2S_V3",
 						OSDiskSizeGB: ptr.To(512),
@@ -376,16 +376,16 @@ func TestAzureManagedMachinePoolUpdatingWebhook(t *testing.T) {
 		},
 		{
 			name: "Unexpected error, value EnableUltraSSD is unchanged",
-			new: &AzureManagedMachinePool{
-				Spec: AzureManagedMachinePoolSpec{
-					AzureManagedMachinePoolClassSpec: AzureManagedMachinePoolClassSpec{
+			new: &infrav1.AzureManagedMachinePool{
+				Spec: infrav1.AzureManagedMachinePoolSpec{
+					AzureManagedMachinePoolClassSpec: infrav1.AzureManagedMachinePoolClassSpec{
 						EnableUltraSSD: ptr.To(true),
 					},
 				},
 			},
-			old: &AzureManagedMachinePool{
-				Spec: AzureManagedMachinePoolSpec{
-					AzureManagedMachinePoolClassSpec: AzureManagedMachinePoolClassSpec{
+			old: &infrav1.AzureManagedMachinePool{
+				Spec: infrav1.AzureManagedMachinePoolSpec{
+					AzureManagedMachinePoolClassSpec: infrav1.AzureManagedMachinePoolClassSpec{
 						EnableUltraSSD: ptr.To(true),
 					},
 				},
@@ -394,16 +394,16 @@ func TestAzureManagedMachinePoolUpdatingWebhook(t *testing.T) {
 		},
 		{
 			name: "EnableUltraSSD feature is immutable and currently enabled on this agentpool",
-			new: &AzureManagedMachinePool{
-				Spec: AzureManagedMachinePoolSpec{
-					AzureManagedMachinePoolClassSpec: AzureManagedMachinePoolClassSpec{
+			new: &infrav1.AzureManagedMachinePool{
+				Spec: infrav1.AzureManagedMachinePoolSpec{
+					AzureManagedMachinePoolClassSpec: infrav1.AzureManagedMachinePoolClassSpec{
 						EnableUltraSSD: ptr.To(false),
 					},
 				},
 			},
-			old: &AzureManagedMachinePool{
-				Spec: AzureManagedMachinePoolSpec{
-					AzureManagedMachinePoolClassSpec: AzureManagedMachinePoolClassSpec{
+			old: &infrav1.AzureManagedMachinePool{
+				Spec: infrav1.AzureManagedMachinePoolSpec{
+					AzureManagedMachinePoolClassSpec: infrav1.AzureManagedMachinePoolClassSpec{
 						EnableUltraSSD: ptr.To(true),
 					},
 				},
@@ -412,16 +412,16 @@ func TestAzureManagedMachinePoolUpdatingWebhook(t *testing.T) {
 		},
 		{
 			name: "Unexpected error, value EnableNodePublicIP is unchanged",
-			new: &AzureManagedMachinePool{
-				Spec: AzureManagedMachinePoolSpec{
-					AzureManagedMachinePoolClassSpec: AzureManagedMachinePoolClassSpec{
+			new: &infrav1.AzureManagedMachinePool{
+				Spec: infrav1.AzureManagedMachinePoolSpec{
+					AzureManagedMachinePoolClassSpec: infrav1.AzureManagedMachinePoolClassSpec{
 						EnableNodePublicIP: ptr.To(true),
 					},
 				},
 			},
-			old: &AzureManagedMachinePool{
-				Spec: AzureManagedMachinePoolSpec{
-					AzureManagedMachinePoolClassSpec: AzureManagedMachinePoolClassSpec{
+			old: &infrav1.AzureManagedMachinePool{
+				Spec: infrav1.AzureManagedMachinePoolSpec{
+					AzureManagedMachinePoolClassSpec: infrav1.AzureManagedMachinePoolClassSpec{
 						EnableNodePublicIP: ptr.To(true),
 					},
 				},
@@ -430,16 +430,16 @@ func TestAzureManagedMachinePoolUpdatingWebhook(t *testing.T) {
 		},
 		{
 			name: "EnableNodePublicIP feature is immutable and currently enabled on this agentpool",
-			new: &AzureManagedMachinePool{
-				Spec: AzureManagedMachinePoolSpec{
-					AzureManagedMachinePoolClassSpec: AzureManagedMachinePoolClassSpec{
+			new: &infrav1.AzureManagedMachinePool{
+				Spec: infrav1.AzureManagedMachinePoolSpec{
+					AzureManagedMachinePoolClassSpec: infrav1.AzureManagedMachinePoolClassSpec{
 						EnableNodePublicIP: ptr.To(false),
 					},
 				},
 			},
-			old: &AzureManagedMachinePool{
-				Spec: AzureManagedMachinePoolSpec{
-					AzureManagedMachinePoolClassSpec: AzureManagedMachinePoolClassSpec{
+			old: &infrav1.AzureManagedMachinePool{
+				Spec: infrav1.AzureManagedMachinePoolSpec{
+					AzureManagedMachinePoolClassSpec: infrav1.AzureManagedMachinePoolClassSpec{
 						EnableNodePublicIP: ptr.To(true),
 					},
 				},
@@ -448,12 +448,12 @@ func TestAzureManagedMachinePoolUpdatingWebhook(t *testing.T) {
 		},
 		{
 			name: "NodeTaints are mutable",
-			new: &AzureManagedMachinePool{
-				Spec: AzureManagedMachinePoolSpec{
-					AzureManagedMachinePoolClassSpec: AzureManagedMachinePoolClassSpec{
-						Taints: []Taint{
+			new: &infrav1.AzureManagedMachinePool{
+				Spec: infrav1.AzureManagedMachinePoolSpec{
+					AzureManagedMachinePoolClassSpec: infrav1.AzureManagedMachinePoolClassSpec{
+						Taints: []infrav1.Taint{
 							{
-								Effect: TaintEffect("NoSchedule"),
+								Effect: infrav1.TaintEffect("NoSchedule"),
 								Key:    "foo",
 								Value:  "baz",
 							},
@@ -461,12 +461,12 @@ func TestAzureManagedMachinePoolUpdatingWebhook(t *testing.T) {
 					},
 				},
 			},
-			old: &AzureManagedMachinePool{
-				Spec: AzureManagedMachinePoolSpec{
-					AzureManagedMachinePoolClassSpec: AzureManagedMachinePoolClassSpec{
-						Taints: []Taint{
+			old: &infrav1.AzureManagedMachinePool{
+				Spec: infrav1.AzureManagedMachinePoolSpec{
+					AzureManagedMachinePoolClassSpec: infrav1.AzureManagedMachinePoolClassSpec{
+						Taints: []infrav1.Taint{
 							{
-								Effect: TaintEffect("NoSchedule"),
+								Effect: infrav1.TaintEffect("NoSchedule"),
 								Key:    "foo",
 								Value:  "bar",
 							},
@@ -478,9 +478,9 @@ func TestAzureManagedMachinePoolUpdatingWebhook(t *testing.T) {
 		},
 		{
 			name: "Can't add a node label that begins with kubernetes.azure.com",
-			new: &AzureManagedMachinePool{
-				Spec: AzureManagedMachinePoolSpec{
-					AzureManagedMachinePoolClassSpec: AzureManagedMachinePoolClassSpec{
+			new: &infrav1.AzureManagedMachinePool{
+				Spec: infrav1.AzureManagedMachinePoolSpec{
+					AzureManagedMachinePoolClassSpec: infrav1.AzureManagedMachinePoolClassSpec{
 						NodeLabels: map[string]string{
 							"foo":                                   "bar",
 							"kubernetes.azure.com/scalesetpriority": "spot",
@@ -488,9 +488,9 @@ func TestAzureManagedMachinePoolUpdatingWebhook(t *testing.T) {
 					},
 				},
 			},
-			old: &AzureManagedMachinePool{
-				Spec: AzureManagedMachinePoolSpec{
-					AzureManagedMachinePoolClassSpec: AzureManagedMachinePoolClassSpec{
+			old: &infrav1.AzureManagedMachinePool{
+				Spec: infrav1.AzureManagedMachinePoolSpec{
+					AzureManagedMachinePoolClassSpec: infrav1.AzureManagedMachinePoolClassSpec{
 						NodeLabels: map[string]string{
 							"foo": "bar",
 						},
@@ -501,19 +501,19 @@ func TestAzureManagedMachinePoolUpdatingWebhook(t *testing.T) {
 		},
 		{
 			name: "Can't update kubeletconfig",
-			new: &AzureManagedMachinePool{
-				Spec: AzureManagedMachinePoolSpec{
-					AzureManagedMachinePoolClassSpec: AzureManagedMachinePoolClassSpec{
-						KubeletConfig: &KubeletConfig{
+			new: &infrav1.AzureManagedMachinePool{
+				Spec: infrav1.AzureManagedMachinePoolSpec{
+					AzureManagedMachinePoolClassSpec: infrav1.AzureManagedMachinePoolClassSpec{
+						KubeletConfig: &infrav1.KubeletConfig{
 							CPUCfsQuota: ptr.To(true),
 						},
 					},
 				},
 			},
-			old: &AzureManagedMachinePool{
-				Spec: AzureManagedMachinePoolSpec{
-					AzureManagedMachinePoolClassSpec: AzureManagedMachinePoolClassSpec{
-						KubeletConfig: &KubeletConfig{
+			old: &infrav1.AzureManagedMachinePool{
+				Spec: infrav1.AzureManagedMachinePoolSpec{
+					AzureManagedMachinePoolClassSpec: infrav1.AzureManagedMachinePoolClassSpec{
+						KubeletConfig: &infrav1.KubeletConfig{
 							CPUCfsQuota: ptr.To(false),
 						},
 					},
@@ -523,19 +523,19 @@ func TestAzureManagedMachinePoolUpdatingWebhook(t *testing.T) {
 		},
 		{
 			name: "Can't update LinuxOSConfig",
-			new: &AzureManagedMachinePool{
-				Spec: AzureManagedMachinePoolSpec{
-					AzureManagedMachinePoolClassSpec: AzureManagedMachinePoolClassSpec{
-						LinuxOSConfig: &LinuxOSConfig{
+			new: &infrav1.AzureManagedMachinePool{
+				Spec: infrav1.AzureManagedMachinePoolSpec{
+					AzureManagedMachinePoolClassSpec: infrav1.AzureManagedMachinePoolClassSpec{
+						LinuxOSConfig: &infrav1.LinuxOSConfig{
 							SwapFileSizeMB: ptr.To(10),
 						},
 					},
 				},
 			},
-			old: &AzureManagedMachinePool{
-				Spec: AzureManagedMachinePoolSpec{
-					AzureManagedMachinePoolClassSpec: AzureManagedMachinePoolClassSpec{
-						LinuxOSConfig: &LinuxOSConfig{
+			old: &infrav1.AzureManagedMachinePool{
+				Spec: infrav1.AzureManagedMachinePoolSpec{
+					AzureManagedMachinePoolClassSpec: infrav1.AzureManagedMachinePoolClassSpec{
+						LinuxOSConfig: &infrav1.LinuxOSConfig{
 							SwapFileSizeMB: ptr.To(5),
 						},
 					},
@@ -545,16 +545,16 @@ func TestAzureManagedMachinePoolUpdatingWebhook(t *testing.T) {
 		},
 		{
 			name: "Can't update SubnetName with error",
-			new: &AzureManagedMachinePool{
-				Spec: AzureManagedMachinePoolSpec{
-					AzureManagedMachinePoolClassSpec: AzureManagedMachinePoolClassSpec{
+			new: &infrav1.AzureManagedMachinePool{
+				Spec: infrav1.AzureManagedMachinePoolSpec{
+					AzureManagedMachinePoolClassSpec: infrav1.AzureManagedMachinePoolClassSpec{
 						SubnetName: ptr.To("my-subnet"),
 					},
 				},
 			},
-			old: &AzureManagedMachinePool{
-				Spec: AzureManagedMachinePoolSpec{
-					AzureManagedMachinePoolClassSpec: AzureManagedMachinePoolClassSpec{
+			old: &infrav1.AzureManagedMachinePool{
+				Spec: infrav1.AzureManagedMachinePoolSpec{
+					AzureManagedMachinePoolClassSpec: infrav1.AzureManagedMachinePoolClassSpec{
 						SubnetName: ptr.To("my-subnet-1"),
 					},
 				},
@@ -563,16 +563,16 @@ func TestAzureManagedMachinePoolUpdatingWebhook(t *testing.T) {
 		},
 		{
 			name: "Can update SubnetName if subnetName is empty",
-			new: &AzureManagedMachinePool{
-				Spec: AzureManagedMachinePoolSpec{
-					AzureManagedMachinePoolClassSpec: AzureManagedMachinePoolClassSpec{
+			new: &infrav1.AzureManagedMachinePool{
+				Spec: infrav1.AzureManagedMachinePoolSpec{
+					AzureManagedMachinePoolClassSpec: infrav1.AzureManagedMachinePoolClassSpec{
 						SubnetName: ptr.To("my-subnet"),
 					},
 				},
 			},
-			old: &AzureManagedMachinePool{
-				Spec: AzureManagedMachinePoolSpec{
-					AzureManagedMachinePoolClassSpec: AzureManagedMachinePoolClassSpec{
+			old: &infrav1.AzureManagedMachinePool{
+				Spec: infrav1.AzureManagedMachinePoolSpec{
+					AzureManagedMachinePoolClassSpec: infrav1.AzureManagedMachinePoolClassSpec{
 						SubnetName: nil,
 					},
 				},
@@ -581,16 +581,16 @@ func TestAzureManagedMachinePoolUpdatingWebhook(t *testing.T) {
 		},
 		{
 			name: "Can't update SubnetName without error",
-			new: &AzureManagedMachinePool{
-				Spec: AzureManagedMachinePoolSpec{
-					AzureManagedMachinePoolClassSpec: AzureManagedMachinePoolClassSpec{
+			new: &infrav1.AzureManagedMachinePool{
+				Spec: infrav1.AzureManagedMachinePoolSpec{
+					AzureManagedMachinePoolClassSpec: infrav1.AzureManagedMachinePoolClassSpec{
 						SubnetName: ptr.To("my-subnet"),
 					},
 				},
 			},
-			old: &AzureManagedMachinePool{
-				Spec: AzureManagedMachinePoolSpec{
-					AzureManagedMachinePoolClassSpec: AzureManagedMachinePoolClassSpec{
+			old: &infrav1.AzureManagedMachinePool{
+				Spec: infrav1.AzureManagedMachinePoolSpec{
+					AzureManagedMachinePoolClassSpec: infrav1.AzureManagedMachinePoolClassSpec{
 						SubnetName: ptr.To("my-subnet"),
 					},
 				},
@@ -599,16 +599,16 @@ func TestAzureManagedMachinePoolUpdatingWebhook(t *testing.T) {
 		},
 		{
 			name: "Cannot update enableFIPS",
-			new: &AzureManagedMachinePool{
-				Spec: AzureManagedMachinePoolSpec{
-					AzureManagedMachinePoolClassSpec: AzureManagedMachinePoolClassSpec{
+			new: &infrav1.AzureManagedMachinePool{
+				Spec: infrav1.AzureManagedMachinePoolSpec{
+					AzureManagedMachinePoolClassSpec: infrav1.AzureManagedMachinePoolClassSpec{
 						EnableFIPS: ptr.To(true),
 					},
 				},
 			},
-			old: &AzureManagedMachinePool{
-				Spec: AzureManagedMachinePoolSpec{
-					AzureManagedMachinePoolClassSpec: AzureManagedMachinePoolClassSpec{
+			old: &infrav1.AzureManagedMachinePool{
+				Spec: infrav1.AzureManagedMachinePoolSpec{
+					AzureManagedMachinePoolClassSpec: infrav1.AzureManagedMachinePoolClassSpec{
 						EnableFIPS: ptr.To(false),
 					},
 				},
@@ -617,16 +617,16 @@ func TestAzureManagedMachinePoolUpdatingWebhook(t *testing.T) {
 		},
 		{
 			name: "Cannot update enableEncryptionAtHost",
-			new: &AzureManagedMachinePool{
-				Spec: AzureManagedMachinePoolSpec{
-					AzureManagedMachinePoolClassSpec: AzureManagedMachinePoolClassSpec{
+			new: &infrav1.AzureManagedMachinePool{
+				Spec: infrav1.AzureManagedMachinePoolSpec{
+					AzureManagedMachinePoolClassSpec: infrav1.AzureManagedMachinePoolClassSpec{
 						EnableEncryptionAtHost: ptr.To(true),
 					},
 				},
 			},
-			old: &AzureManagedMachinePool{
-				Spec: AzureManagedMachinePoolSpec{
-					AzureManagedMachinePoolClassSpec: AzureManagedMachinePoolClassSpec{
+			old: &infrav1.AzureManagedMachinePool{
+				Spec: infrav1.AzureManagedMachinePoolSpec{
+					AzureManagedMachinePoolClassSpec: infrav1.AzureManagedMachinePoolClassSpec{
 						EnableEncryptionAtHost: ptr.To(false),
 					},
 				},
@@ -655,7 +655,7 @@ func TestAzureManagedMachinePoolUpdatingWebhook(t *testing.T) {
 func TestAzureManagedMachinePool_ValidateCreate(t *testing.T) {
 	tests := []struct {
 		name     string
-		ammp     *AzureManagedMachinePool
+		ammp     *infrav1.AzureManagedMachinePool
 		wantErr  bool
 		errorLen int
 	}{
@@ -666,9 +666,9 @@ func TestAzureManagedMachinePool_ValidateCreate(t *testing.T) {
 		},
 		{
 			name: "another valid permutation",
-			ammp: &AzureManagedMachinePool{
-				Spec: AzureManagedMachinePoolSpec{
-					AzureManagedMachinePoolClassSpec: AzureManagedMachinePoolClassSpec{
+			ammp: &infrav1.AzureManagedMachinePool{
+				Spec: infrav1.AzureManagedMachinePoolSpec{
+					AzureManagedMachinePoolClassSpec: infrav1.AzureManagedMachinePoolClassSpec{
 						MaxPods:    ptr.To(249),
 						OsDiskType: ptr.To(string(asocontainerservicev1.OSDiskType_Managed)),
 					},
@@ -678,16 +678,16 @@ func TestAzureManagedMachinePool_ValidateCreate(t *testing.T) {
 		},
 		{
 			name: "valid - optional configuration not present",
-			ammp: &AzureManagedMachinePool{
-				Spec: AzureManagedMachinePoolSpec{},
+			ammp: &infrav1.AzureManagedMachinePool{
+				Spec: infrav1.AzureManagedMachinePoolSpec{},
 			},
 			wantErr: false,
 		},
 		{
 			name: "too many MaxPods",
-			ammp: &AzureManagedMachinePool{
-				Spec: AzureManagedMachinePoolSpec{
-					AzureManagedMachinePoolClassSpec: AzureManagedMachinePoolClassSpec{
+			ammp: &infrav1.AzureManagedMachinePool{
+				Spec: infrav1.AzureManagedMachinePoolSpec{
+					AzureManagedMachinePoolClassSpec: infrav1.AzureManagedMachinePoolClassSpec{
 						MaxPods: ptr.To(251),
 					},
 				},
@@ -697,9 +697,9 @@ func TestAzureManagedMachinePool_ValidateCreate(t *testing.T) {
 		},
 		{
 			name: "invalid subnetname",
-			ammp: &AzureManagedMachinePool{
-				Spec: AzureManagedMachinePoolSpec{
-					AzureManagedMachinePoolClassSpec: AzureManagedMachinePoolClassSpec{
+			ammp: &infrav1.AzureManagedMachinePool{
+				Spec: infrav1.AzureManagedMachinePoolSpec{
+					AzureManagedMachinePoolClassSpec: infrav1.AzureManagedMachinePoolClassSpec{
 						SubnetName: ptr.To("1+subnet"),
 					},
 				},
@@ -709,9 +709,9 @@ func TestAzureManagedMachinePool_ValidateCreate(t *testing.T) {
 		},
 		{
 			name: "invalid subnetname",
-			ammp: &AzureManagedMachinePool{
-				Spec: AzureManagedMachinePoolSpec{
-					AzureManagedMachinePoolClassSpec: AzureManagedMachinePoolClassSpec{
+			ammp: &infrav1.AzureManagedMachinePool{
+				Spec: infrav1.AzureManagedMachinePoolSpec{
+					AzureManagedMachinePoolClassSpec: infrav1.AzureManagedMachinePoolClassSpec{
 						SubnetName: ptr.To("1"),
 					},
 				},
@@ -721,9 +721,9 @@ func TestAzureManagedMachinePool_ValidateCreate(t *testing.T) {
 		},
 		{
 			name: "invalid subnetname",
-			ammp: &AzureManagedMachinePool{
-				Spec: AzureManagedMachinePoolSpec{
-					AzureManagedMachinePoolClassSpec: AzureManagedMachinePoolClassSpec{
+			ammp: &infrav1.AzureManagedMachinePool{
+				Spec: infrav1.AzureManagedMachinePoolSpec{
+					AzureManagedMachinePoolClassSpec: infrav1.AzureManagedMachinePoolClassSpec{
 						SubnetName: ptr.To("-a_b-c"),
 					},
 				},
@@ -733,9 +733,9 @@ func TestAzureManagedMachinePool_ValidateCreate(t *testing.T) {
 		},
 		{
 			name: "invalid subnetname with versioning",
-			ammp: &AzureManagedMachinePool{
-				Spec: AzureManagedMachinePoolSpec{
-					AzureManagedMachinePoolClassSpec: AzureManagedMachinePoolClassSpec{
+			ammp: &infrav1.AzureManagedMachinePool{
+				Spec: infrav1.AzureManagedMachinePoolSpec{
+					AzureManagedMachinePoolClassSpec: infrav1.AzureManagedMachinePoolClassSpec{
 						SubnetName: ptr.To("workload-ampt-v0.1.0."),
 					},
 				},
@@ -745,9 +745,9 @@ func TestAzureManagedMachinePool_ValidateCreate(t *testing.T) {
 		},
 		{
 			name: "invalid subnetname",
-			ammp: &AzureManagedMachinePool{
-				Spec: AzureManagedMachinePoolSpec{
-					AzureManagedMachinePoolClassSpec: AzureManagedMachinePoolClassSpec{
+			ammp: &infrav1.AzureManagedMachinePool{
+				Spec: infrav1.AzureManagedMachinePoolSpec{
+					AzureManagedMachinePoolClassSpec: infrav1.AzureManagedMachinePoolClassSpec{
 						SubnetName: ptr.To("-_-_"),
 					},
 				},
@@ -757,9 +757,9 @@ func TestAzureManagedMachinePool_ValidateCreate(t *testing.T) {
 		},
 		{
 			name: "invalid subnetname",
-			ammp: &AzureManagedMachinePool{
-				Spec: AzureManagedMachinePoolSpec{
-					AzureManagedMachinePoolClassSpec: AzureManagedMachinePoolClassSpec{
+			ammp: &infrav1.AzureManagedMachinePool{
+				Spec: infrav1.AzureManagedMachinePoolSpec{
+					AzureManagedMachinePoolClassSpec: infrav1.AzureManagedMachinePoolClassSpec{
 						SubnetName: ptr.To("abc@#$"),
 					},
 				},
@@ -769,9 +769,9 @@ func TestAzureManagedMachinePool_ValidateCreate(t *testing.T) {
 		},
 		{
 			name: "invalid subnetname with character length 81",
-			ammp: &AzureManagedMachinePool{
-				Spec: AzureManagedMachinePoolSpec{
-					AzureManagedMachinePoolClassSpec: AzureManagedMachinePoolClassSpec{
+			ammp: &infrav1.AzureManagedMachinePool{
+				Spec: infrav1.AzureManagedMachinePoolSpec{
+					AzureManagedMachinePoolClassSpec: infrav1.AzureManagedMachinePoolClassSpec{
 						SubnetName: ptr.To("3DgIb8EZMkLs0KlyPaTcNxoJU9ufmW6jvXrweqz1hVp5nS4RtH2QY7AFOiC5nS4RtH2QY7AFOiC3DgIb8"),
 					},
 				},
@@ -781,9 +781,9 @@ func TestAzureManagedMachinePool_ValidateCreate(t *testing.T) {
 		},
 		{
 			name: "valid subnetname with character length 80",
-			ammp: &AzureManagedMachinePool{
-				Spec: AzureManagedMachinePoolSpec{
-					AzureManagedMachinePoolClassSpec: AzureManagedMachinePoolClassSpec{
+			ammp: &infrav1.AzureManagedMachinePool{
+				Spec: infrav1.AzureManagedMachinePoolSpec{
+					AzureManagedMachinePoolClassSpec: infrav1.AzureManagedMachinePoolClassSpec{
 						SubnetName: ptr.To("3DgIb8EZMkLs0KlyPaTcNxoJU9ufmW6jvXrweqz1hVp5nS4RtH2QY7AFOiC5nS4RtH2QY7AFOiC3DgIb"),
 					},
 				},
@@ -792,9 +792,9 @@ func TestAzureManagedMachinePool_ValidateCreate(t *testing.T) {
 		},
 		{
 			name: "valid subnetname with versioning",
-			ammp: &AzureManagedMachinePool{
-				Spec: AzureManagedMachinePoolSpec{
-					AzureManagedMachinePoolClassSpec: AzureManagedMachinePoolClassSpec{
+			ammp: &infrav1.AzureManagedMachinePool{
+				Spec: infrav1.AzureManagedMachinePoolSpec{
+					AzureManagedMachinePoolClassSpec: infrav1.AzureManagedMachinePoolClassSpec{
 						SubnetName: ptr.To("workload-ampt-v0.1.0"),
 					},
 				},
@@ -803,9 +803,9 @@ func TestAzureManagedMachinePool_ValidateCreate(t *testing.T) {
 		},
 		{
 			name: "valid subnetname",
-			ammp: &AzureManagedMachinePool{
-				Spec: AzureManagedMachinePoolSpec{
-					AzureManagedMachinePoolClassSpec: AzureManagedMachinePoolClassSpec{
+			ammp: &infrav1.AzureManagedMachinePool{
+				Spec: infrav1.AzureManagedMachinePoolSpec{
+					AzureManagedMachinePoolClassSpec: infrav1.AzureManagedMachinePoolClassSpec{
 						SubnetName: ptr.To("1abc"),
 					},
 				},
@@ -814,9 +814,9 @@ func TestAzureManagedMachinePool_ValidateCreate(t *testing.T) {
 		},
 		{
 			name: "valid subnetname",
-			ammp: &AzureManagedMachinePool{
-				Spec: AzureManagedMachinePoolSpec{
-					AzureManagedMachinePoolClassSpec: AzureManagedMachinePoolClassSpec{
+			ammp: &infrav1.AzureManagedMachinePool{
+				Spec: infrav1.AzureManagedMachinePoolSpec{
+					AzureManagedMachinePoolClassSpec: infrav1.AzureManagedMachinePoolClassSpec{
 						SubnetName: ptr.To("1-a-b-c"),
 					},
 				},
@@ -825,9 +825,9 @@ func TestAzureManagedMachinePool_ValidateCreate(t *testing.T) {
 		},
 		{
 			name: "valid subnetname",
-			ammp: &AzureManagedMachinePool{
-				Spec: AzureManagedMachinePoolSpec{
-					AzureManagedMachinePoolClassSpec: AzureManagedMachinePoolClassSpec{
+			ammp: &infrav1.AzureManagedMachinePool{
+				Spec: infrav1.AzureManagedMachinePoolSpec{
+					AzureManagedMachinePoolClassSpec: infrav1.AzureManagedMachinePoolClassSpec{
 						SubnetName: ptr.To("my-subnet"),
 					},
 				},
@@ -836,9 +836,9 @@ func TestAzureManagedMachinePool_ValidateCreate(t *testing.T) {
 		},
 		{
 			name: "too few MaxPods",
-			ammp: &AzureManagedMachinePool{
-				Spec: AzureManagedMachinePoolSpec{
-					AzureManagedMachinePoolClassSpec: AzureManagedMachinePoolClassSpec{
+			ammp: &infrav1.AzureManagedMachinePool{
+				Spec: infrav1.AzureManagedMachinePoolSpec{
+					AzureManagedMachinePoolClassSpec: infrav1.AzureManagedMachinePoolClassSpec{
 						MaxPods: ptr.To(9),
 					},
 				},
@@ -848,11 +848,11 @@ func TestAzureManagedMachinePool_ValidateCreate(t *testing.T) {
 		},
 		{
 			name: "ostype Windows with System mode not allowed",
-			ammp: &AzureManagedMachinePool{
-				Spec: AzureManagedMachinePoolSpec{
-					AzureManagedMachinePoolClassSpec: AzureManagedMachinePoolClassSpec{
+			ammp: &infrav1.AzureManagedMachinePool{
+				Spec: infrav1.AzureManagedMachinePoolSpec{
+					AzureManagedMachinePoolClassSpec: infrav1.AzureManagedMachinePoolClassSpec{
 						Mode:   "System",
-						OSType: ptr.To(WindowsOS),
+						OSType: ptr.To(infrav1.WindowsOS),
 					},
 				},
 			},
@@ -861,11 +861,11 @@ func TestAzureManagedMachinePool_ValidateCreate(t *testing.T) {
 		},
 		{
 			name: "ostype windows with User mode",
-			ammp: &AzureManagedMachinePool{
-				Spec: AzureManagedMachinePoolSpec{
-					AzureManagedMachinePoolClassSpec: AzureManagedMachinePoolClassSpec{
+			ammp: &infrav1.AzureManagedMachinePool{
+				Spec: infrav1.AzureManagedMachinePoolSpec{
+					AzureManagedMachinePoolClassSpec: infrav1.AzureManagedMachinePoolClassSpec{
 						Mode:   "User",
-						OSType: ptr.To(WindowsOS),
+						OSType: ptr.To(infrav1.WindowsOS),
 					},
 				},
 			},
@@ -873,14 +873,14 @@ func TestAzureManagedMachinePool_ValidateCreate(t *testing.T) {
 		},
 		{
 			name: "Windows clusters with 6char or less name",
-			ammp: &AzureManagedMachinePool{
+			ammp: &infrav1.AzureManagedMachinePool{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "pool0",
 				},
-				Spec: AzureManagedMachinePoolSpec{
-					AzureManagedMachinePoolClassSpec: AzureManagedMachinePoolClassSpec{
+				Spec: infrav1.AzureManagedMachinePoolSpec{
+					AzureManagedMachinePoolClassSpec: infrav1.AzureManagedMachinePoolClassSpec{
 						Mode:   "User",
-						OSType: ptr.To(WindowsOS),
+						OSType: ptr.To(infrav1.WindowsOS),
 					},
 				},
 			},
@@ -888,12 +888,12 @@ func TestAzureManagedMachinePool_ValidateCreate(t *testing.T) {
 		},
 		{
 			name: "Windows clusters with more than 6char names are not allowed",
-			ammp: &AzureManagedMachinePool{
-				Spec: AzureManagedMachinePoolSpec{
-					AzureManagedMachinePoolClassSpec: AzureManagedMachinePoolClassSpec{
+			ammp: &infrav1.AzureManagedMachinePool{
+				Spec: infrav1.AzureManagedMachinePoolSpec{
+					AzureManagedMachinePoolClassSpec: infrav1.AzureManagedMachinePoolClassSpec{
 						Name:   ptr.To("pool0-name-too-long"),
 						Mode:   "User",
-						OSType: ptr.To(WindowsOS),
+						OSType: ptr.To(infrav1.WindowsOS),
 					},
 				},
 			},
@@ -902,11 +902,11 @@ func TestAzureManagedMachinePool_ValidateCreate(t *testing.T) {
 		},
 		{
 			name: "valid label",
-			ammp: &AzureManagedMachinePool{
-				Spec: AzureManagedMachinePoolSpec{
-					AzureManagedMachinePoolClassSpec: AzureManagedMachinePoolClassSpec{
+			ammp: &infrav1.AzureManagedMachinePool{
+				Spec: infrav1.AzureManagedMachinePoolSpec{
+					AzureManagedMachinePoolClassSpec: infrav1.AzureManagedMachinePoolClassSpec{
 						Mode:   "User",
-						OSType: ptr.To(LinuxOS),
+						OSType: ptr.To(infrav1.LinuxOS),
 						NodeLabels: map[string]string{
 							"foo": "bar",
 						},
@@ -917,11 +917,11 @@ func TestAzureManagedMachinePool_ValidateCreate(t *testing.T) {
 		},
 		{
 			name: "kubernetes.azure.com label",
-			ammp: &AzureManagedMachinePool{
-				Spec: AzureManagedMachinePoolSpec{
-					AzureManagedMachinePoolClassSpec: AzureManagedMachinePoolClassSpec{
+			ammp: &infrav1.AzureManagedMachinePool{
+				Spec: infrav1.AzureManagedMachinePoolSpec{
+					AzureManagedMachinePoolClassSpec: infrav1.AzureManagedMachinePoolClassSpec{
 						Mode:   "User",
-						OSType: ptr.To(LinuxOS),
+						OSType: ptr.To(infrav1.LinuxOS),
 						NodeLabels: map[string]string{
 							"kubernetes.azure.com/scalesetpriority": "spot",
 						},
@@ -933,9 +933,9 @@ func TestAzureManagedMachinePool_ValidateCreate(t *testing.T) {
 		},
 		{
 			name: "pool with invalid public ip prefix",
-			ammp: &AzureManagedMachinePool{
-				Spec: AzureManagedMachinePoolSpec{
-					AzureManagedMachinePoolClassSpec: AzureManagedMachinePoolClassSpec{
+			ammp: &infrav1.AzureManagedMachinePool{
+				Spec: infrav1.AzureManagedMachinePoolSpec{
+					AzureManagedMachinePoolClassSpec: infrav1.AzureManagedMachinePoolClassSpec{
 						EnableNodePublicIP:   ptr.To(true),
 						NodePublicIPPrefixID: ptr.To("not a valid resource ID"),
 					},
@@ -946,9 +946,9 @@ func TestAzureManagedMachinePool_ValidateCreate(t *testing.T) {
 		},
 		{
 			name: "pool with public ip prefix cannot omit node public IP",
-			ammp: &AzureManagedMachinePool{
-				Spec: AzureManagedMachinePoolSpec{
-					AzureManagedMachinePoolClassSpec: AzureManagedMachinePoolClassSpec{
+			ammp: &infrav1.AzureManagedMachinePool{
+				Spec: infrav1.AzureManagedMachinePoolSpec{
+					AzureManagedMachinePoolClassSpec: infrav1.AzureManagedMachinePoolClassSpec{
 						EnableNodePublicIP:   nil,
 						NodePublicIPPrefixID: ptr.To("subscriptions/11111111-2222-aaaa-bbbb-cccccccccccc/resourceGroups/public-ip-test/providers/Microsoft.Network/publicipprefixes/public-ip-prefix"),
 					},
@@ -959,9 +959,9 @@ func TestAzureManagedMachinePool_ValidateCreate(t *testing.T) {
 		},
 		{
 			name: "pool with public ip prefix cannot disable node public IP",
-			ammp: &AzureManagedMachinePool{
-				Spec: AzureManagedMachinePoolSpec{
-					AzureManagedMachinePoolClassSpec: AzureManagedMachinePoolClassSpec{
+			ammp: &infrav1.AzureManagedMachinePool{
+				Spec: infrav1.AzureManagedMachinePoolSpec{
+					AzureManagedMachinePoolClassSpec: infrav1.AzureManagedMachinePoolClassSpec{
 						EnableNodePublicIP:   ptr.To(false),
 						NodePublicIPPrefixID: ptr.To("subscriptions/11111111-2222-aaaa-bbbb-cccccccccccc/resourceGroups/public-ip-test/providers/Microsoft.Network/publicipprefixes/public-ip-prefix"),
 					},
@@ -972,9 +972,9 @@ func TestAzureManagedMachinePool_ValidateCreate(t *testing.T) {
 		},
 		{
 			name: "pool with public ip prefix with node public IP enabled ok",
-			ammp: &AzureManagedMachinePool{
-				Spec: AzureManagedMachinePoolSpec{
-					AzureManagedMachinePoolClassSpec: AzureManagedMachinePoolClassSpec{
+			ammp: &infrav1.AzureManagedMachinePool{
+				Spec: infrav1.AzureManagedMachinePoolSpec{
+					AzureManagedMachinePoolClassSpec: infrav1.AzureManagedMachinePoolClassSpec{
 						EnableNodePublicIP:   ptr.To(true),
 						NodePublicIPPrefixID: ptr.To("subscriptions/11111111-2222-aaaa-bbbb-cccccccccccc/resourceGroups/public-ip-test/providers/Microsoft.Network/publicipprefixes/public-ip-prefix"),
 					},
@@ -984,9 +984,9 @@ func TestAzureManagedMachinePool_ValidateCreate(t *testing.T) {
 		},
 		{
 			name: "pool with public ip prefix with leading slash with node public IP enabled ok",
-			ammp: &AzureManagedMachinePool{
-				Spec: AzureManagedMachinePoolSpec{
-					AzureManagedMachinePoolClassSpec: AzureManagedMachinePoolClassSpec{
+			ammp: &infrav1.AzureManagedMachinePool{
+				Spec: infrav1.AzureManagedMachinePoolSpec{
+					AzureManagedMachinePoolClassSpec: infrav1.AzureManagedMachinePoolClassSpec{
 						EnableNodePublicIP:   ptr.To(true),
 						NodePublicIPPrefixID: ptr.To("/subscriptions/11111111-2222-aaaa-bbbb-cccccccccccc/resourceGroups/public-ip-test/providers/Microsoft.Network/publicipprefixes/public-ip-prefix"),
 					},
@@ -996,9 +996,9 @@ func TestAzureManagedMachinePool_ValidateCreate(t *testing.T) {
 		},
 		{
 			name: "pool without public ip prefix with node public IP unset ok",
-			ammp: &AzureManagedMachinePool{
-				Spec: AzureManagedMachinePoolSpec{
-					AzureManagedMachinePoolClassSpec: AzureManagedMachinePoolClassSpec{
+			ammp: &infrav1.AzureManagedMachinePool{
+				Spec: infrav1.AzureManagedMachinePoolSpec{
+					AzureManagedMachinePoolClassSpec: infrav1.AzureManagedMachinePoolClassSpec{
 						EnableNodePublicIP: nil,
 					},
 				},
@@ -1007,9 +1007,9 @@ func TestAzureManagedMachinePool_ValidateCreate(t *testing.T) {
 		},
 		{
 			name: "pool without public ip prefix with node public IP enabled ok",
-			ammp: &AzureManagedMachinePool{
-				Spec: AzureManagedMachinePoolSpec{
-					AzureManagedMachinePoolClassSpec: AzureManagedMachinePoolClassSpec{
+			ammp: &infrav1.AzureManagedMachinePool{
+				Spec: infrav1.AzureManagedMachinePoolSpec{
+					AzureManagedMachinePoolClassSpec: infrav1.AzureManagedMachinePoolClassSpec{
 						EnableNodePublicIP: ptr.To(true),
 					},
 				},
@@ -1018,9 +1018,9 @@ func TestAzureManagedMachinePool_ValidateCreate(t *testing.T) {
 		},
 		{
 			name: "pool without public ip prefix with node public IP disabled ok",
-			ammp: &AzureManagedMachinePool{
-				Spec: AzureManagedMachinePoolSpec{
-					AzureManagedMachinePoolClassSpec: AzureManagedMachinePoolClassSpec{
+			ammp: &infrav1.AzureManagedMachinePool{
+				Spec: infrav1.AzureManagedMachinePoolSpec{
+					AzureManagedMachinePoolClassSpec: infrav1.AzureManagedMachinePoolClassSpec{
 						EnableNodePublicIP: ptr.To(false),
 					},
 				},
@@ -1029,10 +1029,10 @@ func TestAzureManagedMachinePool_ValidateCreate(t *testing.T) {
 		},
 		{
 			name: "KubeletConfig CPUCfsQuotaPeriod needs 'ms' suffix",
-			ammp: &AzureManagedMachinePool{
-				Spec: AzureManagedMachinePoolSpec{
-					AzureManagedMachinePoolClassSpec: AzureManagedMachinePoolClassSpec{
-						KubeletConfig: &KubeletConfig{
+			ammp: &infrav1.AzureManagedMachinePool{
+				Spec: infrav1.AzureManagedMachinePoolSpec{
+					AzureManagedMachinePoolClassSpec: infrav1.AzureManagedMachinePoolClassSpec{
+						KubeletConfig: &infrav1.KubeletConfig{
 							CPUCfsQuotaPeriod: ptr.To("100"),
 						},
 					},
@@ -1043,10 +1043,10 @@ func TestAzureManagedMachinePool_ValidateCreate(t *testing.T) {
 		},
 		{
 			name: "KubeletConfig CPUCfsQuotaPeriod has valid 'ms' suffix",
-			ammp: &AzureManagedMachinePool{
-				Spec: AzureManagedMachinePoolSpec{
-					AzureManagedMachinePoolClassSpec: AzureManagedMachinePoolClassSpec{
-						KubeletConfig: &KubeletConfig{
+			ammp: &infrav1.AzureManagedMachinePool{
+				Spec: infrav1.AzureManagedMachinePoolSpec{
+					AzureManagedMachinePoolClassSpec: infrav1.AzureManagedMachinePoolClassSpec{
+						KubeletConfig: &infrav1.KubeletConfig{
 							CPUCfsQuotaPeriod: ptr.To("100ms"),
 						},
 					},
@@ -1056,10 +1056,10 @@ func TestAzureManagedMachinePool_ValidateCreate(t *testing.T) {
 		},
 		{
 			name: "KubeletConfig ImageGcLowThreshold can't be more than ImageGcHighThreshold",
-			ammp: &AzureManagedMachinePool{
-				Spec: AzureManagedMachinePoolSpec{
-					AzureManagedMachinePoolClassSpec: AzureManagedMachinePoolClassSpec{
-						KubeletConfig: &KubeletConfig{
+			ammp: &infrav1.AzureManagedMachinePool{
+				Spec: infrav1.AzureManagedMachinePoolSpec{
+					AzureManagedMachinePoolClassSpec: infrav1.AzureManagedMachinePoolClassSpec{
+						KubeletConfig: &infrav1.KubeletConfig{
 							ImageGcLowThreshold:  ptr.To(100),
 							ImageGcHighThreshold: ptr.To(99),
 						},
@@ -1071,10 +1071,10 @@ func TestAzureManagedMachinePool_ValidateCreate(t *testing.T) {
 		},
 		{
 			name: "KubeletConfig ImageGcLowThreshold is lower than ImageGcHighThreshold",
-			ammp: &AzureManagedMachinePool{
-				Spec: AzureManagedMachinePoolSpec{
-					AzureManagedMachinePoolClassSpec: AzureManagedMachinePoolClassSpec{
-						KubeletConfig: &KubeletConfig{
+			ammp: &infrav1.AzureManagedMachinePool{
+				Spec: infrav1.AzureManagedMachinePoolSpec{
+					AzureManagedMachinePoolClassSpec: infrav1.AzureManagedMachinePoolClassSpec{
+						KubeletConfig: &infrav1.KubeletConfig{
 							ImageGcLowThreshold:  ptr.To(99),
 							ImageGcHighThreshold: ptr.To(100),
 						},
@@ -1085,10 +1085,10 @@ func TestAzureManagedMachinePool_ValidateCreate(t *testing.T) {
 		},
 		{
 			name: "valid KubeletConfig AllowedUnsafeSysctls values",
-			ammp: &AzureManagedMachinePool{
-				Spec: AzureManagedMachinePoolSpec{
-					AzureManagedMachinePoolClassSpec: AzureManagedMachinePoolClassSpec{
-						KubeletConfig: &KubeletConfig{
+			ammp: &infrav1.AzureManagedMachinePool{
+				Spec: infrav1.AzureManagedMachinePoolSpec{
+					AzureManagedMachinePoolClassSpec: infrav1.AzureManagedMachinePoolClassSpec{
+						KubeletConfig: &infrav1.KubeletConfig{
 							AllowedUnsafeSysctls: []string{
 								"kernel.shm*",
 								"kernel.msg*",
@@ -1104,10 +1104,10 @@ func TestAzureManagedMachinePool_ValidateCreate(t *testing.T) {
 		},
 		{
 			name: "more valid KubeletConfig AllowedUnsafeSysctls values",
-			ammp: &AzureManagedMachinePool{
-				Spec: AzureManagedMachinePoolSpec{
-					AzureManagedMachinePoolClassSpec: AzureManagedMachinePoolClassSpec{
-						KubeletConfig: &KubeletConfig{
+			ammp: &infrav1.AzureManagedMachinePool{
+				Spec: infrav1.AzureManagedMachinePoolSpec{
+					AzureManagedMachinePoolClassSpec: infrav1.AzureManagedMachinePoolClassSpec{
+						KubeletConfig: &infrav1.KubeletConfig{
 							AllowedUnsafeSysctls: []string{
 								"kernel.shm.something",
 								"kernel.msg.foo.bar",
@@ -1123,10 +1123,10 @@ func TestAzureManagedMachinePool_ValidateCreate(t *testing.T) {
 		},
 		{
 			name: "an invalid KubeletConfig AllowedUnsafeSysctls value in a set",
-			ammp: &AzureManagedMachinePool{
-				Spec: AzureManagedMachinePoolSpec{
-					AzureManagedMachinePoolClassSpec: AzureManagedMachinePoolClassSpec{
-						KubeletConfig: &KubeletConfig{
+			ammp: &infrav1.AzureManagedMachinePool{
+				Spec: infrav1.AzureManagedMachinePoolSpec{
+					AzureManagedMachinePoolClassSpec: infrav1.AzureManagedMachinePoolClassSpec{
+						KubeletConfig: &infrav1.KubeletConfig{
 							AllowedUnsafeSysctls: []string{
 								"kernel.shm.something",
 								"kernel.msg.foo.bar",
@@ -1144,11 +1144,11 @@ func TestAzureManagedMachinePool_ValidateCreate(t *testing.T) {
 		},
 		{
 			name: "validLinuxOSConfig Sysctls NetIpv4IpLocalPortRange.First is less than NetIpv4IpLocalPortRange.Last",
-			ammp: &AzureManagedMachinePool{
-				Spec: AzureManagedMachinePoolSpec{
-					AzureManagedMachinePoolClassSpec: AzureManagedMachinePoolClassSpec{
-						LinuxOSConfig: &LinuxOSConfig{
-							Sysctls: &SysctlConfig{
+			ammp: &infrav1.AzureManagedMachinePool{
+				Spec: infrav1.AzureManagedMachinePoolSpec{
+					AzureManagedMachinePoolClassSpec: infrav1.AzureManagedMachinePoolClassSpec{
+						LinuxOSConfig: &infrav1.LinuxOSConfig{
+							Sysctls: &infrav1.SysctlConfig{
 								NetIpv4IPLocalPortRange: ptr.To("2000 33000"),
 							},
 						},
@@ -1159,11 +1159,11 @@ func TestAzureManagedMachinePool_ValidateCreate(t *testing.T) {
 		},
 		{
 			name: "an invalid LinuxOSConfig Sysctls NetIpv4IpLocalPortRange.First string is ill-formed",
-			ammp: &AzureManagedMachinePool{
-				Spec: AzureManagedMachinePoolSpec{
-					AzureManagedMachinePoolClassSpec: AzureManagedMachinePoolClassSpec{
-						LinuxOSConfig: &LinuxOSConfig{
-							Sysctls: &SysctlConfig{
+			ammp: &infrav1.AzureManagedMachinePool{
+				Spec: infrav1.AzureManagedMachinePoolSpec{
+					AzureManagedMachinePoolClassSpec: infrav1.AzureManagedMachinePoolClassSpec{
+						LinuxOSConfig: &infrav1.LinuxOSConfig{
+							Sysctls: &infrav1.SysctlConfig{
 								NetIpv4IPLocalPortRange: ptr.To("wrong 33000"),
 							},
 						},
@@ -1175,11 +1175,11 @@ func TestAzureManagedMachinePool_ValidateCreate(t *testing.T) {
 		},
 		{
 			name: "an invalid LinuxOSConfig Sysctls NetIpv4IpLocalPortRange.Last string is ill-formed",
-			ammp: &AzureManagedMachinePool{
-				Spec: AzureManagedMachinePoolSpec{
-					AzureManagedMachinePoolClassSpec: AzureManagedMachinePoolClassSpec{
-						LinuxOSConfig: &LinuxOSConfig{
-							Sysctls: &SysctlConfig{
+			ammp: &infrav1.AzureManagedMachinePool{
+				Spec: infrav1.AzureManagedMachinePoolSpec{
+					AzureManagedMachinePoolClassSpec: infrav1.AzureManagedMachinePoolClassSpec{
+						LinuxOSConfig: &infrav1.LinuxOSConfig{
+							Sysctls: &infrav1.SysctlConfig{
 								NetIpv4IPLocalPortRange: ptr.To("2000 wrong"),
 							},
 						},
@@ -1191,11 +1191,11 @@ func TestAzureManagedMachinePool_ValidateCreate(t *testing.T) {
 		},
 		{
 			name: "an invalid LinuxOSConfig Sysctls NetIpv4IpLocalPortRange.First less than allowed value",
-			ammp: &AzureManagedMachinePool{
-				Spec: AzureManagedMachinePoolSpec{
-					AzureManagedMachinePoolClassSpec: AzureManagedMachinePoolClassSpec{
-						LinuxOSConfig: &LinuxOSConfig{
-							Sysctls: &SysctlConfig{
+			ammp: &infrav1.AzureManagedMachinePool{
+				Spec: infrav1.AzureManagedMachinePoolSpec{
+					AzureManagedMachinePoolClassSpec: infrav1.AzureManagedMachinePoolClassSpec{
+						LinuxOSConfig: &infrav1.LinuxOSConfig{
+							Sysctls: &infrav1.SysctlConfig{
 								NetIpv4IPLocalPortRange: ptr.To("1020 32999"),
 							},
 						},
@@ -1207,11 +1207,11 @@ func TestAzureManagedMachinePool_ValidateCreate(t *testing.T) {
 		},
 		{
 			name: "an invalid LinuxOSConfig Sysctls NetIpv4IpLocalPortRange.Last less than allowed value",
-			ammp: &AzureManagedMachinePool{
-				Spec: AzureManagedMachinePoolSpec{
-					AzureManagedMachinePoolClassSpec: AzureManagedMachinePoolClassSpec{
-						LinuxOSConfig: &LinuxOSConfig{
-							Sysctls: &SysctlConfig{
+			ammp: &infrav1.AzureManagedMachinePool{
+				Spec: infrav1.AzureManagedMachinePoolSpec{
+					AzureManagedMachinePoolClassSpec: infrav1.AzureManagedMachinePoolClassSpec{
+						LinuxOSConfig: &infrav1.LinuxOSConfig{
+							Sysctls: &infrav1.SysctlConfig{
 								NetIpv4IPLocalPortRange: ptr.To("1024 32000"),
 							},
 						},
@@ -1223,11 +1223,11 @@ func TestAzureManagedMachinePool_ValidateCreate(t *testing.T) {
 		},
 		{
 			name: "an invalid LinuxOSConfig Sysctls NetIpv4IpLocalPortRange.First is greater than NetIpv4IpLocalPortRange.Last",
-			ammp: &AzureManagedMachinePool{
-				Spec: AzureManagedMachinePoolSpec{
-					AzureManagedMachinePoolClassSpec: AzureManagedMachinePoolClassSpec{
-						LinuxOSConfig: &LinuxOSConfig{
-							Sysctls: &SysctlConfig{
+			ammp: &infrav1.AzureManagedMachinePool{
+				Spec: infrav1.AzureManagedMachinePoolSpec{
+					AzureManagedMachinePoolClassSpec: infrav1.AzureManagedMachinePoolClassSpec{
+						LinuxOSConfig: &infrav1.LinuxOSConfig{
+							Sysctls: &infrav1.SysctlConfig{
 								NetIpv4IPLocalPortRange: ptr.To("33000 32999"),
 							},
 						},
@@ -1239,13 +1239,13 @@ func TestAzureManagedMachinePool_ValidateCreate(t *testing.T) {
 		},
 		{
 			name: "valid LinuxOSConfig Sysctls is set by disabling FailSwapOn",
-			ammp: &AzureManagedMachinePool{
-				Spec: AzureManagedMachinePoolSpec{
-					AzureManagedMachinePoolClassSpec: AzureManagedMachinePoolClassSpec{
-						KubeletConfig: &KubeletConfig{
+			ammp: &infrav1.AzureManagedMachinePool{
+				Spec: infrav1.AzureManagedMachinePoolSpec{
+					AzureManagedMachinePoolClassSpec: infrav1.AzureManagedMachinePoolClassSpec{
+						KubeletConfig: &infrav1.KubeletConfig{
 							FailSwapOn: ptr.To(false),
 						},
-						LinuxOSConfig: &LinuxOSConfig{
+						LinuxOSConfig: &infrav1.LinuxOSConfig{
 							SwapFileSizeMB: ptr.To(1500),
 						},
 					},
@@ -1255,13 +1255,13 @@ func TestAzureManagedMachinePool_ValidateCreate(t *testing.T) {
 		},
 		{
 			name: "an invalid LinuxOSConfig Sysctls is set with FailSwapOn set to true",
-			ammp: &AzureManagedMachinePool{
-				Spec: AzureManagedMachinePoolSpec{
-					AzureManagedMachinePoolClassSpec: AzureManagedMachinePoolClassSpec{
-						KubeletConfig: &KubeletConfig{
+			ammp: &infrav1.AzureManagedMachinePool{
+				Spec: infrav1.AzureManagedMachinePoolSpec{
+					AzureManagedMachinePoolClassSpec: infrav1.AzureManagedMachinePoolClassSpec{
+						KubeletConfig: &infrav1.KubeletConfig{
 							FailSwapOn: ptr.To(true),
 						},
-						LinuxOSConfig: &LinuxOSConfig{
+						LinuxOSConfig: &infrav1.LinuxOSConfig{
 							SwapFileSizeMB: ptr.To(1500),
 						},
 					},
@@ -1272,10 +1272,10 @@ func TestAzureManagedMachinePool_ValidateCreate(t *testing.T) {
 		},
 		{
 			name: "an invalid LinuxOSConfig Sysctls is set without disabling FailSwapOn",
-			ammp: &AzureManagedMachinePool{
-				Spec: AzureManagedMachinePoolSpec{
-					AzureManagedMachinePoolClassSpec: AzureManagedMachinePoolClassSpec{
-						LinuxOSConfig: &LinuxOSConfig{
+			ammp: &infrav1.AzureManagedMachinePool{
+				Spec: infrav1.AzureManagedMachinePoolSpec{
+					AzureManagedMachinePoolClassSpec: infrav1.AzureManagedMachinePoolClassSpec{
+						LinuxOSConfig: &infrav1.LinuxOSConfig{
 							SwapFileSizeMB: ptr.To(1500),
 						},
 					},
@@ -1307,7 +1307,7 @@ func TestAzureManagedMachinePool_ValidateCreate(t *testing.T) {
 func TestAzureManagedMachinePool_ValidateCreateFailure(t *testing.T) {
 	tests := []struct {
 		name               string
-		ammp               *AzureManagedMachinePool
+		ammp               *infrav1.AzureManagedMachinePool
 		featureGateEnabled *bool
 		expectError        bool
 	}{
@@ -1341,7 +1341,7 @@ func TestAzureManagedMachinePool_validateLastSystemNodePool(t *testing.T) {
 	systemMachinePool := getManagedMachinePoolWithSystemMode()
 	systemMachinePoolWithDeletionAnnotation := getAzureManagedMachinePoolWithChanges(
 		// Add the DeleteForMoveAnnotation annotation to the AMMP
-		func(azureManagedMachinePool *AzureManagedMachinePool) {
+		func(azureManagedMachinePool *infrav1.AzureManagedMachinePool) {
 			azureManagedMachinePool.Annotations = map[string]string{
 				clusterctlv1alpha3.DeleteForMoveAnnotation: "true",
 			}
@@ -1349,7 +1349,7 @@ func TestAzureManagedMachinePool_validateLastSystemNodePool(t *testing.T) {
 	)
 	tests := []struct {
 		name    string
-		ammp    *AzureManagedMachinePool
+		ammp    *infrav1.AzureManagedMachinePool
 		cluster *clusterv1.Cluster
 		wantErr bool
 	}{
@@ -1411,7 +1411,7 @@ func TestAzureManagedMachinePool_validateLastSystemNodePool(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			g := NewWithT(t)
 			scheme := runtime.NewScheme()
-			_ = AddToScheme(scheme)
+			_ = infrav1.AddToScheme(scheme)
 			_ = clusterv1.AddToScheme(scheme)
 			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(tc.cluster, tc.ammp).Build()
 			err := validateLastSystemNodePool(fakeClient, tc.ammp.Spec.NodeLabels, tc.ammp.Namespace, tc.ammp.Annotations)
@@ -1424,10 +1424,10 @@ func TestAzureManagedMachinePool_validateLastSystemNodePool(t *testing.T) {
 	}
 }
 
-func getKnownValidAzureManagedMachinePool() *AzureManagedMachinePool {
-	return &AzureManagedMachinePool{
-		Spec: AzureManagedMachinePoolSpec{
-			AzureManagedMachinePoolClassSpec: AzureManagedMachinePoolClassSpec{
+func getKnownValidAzureManagedMachinePool() *infrav1.AzureManagedMachinePool {
+	return &infrav1.AzureManagedMachinePool{
+		Spec: infrav1.AzureManagedMachinePoolSpec{
+			AzureManagedMachinePoolClassSpec: infrav1.AzureManagedMachinePoolClassSpec{
 				MaxPods:    ptr.To(30),
 				OsDiskType: ptr.To(string(asocontainerservicev1.OSDiskType_Ephemeral)),
 			},
@@ -1435,17 +1435,17 @@ func getKnownValidAzureManagedMachinePool() *AzureManagedMachinePool {
 	}
 }
 
-func getManagedMachinePoolWithSystemMode() *AzureManagedMachinePool {
-	return &AzureManagedMachinePool{
+func getManagedMachinePoolWithSystemMode() *infrav1.AzureManagedMachinePool {
+	return &infrav1.AzureManagedMachinePool{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: metav1.NamespaceDefault,
 			Labels: map[string]string{
 				clusterv1.ClusterNameLabel: "test-cluster",
-				LabelAgentPoolMode:         string(NodePoolModeSystem),
+				infrav1.LabelAgentPoolMode: string(infrav1.NodePoolModeSystem),
 			},
 		},
-		Spec: AzureManagedMachinePoolSpec{
-			AzureManagedMachinePoolClassSpec: AzureManagedMachinePoolClassSpec{
+		Spec: infrav1.AzureManagedMachinePoolSpec{
+			AzureManagedMachinePoolClassSpec: infrav1.AzureManagedMachinePoolClassSpec{
 				NodeLabels: map[string]string{
 					clusterv1.ClusterNameLabel: "test-cluster",
 				},
@@ -1454,7 +1454,7 @@ func getManagedMachinePoolWithSystemMode() *AzureManagedMachinePool {
 	}
 }
 
-func getAzureManagedMachinePoolWithChanges(changes ...func(*AzureManagedMachinePool)) *AzureManagedMachinePool {
+func getAzureManagedMachinePoolWithChanges(changes ...func(*infrav1.AzureManagedMachinePool)) *infrav1.AzureManagedMachinePool {
 	ammp := getManagedMachinePoolWithSystemMode().DeepCopy()
 	for _, change := range changes {
 		change(ammp)

--- a/internal/webhooks/azuremanagedmachinepooltemplate_webhook.go
+++ b/internal/webhooks/azuremanagedmachinepooltemplate_webhook.go
@@ -29,7 +29,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
-	. "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
+	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	apiinternal "sigs.k8s.io/cluster-api-provider-azure/internal/api/v1beta1"
 	webhookutils "sigs.k8s.io/cluster-api-provider-azure/util/webhook"
 )
@@ -39,7 +39,7 @@ func (mpw *AzureManagedMachinePoolTemplateWebhook) SetupWebhookWithManager(mgr c
 	mpw.client = mgr.GetClient()
 
 	return ctrl.NewWebhookManagedBy(mgr).
-		For(&AzureManagedMachinePoolTemplate{}).
+		For(&infrav1.AzureManagedMachinePoolTemplate{}).
 		WithDefaulter(mpw).
 		WithValidator(mpw).
 		Complete()
@@ -54,20 +54,20 @@ type AzureManagedMachinePoolTemplateWebhook struct {
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type.
 func (mpw *AzureManagedMachinePoolTemplateWebhook) Default(_ context.Context, obj runtime.Object) error {
-	mp, ok := obj.(*AzureManagedMachinePoolTemplate)
+	mp, ok := obj.(*infrav1.AzureManagedMachinePoolTemplate)
 	if !ok {
 		return apierrors.NewBadRequest("expected an AzureManagedMachinePoolTemplate")
 	}
 	if mp.Labels == nil {
 		mp.Labels = make(map[string]string)
 	}
-	mp.Labels[LabelAgentPoolMode] = mp.Spec.Template.Spec.Mode
+	mp.Labels[infrav1.LabelAgentPoolMode] = mp.Spec.Template.Spec.Mode
 
 	if mp.Spec.Template.Spec.Name == nil || *mp.Spec.Template.Spec.Name == "" {
 		mp.Spec.Template.Spec.Name = &mp.Name
 	}
 
-	apiinternal.SetZeroPointerDefault[*string](&mp.Spec.Template.Spec.OSType, ptr.To(DefaultOSType))
+	apiinternal.SetZeroPointerDefault[*string](&mp.Spec.Template.Spec.OSType, ptr.To(infrav1.DefaultOSType))
 
 	return nil
 }
@@ -76,7 +76,7 @@ func (mpw *AzureManagedMachinePoolTemplateWebhook) Default(_ context.Context, ob
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
 func (mpw *AzureManagedMachinePoolTemplateWebhook) ValidateCreate(_ context.Context, obj runtime.Object) (admission.Warnings, error) {
-	mp, ok := obj.(*AzureManagedMachinePoolTemplate)
+	mp, ok := obj.(*infrav1.AzureManagedMachinePoolTemplate)
 	if !ok {
 		return nil, apierrors.NewBadRequest("expected an AzureManagedMachinePoolTemplate")
 	}
@@ -126,11 +126,11 @@ func (mpw *AzureManagedMachinePoolTemplateWebhook) ValidateCreate(_ context.Cont
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
 func (mpw *AzureManagedMachinePoolTemplateWebhook) ValidateUpdate(_ context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
 	var allErrs field.ErrorList
-	old, ok := oldObj.(*AzureManagedMachinePoolTemplate)
+	old, ok := oldObj.(*infrav1.AzureManagedMachinePoolTemplate)
 	if !ok {
 		return nil, apierrors.NewBadRequest("expected an AzureManagedMachinePoolTemplate")
 	}
-	mp, ok := newObj.(*AzureManagedMachinePoolTemplate)
+	mp, ok := newObj.(*infrav1.AzureManagedMachinePoolTemplate)
 	if !ok {
 		return nil, apierrors.NewBadRequest("expected an AzureManagedMachinePoolTemplate")
 	}
@@ -193,7 +193,7 @@ func (mpw *AzureManagedMachinePoolTemplateWebhook) ValidateUpdate(_ context.Cont
 				"field is immutable"))
 	}
 
-	if mp.Spec.Template.Spec.Mode != string(NodePoolModeSystem) && old.Spec.Template.Spec.Mode == string(NodePoolModeSystem) {
+	if mp.Spec.Template.Spec.Mode != string(infrav1.NodePoolModeSystem) && old.Spec.Template.Spec.Mode == string(infrav1.NodePoolModeSystem) {
 		// validate for last system node pool
 		if err := validateLastSystemNodePool(mpw.client, mp.Spec.Template.Spec.NodeLabels, mp.Namespace, mp.Annotations); err != nil {
 			allErrs = append(allErrs, field.Forbidden(
@@ -266,16 +266,16 @@ func (mpw *AzureManagedMachinePoolTemplateWebhook) ValidateUpdate(_ context.Cont
 	if len(allErrs) == 0 {
 		return nil, nil
 	}
-	return nil, apierrors.NewInvalid(GroupVersion.WithKind(AzureManagedMachinePoolTemplateKind).GroupKind(), mp.Name, allErrs)
+	return nil, apierrors.NewInvalid(infrav1.GroupVersion.WithKind(infrav1.AzureManagedMachinePoolTemplateKind).GroupKind(), mp.Name, allErrs)
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type.
 func (mpw *AzureManagedMachinePoolTemplateWebhook) ValidateDelete(_ context.Context, obj runtime.Object) (admission.Warnings, error) {
-	mp, ok := obj.(*AzureManagedMachinePoolTemplate)
+	mp, ok := obj.(*infrav1.AzureManagedMachinePoolTemplate)
 	if !ok {
 		return nil, apierrors.NewBadRequest("expected an AzureManagedMachinePoolTemplate")
 	}
-	if mp.Spec.Template.Spec.Mode != string(NodePoolModeSystem) {
+	if mp.Spec.Template.Spec.Mode != string(infrav1.NodePoolModeSystem) {
 		return nil, nil
 	}
 

--- a/internal/webhooks/azuremanagedmachinepooltemplate_webhook_test.go
+++ b/internal/webhooks/azuremanagedmachinepooltemplate_webhook_test.go
@@ -23,7 +23,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 
-	. "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
+	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	azureutil "sigs.k8s.io/cluster-api-provider-azure/util/azure"
 )
 
@@ -36,13 +36,13 @@ func TestManagedMachinePoolTemplateDefaultingWebhook(t *testing.T) {
 	err := mmptw.Default(t.Context(), ammpt)
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(ammpt.Labels).To(Equal(map[string]string{
-		LabelAgentPoolMode: "System",
+		infrav1.LabelAgentPoolMode: "System",
 	}))
 	g.Expect(ammpt.Spec.Template.Spec.Name).To(Equal(ptr.To("fooName")))
 	g.Expect(ammpt.Spec.Template.Spec.OSType).To(Equal(ptr.To("Linux")))
 
 	t.Logf("Testing ammpt defaulting webhook with baseline")
-	ammpt = getAzureManagedMachinePoolTemplate(func(ammpt *AzureManagedMachinePoolTemplate) {
+	ammpt = getAzureManagedMachinePoolTemplate(func(ammpt *infrav1.AzureManagedMachinePoolTemplate) {
 		ammpt.Spec.Template.Spec.Mode = "User"
 		ammpt.Spec.Template.Spec.Name = ptr.To("barName")
 		ammpt.Spec.Template.Spec.OSType = ptr.To("Windows")
@@ -50,7 +50,7 @@ func TestManagedMachinePoolTemplateDefaultingWebhook(t *testing.T) {
 	err = mmptw.Default(t.Context(), ammpt)
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(ammpt.Labels).To(Equal(map[string]string{
-		LabelAgentPoolMode: "User",
+		infrav1.LabelAgentPoolMode: "User",
 	}))
 	g.Expect(ammpt.Spec.Template.Spec.Name).To(Equal(ptr.To("barName")))
 	g.Expect(ammpt.Spec.Template.Spec.OSType).To(Equal(ptr.To("Windows")))
@@ -59,8 +59,8 @@ func TestManagedMachinePoolTemplateDefaultingWebhook(t *testing.T) {
 func TestManagedMachinePoolTemplateUpdateWebhook(t *testing.T) {
 	tests := []struct {
 		name                   string
-		oldMachinePoolTemplate *AzureManagedMachinePoolTemplate
-		machinePoolTemplate    *AzureManagedMachinePoolTemplate
+		oldMachinePoolTemplate *infrav1.AzureManagedMachinePoolTemplate
+		machinePoolTemplate    *infrav1.AzureManagedMachinePoolTemplate
 		wantErr                bool
 	}{
 		{
@@ -72,7 +72,7 @@ func TestManagedMachinePoolTemplateUpdateWebhook(t *testing.T) {
 		{
 			name:                   "azuremanagedmachinepooltemplate name is immutable",
 			oldMachinePoolTemplate: getAzureManagedMachinePoolTemplate(),
-			machinePoolTemplate: getAzureManagedMachinePoolTemplate(func(ammpt *AzureManagedMachinePoolTemplate) {
+			machinePoolTemplate: getAzureManagedMachinePoolTemplate(func(ammpt *infrav1.AzureManagedMachinePoolTemplate) {
 				ammpt.Spec.Template.Spec.Name = ptr.To("barName")
 			}),
 			wantErr: true,
@@ -80,7 +80,7 @@ func TestManagedMachinePoolTemplateUpdateWebhook(t *testing.T) {
 		{
 			name:                   "azuremanagedmachinepooltemplate invalid nodeLabel",
 			oldMachinePoolTemplate: getAzureManagedMachinePoolTemplate(),
-			machinePoolTemplate: getAzureManagedMachinePoolTemplate(func(ammpt *AzureManagedMachinePoolTemplate) {
+			machinePoolTemplate: getAzureManagedMachinePoolTemplate(func(ammpt *infrav1.AzureManagedMachinePoolTemplate) {
 				ammpt.Spec.Template.Spec.NodeLabels = map[string]string{
 					azureutil.AzureSystemNodeLabelPrefix: "foo",
 				}
@@ -89,121 +89,121 @@ func TestManagedMachinePoolTemplateUpdateWebhook(t *testing.T) {
 		},
 		{
 			name: "azuremanagedmachinepooltemplate osType is immutable",
-			oldMachinePoolTemplate: getAzureManagedMachinePoolTemplate(func(ammpt *AzureManagedMachinePoolTemplate) {
+			oldMachinePoolTemplate: getAzureManagedMachinePoolTemplate(func(ammpt *infrav1.AzureManagedMachinePoolTemplate) {
 				ammpt.Spec.Template.Spec.OSType = ptr.To("Windows")
 			}),
-			machinePoolTemplate: getAzureManagedMachinePoolTemplate(func(ammpt *AzureManagedMachinePoolTemplate) {
+			machinePoolTemplate: getAzureManagedMachinePoolTemplate(func(ammpt *infrav1.AzureManagedMachinePoolTemplate) {
 				ammpt.Spec.Template.Spec.OSType = ptr.To("Linux")
 			}),
 			wantErr: true,
 		},
 		{
 			name: "azuremanagedmachinepooltemplate SKU is immutable",
-			oldMachinePoolTemplate: getAzureManagedMachinePoolTemplate(func(ammpt *AzureManagedMachinePoolTemplate) {
+			oldMachinePoolTemplate: getAzureManagedMachinePoolTemplate(func(ammpt *infrav1.AzureManagedMachinePoolTemplate) {
 				ammpt.Spec.Template.Spec.SKU = "Standard_D2s_v3"
 			}),
-			machinePoolTemplate: getAzureManagedMachinePoolTemplate(func(ammpt *AzureManagedMachinePoolTemplate) {
+			machinePoolTemplate: getAzureManagedMachinePoolTemplate(func(ammpt *infrav1.AzureManagedMachinePoolTemplate) {
 				ammpt.Spec.Template.Spec.SKU = "Standard_D4s_v3"
 			}),
 			wantErr: true,
 		},
 		{
 			name: "azuremanagedmachinepooltemplate OSDiskSizeGB is immutable",
-			oldMachinePoolTemplate: getAzureManagedMachinePoolTemplate(func(ammpt *AzureManagedMachinePoolTemplate) {
+			oldMachinePoolTemplate: getAzureManagedMachinePoolTemplate(func(ammpt *infrav1.AzureManagedMachinePoolTemplate) {
 				ammpt.Spec.Template.Spec.OSDiskSizeGB = ptr.To(128)
 			}),
-			machinePoolTemplate: getAzureManagedMachinePoolTemplate(func(ammpt *AzureManagedMachinePoolTemplate) {
+			machinePoolTemplate: getAzureManagedMachinePoolTemplate(func(ammpt *infrav1.AzureManagedMachinePoolTemplate) {
 				ammpt.Spec.Template.Spec.OSDiskSizeGB = ptr.To(256)
 			}),
 			wantErr: true,
 		},
 		{
 			name: "azuremanagedmachinepooltemplate SubnetName is immutable",
-			oldMachinePoolTemplate: getAzureManagedMachinePoolTemplate(func(ammpt *AzureManagedMachinePoolTemplate) {
+			oldMachinePoolTemplate: getAzureManagedMachinePoolTemplate(func(ammpt *infrav1.AzureManagedMachinePoolTemplate) {
 				ammpt.Spec.Template.Spec.SubnetName = ptr.To("fooSubnet")
 			}),
-			machinePoolTemplate: getAzureManagedMachinePoolTemplate(func(ammpt *AzureManagedMachinePoolTemplate) {
+			machinePoolTemplate: getAzureManagedMachinePoolTemplate(func(ammpt *infrav1.AzureManagedMachinePoolTemplate) {
 				ammpt.Spec.Template.Spec.SubnetName = ptr.To("barSubnet")
 			}),
 			wantErr: true,
 		},
 		{
 			name: "azuremanagedmachinepooltemplate enableFIPS is immutable",
-			oldMachinePoolTemplate: getAzureManagedMachinePoolTemplate(func(ammpt *AzureManagedMachinePoolTemplate) {
+			oldMachinePoolTemplate: getAzureManagedMachinePoolTemplate(func(ammpt *infrav1.AzureManagedMachinePoolTemplate) {
 				ammpt.Spec.Template.Spec.EnableFIPS = ptr.To(true)
 			}),
-			machinePoolTemplate: getAzureManagedMachinePoolTemplate(func(ammpt *AzureManagedMachinePoolTemplate) {
+			machinePoolTemplate: getAzureManagedMachinePoolTemplate(func(ammpt *infrav1.AzureManagedMachinePoolTemplate) {
 				ammpt.Spec.Template.Spec.EnableFIPS = ptr.To(false)
 			}),
 			wantErr: true,
 		},
 		{
 			name: "azuremanagedmachinepooltemplate MaxPods is immutable",
-			oldMachinePoolTemplate: getAzureManagedMachinePoolTemplate(func(ammpt *AzureManagedMachinePoolTemplate) {
+			oldMachinePoolTemplate: getAzureManagedMachinePoolTemplate(func(ammpt *infrav1.AzureManagedMachinePoolTemplate) {
 				ammpt.Spec.Template.Spec.MaxPods = ptr.To(128)
 			}),
-			machinePoolTemplate: getAzureManagedMachinePoolTemplate(func(ammpt *AzureManagedMachinePoolTemplate) {
+			machinePoolTemplate: getAzureManagedMachinePoolTemplate(func(ammpt *infrav1.AzureManagedMachinePoolTemplate) {
 				ammpt.Spec.Template.Spec.MaxPods = ptr.To(256)
 			}),
 			wantErr: true,
 		},
 		{
 			name: "azuremanagedmachinepooltemplate OSDiskType is immutable",
-			oldMachinePoolTemplate: getAzureManagedMachinePoolTemplate(func(ammpt *AzureManagedMachinePoolTemplate) {
+			oldMachinePoolTemplate: getAzureManagedMachinePoolTemplate(func(ammpt *infrav1.AzureManagedMachinePoolTemplate) {
 				ammpt.Spec.Template.Spec.OsDiskType = ptr.To("Standard_LRS")
 			}),
-			machinePoolTemplate: getAzureManagedMachinePoolTemplate(func(ammpt *AzureManagedMachinePoolTemplate) {
+			machinePoolTemplate: getAzureManagedMachinePoolTemplate(func(ammpt *infrav1.AzureManagedMachinePoolTemplate) {
 				ammpt.Spec.Template.Spec.OsDiskType = ptr.To("Premium_LRS")
 			}),
 			wantErr: true,
 		},
 		{
 			name: "azuremanagedmachinepooltemplate scaleSetPriority is immutable",
-			oldMachinePoolTemplate: getAzureManagedMachinePoolTemplate(func(ammpt *AzureManagedMachinePoolTemplate) {
+			oldMachinePoolTemplate: getAzureManagedMachinePoolTemplate(func(ammpt *infrav1.AzureManagedMachinePoolTemplate) {
 				ammpt.Spec.Template.Spec.ScaleSetPriority = ptr.To("Regular")
 			}),
-			machinePoolTemplate: getAzureManagedMachinePoolTemplate(func(ammpt *AzureManagedMachinePoolTemplate) {
+			machinePoolTemplate: getAzureManagedMachinePoolTemplate(func(ammpt *infrav1.AzureManagedMachinePoolTemplate) {
 				ammpt.Spec.Template.Spec.ScaleSetPriority = ptr.To("Spot")
 			}),
 			wantErr: true,
 		},
 		{
 			name: "azuremanagedmachinepooltemplate enableUltraSSD is immutable",
-			oldMachinePoolTemplate: getAzureManagedMachinePoolTemplate(func(ammpt *AzureManagedMachinePoolTemplate) {
+			oldMachinePoolTemplate: getAzureManagedMachinePoolTemplate(func(ammpt *infrav1.AzureManagedMachinePoolTemplate) {
 				ammpt.Spec.Template.Spec.EnableUltraSSD = ptr.To(true)
 			}),
-			machinePoolTemplate: getAzureManagedMachinePoolTemplate(func(ammpt *AzureManagedMachinePoolTemplate) {
+			machinePoolTemplate: getAzureManagedMachinePoolTemplate(func(ammpt *infrav1.AzureManagedMachinePoolTemplate) {
 				ammpt.Spec.Template.Spec.EnableUltraSSD = ptr.To(false)
 			}),
 			wantErr: true,
 		},
 		{
 			name: "azuremanagedmachinepooltemplate enableNodePublicIP is immutable",
-			oldMachinePoolTemplate: getAzureManagedMachinePoolTemplate(func(ammpt *AzureManagedMachinePoolTemplate) {
+			oldMachinePoolTemplate: getAzureManagedMachinePoolTemplate(func(ammpt *infrav1.AzureManagedMachinePoolTemplate) {
 				ammpt.Spec.Template.Spec.EnableNodePublicIP = ptr.To(true)
 			}),
-			machinePoolTemplate: getAzureManagedMachinePoolTemplate(func(ammpt *AzureManagedMachinePoolTemplate) {
+			machinePoolTemplate: getAzureManagedMachinePoolTemplate(func(ammpt *infrav1.AzureManagedMachinePoolTemplate) {
 				ammpt.Spec.Template.Spec.EnableNodePublicIP = ptr.To(false)
 			}),
 			wantErr: true,
 		},
 		{
 			name: "azuremanagedmachinepooltemplate nodePublicIPPrefixID is immutable",
-			oldMachinePoolTemplate: getAzureManagedMachinePoolTemplate(func(ammpt *AzureManagedMachinePoolTemplate) {
+			oldMachinePoolTemplate: getAzureManagedMachinePoolTemplate(func(ammpt *infrav1.AzureManagedMachinePoolTemplate) {
 				ammpt.Spec.Template.Spec.NodePublicIPPrefixID = ptr.To("fooPublicIPPrefixID")
 			}),
-			machinePoolTemplate: getAzureManagedMachinePoolTemplate(func(ammpt *AzureManagedMachinePoolTemplate) {
+			machinePoolTemplate: getAzureManagedMachinePoolTemplate(func(ammpt *infrav1.AzureManagedMachinePoolTemplate) {
 				ammpt.Spec.Template.Spec.NodePublicIPPrefixID = ptr.To("barPublicIPPrefixID")
 			}),
 			wantErr: true,
 		},
 		{
 			name: "azuremanagedmachinepooltemplate kubeletConfig is immutable",
-			oldMachinePoolTemplate: getAzureManagedMachinePoolTemplate(func(ammpt *AzureManagedMachinePoolTemplate) {
-				ammpt.Spec.Template.Spec.KubeletConfig = &KubeletConfig{}
+			oldMachinePoolTemplate: getAzureManagedMachinePoolTemplate(func(ammpt *infrav1.AzureManagedMachinePoolTemplate) {
+				ammpt.Spec.Template.Spec.KubeletConfig = &infrav1.KubeletConfig{}
 			}),
-			machinePoolTemplate: getAzureManagedMachinePoolTemplate(func(ammpt *AzureManagedMachinePoolTemplate) {
-				ammpt.Spec.Template.Spec.KubeletConfig = &KubeletConfig{
+			machinePoolTemplate: getAzureManagedMachinePoolTemplate(func(ammpt *infrav1.AzureManagedMachinePoolTemplate) {
+				ammpt.Spec.Template.Spec.KubeletConfig = &infrav1.KubeletConfig{
 					FailSwapOn: ptr.To(true),
 				}
 			}),
@@ -211,21 +211,21 @@ func TestManagedMachinePoolTemplateUpdateWebhook(t *testing.T) {
 		},
 		{
 			name: "azuremanagedmachinepooltemplate kubeletDiskType is immutable",
-			oldMachinePoolTemplate: getAzureManagedMachinePoolTemplate(func(ammpt *AzureManagedMachinePoolTemplate) {
-				ammpt.Spec.Template.Spec.KubeletDiskType = ptr.To(KubeletDiskTypeOS)
+			oldMachinePoolTemplate: getAzureManagedMachinePoolTemplate(func(ammpt *infrav1.AzureManagedMachinePoolTemplate) {
+				ammpt.Spec.Template.Spec.KubeletDiskType = ptr.To(infrav1.KubeletDiskTypeOS)
 			}),
-			machinePoolTemplate: getAzureManagedMachinePoolTemplate(func(ammpt *AzureManagedMachinePoolTemplate) {
-				ammpt.Spec.Template.Spec.KubeletDiskType = ptr.To(KubeletDiskTypeTemporary)
+			machinePoolTemplate: getAzureManagedMachinePoolTemplate(func(ammpt *infrav1.AzureManagedMachinePoolTemplate) {
+				ammpt.Spec.Template.Spec.KubeletDiskType = ptr.To(infrav1.KubeletDiskTypeTemporary)
 			}),
 			wantErr: true,
 		},
 		{
 			name: "azuremanagedmachinepooltemplate linuxOSConfig is immutable",
-			oldMachinePoolTemplate: getAzureManagedMachinePoolTemplate(func(ammpt *AzureManagedMachinePoolTemplate) {
-				ammpt.Spec.Template.Spec.LinuxOSConfig = &LinuxOSConfig{}
+			oldMachinePoolTemplate: getAzureManagedMachinePoolTemplate(func(ammpt *infrav1.AzureManagedMachinePoolTemplate) {
+				ammpt.Spec.Template.Spec.LinuxOSConfig = &infrav1.LinuxOSConfig{}
 			}),
-			machinePoolTemplate: getAzureManagedMachinePoolTemplate(func(ammpt *AzureManagedMachinePoolTemplate) {
-				ammpt.Spec.Template.Spec.LinuxOSConfig = &LinuxOSConfig{
+			machinePoolTemplate: getAzureManagedMachinePoolTemplate(func(ammpt *infrav1.AzureManagedMachinePoolTemplate) {
+				ammpt.Spec.Template.Spec.LinuxOSConfig = &infrav1.LinuxOSConfig{
 					SwapFileSizeMB: ptr.To(128),
 				}
 			}),
@@ -246,15 +246,15 @@ func TestManagedMachinePoolTemplateUpdateWebhook(t *testing.T) {
 	}
 }
 
-func getAzureManagedMachinePoolTemplate(changes ...func(*AzureManagedMachinePoolTemplate)) *AzureManagedMachinePoolTemplate {
-	input := &AzureManagedMachinePoolTemplate{
+func getAzureManagedMachinePoolTemplate(changes ...func(*infrav1.AzureManagedMachinePoolTemplate)) *infrav1.AzureManagedMachinePoolTemplate {
+	input := &infrav1.AzureManagedMachinePoolTemplate{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "fooName",
 		},
-		Spec: AzureManagedMachinePoolTemplateSpec{
-			Template: AzureManagedMachinePoolTemplateResource{
-				Spec: AzureManagedMachinePoolTemplateResourceSpec{
-					AzureManagedMachinePoolClassSpec: AzureManagedMachinePoolClassSpec{
+		Spec: infrav1.AzureManagedMachinePoolTemplateSpec{
+			Template: infrav1.AzureManagedMachinePoolTemplateResource{
+				Spec: infrav1.AzureManagedMachinePoolTemplateResourceSpec{
+					AzureManagedMachinePoolClassSpec: infrav1.AzureManagedMachinePoolClassSpec{
 						Mode: "System",
 					},
 				},


### PR DESCRIPTION
This is an extension to https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/6141

That PR makes extensive use of dot imports in files moved out of the api
package in order to keep the diff under control for review. This PR is a simple
mechanical change which replaces the dot imports with a more appropriate and
idiomatic use of `infrav1`. I have kept it separate because it introduces an
additional 8klocs of diff.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```