### PR TITLE
azure: support system-assigned managed identity

### DIFF
--- a/azure/credential_cache.go
+++ b/azure/credential_cache.go
@@ -104,12 +104,16 @@ func (c *credentialCache) GetOrStoreClientCert(tenantID, clientID string, cert, 
 }
 
 func (c *credentialCache) GetOrStoreManagedIdentity(opts *azidentity.ManagedIdentityCredentialOptions) (azcore.TokenCredential, error) {
+	var clientID string
+	if opts.ID != nil {
+		clientID = opts.ID.String()
+	}
 	return c.getOrStore(
 		credentialCacheKey{
 			authorityHost:  opts.Cloud.ActiveDirectoryAuthorityHost,
 			credentialType: CredentialTypeManagedIdentity,
 			// tenantID not used for managed identity
-			clientID: opts.ID.String(),
+			clientID: clientID,
 		},
 		func() (azcore.TokenCredential, error) {
 			return c.credFactory.newManagedIdentityCredential(opts)

--- a/azure/scope/identity.go
+++ b/azure/scope/identity.go
@@ -154,7 +154,9 @@ func (p *AzureCredentialsProvider) GetTokenCredential(ctx context.Context, resou
 			ClientOptions: azcore.ClientOptions{
 				TracingProvider: tracingProvider,
 			},
-			ID: azidentity.ClientID(p.Identity.Spec.ClientID),
+		}
+		if p.Identity.Spec.ClientID != "" {
+			options.ID = azidentity.ClientID(p.Identity.Spec.ClientID)
 		}
 		cred, authErr = p.cache.GetOrStoreManagedIdentity(&options)
 

--- a/azure/scope/identity_test.go
+++ b/azure/scope/identity_test.go
@@ -421,6 +421,28 @@ func TestGetTokenCredential(t *testing.T) {
 			},
 		},
 		{
+			name: "system-assigned identity",
+			cluster: &infrav1.AzureCluster{
+				Spec: infrav1.AzureClusterSpec{
+					AzureClusterClassSpec: infrav1.AzureClusterClassSpec{
+						IdentityRef: &corev1.ObjectReference{
+							Kind: infrav1.AzureClusterIdentityKind,
+						},
+					},
+				},
+			},
+			identity: &infrav1.AzureClusterIdentity{
+				Spec: infrav1.AzureClusterIdentitySpec{
+					Type: infrav1.UserAssignedMSI,
+				},
+			},
+			cacheExpect: func(cache *mock_azure.MockCredentialCache) {
+				cache.EXPECT().GetOrStoreManagedIdentity(gomock.Cond(func(opts *azidentity.ManagedIdentityCredentialOptions) bool {
+					return opts.ID == nil
+				}))
+			},
+		},
+		{
 			name: "UserAssignedIdentityCredential",
 			cluster: &infrav1.AzureCluster{
 				Spec: infrav1.AzureClusterSpec{


### PR DESCRIPTION
System-assigned managed identities can be used in the same manner as user-assigned managed identities, simply by leaving the ID unset.

 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

/kind feature

**What this PR does / why we need it**:
Allows system-assigned managed identities as well as the currently supported user-assigned managed identity.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

One thing that's ugly about this is that it currently uses the `UserAssignedMSI` identity type. I figured I would float this simple fix to start the conversation. Happy to add a new type if that is better.
 
**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [X] adds unit tests
- [ ] cherry-pick candidate

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Adds support for system-assigned managed identities.
```
