### PR TITLE
Updated Makefile to check and warn if az cli if unavailable in local

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,6 +117,8 @@ make kind-reset
 
 **tilt-settings.yaml** is required with Azure credentials (see docs/book/src/developers/development.md for details).
 
+`make tilt-up` runs `check-az-cli`; if `az` is missing, it warns and tells you to install the Azure CLI and retry `make tilt-up` (needed for Tilt flows that call `az`, e.g. VNet peering with AKS as management cluster). Use `VERBOSE=1 make check-az-cli` to print the detected binary path.
+
 ### E2E Testing
 
 ```bash

--- a/Makefile
+++ b/Makefile
@@ -829,8 +829,19 @@ aks-create: $(KUBECTL) ## Create aks cluster as mgmt cluster.
 aks-delete: $(KUBECTL) ## Deletes the resource group and the associated AKS clusters listed under allowed_contexts in ./tilt-settings.yaml .
 	./scripts/aks-delete.sh
 
+.PHONY: check-az-cli
+check-az-cli: ## Warn if Azure CLI (az) is not installed (Tilt uses it for VNet peering with AKS management clusters). Set VERBOSE=1 to print path when found.
+	@if ! command -v az >/dev/null 2>&1; then \
+		echo "WARNING: Azure CLI (az) is not installed or not on your PATH."; \
+		echo "  Please install it before continuing with Tilt; without it, steps that call 'az' (for example VNet peering with an AKS management cluster) will fail."; \
+		echo "  Install: https://learn.microsoft.com/en-us/cli/azure/install-azure-cli"; \
+		echo "  After installing, ensure 'az' is on your PATH, then run make tilt-up again."; \
+	elif [ -n "$(VERBOSE)" ]; then \
+		echo "Azure CLI (az) found: $$(command -v az)"; \
+	fi
+
 .PHONY: tilt-up
-tilt-up: install-tools ## Start tilt and build kind cluster if needed.
+tilt-up: install-tools check-az-cli ## Start tilt and build kind cluster if needed.
 	@if [ -z "${AZURE_CLIENT_ID_USER_ASSIGNED_IDENTITY}" ]; then \
 		export AZURE_CLIENT_ID_USER_ASSIGNED_IDENTITY=$(shell cat $(AZURE_IDENTITY_ID_FILEPATH)); \
 	fi; \

--- a/Tiltfile
+++ b/Tiltfile
@@ -538,7 +538,6 @@ def waitforsystem():
     local(kubectl_cmd + " wait --for=condition=ready --timeout=300s pod --all -n capi-system")
 
 def peer_vnets():
-    # TODO: check for az cli to be installed in local
     peering_cmd = '''
     echo "--------Peering VNETs--------";
     az network vnet wait --resource-group ${AKS_RESOURCE_GROUP} --name ${AKS_MGMT_VNET_NAME} --created --timeout 180;

--- a/docs/book/src/developers/development.md
+++ b/docs/book/src/developers/development.md
@@ -143,6 +143,8 @@ Install [Helm](https://helm.sh/docs/intro/install/):
 
 You would require installation of Helm for successfully setting up Tilt.
 
+Install the [Azure CLI][azure_cli] if you use Tilt workflows that invoke `az` against Azure (for example VNet peering when using an AKS management cluster with an internal load balancer; see [Tilt with AKS as management cluster (ILB)](tilt-with-aks-as-mgmt-ilb.md)). `make tilt-up` runs `make check-az-cli` first; if `az` is missing, it prints a warning that asks you to install the CLI and fix your `PATH` before continuing with Tilt. To print the resolved `az` path when it is installed, run `VERBOSE=1 make check-az-cli`.
+
 ### Using Tilt
 
 Both of the [Tilt](https://tilt.dev) setups below will get you started developing CAPZ in a local kind cluster.


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind feature

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
Adds a `check-az-cli` Makefile target that detects whether azure-cli (az) is on PATH, prints a clear warning with install instructions when it is not, and runs automatically before `make tilt-up` so developers are told to install Azure CLI before Tilt hits az (e.g. VNet peering with an AKS management cluster). Supports `VERBOSE=1 make check-az-cli` to print the resolved az path when present.
Removes the obsolete TODO in the Tiltfile now covered by the Makefile check. Updates the development guide and AGENTS.md to describe the behavior.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #5291 

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->


**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [x] includes documentation
- [ ] adds unit tests
- [ ] cherry-pick candidate

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
make tilt-up now runs a check that warns when the Azure CLI (az) is not installed or not on PATH, with optional VERBOSE=1 on make check-az-cli to print the detected binary path.
```
