### PR TITLE
Add curl fallback when az command fails

### DIFF
--- a/templates/test/dev/cluster-template-custom-builds-dra.yaml
+++ b/templates/test/dev/cluster-template-custom-builds-dra.yaml
@@ -120,10 +120,20 @@ spec:
         declare -a CONTAINERS_TO_TEST=("kube-apiserver" "kube-controller-manager" "kube-proxy" "kube-scheduler")
         CONTAINER_EXT="tar"
         echo "* testing version $${CI_VERSION}"
-        az login --identity
+        USE_AZ="false"
+        if az login --identity > /dev/null 2>&1; then
+          echo "Logged in Azure with managed identity"
+          USE_AZ="true"
+        else
+          echo "az CLI not available, falling back to curl for binary downloads"
+        fi
         for CI_PACKAGE in "$${PACKAGES_TO_TEST[@]}"; do
             echo "* downloading binary: https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${CI_PACKAGE}"
-            az storage blob download --blob-url "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${CI_PACKAGE}" -f "$${CI_DIR}/$${CI_PACKAGE}" --auth-mode login
+            if [[ "$${USE_AZ}" == "true" ]]; then
+              az storage blob download --blob-url "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${CI_PACKAGE}" -f "$${CI_DIR}/$${CI_PACKAGE}" --auth-mode login
+            else
+              curl --fail -L --retry 10 --retry-delay 5 "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${CI_PACKAGE}" -o "$${CI_DIR}/$${CI_PACKAGE}"
+            fi
             chmod +x "$${CI_DIR}/$${CI_PACKAGE}"
             mv "$${CI_DIR}/$${CI_PACKAGE}" "/usr/bin/$${CI_PACKAGE}"
         done

--- a/templates/test/dev/cluster-template-custom-builds-load-dra.yaml
+++ b/templates/test/dev/cluster-template-custom-builds-load-dra.yaml
@@ -401,10 +401,20 @@ spec:
           declare -a CONTAINERS_TO_TEST=("kube-apiserver" "kube-controller-manager" "kube-proxy" "kube-scheduler")
           CONTAINER_EXT="tar"
           echo "* testing version $${CI_VERSION}"
-          az login --identity
+          USE_AZ="false"
+          if az login --identity > /dev/null 2>&1; then
+            echo "Logged in Azure with managed identity"
+            USE_AZ="true"
+          else
+            echo "az CLI not available, falling back to curl for binary downloads"
+          fi
           for CI_PACKAGE in "$${PACKAGES_TO_TEST[@]}"; do
               echo "* downloading binary: https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${CI_PACKAGE}"
-              az storage blob download --blob-url "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${CI_PACKAGE}" -f "$${CI_DIR}/$${CI_PACKAGE}" --auth-mode login
+              if [[ "$${USE_AZ}" == "true" ]]; then
+                az storage blob download --blob-url "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${CI_PACKAGE}" -f "$${CI_DIR}/$${CI_PACKAGE}" --auth-mode login
+              else
+                curl --fail -L --retry 10 --retry-delay 5 "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${CI_PACKAGE}" -o "$${CI_DIR}/$${CI_PACKAGE}"
+              fi
               chmod +x "$${CI_DIR}/$${CI_PACKAGE}"
               mv "$${CI_DIR}/$${CI_PACKAGE}" "/usr/bin/$${CI_PACKAGE}"
           done
@@ -1001,10 +1011,20 @@ spec:
           declare -a CONTAINERS_TO_TEST=("kube-apiserver" "kube-controller-manager" "kube-proxy" "kube-scheduler")
           CONTAINER_EXT="tar"
           echo "* testing version $${CI_VERSION}"
-          az login --identity
+          USE_AZ="false"
+          if az login --identity > /dev/null 2>&1; then
+            echo "Logged in Azure with managed identity"
+            USE_AZ="true"
+          else
+            echo "az CLI not available, falling back to curl for binary downloads"
+          fi
           for CI_PACKAGE in "$${PACKAGES_TO_TEST[@]}"; do
               echo "* downloading binary: https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${CI_PACKAGE}"
-              az storage blob download --blob-url "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${CI_PACKAGE}" -f "$${CI_DIR}/$${CI_PACKAGE}" --auth-mode login
+              if [[ "$${USE_AZ}" == "true" ]]; then
+                az storage blob download --blob-url "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${CI_PACKAGE}" -f "$${CI_DIR}/$${CI_PACKAGE}" --auth-mode login
+              else
+                curl --fail -L --retry 10 --retry-delay 5 "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${CI_PACKAGE}" -o "$${CI_DIR}/$${CI_PACKAGE}"
+              fi
               chmod +x "$${CI_DIR}/$${CI_PACKAGE}"
               mv "$${CI_DIR}/$${CI_PACKAGE}" "/usr/bin/$${CI_PACKAGE}"
           done

--- a/templates/test/dev/cluster-template-custom-builds-load.yaml
+++ b/templates/test/dev/cluster-template-custom-builds-load.yaml
@@ -383,10 +383,20 @@ spec:
           declare -a CONTAINERS_TO_TEST=("kube-apiserver" "kube-controller-manager" "kube-proxy" "kube-scheduler")
           CONTAINER_EXT="tar"
           echo "* testing version $${CI_VERSION}"
-          az login --identity
+          USE_AZ="false"
+          if az login --identity > /dev/null 2>&1; then
+            echo "Logged in Azure with managed identity"
+            USE_AZ="true"
+          else
+            echo "az CLI not available, falling back to curl for binary downloads"
+          fi
           for CI_PACKAGE in "$${PACKAGES_TO_TEST[@]}"; do
               echo "* downloading binary: https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${CI_PACKAGE}"
-              az storage blob download --blob-url "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${CI_PACKAGE}" -f "$${CI_DIR}/$${CI_PACKAGE}" --auth-mode login
+              if [[ "$${USE_AZ}" == "true" ]]; then
+                az storage blob download --blob-url "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${CI_PACKAGE}" -f "$${CI_DIR}/$${CI_PACKAGE}" --auth-mode login
+              else
+                curl --fail -L --retry 10 --retry-delay 5 "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${CI_PACKAGE}" -o "$${CI_DIR}/$${CI_PACKAGE}"
+              fi
               chmod +x "$${CI_DIR}/$${CI_PACKAGE}"
               mv "$${CI_DIR}/$${CI_PACKAGE}" "/usr/bin/$${CI_PACKAGE}"
           done
@@ -972,10 +982,20 @@ spec:
           declare -a CONTAINERS_TO_TEST=("kube-apiserver" "kube-controller-manager" "kube-proxy" "kube-scheduler")
           CONTAINER_EXT="tar"
           echo "* testing version $${CI_VERSION}"
-          az login --identity
+          USE_AZ="false"
+          if az login --identity > /dev/null 2>&1; then
+            echo "Logged in Azure with managed identity"
+            USE_AZ="true"
+          else
+            echo "az CLI not available, falling back to curl for binary downloads"
+          fi
           for CI_PACKAGE in "$${PACKAGES_TO_TEST[@]}"; do
               echo "* downloading binary: https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${CI_PACKAGE}"
-              az storage blob download --blob-url "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${CI_PACKAGE}" -f "$${CI_DIR}/$${CI_PACKAGE}" --auth-mode login
+              if [[ "$${USE_AZ}" == "true" ]]; then
+                az storage blob download --blob-url "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${CI_PACKAGE}" -f "$${CI_DIR}/$${CI_PACKAGE}" --auth-mode login
+              else
+                curl --fail -L --retry 10 --retry-delay 5 "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${CI_PACKAGE}" -o "$${CI_DIR}/$${CI_PACKAGE}"
+              fi
               chmod +x "$${CI_DIR}/$${CI_PACKAGE}"
               mv "$${CI_DIR}/$${CI_PACKAGE}" "/usr/bin/$${CI_PACKAGE}"
           done

--- a/templates/test/dev/cluster-template-custom-builds-machine-pool-load-dra.yaml
+++ b/templates/test/dev/cluster-template-custom-builds-machine-pool-load-dra.yaml
@@ -126,10 +126,20 @@ spec:
         declare -a CONTAINERS_TO_TEST=("kube-apiserver" "kube-controller-manager" "kube-proxy" "kube-scheduler")
         CONTAINER_EXT="tar"
         echo "* testing version $${CI_VERSION}"
-        az login --identity
+        USE_AZ="false"
+        if az login --identity > /dev/null 2>&1; then
+          echo "Logged in Azure with managed identity"
+          USE_AZ="true"
+        else
+          echo "az CLI not available, falling back to curl for binary downloads"
+        fi
         for CI_PACKAGE in "$${PACKAGES_TO_TEST[@]}"; do
             echo "* downloading binary: https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${CI_PACKAGE}"
-            az storage blob download --blob-url "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${CI_PACKAGE}" -f "$${CI_DIR}/$${CI_PACKAGE}" --auth-mode login
+            if [[ "$${USE_AZ}" == "true" ]]; then
+              az storage blob download --blob-url "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${CI_PACKAGE}" -f "$${CI_DIR}/$${CI_PACKAGE}" --auth-mode login
+            else
+              curl --fail -L --retry 10 --retry-delay 5 "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${CI_PACKAGE}" -o "$${CI_DIR}/$${CI_PACKAGE}"
+            fi
             chmod +x "$${CI_DIR}/$${CI_PACKAGE}"
             mv "$${CI_DIR}/$${CI_PACKAGE}" "/usr/bin/$${CI_PACKAGE}"
         done
@@ -727,10 +737,20 @@ spec:
           declare -a CONTAINERS_TO_TEST=("kube-apiserver" "kube-controller-manager" "kube-proxy" "kube-scheduler")
           CONTAINER_EXT="tar"
           echo "* testing version $${CI_VERSION}"
-          az login --identity
+          USE_AZ="false"
+          if az login --identity > /dev/null 2>&1; then
+            echo "Logged in Azure with managed identity"
+            USE_AZ="true"
+          else
+            echo "az CLI not available, falling back to curl for binary downloads"
+          fi
           for CI_PACKAGE in "$${PACKAGES_TO_TEST[@]}"; do
               echo "* downloading binary: https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${CI_PACKAGE}"
-              az storage blob download --blob-url "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${CI_PACKAGE}" -f "$${CI_DIR}/$${CI_PACKAGE}" --auth-mode login
+              if [[ "$${USE_AZ}" == "true" ]]; then
+                az storage blob download --blob-url "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${CI_PACKAGE}" -f "$${CI_DIR}/$${CI_PACKAGE}" --auth-mode login
+              else
+                curl --fail -L --retry 10 --retry-delay 5 "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${CI_PACKAGE}" -o "$${CI_DIR}/$${CI_PACKAGE}"
+              fi
               chmod +x "$${CI_DIR}/$${CI_PACKAGE}"
               mv "$${CI_DIR}/$${CI_PACKAGE}" "/usr/bin/$${CI_PACKAGE}"
           done

--- a/templates/test/dev/cluster-template-custom-builds-machine-pool-load.yaml
+++ b/templates/test/dev/cluster-template-custom-builds-machine-pool-load.yaml
@@ -120,10 +120,20 @@ spec:
         declare -a CONTAINERS_TO_TEST=("kube-apiserver" "kube-controller-manager" "kube-proxy" "kube-scheduler")
         CONTAINER_EXT="tar"
         echo "* testing version $${CI_VERSION}"
-        az login --identity
+        USE_AZ="false"
+        if az login --identity > /dev/null 2>&1; then
+          echo "Logged in Azure with managed identity"
+          USE_AZ="true"
+        else
+          echo "az CLI not available, falling back to curl for binary downloads"
+        fi
         for CI_PACKAGE in "$${PACKAGES_TO_TEST[@]}"; do
             echo "* downloading binary: https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${CI_PACKAGE}"
-            az storage blob download --blob-url "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${CI_PACKAGE}" -f "$${CI_DIR}/$${CI_PACKAGE}" --auth-mode login
+            if [[ "$${USE_AZ}" == "true" ]]; then
+              az storage blob download --blob-url "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${CI_PACKAGE}" -f "$${CI_DIR}/$${CI_PACKAGE}" --auth-mode login
+            else
+              curl --fail -L --retry 10 --retry-delay 5 "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${CI_PACKAGE}" -o "$${CI_DIR}/$${CI_PACKAGE}"
+            fi
             chmod +x "$${CI_DIR}/$${CI_PACKAGE}"
             mv "$${CI_DIR}/$${CI_PACKAGE}" "/usr/bin/$${CI_PACKAGE}"
         done
@@ -698,10 +708,20 @@ spec:
           declare -a CONTAINERS_TO_TEST=("kube-apiserver" "kube-controller-manager" "kube-proxy" "kube-scheduler")
           CONTAINER_EXT="tar"
           echo "* testing version $${CI_VERSION}"
-          az login --identity
+          USE_AZ="false"
+          if az login --identity > /dev/null 2>&1; then
+            echo "Logged in Azure with managed identity"
+            USE_AZ="true"
+          else
+            echo "az CLI not available, falling back to curl for binary downloads"
+          fi
           for CI_PACKAGE in "$${PACKAGES_TO_TEST[@]}"; do
               echo "* downloading binary: https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${CI_PACKAGE}"
-              az storage blob download --blob-url "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${CI_PACKAGE}" -f "$${CI_DIR}/$${CI_PACKAGE}" --auth-mode login
+              if [[ "$${USE_AZ}" == "true" ]]; then
+                az storage blob download --blob-url "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${CI_PACKAGE}" -f "$${CI_DIR}/$${CI_PACKAGE}" --auth-mode login
+              else
+                curl --fail -L --retry 10 --retry-delay 5 "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${CI_PACKAGE}" -o "$${CI_DIR}/$${CI_PACKAGE}"
+              fi
               chmod +x "$${CI_DIR}/$${CI_PACKAGE}"
               mv "$${CI_DIR}/$${CI_PACKAGE}" "/usr/bin/$${CI_PACKAGE}"
           done

--- a/templates/test/dev/cluster-template-custom-builds-machine-pool-windows.yaml
+++ b/templates/test/dev/cluster-template-custom-builds-machine-pool-windows.yaml
@@ -118,10 +118,20 @@ spec:
         declare -a CONTAINERS_TO_TEST=("kube-apiserver" "kube-controller-manager" "kube-proxy" "kube-scheduler")
         CONTAINER_EXT="tar"
         echo "* testing version $${CI_VERSION}"
-        az login --identity
+        USE_AZ="false"
+        if az login --identity > /dev/null 2>&1; then
+          echo "Logged in Azure with managed identity"
+          USE_AZ="true"
+        else
+          echo "az CLI not available, falling back to curl for binary downloads"
+        fi
         for CI_PACKAGE in "$${PACKAGES_TO_TEST[@]}"; do
             echo "* downloading binary: https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${CI_PACKAGE}"
-            az storage blob download --blob-url "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${CI_PACKAGE}" -f "$${CI_DIR}/$${CI_PACKAGE}" --auth-mode login
+            if [[ "$${USE_AZ}" == "true" ]]; then
+              az storage blob download --blob-url "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${CI_PACKAGE}" -f "$${CI_DIR}/$${CI_PACKAGE}" --auth-mode login
+            else
+              curl --fail -L --retry 10 --retry-delay 5 "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${CI_PACKAGE}" -o "$${CI_DIR}/$${CI_PACKAGE}"
+            fi
             chmod +x "$${CI_DIR}/$${CI_PACKAGE}"
             mv "$${CI_DIR}/$${CI_PACKAGE}" "/usr/bin/$${CI_PACKAGE}"
         done

--- a/templates/test/dev/cluster-template-custom-builds-machine-pool.yaml
+++ b/templates/test/dev/cluster-template-custom-builds-machine-pool.yaml
@@ -114,10 +114,20 @@ spec:
         declare -a CONTAINERS_TO_TEST=("kube-apiserver" "kube-controller-manager" "kube-proxy" "kube-scheduler")
         CONTAINER_EXT="tar"
         echo "* testing version $${CI_VERSION}"
-        az login --identity
+        USE_AZ="false"
+        if az login --identity > /dev/null 2>&1; then
+          echo "Logged in Azure with managed identity"
+          USE_AZ="true"
+        else
+          echo "az CLI not available, falling back to curl for binary downloads"
+        fi
         for CI_PACKAGE in "$${PACKAGES_TO_TEST[@]}"; do
             echo "* downloading binary: https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${CI_PACKAGE}"
-            az storage blob download --blob-url "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${CI_PACKAGE}" -f "$${CI_DIR}/$${CI_PACKAGE}" --auth-mode login
+            if [[ "$${USE_AZ}" == "true" ]]; then
+              az storage blob download --blob-url "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${CI_PACKAGE}" -f "$${CI_DIR}/$${CI_PACKAGE}" --auth-mode login
+            else
+              curl --fail -L --retry 10 --retry-delay 5 "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${CI_PACKAGE}" -o "$${CI_DIR}/$${CI_PACKAGE}"
+            fi
             chmod +x "$${CI_DIR}/$${CI_PACKAGE}"
             mv "$${CI_DIR}/$${CI_PACKAGE}" "/usr/bin/$${CI_PACKAGE}"
         done

--- a/templates/test/dev/cluster-template-custom-builds-windows.yaml
+++ b/templates/test/dev/cluster-template-custom-builds-windows.yaml
@@ -154,10 +154,20 @@ spec:
         declare -a CONTAINERS_TO_TEST=("kube-apiserver" "kube-controller-manager" "kube-proxy" "kube-scheduler")
         CONTAINER_EXT="tar"
         echo "* testing version $${CI_VERSION}"
-        az login --identity
+        USE_AZ="false"
+        if az login --identity > /dev/null 2>&1; then
+          echo "Logged in Azure with managed identity"
+          USE_AZ="true"
+        else
+          echo "az CLI not available, falling back to curl for binary downloads"
+        fi
         for CI_PACKAGE in "$${PACKAGES_TO_TEST[@]}"; do
             echo "* downloading binary: https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${CI_PACKAGE}"
-            az storage blob download --blob-url "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${CI_PACKAGE}" -f "$${CI_DIR}/$${CI_PACKAGE}" --auth-mode login
+            if [[ "$${USE_AZ}" == "true" ]]; then
+              az storage blob download --blob-url "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${CI_PACKAGE}" -f "$${CI_DIR}/$${CI_PACKAGE}" --auth-mode login
+            else
+              curl --fail -L --retry 10 --retry-delay 5 "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${CI_PACKAGE}" -o "$${CI_DIR}/$${CI_PACKAGE}"
+            fi
             chmod +x "$${CI_DIR}/$${CI_PACKAGE}"
             mv "$${CI_DIR}/$${CI_PACKAGE}" "/usr/bin/$${CI_PACKAGE}"
         done
@@ -369,10 +379,20 @@ spec:
           declare -a CONTAINERS_TO_TEST=("kube-apiserver" "kube-controller-manager" "kube-proxy" "kube-scheduler")
           CONTAINER_EXT="tar"
           echo "* testing version $${CI_VERSION}"
-          az login --identity
+          USE_AZ="false"
+          if az login --identity > /dev/null 2>&1; then
+            echo "Logged in Azure with managed identity"
+            USE_AZ="true"
+          else
+            echo "az CLI not available, falling back to curl for binary downloads"
+          fi
           for CI_PACKAGE in "$${PACKAGES_TO_TEST[@]}"; do
               echo "* downloading binary: https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${CI_PACKAGE}"
-              az storage blob download --blob-url "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${CI_PACKAGE}" -f "$${CI_DIR}/$${CI_PACKAGE}" --auth-mode login
+              if [[ "$${USE_AZ}" == "true" ]]; then
+                az storage blob download --blob-url "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${CI_PACKAGE}" -f "$${CI_DIR}/$${CI_PACKAGE}" --auth-mode login
+              else
+                curl --fail -L --retry 10 --retry-delay 5 "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${CI_PACKAGE}" -o "$${CI_DIR}/$${CI_PACKAGE}"
+              fi
               chmod +x "$${CI_DIR}/$${CI_PACKAGE}"
               mv "$${CI_DIR}/$${CI_PACKAGE}" "/usr/bin/$${CI_PACKAGE}"
           done

--- a/templates/test/dev/cluster-template-custom-builds.yaml
+++ b/templates/test/dev/cluster-template-custom-builds.yaml
@@ -377,10 +377,20 @@ spec:
           declare -a CONTAINERS_TO_TEST=("kube-apiserver" "kube-controller-manager" "kube-proxy" "kube-scheduler")
           CONTAINER_EXT="tar"
           echo "* testing version $${CI_VERSION}"
-          az login --identity
+          USE_AZ="false"
+          if az login --identity > /dev/null 2>&1; then
+            echo "Logged in Azure with managed identity"
+            USE_AZ="true"
+          else
+            echo "az CLI not available, falling back to curl for binary downloads"
+          fi
           for CI_PACKAGE in "$${PACKAGES_TO_TEST[@]}"; do
               echo "* downloading binary: https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${CI_PACKAGE}"
-              az storage blob download --blob-url "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${CI_PACKAGE}" -f "$${CI_DIR}/$${CI_PACKAGE}" --auth-mode login
+              if [[ "$${USE_AZ}" == "true" ]]; then
+                az storage blob download --blob-url "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${CI_PACKAGE}" -f "$${CI_DIR}/$${CI_PACKAGE}" --auth-mode login
+              else
+                curl --fail -L --retry 10 --retry-delay 5 "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${CI_PACKAGE}" -o "$${CI_DIR}/$${CI_PACKAGE}"
+              fi
               chmod +x "$${CI_DIR}/$${CI_PACKAGE}"
               mv "$${CI_DIR}/$${CI_PACKAGE}" "/usr/bin/$${CI_PACKAGE}"
           done

--- a/templates/test/dev/custom-builds-windows/patches/kubeadm-bootstrap.yaml
+++ b/templates/test/dev/custom-builds-windows/patches/kubeadm-bootstrap.yaml
@@ -26,10 +26,20 @@
       declare -a CONTAINERS_TO_TEST=("kube-apiserver" "kube-controller-manager" "kube-proxy" "kube-scheduler")
       CONTAINER_EXT="tar"
       echo "* testing version $${CI_VERSION}"
-      az login --identity
+      USE_AZ="false"
+      if az login --identity > /dev/null 2>&1; then
+        echo "Logged in Azure with managed identity"
+        USE_AZ="true"
+      else
+        echo "az CLI not available, falling back to curl for binary downloads"
+      fi
       for CI_PACKAGE in "$${PACKAGES_TO_TEST[@]}"; do
           echo "* downloading binary: https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${CI_PACKAGE}"
-          az storage blob download --blob-url "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${CI_PACKAGE}" -f "$${CI_DIR}/$${CI_PACKAGE}" --auth-mode login
+          if [[ "$${USE_AZ}" == "true" ]]; then
+            az storage blob download --blob-url "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${CI_PACKAGE}" -f "$${CI_DIR}/$${CI_PACKAGE}" --auth-mode login
+          else
+            curl --fail -L --retry 10 --retry-delay 5 "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${CI_PACKAGE}" -o "$${CI_DIR}/$${CI_PACKAGE}"
+          fi
           chmod +x "$${CI_DIR}/$${CI_PACKAGE}"
           mv "$${CI_DIR}/$${CI_PACKAGE}" "/usr/bin/$${CI_PACKAGE}"
       done

--- a/templates/test/dev/custom-builds-windows/patches/kubeadm-controlplane-bootstrap.yaml
+++ b/templates/test/dev/custom-builds-windows/patches/kubeadm-controlplane-bootstrap.yaml
@@ -26,10 +26,20 @@
       declare -a CONTAINERS_TO_TEST=("kube-apiserver" "kube-controller-manager" "kube-proxy" "kube-scheduler")
       CONTAINER_EXT="tar"
       echo "* testing version $${CI_VERSION}"
-      az login --identity
+      USE_AZ="false"
+      if az login --identity > /dev/null 2>&1; then
+        echo "Logged in Azure with managed identity"
+        USE_AZ="true"
+      else
+        echo "az CLI not available, falling back to curl for binary downloads"
+      fi
       for CI_PACKAGE in "$${PACKAGES_TO_TEST[@]}"; do
           echo "* downloading binary: https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${CI_PACKAGE}"
-          az storage blob download --blob-url "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${CI_PACKAGE}" -f "$${CI_DIR}/$${CI_PACKAGE}" --auth-mode login
+          if [[ "$${USE_AZ}" == "true" ]]; then
+            az storage blob download --blob-url "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${CI_PACKAGE}" -f "$${CI_DIR}/$${CI_PACKAGE}" --auth-mode login
+          else
+            curl --fail -L --retry 10 --retry-delay 5 "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${CI_PACKAGE}" -o "$${CI_DIR}/$${CI_PACKAGE}"
+          fi
           chmod +x "$${CI_DIR}/$${CI_PACKAGE}"
           mv "$${CI_DIR}/$${CI_PACKAGE}" "/usr/bin/$${CI_PACKAGE}"
       done

--- a/templates/test/dev/custom-builds/patches/kubeadm-bootstrap.yaml
+++ b/templates/test/dev/custom-builds/patches/kubeadm-bootstrap.yaml
@@ -26,10 +26,20 @@
       declare -a CONTAINERS_TO_TEST=("kube-apiserver" "kube-controller-manager" "kube-proxy" "kube-scheduler")
       CONTAINER_EXT="tar"
       echo "* testing version $${CI_VERSION}"
-      az login --identity
+      USE_AZ="false"
+      if az login --identity > /dev/null 2>&1; then
+        echo "Logged in Azure with managed identity"
+        USE_AZ="true"
+      else
+        echo "az CLI not available, falling back to curl for binary downloads"
+      fi
       for CI_PACKAGE in "$${PACKAGES_TO_TEST[@]}"; do
           echo "* downloading binary: https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${CI_PACKAGE}"
-          az storage blob download --blob-url "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${CI_PACKAGE}" -f "$${CI_DIR}/$${CI_PACKAGE}" --auth-mode login
+          if [[ "$${USE_AZ}" == "true" ]]; then
+            az storage blob download --blob-url "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${CI_PACKAGE}" -f "$${CI_DIR}/$${CI_PACKAGE}" --auth-mode login
+          else
+            curl --fail -L --retry 10 --retry-delay 5 "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${CI_PACKAGE}" -o "$${CI_DIR}/$${CI_PACKAGE}"
+          fi
           chmod +x "$${CI_DIR}/$${CI_PACKAGE}"
           mv "$${CI_DIR}/$${CI_PACKAGE}" "/usr/bin/$${CI_PACKAGE}"
       done

--- a/templates/test/dev/patches/control-plane-custom-builds.yaml
+++ b/templates/test/dev/patches/control-plane-custom-builds.yaml
@@ -40,10 +40,20 @@ spec:
         declare -a CONTAINERS_TO_TEST=("kube-apiserver" "kube-controller-manager" "kube-proxy" "kube-scheduler")
         CONTAINER_EXT="tar"
         echo "* testing version $${CI_VERSION}"
-        az login --identity
+        USE_AZ="false"
+        if az login --identity > /dev/null 2>&1; then
+          echo "Logged in Azure with managed identity"
+          USE_AZ="true"
+        else
+          echo "az CLI not available, falling back to curl for binary downloads"
+        fi
         for CI_PACKAGE in "$${PACKAGES_TO_TEST[@]}"; do
             echo "* downloading binary: https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${CI_PACKAGE}"
-            az storage blob download --blob-url "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${CI_PACKAGE}" -f "$${CI_DIR}/$${CI_PACKAGE}" --auth-mode login
+            if [[ "$${USE_AZ}" == "true" ]]; then
+              az storage blob download --blob-url "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${CI_PACKAGE}" -f "$${CI_DIR}/$${CI_PACKAGE}" --auth-mode login
+            else
+              curl --fail -L --retry 10 --retry-delay 5 "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${KUBE_GIT_VERSION}/bin/linux/amd64/$${CI_PACKAGE}" -o "$${CI_DIR}/$${CI_PACKAGE}"
+            fi
             chmod +x "$${CI_DIR}/$${CI_PACKAGE}"
             mv "$${CI_DIR}/$${CI_PACKAGE}" "/usr/bin/$${CI_PACKAGE}"
         done


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind failing-test

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
Fixes issues with some custom builds templates failing due to az cli not being found
Example run with failure: https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/kubernetes-sigs_cluster-api-provider-azure/6121/pull-cluster-api-provider-azure-conformance-custom-builds/2029306063383171072

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->


**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] cherry-pick candidate

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
