### PR TITLE
Adding IPVersion to load balancer frontend config

### DIFF
--- a/api/v1beta1/types.go
+++ b/api/v1beta1/types.go
@@ -402,6 +402,16 @@ const (
 	Public = LBType("Public")
 )
 
+// IPVersion defines an IP version.
+type IPVersion string
+
+const (
+	// IPv4 is the value for IPv4 address version.
+	IPv4 = IPVersion("IPv4")
+	// IPv6 is the value for IPv6 address version.
+	IPv6 = IPVersion("IPv6")
+)
+
 // FrontendIP defines a load balancer frontend IP configuration.
 type FrontendIP struct {
 	// +kubebuilder:validation:MinLength=1

--- a/api/v1beta1/types.go
+++ b/api/v1beta1/types.go
@@ -398,6 +398,11 @@ const (
 	Public = LBType("Public")
 )
 
+const (
+	// IPv6 is the value for IPv6 address version.
+	IPv6 = "IPv6"
+)
+
 // FrontendIP defines a load balancer frontend IP configuration.
 type FrontendIP struct {
 	// +kubebuilder:validation:MinLength=1

--- a/api/v1beta1/types_class.go
+++ b/api/v1beta1/types_class.go
@@ -535,4 +535,9 @@ type SecurityGroupClass struct {
 type FrontendIPClass struct {
 	// +optional
 	PrivateIPAddress string `json:"privateIP,omitempty"`
+	// IPVersion specifies the IP version for this frontend IP. Valid values are "IPv4" and "IPv6".
+	// Defaults to "IPv4" if not specified.
+	// +kubebuilder:validation:Enum=IPv4;IPv6
+	// +optional
+	IPVersion string `json:"ipVersion,omitempty"`
 }

--- a/api/v1beta1/types_class.go
+++ b/api/v1beta1/types_class.go
@@ -535,4 +535,9 @@ type SecurityGroupClass struct {
 type FrontendIPClass struct {
 	// +optional
 	PrivateIPAddress string `json:"privateIP,omitempty"`
+	// IPVersion specifies the IP version for this frontend IP. Valid values are "IPv4" and "IPv6".
+	// Defaults to "IPv4" if not specified.
+	// +kubebuilder:validation:Enum=IPv4;IPv6
+	// +optional
+	IPVersion IPVersion `json:"ipVersion,omitempty"`
 }

--- a/azure/scope/cluster.go
+++ b/azure/scope/cluster.go
@@ -164,8 +164,8 @@ func (s *ClusterScope) PublicIPSpecs() []azure.ResourceSpecGetter {
 					Name:             ip.PublicIP.Name,
 					ResourceGroup:    s.ResourceGroup(),
 					ClusterName:      s.ClusterName(),
-					DNSName:          "",    // Set to default value
-					IsIPv6:           false, // Set to default value
+					DNSName:          "", // Set to default value
+					IsIPv6:           ip.IPVersion == infrav1.IPv6,
 					Location:         s.Location(),
 					ExtendedLocation: s.ExtendedLocation(),
 					FailureDomains:   failureDomains,
@@ -181,7 +181,7 @@ func (s *ClusterScope) PublicIPSpecs() []azure.ResourceSpecGetter {
 					Name:             s.APIServerPublicIP().Name,
 					ResourceGroup:    s.ResourceGroup(),
 					DNSName:          s.APIServerPublicIP().DNSName,
-					IsIPv6:           false, // Currently azure requires an IPv4 lb rule to enable IPv6
+					IsIPv6:           s.APIServerLB().FrontendIPs[0].IPVersion == infrav1.IPv6,
 					ClusterName:      s.ClusterName(),
 					Location:         s.Location(),
 					ExtendedLocation: s.ExtendedLocation(),
@@ -202,8 +202,8 @@ func (s *ClusterScope) PublicIPSpecs() []azure.ResourceSpecGetter {
 				Name:             ip.PublicIP.Name,
 				ResourceGroup:    s.ResourceGroup(),
 				ClusterName:      s.ClusterName(),
-				DNSName:          "",    // Set to default value
-				IsIPv6:           false, // Set to default value
+				DNSName:          "", // Set to default value
+				IsIPv6:           ip.IPVersion == infrav1.IPv6,
 				Location:         s.Location(),
 				ExtendedLocation: s.ExtendedLocation(),
 				FailureDomains:   failureDomains,

--- a/azure/scope/cluster.go
+++ b/azure/scope/cluster.go
@@ -165,8 +165,8 @@ func (s *ClusterScope) PublicIPSpecs() []azure.ResourceSpecGetter {
 					Name:             ip.PublicIP.Name,
 					ResourceGroup:    s.ResourceGroup(),
 					ClusterName:      s.ClusterName(),
-					DNSName:          "",    // Set to default value
-					IsIPv6:           false, // Set to default value
+					DNSName:          "", // Set to default value
+					IsIPv6:           ip.IPVersion == infrav1.IPv6,
 					Location:         s.Location(),
 					ExtendedLocation: s.ExtendedLocation(),
 					FailureDomains:   failureDomains,
@@ -182,7 +182,7 @@ func (s *ClusterScope) PublicIPSpecs() []azure.ResourceSpecGetter {
 					Name:             s.APIServerPublicIP().Name,
 					ResourceGroup:    s.ResourceGroup(),
 					DNSName:          s.APIServerPublicIP().DNSName,
-					IsIPv6:           false, // Currently azure requires an IPv4 lb rule to enable IPv6
+					IsIPv6:           len(s.APIServerLB().FrontendIPs) > 0 && s.APIServerLB().FrontendIPs[0].IPVersion == infrav1.IPv6,
 					ClusterName:      s.ClusterName(),
 					Location:         s.Location(),
 					ExtendedLocation: s.ExtendedLocation(),
@@ -203,8 +203,8 @@ func (s *ClusterScope) PublicIPSpecs() []azure.ResourceSpecGetter {
 				Name:             ip.PublicIP.Name,
 				ResourceGroup:    s.ResourceGroup(),
 				ClusterName:      s.ClusterName(),
-				DNSName:          "",    // Set to default value
-				IsIPv6:           false, // Set to default value
+				DNSName:          "", // Set to default value
+				IsIPv6:           ip.IPVersion == infrav1.IPv6,
 				Location:         s.Location(),
 				ExtendedLocation: s.ExtendedLocation(),
 				FailureDomains:   failureDomains,
@@ -271,6 +271,7 @@ func (s *ClusterScope) LBSpecs() []azure.ResourceSpecGetter {
 			Type:                  s.APIServerLB().Type,
 			SKU:                   s.APIServerLB().SKU,
 			Role:                  infrav1.APIServerRole,
+			IPv6Enabled:           s.IsIPv6Enabled(),
 			BackendPoolName:       s.APIServerLB().BackendPool.Name,
 			IdleTimeoutInMinutes:  s.APIServerLB().IdleTimeoutInMinutes,
 			AdditionalTags:        s.AdditionalTags(),
@@ -356,6 +357,7 @@ func (s *ClusterScope) LBSpecs() []azure.ResourceSpecGetter {
 			Type:                 s.NodeOutboundLB().Type,
 			SKU:                  s.NodeOutboundLB().SKU,
 			BackendPoolName:      s.NodeOutboundLB().BackendPool.Name,
+			IPv6Enabled:          s.IsIPv6Enabled(),
 			IdleTimeoutInMinutes: s.NodeOutboundLB().IdleTimeoutInMinutes,
 			Role:                 infrav1.NodeOutboundRole,
 			AdditionalTags:       s.AdditionalTags(),
@@ -378,6 +380,7 @@ func (s *ClusterScope) LBSpecs() []azure.ResourceSpecGetter {
 			Type:                 s.ControlPlaneOutboundLB().Type,
 			SKU:                  s.ControlPlaneOutboundLB().SKU,
 			BackendPoolName:      s.ControlPlaneOutboundLB().BackendPool.Name,
+			IPv6Enabled:          s.IsIPv6Enabled(),
 			IdleTimeoutInMinutes: s.ControlPlaneOutboundLB().IdleTimeoutInMinutes,
 			Role:                 infrav1.ControlPlaneOutboundRole,
 			AdditionalTags:       s.AdditionalTags(),

--- a/azure/scope/machine.go
+++ b/azure/scope/machine.go
@@ -318,6 +318,10 @@ func (m *MachineScope) BuildNICSpec(nicName string, infrav1NetworkInterface infr
 			spec.PublicLBName = m.OutboundLBName(m.Role())
 			spec.PublicLBAddressPoolName = m.OutboundPoolName(m.Role())
 		}
+
+		if spec.IPv6Enabled && spec.PublicLBAddressPoolName != "" {
+			spec.PublicLBAddressPoolNameIPv6 = spec.PublicLBAddressPoolName + "-IPv6"
+		}
 	}
 
 	return spec

--- a/azure/scope/machinepool.go
+++ b/azure/scope/machinepool.go
@@ -214,6 +214,10 @@ func (m *MachinePoolScope) ScaleSetSpec(ctx context.Context) azure.ResourceSpecG
 		ZoneBalance:                  m.AzureMachinePool.Spec.ZoneBalance,
 	}
 
+	if spec.IPv6Enabled && spec.PublicLBAddressPoolName != "" {
+		spec.PublicLBAddressPoolNameIPv6 = spec.PublicLBAddressPoolName + "-IPv6"
+	}
+
 	if m.AzureMachinePool.Spec.ZoneBalance != nil && len(m.MachinePool.Spec.FailureDomains) <= 1 {
 		log.V(4).Info("zone balance is enabled but one or less failure domains are specified, zone balance will be disabled")
 		spec.ZoneBalance = nil

--- a/azure/services/loadbalancers/loadbalancers_test.go
+++ b/azure/services/loadbalancers/loadbalancers_test.go
@@ -188,6 +188,34 @@ var (
 		},
 	}
 
+	fakePublicAPILBSpecIPv6 = LBSpec{
+		Name:                 "my-publiclb",
+		ResourceGroup:        "my-rg",
+		SubscriptionID:       "123",
+		ClusterName:          "my-cluster",
+		Location:             "my-location",
+		Role:                 infrav1.APIServerRole,
+		Type:                 infrav1.Public,
+		SKU:                  infrav1.SKUStandard,
+		SubnetName:           "my-cp-subnet",
+		BackendPoolName:      "my-publiclb-backendPool",
+		IPv6Enabled:          true,
+		IdleTimeoutInMinutes: ptr.To[int32](4),
+		FrontendIPConfigs: []infrav1.FrontendIP{
+			{
+				Name: "my-publiclb-frontEnd-ipv6",
+				FrontendIPClass: infrav1.FrontendIPClass{
+					IPVersion: infrav1.IPv6,
+				},
+				PublicIP: &infrav1.PublicIPSpec{
+					Name:    "my-publicip-ipv6",
+					DNSName: "my-cluster.12345.mydomain.com",
+				},
+			},
+		},
+		APIServerPort: 6443,
+	}
+
 	internalError = &azcore.ResponseError{
 		RawResponse: &http.Response{
 			Body:       io.NopCloser(strings.NewReader("#: Internal Server Error: StatusCode=500")),

--- a/azure/services/loadbalancers/loadbalancers_test.go
+++ b/azure/services/loadbalancers/loadbalancers_test.go
@@ -185,6 +185,58 @@ var (
 		},
 	}
 
+	fakeInternalAPILBSpecIPv6 = LBSpec{
+		Name:                 "my-private-lb",
+		ResourceGroup:        "my-rg",
+		SubscriptionID:       "123",
+		ClusterName:          "my-cluster",
+		Location:             "my-location",
+		VNetName:             "my-vnet",
+		VNetResourceGroup:    "my-rg",
+		Role:                 infrav1.APIServerRole,
+		Type:                 infrav1.Internal,
+		SKU:                  infrav1.SKUStandard,
+		SubnetName:           "my-cp-subnet",
+		BackendPoolName:      "my-private-lb-backendPool",
+		IdleTimeoutInMinutes: ptr.To[int32](4),
+		FrontendIPConfigs: []infrav1.FrontendIP{
+			{
+				Name: "my-private-lb-frontEnd-ipv6",
+				FrontendIPClass: infrav1.FrontendIPClass{
+					IPVersion: infrav1.IPv6,
+				},
+			},
+		},
+		APIServerPort: 6443,
+	}
+
+	fakePublicAPILBSpecIPv6 = LBSpec{
+		Name:                 "my-publiclb",
+		ResourceGroup:        "my-rg",
+		SubscriptionID:       "123",
+		ClusterName:          "my-cluster",
+		Location:             "my-location",
+		Role:                 infrav1.APIServerRole,
+		Type:                 infrav1.Public,
+		SKU:                  infrav1.SKUStandard,
+		SubnetName:           "my-cp-subnet",
+		BackendPoolName:      "my-publiclb-backendPool",
+		IdleTimeoutInMinutes: ptr.To[int32](4),
+		FrontendIPConfigs: []infrav1.FrontendIP{
+			{
+				Name: "my-publiclb-frontEnd-ipv6",
+				FrontendIPClass: infrav1.FrontendIPClass{
+					IPVersion: infrav1.IPv6,
+				},
+				PublicIP: &infrav1.PublicIPSpec{
+					Name:    "my-publicip-ipv6",
+					DNSName: "my-cluster.12345.mydomain.com",
+				},
+			},
+		},
+		APIServerPort: 6443,
+	}
+
 	internalError = &azcore.ResponseError{
 		RawResponse: &http.Response{
 			Body:       io.NopCloser(strings.NewReader("#: Internal Server Error: StatusCode=500")),

--- a/azure/services/loadbalancers/spec.go
+++ b/azure/services/loadbalancers/spec.go
@@ -44,6 +44,7 @@ type LBSpec struct {
 	VNetResourceGroup     string
 	SubnetName            string
 	BackendPoolName       string
+	IPv6Enabled           bool
 	FrontendIPConfigs     []infrav1.FrontendIP
 	APIServerPort         int32
 	APIServerFrontendPort int32
@@ -220,19 +221,62 @@ func getOutboundRules(lbSpec LBSpec, frontendIDs []*armnetwork.SubResource) []*a
 	if lbSpec.Type == infrav1.Internal {
 		return []*armnetwork.OutboundRule{}
 	}
-	return []*armnetwork.OutboundRule{
-		{
+
+	if !lbSpec.IPv6Enabled {
+		return []*armnetwork.OutboundRule{
+			{
+				Name: ptr.To(outboundNAT),
+				Properties: &armnetwork.OutboundRulePropertiesFormat{
+					Protocol:                 ptr.To(armnetwork.LoadBalancerOutboundRuleProtocolAll),
+					IdleTimeoutInMinutes:     lbSpec.IdleTimeoutInMinutes,
+					FrontendIPConfigurations: frontendIDs,
+					BackendAddressPool: &armnetwork.SubResource{
+						ID: ptr.To(azure.AddressPoolID(lbSpec.SubscriptionID, lbSpec.ResourceGroup, lbSpec.Name, lbSpec.BackendPoolName)),
+					},
+				},
+			},
+		}
+	}
+
+	var ipv4FrontendIDs, ipv6FrontendIDs []*armnetwork.SubResource
+	for i, ipConfig := range lbSpec.FrontendIPConfigs {
+		if i < len(frontendIDs) {
+			if ipConfig.IPVersion == infrav1.IPv6 {
+				ipv6FrontendIDs = append(ipv6FrontendIDs, frontendIDs[i])
+			} else {
+				ipv4FrontendIDs = append(ipv4FrontendIDs, frontendIDs[i])
+			}
+		}
+	}
+
+	var rules []*armnetwork.OutboundRule
+	if len(ipv4FrontendIDs) > 0 {
+		rules = append(rules, &armnetwork.OutboundRule{
 			Name: ptr.To(outboundNAT),
 			Properties: &armnetwork.OutboundRulePropertiesFormat{
 				Protocol:                 ptr.To(armnetwork.LoadBalancerOutboundRuleProtocolAll),
 				IdleTimeoutInMinutes:     lbSpec.IdleTimeoutInMinutes,
-				FrontendIPConfigurations: frontendIDs,
+				FrontendIPConfigurations: ipv4FrontendIDs,
 				BackendAddressPool: &armnetwork.SubResource{
 					ID: ptr.To(azure.AddressPoolID(lbSpec.SubscriptionID, lbSpec.ResourceGroup, lbSpec.Name, lbSpec.BackendPoolName)),
 				},
 			},
-		},
+		})
 	}
+	if len(ipv6FrontendIDs) > 0 {
+		rules = append(rules, &armnetwork.OutboundRule{
+			Name: ptr.To(outboundNAT + "IPv6"),
+			Properties: &armnetwork.OutboundRulePropertiesFormat{
+				Protocol:                 ptr.To(armnetwork.LoadBalancerOutboundRuleProtocolAll),
+				IdleTimeoutInMinutes:     lbSpec.IdleTimeoutInMinutes,
+				FrontendIPConfigurations: ipv6FrontendIDs,
+				BackendAddressPool: &armnetwork.SubResource{
+					ID: ptr.To(azure.AddressPoolID(lbSpec.SubscriptionID, lbSpec.ResourceGroup, lbSpec.Name, lbSpec.BackendPoolName+"-IPv6")),
+				},
+			},
+		})
+	}
+	return rules
 }
 
 func getLoadBalancingRules(lbSpec LBSpec, frontendIDs []*armnetwork.SubResource) []*armnetwork.LoadBalancingRule {
@@ -293,11 +337,17 @@ func getLoadBalancingRules(lbSpec LBSpec, frontendIDs []*armnetwork.SubResource)
 }
 
 func getBackendAddressPools(lbSpec LBSpec) []*armnetwork.BackendAddressPool {
-	return []*armnetwork.BackendAddressPool{
+	pools := []*armnetwork.BackendAddressPool{
 		{
 			Name: ptr.To(lbSpec.BackendPoolName),
 		},
 	}
+	if lbSpec.IPv6Enabled {
+		pools = append(pools, &armnetwork.BackendAddressPool{
+			Name: ptr.To(lbSpec.BackendPoolName + "-IPv6"),
+		})
+	}
+	return pools
 }
 
 func getProbes(lbSpec LBSpec) []*armnetwork.Probe {

--- a/azure/services/loadbalancers/spec.go
+++ b/azure/services/loadbalancers/spec.go
@@ -199,6 +199,11 @@ func getFrontendIPConfigs(lbSpec LBSpec) ([]*armnetwork.FrontendIPConfiguration,
 				},
 				PrivateIPAddress: ptr.To(ipConfig.PrivateIPAddress),
 			}
+			if ipConfig.IPVersion == infrav1.IPv6 {
+				properties.PrivateIPAddressVersion = ptr.To(armnetwork.IPVersionIPv6)
+				properties.PrivateIPAllocationMethod = ptr.To(armnetwork.IPAllocationMethodDynamic)
+				properties.PrivateIPAddress = nil
+			}
 		} else {
 			properties = armnetwork.FrontendIPConfigurationPropertiesFormat{
 				PublicIPAddress: &armnetwork.PublicIPAddress{

--- a/azure/services/loadbalancers/spec_test.go
+++ b/azure/services/loadbalancers/spec_test.go
@@ -195,6 +195,22 @@ func TestParameters(t *testing.T) {
 			expectedError: "",
 		},
 		{
+			name:     "internal API load balancer with IPv6 frontend",
+			spec:     &fakeInternalAPILBSpecIPv6,
+			existing: nil,
+			expect: func(g *WithT, result any) {
+				g.Expect(result).To(BeAssignableToTypeOf(armnetwork.LoadBalancer{}))
+				lb := result.(armnetwork.LoadBalancer)
+				g.Expect(lb.Properties.FrontendIPConfigurations).To(HaveLen(1))
+				frontendIP := lb.Properties.FrontendIPConfigurations[0]
+				g.Expect(*frontendIP.Name).To(Equal("my-private-lb-frontEnd-ipv6"))
+				g.Expect(*frontendIP.Properties.PrivateIPAllocationMethod).To(Equal(armnetwork.IPAllocationMethodDynamic))
+				g.Expect(*frontendIP.Properties.PrivateIPAddressVersion).To(Equal(armnetwork.IPVersionIPv6))
+				g.Expect(frontendIP.Properties.PrivateIPAddress).To(BeNil())
+			},
+			expectedError: "",
+		},
+		{
 			name:     "public load balancer with availability zones - zones NOT applied to frontend",
 			spec:     &fakePublicAPILBSpecWithZones,
 			existing: nil,
@@ -208,6 +224,20 @@ func TestParameters(t *testing.T) {
 				g.Expect(lb.Properties.FrontendIPConfigurations).To(HaveLen(1))
 				g.Expect(lb.Properties.FrontendIPConfigurations[0].Zones).To(BeNil(),
 					"zones should not be set on public LB frontend - Azure error: LoadBalancerFrontendIPConfigCannotHaveZoneWhenReferencingPublicIPAddress")
+			},
+			expectedError: "",
+		},
+		{
+			name:     "public API load balancer with IPv6 frontend",
+			spec:     &fakePublicAPILBSpecIPv6,
+			existing: nil,
+			expect: func(g *WithT, result any) {
+				g.Expect(result).To(BeAssignableToTypeOf(armnetwork.LoadBalancer{}))
+				lb := result.(armnetwork.LoadBalancer)
+				g.Expect(lb.Properties.FrontendIPConfigurations).To(HaveLen(1))
+				frontendIP := lb.Properties.FrontendIPConfigurations[0]
+				g.Expect(*frontendIP.Name).To(Equal("my-publiclb-frontEnd-ipv6"))
+				g.Expect(*frontendIP.Properties.PublicIPAddress.ID).To(Equal("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/publicIPAddresses/my-publicip-ipv6"))
 			},
 			expectedError: "",
 		},

--- a/azure/services/loadbalancers/spec_test.go
+++ b/azure/services/loadbalancers/spec_test.go
@@ -237,6 +237,27 @@ func TestParameters(t *testing.T) {
 			},
 			expectedError: "",
 		},
+		{
+			name:     "public API load balancer with IPv6 frontend",
+			spec:     &fakePublicAPILBSpecIPv6,
+			existing: nil,
+			expect: func(g *WithT, result any) {
+				g.Expect(result).To(BeAssignableToTypeOf(armnetwork.LoadBalancer{}))
+				lb := result.(armnetwork.LoadBalancer)
+				g.Expect(lb.Properties.FrontendIPConfigurations).To(HaveLen(1))
+				frontendIP := lb.Properties.FrontendIPConfigurations[0]
+				g.Expect(*frontendIP.Name).To(Equal("my-publiclb-frontEnd-ipv6"))
+				g.Expect(*frontendIP.Properties.PublicIPAddress.ID).To(Equal("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/publicIPAddresses/my-publicip-ipv6"))
+				g.Expect(lb.Properties.BackendAddressPools).To(HaveLen(2))
+				g.Expect(*lb.Properties.BackendAddressPools[0].Name).To(Equal("my-publiclb-backendPool"))
+				g.Expect(*lb.Properties.BackendAddressPools[1].Name).To(Equal("my-publiclb-backendPool-IPv6"))
+				g.Expect(lb.Properties.OutboundRules).To(HaveLen(1))
+				g.Expect(*lb.Properties.OutboundRules[0].Name).To(Equal("OutboundNATAllProtocolsIPv6"))
+				g.Expect(*lb.Properties.OutboundRules[0].Properties.BackendAddressPool.ID).To(
+					ContainSubstring("my-publiclb-backendPool-IPv6"))
+			},
+			expectedError: "",
+		},
 	}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/azure/services/networkinterfaces/spec.go
+++ b/azure/services/networkinterfaces/spec.go
@@ -33,30 +33,31 @@ import (
 
 // NICSpec defines the specification for a Network Interface.
 type NICSpec struct {
-	Name                      string
-	ResourceGroup             string
-	Location                  string
-	ExtendedLocation          *infrav1.ExtendedLocationSpec
-	SubscriptionID            string
-	MachineName               string
-	SubnetName                string
-	VNetName                  string
-	VNetResourceGroup         string
-	StaticIPAddress           string
-	PublicLBName              string
-	PublicLBAddressPoolName   string
-	PublicLBNATRuleName       string
-	InternalLBName            string
-	InternalLBAddressPoolName string
-	PublicIPName              string
-	AcceleratedNetworking     *bool
-	IPv6Enabled               bool
-	EnableIPForwarding        bool
-	SKU                       *resourceskus.SKU
-	DNSServers                []string
-	AdditionalTags            infrav1.Tags
-	ClusterName               string
-	IPConfigs                 []IPConfig
+	Name                        string
+	ResourceGroup               string
+	Location                    string
+	ExtendedLocation            *infrav1.ExtendedLocationSpec
+	SubscriptionID              string
+	MachineName                 string
+	SubnetName                  string
+	VNetName                    string
+	VNetResourceGroup           string
+	StaticIPAddress             string
+	PublicLBName                string
+	PublicLBAddressPoolName     string
+	PublicLBAddressPoolNameIPv6 string
+	PublicLBNATRuleName         string
+	InternalLBName              string
+	InternalLBAddressPoolName   string
+	PublicIPName                string
+	AcceleratedNetworking       *bool
+	IPv6Enabled                 bool
+	EnableIPForwarding          bool
+	SKU                         *resourceskus.SKU
+	DNSServers                  []string
+	AdditionalTags              infrav1.Tags
+	ClusterName                 string
+	IPConfigs                   []IPConfig
 }
 
 // IPConfig defines the specification for an IP address configuration.
@@ -118,10 +119,10 @@ func (s *NICSpec) Parameters(ctx context.Context, existing any) (parameters any,
 		primaryIPConfig.PrivateIPAddress = ptr.To(s.StaticIPAddress)
 	}
 
-	backendAddressPools := []*armnetwork.BackendAddressPool{}
+	var publicLBBackendAddressPools []*armnetwork.BackendAddressPool
 	if s.PublicLBName != "" {
 		if s.PublicLBAddressPoolName != "" {
-			backendAddressPools = append(backendAddressPools,
+			publicLBBackendAddressPools = append(publicLBBackendAddressPools,
 				&armnetwork.BackendAddressPool{
 					ID: ptr.To(azure.AddressPoolID(s.SubscriptionID, s.ResourceGroup, s.PublicLBName, s.PublicLBAddressPoolName)),
 				})
@@ -134,6 +135,7 @@ func (s *NICSpec) Parameters(ctx context.Context, existing any) (parameters any,
 			}
 		}
 	}
+	backendAddressPools := append([]*armnetwork.BackendAddressPool{}, publicLBBackendAddressPools...)
 	if s.InternalLBName != "" && s.InternalLBAddressPoolName != "" {
 		backendAddressPools = append(backendAddressPools,
 			&armnetwork.BackendAddressPool{
@@ -204,12 +206,20 @@ func (s *NICSpec) Parameters(ctx context.Context, existing any) (parameters any,
 		ipConfigurations = append(ipConfigurations, config)
 	}
 	if s.IPv6Enabled {
+		var publicLBBackendAddressPoolsIPv6 []*armnetwork.BackendAddressPool
+		if s.PublicLBName != "" && s.PublicLBAddressPoolNameIPv6 != "" {
+			publicLBBackendAddressPoolsIPv6 = append(publicLBBackendAddressPoolsIPv6,
+				&armnetwork.BackendAddressPool{
+					ID: ptr.To(azure.AddressPoolID(s.SubscriptionID, s.ResourceGroup, s.PublicLBName, s.PublicLBAddressPoolNameIPv6)),
+				})
+		}
 		ipv6Config := &armnetwork.InterfaceIPConfiguration{
 			Name: ptr.To("ipConfigv6"),
 			Properties: &armnetwork.InterfaceIPConfigurationPropertiesFormat{
-				PrivateIPAddressVersion: ptr.To(armnetwork.IPVersionIPv6),
-				Primary:                 ptr.To(false),
-				Subnet:                  &armnetwork.Subnet{ID: subnet.ID},
+				PrivateIPAddressVersion:         ptr.To(armnetwork.IPVersionIPv6),
+				Primary:                         ptr.To(false),
+				Subnet:                          &armnetwork.Subnet{ID: subnet.ID},
+				LoadBalancerBackendAddressPools: publicLBBackendAddressPoolsIPv6,
 			},
 		}
 

--- a/azure/services/networkinterfaces/spec_test.go
+++ b/azure/services/networkinterfaces/spec_test.go
@@ -162,6 +162,28 @@ var (
 		ClusterName:           "my-cluster",
 	}
 
+	fakeIpv6ControlPlaneNICSpec = NICSpec{
+		Name:                        "my-net-interface",
+		ResourceGroup:               "my-rg",
+		Location:                    "fake-location",
+		SubscriptionID:              "123",
+		MachineName:                 "azure-test1",
+		SubnetName:                  "my-subnet",
+		VNetName:                    "my-vnet",
+		VNetResourceGroup:           "my-rg",
+		IPv6Enabled:                 true,
+		PublicLBName:                "my-public-lb",
+		PublicLBAddressPoolName:     "my-public-lb-backendPool",
+		PublicLBAddressPoolNameIPv6: "my-public-lb-backendPool-IPv6",
+		PublicLBNATRuleName:         "azure-test1",
+		InternalLBName:              "my-internal-lb",
+		InternalLBAddressPoolName:   "my-internal-lb-backendPool",
+		AcceleratedNetworking:       nil,
+		SKU:                         &fakeSku,
+		EnableIPForwarding:          true,
+		ClusterName:                 "my-cluster",
+	}
+
 	fakeControlPlaneCustomDNSSettingsNICSpec = NICSpec{
 		Name:                      "my-net-interface",
 		ResourceGroup:             "my-rg",
@@ -475,6 +497,28 @@ func TestParameters(t *testing.T) {
 						},
 					},
 				}))
+			},
+			expectedError: "",
+		},
+		{
+			name:     "get parameters for network interface ipv6 with backend pools",
+			spec:     &fakeIpv6ControlPlaneNICSpec,
+			existing: nil,
+			expect: func(g *WithT, result any) {
+				g.Expect(result).To(BeAssignableToTypeOf(armnetwork.Interface{}))
+				nic := result.(armnetwork.Interface)
+				g.Expect(nic.Properties.IPConfigurations).To(HaveLen(2))
+
+				primaryIP := nic.Properties.IPConfigurations[0]
+				g.Expect(*primaryIP.Name).To(Equal("pipConfig"))
+				g.Expect(primaryIP.Properties.LoadBalancerBackendAddressPools).To(HaveLen(2))
+
+				ipv6Config := nic.Properties.IPConfigurations[1]
+				g.Expect(*ipv6Config.Name).To(Equal("ipConfigv6"))
+				g.Expect(*ipv6Config.Properties.PrivateIPAddressVersion).To(Equal(armnetwork.IPVersionIPv6))
+				g.Expect(ipv6Config.Properties.LoadBalancerBackendAddressPools).To(HaveLen(1))
+				g.Expect(*ipv6Config.Properties.LoadBalancerBackendAddressPools[0].ID).To(
+					Equal("/subscriptions/123/resourceGroups/my-rg/providers/Microsoft.Network/loadBalancers/my-public-lb/backendAddressPools/my-public-lb-backendPool-IPv6"))
 			},
 			expectedError: "",
 		},

--- a/azure/services/scalesets/spec.go
+++ b/azure/services/scalesets/spec.go
@@ -52,6 +52,7 @@ type ScaleSetSpec struct {
 	VNetResourceGroup            string
 	PublicLBName                 string
 	PublicLBAddressPoolName      string
+	PublicLBAddressPoolNameIPv6  string
 	AcceleratedNetworking        *bool
 	TerminateNotificationTimeout *int
 	Identity                     infrav1.VMIdentity
@@ -391,6 +392,16 @@ func (s *ScaleSetSpec) getVirtualMachineScaleSetNetworkConfiguration() *[]armcom
 		}
 		if i == 0 {
 			ipconfigs[0].Properties.LoadBalancerBackendAddressPools = azure.PtrSlice(&backendAddressPools)
+			if s.IPv6Enabled {
+				var backendAddressPoolsIPv6 []armcompute.SubResource
+				if s.PublicLBName != "" && s.PublicLBAddressPoolNameIPv6 != "" {
+					backendAddressPoolsIPv6 = append(backendAddressPoolsIPv6,
+						armcompute.SubResource{
+							ID: ptr.To(azure.AddressPoolID(s.SubscriptionID, s.ResourceGroup, s.PublicLBName, s.PublicLBAddressPoolNameIPv6)),
+						})
+				}
+				ipconfigs[len(ipconfigs)-1].Properties.LoadBalancerBackendAddressPools = azure.PtrSlice(&backendAddressPoolsIPv6)
+			}
 			nicConfig.Properties.Primary = ptr.To(true)
 		}
 		nicConfig.Properties.IPConfigurations = azure.PtrSlice(&ipconfigs)

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azureclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azureclusters.yaml
@@ -713,6 +713,14 @@ spec:
                           description: FrontendIP defines a load balancer frontend
                             IP configuration.
                           properties:
+                            ipVersion:
+                              description: |-
+                                IPVersion specifies the IP version for this frontend IP. Valid values are "IPv4" and "IPv6".
+                                Defaults to "IPv4" if not specified.
+                              enum:
+                              - IPv4
+                              - IPv6
+                              type: string
                             name:
                               minLength: 1
                               type: string
@@ -873,6 +881,14 @@ spec:
                           description: FrontendIP defines a load balancer frontend
                             IP configuration.
                           properties:
+                            ipVersion:
+                              description: |-
+                                IPVersion specifies the IP version for this frontend IP. Valid values are "IPv4" and "IPv6".
+                                Defaults to "IPv4" if not specified.
+                              enum:
+                              - IPv4
+                              - IPv6
+                              type: string
                             name:
                               minLength: 1
                               type: string
@@ -1032,6 +1048,14 @@ spec:
                           description: FrontendIP defines a load balancer frontend
                             IP configuration.
                           properties:
+                            ipVersion:
+                              description: |-
+                                IPVersion specifies the IP version for this frontend IP. Valid values are "IPv4" and "IPv6".
+                                Defaults to "IPv4" if not specified.
+                              enum:
+                              - IPv4
+                              - IPv6
+                              type: string
                             name:
                               minLength: 1
                               type: string

--- a/docs/book/src/self-managed/api-server-endpoint.md
+++ b/docs/book/src/self-managed/api-server-endpoint.md
@@ -101,6 +101,50 @@ Note that `dns` is the FQDN associated to your public IP address (look for "DNS 
 
 When you BYO api server IP, CAPZ does not manage its lifecycle, ie. the IP will not get deleted as part of cluster deletion.
 
+### Frontend IP Version
+
+By default, frontend IPs are IPv4. You can configure individual frontend IPs to use IPv6 by setting the `ipVersion` field to `"IPv6"`.
+
+For a public load balancer with an IPv6 frontend:
+
+```yaml
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: AzureCluster
+metadata:
+  name: my-cluster
+  namespace: default
+spec:
+  location: eastus
+  networkSpec:
+    apiServerLB:
+      type: Public
+      frontendIPs:
+        - name: lb-public-ip-frontend-ipv6
+          ipVersion: IPv6
+          publicIP:
+            name: my-public-ipv6
+```
+
+For an internal load balancer with an IPv6 frontend:
+
+```yaml
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: AzureCluster
+metadata:
+  name: my-private-cluster
+  namespace: default
+spec:
+  location: eastus
+  networkSpec:
+    apiServerLB:
+      type: Internal
+      frontendIPs:
+        - name: lb-private-ip-frontend-ipv6
+          ipVersion: IPv6
+```
+
+Note that IPv6 internal frontend IPs use dynamic allocation and do not support specifying a `privateIP` address.
+
 ### Load Balancer SKU
 
 At this time, CAPZ only supports Azure Standard Load Balancers. See [SKU comparison](https://learn.microsoft.com/azure/load-balancer/skus#skus) for more information on Azure Load Balancers SKUs.

--- a/docs/book/src/self-managed/api-server-endpoint.md
+++ b/docs/book/src/self-managed/api-server-endpoint.md
@@ -141,6 +141,32 @@ Note that `dns` is the FQDN associated to your public IP address (look for "DNS 
 
 When you BYO api server IP, CAPZ does not manage its lifecycle, ie. the IP will not get deleted as part of cluster deletion.
 
+### Frontend IP Version
+
+By default, frontend IPs are IPv4. You can configure individual frontend IPs to use IPv6 by setting the `ipVersion` field to `"IPv6"`.
+
+For a public load balancer with an IPv6 frontend:
+
+```yaml
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: AzureCluster
+metadata:
+  name: my-cluster
+  namespace: default
+spec:
+  location: eastus
+  networkSpec:
+    apiServerLB:
+      type: Public
+      frontendIPs:
+        - name: lb-public-ip-frontend-ipv6
+          ipVersion: IPv6
+          publicIP:
+            name: my-public-ipv6
+```
+
+Note that IPv6 frontend IPs are only supported on public load balancers. Internal load balancers always use IPv4.
+
 ### Load Balancer SKU
 
 At this time, CAPZ only supports Azure Standard Load Balancers. See [SKU comparison](https://learn.microsoft.com/azure/load-balancer/skus#skus) for more information on Azure Load Balancers SKUs.

--- a/internal/api/v1beta1/azurecluster_default.go
+++ b/internal/api/v1beta1/azurecluster_default.go
@@ -442,6 +442,9 @@ func setDefaultAzureClusterControlPlaneOutboundLBBackendPoolName(c *infrav1.Azur
 // setDefaultAzureClusterOutboundLBFrontendIPs sets the frontend IPs for the given load balancer.
 // The name of the frontend IP is generated using generatePublicIPName function.
 func setDefaultAzureClusterOutboundLBFrontendIPs(c *infrav1.AzureCluster, lb *infrav1.LoadBalancerSpec, generatePublicIPName func(string) string) {
+	if len(lb.FrontendIPs) == int(*lb.FrontendIPsCount) {
+		return
+	}
 	switch *lb.FrontendIPsCount {
 	case 0:
 		lb.FrontendIPs = []infrav1.FrontendIP{}

--- a/internal/webhooks/azurecluster_validation.go
+++ b/internal/webhooks/azurecluster_validation.go
@@ -180,28 +180,41 @@ func validateNetworkSpec(controlPlaneEnabled bool, networkSpec infrav1.NetworkSp
 	}
 
 	var cidrBlocks []string
+	var controlPlaneSubnet infrav1.SubnetSpec
 	if controlPlaneEnabled {
-		controlPlaneSubnet, err := networkSpec.GetControlPlaneSubnet()
+		var err error
+		controlPlaneSubnet, err = networkSpec.GetControlPlaneSubnet()
 		if err != nil {
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("subnets"), networkSpec.Subnets, "ControlPlaneSubnet invalid"))
 		}
 
 		cidrBlocks = controlPlaneSubnet.CIDRBlocks
 		allErrs = append(allErrs, validateAPIServerLB(networkSpec.APIServerLB, old.APIServerLB, networkSpec.Subnets, cidrBlocks, fldPath.Child("apiServerLB"))...)
+		allErrs = append(allErrs, validateIPv6FrontendRequiresIPv6Subnet(networkSpec.APIServerLB, controlPlaneSubnet, fldPath.Child("apiServerLB"))...)
 	}
 
-	var needOutboundLB bool
+	var hasIPv6NodeSubnet bool
 	for _, subnet := range networkSpec.Subnets {
 		if (subnet.Role == infrav1.SubnetNode || subnet.Role == infrav1.SubnetCluster) && subnet.IsIPv6Enabled() {
-			needOutboundLB = true
+			hasIPv6NodeSubnet = true
 			break
 		}
 	}
-	if needOutboundLB {
+	if hasIPv6NodeSubnet {
 		allErrs = append(allErrs, validateNodeOutboundLB(networkSpec.NodeOutboundLB, old.NodeOutboundLB, networkSpec.APIServerLB, fldPath.Child("nodeOutboundLB"))...)
+	}
+	if networkSpec.NodeOutboundLB != nil && !hasIPv6NodeSubnet {
+		for i, frontendIP := range networkSpec.NodeOutboundLB.FrontendIPs {
+			if frontendIP.IPVersion == infrav1.IPv6 {
+				allErrs = append(allErrs, field.Invalid(fldPath.Child("nodeOutboundLB", "frontendIPConfigs").Index(i).Child("ipVersion"),
+					frontendIP.IPVersion,
+					"IPv6 frontend IPs require at least one node subnet to have IPv6 CIDR blocks"))
+			}
+		}
 	}
 	if controlPlaneEnabled {
 		allErrs = append(allErrs, validateControlPlaneOutboundLB(networkSpec.ControlPlaneOutboundLB, networkSpec.APIServerLB, fldPath.Child("controlPlaneOutboundLB"))...)
+		allErrs = append(allErrs, validateIPv6FrontendRequiresIPv6Subnet(networkSpec.ControlPlaneOutboundLB, controlPlaneSubnet, fldPath.Child("controlPlaneOutboundLB"))...)
 	}
 	var lbType = infrav1.Internal
 	if networkSpec.APIServerLB != nil {
@@ -481,6 +494,12 @@ func validateAPIServerLB(lb *infrav1.LoadBalancerSpec, old *infrav1.LoadBalancer
 
 	// internal LB should not have a public IP.
 	if lb.Type == infrav1.Internal {
+		for i, frontendIP := range lb.FrontendIPs {
+			if frontendIP.IPVersion == infrav1.IPv6 {
+				allErrs = append(allErrs, field.Forbidden(fldPath.Child("frontendIPConfigs").Index(i).Child("ipVersion"),
+					"Internal Load Balancers do not support IPv6 frontend IPs"))
+			}
+		}
 		if publicIPCount != 0 {
 			allErrs = append(allErrs, field.Forbidden(fldPath.Child("frontendIPConfigs").Index(0).Child("publicIP"),
 				"Internal Load Balancers cannot have a Public IP"))
@@ -586,6 +605,21 @@ func validateControlPlaneOutboundLB(lb *infrav1.LoadBalancerSpec, apiserverLB *i
 		}
 	}
 
+	return allErrs
+}
+
+func validateIPv6FrontendRequiresIPv6Subnet(lb *infrav1.LoadBalancerSpec, subnet infrav1.SubnetSpec, fldPath *field.Path) field.ErrorList {
+	var allErrs field.ErrorList
+	if lb == nil {
+		return allErrs
+	}
+	for i, frontendIP := range lb.FrontendIPs {
+		if frontendIP.IPVersion == infrav1.IPv6 && !subnet.IsIPv6Enabled() {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("frontendIPConfigs").Index(i).Child("ipVersion"),
+				frontendIP.IPVersion,
+				"IPv6 frontend IPs require the control plane subnet to have IPv6 CIDR blocks"))
+		}
+	}
 	return allErrs
 }
 

--- a/internal/webhooks/azurecluster_validation_test.go
+++ b/internal/webhooks/azurecluster_validation_test.go
@@ -1467,6 +1467,32 @@ func TestValidateAPIServerLB(t *testing.T) {
 			cpCIDRS: []string{"10.1.0.0/24"},
 			wantErr: false,
 		},
+		{
+			name: "internal LB with IPv6 frontend",
+			lb: &infrav1.LoadBalancerSpec{
+				FrontendIPs: []infrav1.FrontendIP{
+					{
+						Name: "ip-1",
+						FrontendIPClass: infrav1.FrontendIPClass{
+							PrivateIPAddress: "10.0.0.4",
+							IPVersion:        infrav1.IPv6,
+						},
+					},
+				},
+				LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{
+					Type: infrav1.Internal,
+					SKU:  infrav1.SKUStandard,
+				},
+				Name: "my-private-lb",
+			},
+			cpCIDRS: []string{"10.0.0.0/24"},
+			wantErr: true,
+			expectedErr: field.Error{
+				Type:   "FieldValueForbidden",
+				Field:  "apiServerLB.frontendIPConfigs[0].ipVersion",
+				Detail: "Internal Load Balancers do not support IPv6 frontend IPs",
+			},
+		},
 	}
 
 	for _, test := range testcases {
@@ -2397,6 +2423,110 @@ func TestValidatePrivateLinks(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			err := validateLBPrivateLinks(&test.lb, &test.old, test.subnets, field.NewPath("apiServerLB"))
+			if test.wantErr {
+				g.Expect(err).To(ContainElement(MatchError(test.expectedErr.Error())))
+			} else {
+				g.Expect(err).To(BeEmpty())
+			}
+		})
+	}
+}
+
+func TestValidateIPv6FrontendRequiresIPv6Subnet(t *testing.T) {
+	testcases := []struct {
+		name        string
+		lb          *infrav1.LoadBalancerSpec
+		subnet      infrav1.SubnetSpec
+		wantErr     bool
+		expectedErr field.Error
+	}{
+		{
+			name: "IPv6 frontend with IPv6 subnet is valid",
+			lb: &infrav1.LoadBalancerSpec{
+				FrontendIPs: []infrav1.FrontendIP{
+					{
+						Name: "ip-1",
+						FrontendIPClass: infrav1.FrontendIPClass{
+							IPVersion: infrav1.IPv6,
+						},
+						PublicIP: &infrav1.PublicIPSpec{Name: "my-ipv6-pip"},
+					},
+				},
+				LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{
+					Type: infrav1.Public,
+					SKU:  infrav1.SKUStandard,
+				},
+			},
+			subnet: infrav1.SubnetSpec{
+				SubnetClassSpec: infrav1.SubnetClassSpec{
+					CIDRBlocks: []string{"10.0.0.0/24", "fd00::/64"},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "IPv6 frontend without IPv6 subnet is invalid",
+			lb: &infrav1.LoadBalancerSpec{
+				FrontendIPs: []infrav1.FrontendIP{
+					{
+						Name: "ip-1",
+						FrontendIPClass: infrav1.FrontendIPClass{
+							IPVersion: infrav1.IPv6,
+						},
+						PublicIP: &infrav1.PublicIPSpec{Name: "my-ipv6-pip"},
+					},
+				},
+				LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{
+					Type: infrav1.Public,
+					SKU:  infrav1.SKUStandard,
+				},
+			},
+			subnet: infrav1.SubnetSpec{
+				SubnetClassSpec: infrav1.SubnetClassSpec{
+					CIDRBlocks: []string{"10.0.0.0/24"},
+				},
+			},
+			wantErr: true,
+			expectedErr: field.Error{
+				Type:     "FieldValueInvalid",
+				Field:    "lb.frontendIPConfigs[0].ipVersion",
+				BadValue: "IPv6",
+				Detail:   "IPv6 frontend IPs require the control plane subnet to have IPv6 CIDR blocks",
+			},
+		},
+		{
+			name: "IPv4 frontend without IPv6 subnet is valid",
+			lb: &infrav1.LoadBalancerSpec{
+				FrontendIPs: []infrav1.FrontendIP{
+					{
+						Name:     "ip-1",
+						PublicIP: &infrav1.PublicIPSpec{Name: "my-pip"},
+					},
+				},
+				LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{
+					Type: infrav1.Public,
+					SKU:  infrav1.SKUStandard,
+				},
+			},
+			subnet: infrav1.SubnetSpec{
+				SubnetClassSpec: infrav1.SubnetClassSpec{
+					CIDRBlocks: []string{"10.0.0.0/24"},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name:    "nil LB is valid",
+			lb:      nil,
+			subnet:  infrav1.SubnetSpec{},
+			wantErr: false,
+		},
+	}
+
+	for _, test := range testcases {
+		t.Run(test.name, func(t *testing.T) {
+			g := NewWithT(t)
+			err := validateIPv6FrontendRequiresIPv6Subnet(test.lb, test.subnet, field.NewPath("lb"))
 			if test.wantErr {
 				g.Expect(err).To(ContainElement(MatchError(test.expectedErr.Error())))
 			} else {


### PR DESCRIPTION
Adding a version option for the users to allow for creation of ipv6 frontend
configurations in the load balancer.

 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
-->

**What this PR does / why we need it**:
Adds a version option in the load balancer frontend IP configs for the users to install IPv6 IPs too.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->


**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [x] includes documentation
- [x] adds unit tests
- [ ] cherry-pick candidate

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Enable ipv6 frontend LB configuration
```
