### PR TITLE
Fix: add dry-run AzureCluster create to ensure CA bundle availability

### DIFF
--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -47,6 +47,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	typedappsv1 "k8s.io/client-go/kubernetes/typed/apps/v1"
@@ -875,6 +876,16 @@ func waitForWebhookCAInjection(ctx context.Context, c client.Client) {
 				ResourceGroup: "capz-webhook-probe",
 			},
 		}
-		return client.NewDryRunClient(c).Create(ctx, obj)
+		err := client.NewDryRunClient(c).Create(ctx, obj)
+		if err == nil {
+			return nil
+		}
+		// A webhook validation rejection (e.g. Invalid/Forbidden) means the
+		// webhook was reachable with valid TLS, which is all we need to verify.
+		// Only keep retrying on errors that indicate TLS is not yet working.
+		if apierrors.IsInvalid(err) || apierrors.IsForbidden(err) {
+			return nil
+		}
+		return err
 	}, 2*time.Minute, 5*time.Second).Should(Succeed(), "dry-run AzureCluster create failed, webhook TLS may not be ready")
 }

--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -58,6 +58,7 @@ import (
 	"sigs.k8s.io/cluster-api/test/framework/kubernetesversions"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
 )
 
@@ -854,4 +855,26 @@ func waitForWebhookCAInjection(ctx context.Context, c client.Client) {
 			}
 		}
 	}, 5*time.Minute, 5*time.Second).Should(Succeed(), "cert-manager cainjector did not inject CA bundles into webhook configurations in time")
+
+	// Even after the CABundle is populated on the webhook configuration, the
+	// kube-apiserver may not have picked up the updated config from its
+	// informer cache yet. Perform a dry-run create of an AzureCluster to
+	// verify the CAPZ mutating webhook is reachable end-to-end with valid TLS.
+	By("Verifying CAPZ webhook is reachable via dry-run create")
+	Eventually(func() error {
+		obj := &infrav1.AzureCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "capz-webhook-probe",
+				Namespace: "default",
+			},
+			Spec: infrav1.AzureClusterSpec{
+				AzureClusterClassSpec: infrav1.AzureClusterClassSpec{
+					SubscriptionID: "00000000-0000-0000-0000-000000000000",
+					Location:       "eastus",
+				},
+				ResourceGroup: "capz-webhook-probe",
+			},
+		}
+		return client.NewDryRunClient(c).Create(ctx, obj)
+	}, 2*time.Minute, 5*time.Second).Should(Succeed(), "dry-run AzureCluster create failed, webhook TLS may not be ready")
 }

--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -887,5 +887,5 @@ func waitForWebhookCAInjection(ctx context.Context, c client.Client) {
 			return nil
 		}
 		return err
-	}, 2*time.Minute, 5*time.Second).Should(Succeed(), "dry-run AzureCluster create failed, webhook TLS may not be ready")
+	}, 5*time.Minute, 5*time.Second).Should(Succeed(), "dry-run AzureCluster create failed, webhook TLS may not be ready")
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind flake

**What this PR does / why we need it**:

Fixes a flaky e2e test failure where the kube-apiserver hasn't yet picked up updated webhook CA bundles from its informer cache, even though cert-manager's cainjector has already populated them on the webhook configurations: the well-known "x509 error."

After the existing check that waits for CA bundle injection into all ValidatingWebhookConfigurations and MutatingWebhookConfigurations, this adds a dry-run `AzureCluster` create to verify the CAPZ mutating webhook is actually reachable end-to-end with valid TLS. This closes the race window between the CA bundle being written and the apiserver serving requests through the webhook with the new certificate.

**Which issue(s) this PR fixes**:
Fixes #5690 (hopefully)
See also #6144, which apparently didn't work. :-(

**Special notes for your reviewer**:


**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [x] cherry-pick candidate

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
