### PR TITLE
Enable DRADeviceTaints and DRADeviceTaintRules feature gate in DRA templates

### DIFF
--- a/templates/test/ci/cluster-template-prow-ci-version-dra.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version-dra.yaml
@@ -56,7 +56,7 @@ spec:
     clusterConfiguration:
       apiServer:
         extraArgs:
-          feature-gates: ${K8S_FEATURE_GATES:-"DynamicResourceAllocation=true"}
+          feature-gates: ${K8S_FEATURE_GATES:-"DynamicResourceAllocation=true,DRADeviceTaints=true,DRADeviceTaintRules=true"}
           runtime-config: resource.k8s.io/v1beta1=true,resource.k8s.io/v1beta2=true
         timeoutForControlPlane: 20m
       controllerManager:
@@ -64,7 +64,7 @@ spec:
           allocate-node-cidrs: "false"
           cloud-provider: external
           cluster-name: ${CLUSTER_NAME}
-          feature-gates: DynamicResourceAllocation=true
+          feature-gates: DynamicResourceAllocation=true,DRADeviceTaints=true,DRADeviceTaintRules=true
           v: "4"
       etcd:
         local:
@@ -74,7 +74,7 @@ spec:
       kubernetesVersion: ci/${CI_VERSION}
       scheduler:
         extraArgs:
-          feature-gates: DynamicResourceAllocation=true
+          feature-gates: DynamicResourceAllocation=true,DRADeviceTaints=true,DRADeviceTaintRules=true
     diskSetup:
       filesystems:
       - device: /dev/disk/azure/scsi1/lun0
@@ -207,7 +207,7 @@ spec:
       nodeRegistration:
         kubeletExtraArgs:
           cloud-provider: external
-          feature-gates: DynamicResourceAllocation=true
+          feature-gates: DynamicResourceAllocation=true,DRADeviceTaints=true,DRADeviceTaintRules=true
           image-credential-provider-bin-dir: /var/lib/kubelet/credential-provider
           image-credential-provider-config: /var/lib/kubelet/credential-provider-config.yaml
         name: '{{ ds.meta_data["local_hostname"] }}'
@@ -215,7 +215,7 @@ spec:
       nodeRegistration:
         kubeletExtraArgs:
           cloud-provider: external
-          feature-gates: DynamicResourceAllocation=true
+          feature-gates: DynamicResourceAllocation=true,DRADeviceTaints=true,DRADeviceTaintRules=true
           image-credential-provider-bin-dir: /var/lib/kubelet/credential-provider
           image-credential-provider-config: /var/lib/kubelet/credential-provider-config.yaml
         name: '{{ ds.meta_data["local_hostname"] }}'
@@ -447,7 +447,7 @@ spec:
     nodeRegistration:
       kubeletExtraArgs:
         cloud-provider: external
-        feature-gates: ${NODE_FEATURE_GATES:-"DynamicResourceAllocation=true"}
+        feature-gates: ${NODE_FEATURE_GATES:-"DynamicResourceAllocation=true,DRADeviceTaints=true,DRADeviceTaintRules=true"}
         image-credential-provider-bin-dir: /var/lib/kubelet/credential-provider
         image-credential-provider-config: /var/lib/kubelet/credential-provider-config.yaml
       name: '{{ ds.meta_data["local_hostname"] }}'

--- a/templates/test/ci/patches/dra-kubeadmconfig.yaml
+++ b/templates/test/ci/patches/dra-kubeadmconfig.yaml
@@ -15,4 +15,4 @@
   value: bash -c /tmp/containerd-config.sh
 - op: add
   path: /spec/joinConfiguration/nodeRegistration/kubeletExtraArgs/feature-gates
-  value: ${NODE_FEATURE_GATES:-"DynamicResourceAllocation=true"}
+  value: ${NODE_FEATURE_GATES:-"DynamicResourceAllocation=true,DRADeviceTaints=true,DRADeviceTaintRules=true"}

--- a/templates/test/ci/patches/dra-kubeadmconfigtemplate.yaml
+++ b/templates/test/ci/patches/dra-kubeadmconfigtemplate.yaml
@@ -15,4 +15,4 @@
   value: bash -c /tmp/containerd-config.sh
 - op: add
   path: /spec/template/spec/joinConfiguration/nodeRegistration/kubeletExtraArgs/feature-gates
-  value: ${NODE_FEATURE_GATES:-"DynamicResourceAllocation=true"}
+  value: ${NODE_FEATURE_GATES:-"DynamicResourceAllocation=true,DRADeviceTaints=true,DRADeviceTaintRules=true"}

--- a/templates/test/ci/patches/dra-kubeadmcontrolplane.yaml
+++ b/templates/test/ci/patches/dra-kubeadmcontrolplane.yaml
@@ -15,19 +15,19 @@
   value: bash -c /tmp/containerd-config.sh
 - op: add
   path: /spec/kubeadmConfigSpec/clusterConfiguration/apiServer/extraArgs/feature-gates
-  value: ${K8S_FEATURE_GATES:-"DynamicResourceAllocation=true"}
+  value: ${K8S_FEATURE_GATES:-"DynamicResourceAllocation=true,DRADeviceTaints=true,DRADeviceTaintRules=true"}
 - op: add
   path: /spec/kubeadmConfigSpec/clusterConfiguration/controllerManager/extraArgs/feature-gates
-  value: DynamicResourceAllocation=true
+  value: DynamicResourceAllocation=true,DRADeviceTaints=true,DRADeviceTaintRules=true
 - op: add
   path: /spec/kubeadmConfigSpec/clusterConfiguration/apiServer/extraArgs/runtime-config
   value: resource.k8s.io/v1beta1=true,resource.k8s.io/v1beta2=true
 - op: add
   path: /spec/kubeadmConfigSpec/clusterConfiguration/scheduler/extraArgs/feature-gates
-  value: DynamicResourceAllocation=true
+  value: DynamicResourceAllocation=true,DRADeviceTaints=true,DRADeviceTaintRules=true
 - op: add
   path: /spec/kubeadmConfigSpec/initConfiguration/nodeRegistration/kubeletExtraArgs/feature-gates
-  value: DynamicResourceAllocation=true
+  value: DynamicResourceAllocation=true,DRADeviceTaints=true,DRADeviceTaintRules=true
 - op: add
   path: /spec/kubeadmConfigSpec/joinConfiguration/nodeRegistration/kubeletExtraArgs/feature-gates
-  value: DynamicResourceAllocation=true
+  value: DynamicResourceAllocation=true,DRADeviceTaints=true,DRADeviceTaintRules=true

--- a/templates/test/dev/cluster-template-custom-builds-dra.yaml
+++ b/templates/test/dev/cluster-template-custom-builds-dra.yaml
@@ -58,7 +58,7 @@ spec:
     clusterConfiguration:
       apiServer:
         extraArgs:
-          feature-gates: ${K8S_FEATURE_GATES:-"DynamicResourceAllocation=true"}
+          feature-gates: ${K8S_FEATURE_GATES:-"DynamicResourceAllocation=true,DRADeviceTaints=true,DRADeviceTaintRules=true"}
           runtime-config: resource.k8s.io/v1beta1=true,resource.k8s.io/v1beta2=true
         timeoutForControlPlane: 20m
       controllerManager:
@@ -66,7 +66,7 @@ spec:
           allocate-node-cidrs: "false"
           cloud-provider: external
           cluster-name: ${CLUSTER_NAME}
-          feature-gates: DynamicResourceAllocation=true
+          feature-gates: DynamicResourceAllocation=true,DRADeviceTaints=true,DRADeviceTaintRules=true
           v: "4"
       etcd:
         local:
@@ -76,7 +76,7 @@ spec:
       kubernetesVersion: ci/${CI_VERSION}
       scheduler:
         extraArgs:
-          feature-gates: DynamicResourceAllocation=true
+          feature-gates: DynamicResourceAllocation=true,DRADeviceTaints=true,DRADeviceTaintRules=true
     diskSetup:
       filesystems:
       - device: /dev/disk/azure/scsi1/lun0
@@ -197,7 +197,7 @@ spec:
       nodeRegistration:
         kubeletExtraArgs:
           cloud-provider: external
-          feature-gates: DynamicResourceAllocation=true
+          feature-gates: DynamicResourceAllocation=true,DRADeviceTaints=true,DRADeviceTaintRules=true
           image-credential-provider-bin-dir: /var/lib/kubelet/credential-provider
           image-credential-provider-config: /var/lib/kubelet/credential-provider-config.yaml
         name: '{{ ds.meta_data["local_hostname"] }}'
@@ -205,7 +205,7 @@ spec:
       nodeRegistration:
         kubeletExtraArgs:
           cloud-provider: external
-          feature-gates: DynamicResourceAllocation=true
+          feature-gates: DynamicResourceAllocation=true,DRADeviceTaints=true,DRADeviceTaintRules=true
           image-credential-provider-bin-dir: /var/lib/kubelet/credential-provider
           image-credential-provider-config: /var/lib/kubelet/credential-provider-config.yaml
         name: '{{ ds.meta_data["local_hostname"] }}'
@@ -389,7 +389,7 @@ spec:
     nodeRegistration:
       kubeletExtraArgs:
         cloud-provider: external
-        feature-gates: ${NODE_FEATURE_GATES:-"DynamicResourceAllocation=true"}
+        feature-gates: ${NODE_FEATURE_GATES:-"DynamicResourceAllocation=true,DRADeviceTaints=true,DRADeviceTaintRules=true"}
         image-credential-provider-bin-dir: /var/lib/kubelet/credential-provider
         image-credential-provider-config: /var/lib/kubelet/credential-provider-config.yaml
       name: '{{ ds.meta_data["local_hostname"] }}'

--- a/templates/test/dev/cluster-template-custom-builds-load-dra.yaml
+++ b/templates/test/dev/cluster-template-custom-builds-load-dra.yaml
@@ -61,7 +61,7 @@ spec:
     clusterConfiguration:
       apiServer:
         extraArgs:
-          feature-gates: ${K8S_FEATURE_GATES:-"DynamicResourceAllocation=true"}
+          feature-gates: ${K8S_FEATURE_GATES:-"DynamicResourceAllocation=true,DRADeviceTaints=true,DRADeviceTaintRules=true"}
           runtime-config: resource.k8s.io/v1beta1=true,resource.k8s.io/v1beta2=true
         timeoutForControlPlane: 20m
       controllerManager:
@@ -69,7 +69,7 @@ spec:
           allocate-node-cidrs: "false"
           cloud-provider: external
           cluster-name: ${CLUSTER_NAME}
-          feature-gates: DynamicResourceAllocation=true
+          feature-gates: DynamicResourceAllocation=true,DRADeviceTaints=true,DRADeviceTaintRules=true
           kube-api-burst: "150"
           kube-api-qps: "75"
           v: "4"
@@ -83,7 +83,7 @@ spec:
         extraArgs:
           authorization-always-allow-paths: /healthz,/readyz,/livez,/metrics
           bind-address: 0.0.0.0
-          feature-gates: DynamicResourceAllocation=true
+          feature-gates: DynamicResourceAllocation=true,DRADeviceTaints=true,DRADeviceTaintRules=true
     diskSetup:
       filesystems:
       - device: /dev/disk/azure/scsi1/lun0
@@ -216,7 +216,7 @@ spec:
       nodeRegistration:
         kubeletExtraArgs:
           cloud-provider: external
-          feature-gates: DynamicResourceAllocation=true
+          feature-gates: DynamicResourceAllocation=true,DRADeviceTaints=true,DRADeviceTaintRules=true
           image-credential-provider-bin-dir: /var/lib/kubelet/credential-provider
           image-credential-provider-config: /var/lib/kubelet/credential-provider-config.yaml
         name: '{{ ds.meta_data["local_hostname"] }}'
@@ -224,7 +224,7 @@ spec:
       nodeRegistration:
         kubeletExtraArgs:
           cloud-provider: external
-          feature-gates: DynamicResourceAllocation=true
+          feature-gates: DynamicResourceAllocation=true,DRADeviceTaints=true,DRADeviceTaintRules=true
           image-credential-provider-bin-dir: /var/lib/kubelet/credential-provider
           image-credential-provider-config: /var/lib/kubelet/credential-provider-config.yaml
         name: '{{ ds.meta_data["local_hostname"] }}'
@@ -443,7 +443,7 @@ spec:
         nodeRegistration:
           kubeletExtraArgs:
             cloud-provider: external
-            feature-gates: ${NODE_FEATURE_GATES:-"DynamicResourceAllocation=true"}
+            feature-gates: ${NODE_FEATURE_GATES:-"DynamicResourceAllocation=true,DRADeviceTaints=true,DRADeviceTaintRules=true"}
             image-credential-provider-bin-dir: /var/lib/kubelet/credential-provider
             image-credential-provider-config: /var/lib/kubelet/credential-provider-config.yaml
           name: '{{ ds.meta_data["local_hostname"] }}'
@@ -1043,7 +1043,7 @@ spec:
         nodeRegistration:
           kubeletExtraArgs:
             cloud-provider: external
-            feature-gates: ${NODE_FEATURE_GATES:-"DynamicResourceAllocation=true"}
+            feature-gates: ${NODE_FEATURE_GATES:-"DynamicResourceAllocation=true,DRADeviceTaints=true,DRADeviceTaintRules=true"}
             image-credential-provider-bin-dir: /var/lib/kubelet/credential-provider
             image-credential-provider-config: /var/lib/kubelet/credential-provider-config.yaml
             register-with-taints: monitoring:NoSchedule

--- a/templates/test/dev/cluster-template-custom-builds-machine-pool-load-dra.yaml
+++ b/templates/test/dev/cluster-template-custom-builds-machine-pool-load-dra.yaml
@@ -60,7 +60,7 @@ spec:
     clusterConfiguration:
       apiServer:
         extraArgs:
-          feature-gates: ${K8S_FEATURE_GATES:-"DynamicResourceAllocation=true"}
+          feature-gates: ${K8S_FEATURE_GATES:-"DynamicResourceAllocation=true,DRADeviceTaints=true,DRADeviceTaintRules=true"}
           runtime-config: resource.k8s.io/v1beta1=true,resource.k8s.io/v1beta2=true
         timeoutForControlPlane: 20m
       controllerManager:
@@ -68,7 +68,7 @@ spec:
           allocate-node-cidrs: "false"
           cloud-provider: external
           cluster-name: ${CLUSTER_NAME}
-          feature-gates: DynamicResourceAllocation=true
+          feature-gates: DynamicResourceAllocation=true,DRADeviceTaints=true,DRADeviceTaintRules=true
           kube-api-burst: "150"
           kube-api-qps: "75"
           v: "4"
@@ -82,7 +82,7 @@ spec:
         extraArgs:
           authorization-always-allow-paths: /healthz,/readyz,/livez,/metrics
           bind-address: 0.0.0.0
-          feature-gates: DynamicResourceAllocation=true
+          feature-gates: DynamicResourceAllocation=true,DRADeviceTaints=true,DRADeviceTaintRules=true
     diskSetup:
       filesystems:
       - device: /dev/disk/azure/scsi1/lun0
@@ -203,7 +203,7 @@ spec:
       nodeRegistration:
         kubeletExtraArgs:
           cloud-provider: external
-          feature-gates: DynamicResourceAllocation=true
+          feature-gates: DynamicResourceAllocation=true,DRADeviceTaints=true,DRADeviceTaintRules=true
           image-credential-provider-bin-dir: /var/lib/kubelet/credential-provider
           image-credential-provider-config: /var/lib/kubelet/credential-provider-config.yaml
         name: '{{ ds.meta_data["local_hostname"] }}'
@@ -211,7 +211,7 @@ spec:
       nodeRegistration:
         kubeletExtraArgs:
           cloud-provider: external
-          feature-gates: DynamicResourceAllocation=true
+          feature-gates: DynamicResourceAllocation=true,DRADeviceTaints=true,DRADeviceTaintRules=true
           image-credential-provider-bin-dir: /var/lib/kubelet/credential-provider
           image-credential-provider-config: /var/lib/kubelet/credential-provider-config.yaml
         name: '{{ ds.meta_data["local_hostname"] }}'
@@ -399,7 +399,7 @@ spec:
     nodeRegistration:
       kubeletExtraArgs:
         cloud-provider: external
-        feature-gates: ${NODE_FEATURE_GATES:-"DynamicResourceAllocation=true"}
+        feature-gates: ${NODE_FEATURE_GATES:-"DynamicResourceAllocation=true,DRADeviceTaints=true,DRADeviceTaintRules=true"}
         image-credential-provider-bin-dir: /var/lib/kubelet/credential-provider
         image-credential-provider-config: /var/lib/kubelet/credential-provider-config.yaml
       name: '{{ ds.meta_data["local_hostname"] }}'
@@ -769,7 +769,7 @@ spec:
         nodeRegistration:
           kubeletExtraArgs:
             cloud-provider: external
-            feature-gates: ${NODE_FEATURE_GATES:-"DynamicResourceAllocation=true"}
+            feature-gates: ${NODE_FEATURE_GATES:-"DynamicResourceAllocation=true,DRADeviceTaints=true,DRADeviceTaintRules=true"}
             image-credential-provider-bin-dir: /var/lib/kubelet/credential-provider
             image-credential-provider-config: /var/lib/kubelet/credential-provider-config.yaml
             register-with-taints: monitoring:NoSchedule


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind failing-test

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
Fixes DRA conformance test failures regarding missing feature gates: https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/periodic-cluster-api-provider-azure-conformance-with-ci-artifacts-dra-main/2036346346713124864

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->


**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] cherry-pick candidate

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
