### PR TITLE
Bump CAAPH to v0.6.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -364,7 +364,7 @@ create-management-cluster: $(KUSTOMIZE) $(ENVSUBST) $(KUBECTL) $(KIND) ## Create
 	timeout --foreground 300 bash -c "until curl --retry $(CURL_RETRIES) -sSL https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.12.4/cluster-api-components.yaml | $(ENVSUBST) | $(KUBECTL) apply -f - --server-side=true; do sleep 5; done"
 
 	# Deploy CAAPH
-	timeout --foreground 300 bash -c "until curl --retry $(CURL_RETRIES) -sSL https://github.com/kubernetes-sigs/cluster-api-addon-provider-helm/releases/download/v0.6.1/addon-components.yaml | $(ENVSUBST) | $(KUBECTL) apply -f - --server-side=true; do sleep 5; done"
+	timeout --foreground 300 bash -c "until curl --retry $(CURL_RETRIES) -sSL https://github.com/kubernetes-sigs/cluster-api-addon-provider-helm/releases/download/v0.6.2/addon-components.yaml | $(ENVSUBST) | $(KUBECTL) apply -f - --server-side=true; do sleep 5; done"
 
 	# Deploy CAPZ
 	if [ "$(MGMT_CLUSTER_TYPE)" != "aks" ]; then \

--- a/Tiltfile
+++ b/Tiltfile
@@ -23,7 +23,7 @@ settings = {
     "preload_images_for_kind": True,
     "kind_cluster_name": "capz",
     "capi_version": "v1.12.4",
-    "caaph_version": "v0.6.1",
+    "caaph_version": "v0.6.2",
     "cert_manager_version": "v1.19.1",
     "kubernetes_version": "v1.33.6",
     "aks_kubernetes_version": "v1.30.2",

--- a/docs/book/src/developers/getting-started-with-capi-operator.md
+++ b/docs/book/src/developers/getting-started-with-capi-operator.md
@@ -122,7 +122,7 @@ Create a `values.yaml` file for the CAPI Operator Helm chart like so:
 ```yaml
 core: "cluster-api:v1.12.4"
 infrastructure: "azure:v1.17.2"
-addon: "helm:v0.6.1"
+addon: "helm:v0.6.2"
 manager:
   featureGates:
     core:

--- a/test/e2e/config/azure-dev.yaml
+++ b/test/e2e/config/azure-dev.yaml
@@ -209,8 +209,8 @@ providers:
       replacements:
       - old: "imagePullPolicy: Always"
         new: "imagePullPolicy: IfNotPresent"
-    - name: v0.6.1
-      value: https://github.com/kubernetes-sigs/cluster-api-addon-provider-helm/releases/download/v0.6.1/addon-components.yaml
+    - name: v0.6.2
+      value: https://github.com/kubernetes-sigs/cluster-api-addon-provider-helm/releases/download/v0.6.2/addon-components.yaml
       type: url
       contract: v1beta1
       files:
@@ -263,7 +263,7 @@ variables:
   OLD_PROVIDER_UPGRADE_VERSION: "v1.22.2"
   LATEST_PROVIDER_UPGRADE_VERSION: "v1.23.0"
   OLD_CAAPH_UPGRADE_VERSION: "v0.5.3"
-  LATEST_CAAPH_UPGRADE_VERSION: "v0.6.1"
+  LATEST_CAAPH_UPGRADE_VERSION: "v0.6.2"
   CI_RG: "${CI_RG:-capz-ci}"
   USER_IDENTITY: "${USER_IDENTITY:-cloud-provider-user-identity}"
   EXP_APISERVER_ILB: "true"


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Updates CAAPH to the latest version [v0.6.2](https://github.com/kubernetes-sigs/cluster-api-addon-provider-helm/releases/tag/v0.6.2).

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->


**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] cherry-pick candidate

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```