### PR TITLE
[WIP] Add e2e test for KubeRay NativeWorkloadScheduling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,6 @@ azure_identity_id
 azure_wi_back_compat
 openid-configuration.json
 aks-mgmt.config
+
+# kuberay source checkout for NativeScheduling e2e tests
+_kuberay-source/

--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,6 @@ azure_wi_back_compat
 openid-configuration.json
 aks-mgmt.config
 .service-account-issuer.env
+
+# kuberay source checkout for NativeScheduling e2e tests
+_kuberay-source/

--- a/scripts/ci-build-kuberay-operator.sh
+++ b/scripts/ci-build-kuberay-operator.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+###############################################################################
+
+# This script builds and pushes the kuberay-operator Docker image from the
+# marosset/kuberay workload-poc branch. It is sourced by ci-e2e.sh when
+# running the NativeScheduling e2e tests.
+#
+# After sourcing, the following environment variables are exported:
+#   KUBERAY_SOURCE_DIR          - path to the cloned kuberay repo
+#   KUBERAY_OPERATOR_IMAGE_TAG  - tag applied to the built image
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
+cd "${REPO_ROOT}" || exit 1
+
+: "${REGISTRY:?Environment variable empty or not defined.}"
+
+KUBERAY_SOURCE_REPO="${KUBERAY_SOURCE_REPO:-https://github.com/marosset/kuberay.git}"
+KUBERAY_SOURCE_BRANCH="${KUBERAY_SOURCE_BRANCH:-workload-poc}"
+
+# Clone kuberay source if not already present.
+KUBERAY_SOURCE_DIR="${KUBERAY_SOURCE_DIR:-${REPO_ROOT}/_kuberay-source}"
+if [[ ! -d "${KUBERAY_SOURCE_DIR}" ]]; then
+    echo "Cloning kuberay from ${KUBERAY_SOURCE_REPO} (branch: ${KUBERAY_SOURCE_BRANCH})"
+    git clone --depth 1 --branch "${KUBERAY_SOURCE_BRANCH}" "${KUBERAY_SOURCE_REPO}" "${KUBERAY_SOURCE_DIR}"
+else
+    echo "Using existing kuberay source at ${KUBERAY_SOURCE_DIR}"
+fi
+
+# Determine the image tag from the kuberay source commit.
+pushd "${KUBERAY_SOURCE_DIR}" > /dev/null
+KUBERAY_OPERATOR_IMAGE_TAG="${KUBERAY_OPERATOR_IMAGE_TAG:-$(git rev-parse --short=7 HEAD)}"
+popd > /dev/null
+
+KUBERAY_OPERATOR_IMAGE="${REGISTRY}/kuberay-operator:${KUBERAY_OPERATOR_IMAGE_TAG}"
+
+echo "Building kuberay-operator image: ${KUBERAY_OPERATOR_IMAGE}"
+docker build -t "${KUBERAY_OPERATOR_IMAGE}" "${KUBERAY_SOURCE_DIR}/ray-operator"
+
+echo "Pushing kuberay-operator image: ${KUBERAY_OPERATOR_IMAGE}"
+docker push "${KUBERAY_OPERATOR_IMAGE}"
+
+export KUBERAY_SOURCE_DIR
+export KUBERAY_OPERATOR_IMAGE_TAG
+
+echo "kuberay-operator image built and pushed successfully"
+echo "  KUBERAY_SOURCE_DIR=${KUBERAY_SOURCE_DIR}"
+echo "  KUBERAY_OPERATOR_IMAGE_TAG=${KUBERAY_OPERATOR_IMAGE_TAG}"
+echo "  REGISTRY=${REGISTRY}"

--- a/scripts/ci-build-kuberay-operator.sh
+++ b/scripts/ci-build-kuberay-operator.sh
@@ -30,6 +30,7 @@ set -o pipefail
 
 REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 cd "${REPO_ROOT}" || exit 1
+REPO_ROOT="$(pwd)"
 
 : "${REGISTRY:?Environment variable empty or not defined.}"
 
@@ -37,6 +38,7 @@ KUBERAY_SOURCE_REPO="${KUBERAY_SOURCE_REPO:-https://github.com/marosset/kuberay.
 KUBERAY_SOURCE_BRANCH="${KUBERAY_SOURCE_BRANCH:-workload-poc}"
 
 # Clone kuberay source if not already present.
+# Use an absolute path so it resolves correctly regardless of cwd (e.g., from Ginkgo test binaries).
 KUBERAY_SOURCE_DIR="${KUBERAY_SOURCE_DIR:-${REPO_ROOT}/_kuberay-source}"
 if [[ ! -d "${KUBERAY_SOURCE_DIR}" ]]; then
     echo "Cloning kuberay from ${KUBERAY_SOURCE_REPO} (branch: ${KUBERAY_SOURCE_BRANCH})"

--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -54,7 +54,7 @@ if [[ "${BUILD_MANAGER_IMAGE}" == "true" ]]; then
   export TAG="${defaultTag:-dev}"
 fi
 
-if [[ "$(capz::util::should_build_ccm)" == "true" ]]; then
+if [[ "$(capz::util::should_build_ccm)" == "true" ]] || [[ "${GINKGO_FOCUS:-}" =~ NativeScheduling ]]; then
   # shellcheck source=scripts/ci-build-azure-ccm.sh
   source "${REPO_ROOT}/scripts/ci-build-azure-ccm.sh"
   echo "Will use the ${IMAGE_REGISTRY}/${CCM_IMAGE_NAME}:${IMAGE_TAG_CCM} cloud-controller-manager image for external cloud-provider-cluster"

--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -61,9 +61,9 @@ if [[ "$(capz::util::should_build_ccm)" == "true" ]] || [[ "${GINKGO_FOCUS:-}" =
   echo "Will use the ${IMAGE_REGISTRY}/${CNM_IMAGE_NAME}:${IMAGE_TAG_CNM} cloud-node-manager image for external cloud-provider-azure cluster"
 fi
 
-# Build the kuberay-operator from source when running NativeScheduling tests.
-if [[ "${GINKGO_FOCUS:-}" =~ NativeScheduling ]]; then
-  echo "NativeScheduling tests detected, building kuberay-operator from source"
+# Build the kuberay-operator from source when running KubeRay or NativeScheduling tests.
+if [[ "${GINKGO_FOCUS:-}" =~ KubeRay ]] || [[ "${GINKGO_FOCUS:-}" =~ NativeScheduling ]]; then
+  echo "KubeRay/NativeScheduling tests detected, building kuberay-operator from source"
   # shellcheck source=scripts/ci-build-kuberay-operator.sh
   source "${REPO_ROOT}/scripts/ci-build-kuberay-operator.sh"
 fi

--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -61,6 +61,13 @@ if [[ "$(capz::util::should_build_ccm)" == "true" ]]; then
   echo "Will use the ${IMAGE_REGISTRY}/${CNM_IMAGE_NAME}:${IMAGE_TAG_CNM} cloud-node-manager image for external cloud-provider-azure cluster"
 fi
 
+# Build the kuberay-operator from source when running NativeScheduling tests.
+if [[ "${GINKGO_FOCUS:-}" =~ NativeScheduling ]]; then
+  echo "NativeScheduling tests detected, building kuberay-operator from source"
+  # shellcheck source=scripts/ci-build-kuberay-operator.sh
+  source "${REPO_ROOT}/scripts/ci-build-kuberay-operator.sh"
+fi
+
 export GINKGO_NODES=10
 
 export AZURE_LOCATION="${AZURE_LOCATION:-$(capz::util::get_random_region)}"

--- a/templates/test/ci/cluster-template-prow-ci-version-native-scheduling.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version-native-scheduling.yaml
@@ -57,7 +57,7 @@ spec:
     clusterConfiguration:
       apiServer:
         extraArgs:
-          feature-gates: ${K8S_FEATURE_GATES:-"GenericWorkload=true"}
+          feature-gates: GenericWorkload=true
           runtime-config: scheduling.k8s.io/v1alpha2=true
         timeoutForControlPlane: 20m
       controllerManager:

--- a/templates/test/ci/cluster-template-prow-ci-version-native-scheduling.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version-native-scheduling.yaml
@@ -109,6 +109,34 @@ spec:
         set -o errexit
         [[ $(id -u) != 0 ]] && SUDO="sudo" || SUDO=""
 
+        # Run the az login command with managed identity
+        if az login --identity > /dev/null 2>&1; then
+          echo "Logged in Azure with managed identity"
+          echo "Use OOT credential provider"
+          mkdir -p /var/lib/kubelet/credential-provider
+          az storage blob download --blob-url "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${IMAGE_TAG_ACR_CREDENTIAL_PROVIDER}/azure-acr-credential-provider" -f /var/lib/kubelet/credential-provider/acr-credential-provider --auth-mode login
+          chmod 755 /var/lib/kubelet/credential-provider/acr-credential-provider
+          az storage blob download --blob-url "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${IMAGE_TAG_ACR_CREDENTIAL_PROVIDER}/credential-provider-config.yaml" -f /var/lib/kubelet/credential-provider-config.yaml --auth-mode login
+          chmod 644 /var/lib/kubelet/credential-provider-config.yaml
+        else
+          echo "Using curl to download the OOT credential provider"
+          mkdir -p /var/lib/kubelet/credential-provider
+          curl --retry 10 --retry-delay 5 -w "response status code is %{http_code}" -Lo /var/lib/kubelet/credential-provider/acr-credential-provider "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${IMAGE_TAG_ACR_CREDENTIAL_PROVIDER}/azure-acr-credential-provider"
+          chmod 755 /var/lib/kubelet/credential-provider/acr-credential-provider
+          curl --retry 10 --retry-delay 5 -w "response status code is %{http_code}" -Lo /var/lib/kubelet/credential-provider-config.yaml "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${IMAGE_TAG_ACR_CREDENTIAL_PROVIDER}/credential-provider-config.yaml"
+          chmod 644 /var/lib/kubelet/credential-provider-config.yaml
+        fi
+      owner: root:root
+      path: /tmp/oot-cred-provider.sh
+      permissions: "0744"
+    - content: |
+        #!/bin/bash
+
+        set -o nounset
+        set -o pipefail
+        set -o errexit
+        [[ $(id -u) != 0 ]] && SUDO="sudo" || SUDO=""
+
         # This test installs release packages or binaries that are a result of the CI and release builds.
         # It runs '... --version' commands to verify that the binaries are correctly installed
         # and finally uninstalls the packages.
@@ -171,17 +199,22 @@ spec:
       nodeRegistration:
         kubeletExtraArgs:
           cloud-provider: external
+          image-credential-provider-bin-dir: /var/lib/kubelet/credential-provider
+          image-credential-provider-config: /var/lib/kubelet/credential-provider-config.yaml
         name: '{{ ds.meta_data["local_hostname"] }}'
     joinConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
           cloud-provider: external
+          image-credential-provider-bin-dir: /var/lib/kubelet/credential-provider
+          image-credential-provider-config: /var/lib/kubelet/credential-provider-config.yaml
         name: '{{ ds.meta_data["local_hostname"] }}'
     mounts:
     - - LABEL=etcd_disk
       - /var/lib/etcddisk
     postKubeadmCommands: []
     preKubeadmCommands:
+    - bash -c /tmp/oot-cred-provider.sh
     - bash -c /tmp/kubeadm-bootstrap.sh
     verbosity: 5
   machineTemplate:
@@ -303,6 +336,34 @@ spec:
           set -o errexit
           [[ $(id -u) != 0 ]] && SUDO="sudo" || SUDO=""
 
+          # Run the az login command with managed identity
+          if az login --identity > /dev/null 2>&1; then
+            echo "Logged in Azure with managed identity"
+            echo "Use OOT credential provider"
+            mkdir -p /var/lib/kubelet/credential-provider
+            az storage blob download --blob-url "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${IMAGE_TAG_ACR_CREDENTIAL_PROVIDER}/azure-acr-credential-provider" -f /var/lib/kubelet/credential-provider/acr-credential-provider --auth-mode login
+            chmod 755 /var/lib/kubelet/credential-provider/acr-credential-provider
+            az storage blob download --blob-url "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${IMAGE_TAG_ACR_CREDENTIAL_PROVIDER}/credential-provider-config.yaml" -f /var/lib/kubelet/credential-provider-config.yaml --auth-mode login
+            chmod 644 /var/lib/kubelet/credential-provider-config.yaml
+          else
+            echo "Use OOT credential provider"
+            mkdir -p /var/lib/kubelet/credential-provider
+            curl --retry 10 --retry-delay 5 -w "response status code is %{http_code}" -Lo /var/lib/kubelet/credential-provider/acr-credential-provider "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${IMAGE_TAG_ACR_CREDENTIAL_PROVIDER}/azure-acr-credential-provider"
+            chmod 755 /var/lib/kubelet/credential-provider/acr-credential-provider
+            curl --retry 10 --retry-delay 5 -w "response status code is %{http_code}" -Lo /var/lib/kubelet/credential-provider-config.yaml "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${IMAGE_TAG_ACR_CREDENTIAL_PROVIDER}/credential-provider-config.yaml"
+            chmod 644 /var/lib/kubelet/credential-provider-config.yaml
+          fi
+        owner: root:root
+        path: /tmp/oot-cred-provider.sh
+        permissions: "0744"
+      - content: |
+          #!/bin/bash
+
+          set -o nounset
+          set -o pipefail
+          set -o errexit
+          [[ $(id -u) != 0 ]] && SUDO="sudo" || SUDO=""
+
           # This test installs release packages or binaries that are a result of the CI and release builds.
           # It runs '... --version' commands to verify that the binaries are correctly installed
           # and finally uninstalls the packages.
@@ -365,8 +426,11 @@ spec:
         nodeRegistration:
           kubeletExtraArgs:
             cloud-provider: external
+            image-credential-provider-bin-dir: /var/lib/kubelet/credential-provider
+            image-credential-provider-config: /var/lib/kubelet/credential-provider-config.yaml
           name: '{{ ds.meta_data["local_hostname"] }}'
       preKubeadmCommands:
+      - bash -c /tmp/oot-cred-provider.sh
       - bash -c /tmp/kubeadm-bootstrap.sh
       verbosity: 5
 ---
@@ -542,6 +606,36 @@ spec:
     cloudControllerManager:
       clusterCIDR: {{ .Cluster.spec.clusterNetwork.pods.cidrBlocks | join "," }}
       logVerbosity: 4
+---
+apiVersion: addons.cluster.x-k8s.io/v1alpha1
+kind: HelmChartProxy
+metadata:
+  name: cloud-provider-azure-chart-ci
+  namespace: default
+spec:
+  chartName: cloud-provider-azure
+  clusterSelector:
+    matchLabels:
+      cloud-provider: azure-ci
+  releaseName: cloud-provider-azure-oot
+  repoURL: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/helm/repo
+  valuesTemplate: |
+    infra:
+      clusterName: {{ .Cluster.metadata.name }}
+    cloudControllerManager:
+      cloudConfig: ${CLOUD_CONFIG:-"/etc/kubernetes/azure.json"}
+      cloudConfigSecretName: ${CONFIG_SECRET_NAME:-""}
+      clusterCIDR: {{ .Cluster.spec.clusterNetwork.pods.cidrBlocks | join "," }}
+      imageName: "${CCM_IMAGE_NAME:-""}"
+      imageRepository: "${IMAGE_REGISTRY:-""}"
+      imageTag: "${IMAGE_TAG_CCM:-""}"
+      logVerbosity: ${CCM_LOG_VERBOSITY:-4}
+      replicas: ${CCM_COUNT:-1}
+      enableDynamicReloading: ${ENABLE_DYNAMIC_RELOADING:-false}
+    cloudNodeManager:
+      imageName: "${CNM_IMAGE_NAME:-""}"
+      imageRepository: "${IMAGE_REGISTRY:-""}"
+      imageTag: "${IMAGE_TAG_CNM:-""}"
 ---
 apiVersion: addons.cluster.x-k8s.io/v1beta1
 kind: ClusterResourceSet

--- a/templates/test/ci/cluster-template-prow-ci-version-native-scheduling.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version-native-scheduling.yaml
@@ -109,34 +109,6 @@ spec:
         set -o errexit
         [[ $(id -u) != 0 ]] && SUDO="sudo" || SUDO=""
 
-        # Run the az login command with managed identity
-        if az login --identity > /dev/null 2>&1; then
-          echo "Logged in Azure with managed identity"
-          echo "Use OOT credential provider"
-          mkdir -p /var/lib/kubelet/credential-provider
-          az storage blob download --blob-url "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${IMAGE_TAG_ACR_CREDENTIAL_PROVIDER}/azure-acr-credential-provider" -f /var/lib/kubelet/credential-provider/acr-credential-provider --auth-mode login
-          chmod 755 /var/lib/kubelet/credential-provider/acr-credential-provider
-          az storage blob download --blob-url "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${IMAGE_TAG_ACR_CREDENTIAL_PROVIDER}/credential-provider-config.yaml" -f /var/lib/kubelet/credential-provider-config.yaml --auth-mode login
-          chmod 644 /var/lib/kubelet/credential-provider-config.yaml
-        else
-          echo "Using curl to download the OOT credential provider"
-          mkdir -p /var/lib/kubelet/credential-provider
-          curl --retry 10 --retry-delay 5 -w "response status code is %{http_code}" -Lo /var/lib/kubelet/credential-provider/acr-credential-provider "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${IMAGE_TAG_ACR_CREDENTIAL_PROVIDER}/azure-acr-credential-provider"
-          chmod 755 /var/lib/kubelet/credential-provider/acr-credential-provider
-          curl --retry 10 --retry-delay 5 -w "response status code is %{http_code}" -Lo /var/lib/kubelet/credential-provider-config.yaml "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${IMAGE_TAG_ACR_CREDENTIAL_PROVIDER}/credential-provider-config.yaml"
-          chmod 644 /var/lib/kubelet/credential-provider-config.yaml
-        fi
-      owner: root:root
-      path: /tmp/oot-cred-provider.sh
-      permissions: "0744"
-    - content: |
-        #!/bin/bash
-
-        set -o nounset
-        set -o pipefail
-        set -o errexit
-        [[ $(id -u) != 0 ]] && SUDO="sudo" || SUDO=""
-
         # This test installs release packages or binaries that are a result of the CI and release builds.
         # It runs '... --version' commands to verify that the binaries are correctly installed
         # and finally uninstalls the packages.
@@ -199,22 +171,17 @@ spec:
       nodeRegistration:
         kubeletExtraArgs:
           cloud-provider: external
-          image-credential-provider-bin-dir: /var/lib/kubelet/credential-provider
-          image-credential-provider-config: /var/lib/kubelet/credential-provider-config.yaml
         name: '{{ ds.meta_data["local_hostname"] }}'
     joinConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
           cloud-provider: external
-          image-credential-provider-bin-dir: /var/lib/kubelet/credential-provider
-          image-credential-provider-config: /var/lib/kubelet/credential-provider-config.yaml
         name: '{{ ds.meta_data["local_hostname"] }}'
     mounts:
     - - LABEL=etcd_disk
       - /var/lib/etcddisk
     postKubeadmCommands: []
     preKubeadmCommands:
-    - bash -c /tmp/oot-cred-provider.sh
     - bash -c /tmp/kubeadm-bootstrap.sh
     verbosity: 5
   machineTemplate:
@@ -336,34 +303,6 @@ spec:
           set -o errexit
           [[ $(id -u) != 0 ]] && SUDO="sudo" || SUDO=""
 
-          # Run the az login command with managed identity
-          if az login --identity > /dev/null 2>&1; then
-            echo "Logged in Azure with managed identity"
-            echo "Use OOT credential provider"
-            mkdir -p /var/lib/kubelet/credential-provider
-            az storage blob download --blob-url "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${IMAGE_TAG_ACR_CREDENTIAL_PROVIDER}/azure-acr-credential-provider" -f /var/lib/kubelet/credential-provider/acr-credential-provider --auth-mode login
-            chmod 755 /var/lib/kubelet/credential-provider/acr-credential-provider
-            az storage blob download --blob-url "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${IMAGE_TAG_ACR_CREDENTIAL_PROVIDER}/credential-provider-config.yaml" -f /var/lib/kubelet/credential-provider-config.yaml --auth-mode login
-            chmod 644 /var/lib/kubelet/credential-provider-config.yaml
-          else
-            echo "Use OOT credential provider"
-            mkdir -p /var/lib/kubelet/credential-provider
-            curl --retry 10 --retry-delay 5 -w "response status code is %{http_code}" -Lo /var/lib/kubelet/credential-provider/acr-credential-provider "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${IMAGE_TAG_ACR_CREDENTIAL_PROVIDER}/azure-acr-credential-provider"
-            chmod 755 /var/lib/kubelet/credential-provider/acr-credential-provider
-            curl --retry 10 --retry-delay 5 -w "response status code is %{http_code}" -Lo /var/lib/kubelet/credential-provider-config.yaml "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${IMAGE_TAG_ACR_CREDENTIAL_PROVIDER}/credential-provider-config.yaml"
-            chmod 644 /var/lib/kubelet/credential-provider-config.yaml
-          fi
-        owner: root:root
-        path: /tmp/oot-cred-provider.sh
-        permissions: "0744"
-      - content: |
-          #!/bin/bash
-
-          set -o nounset
-          set -o pipefail
-          set -o errexit
-          [[ $(id -u) != 0 ]] && SUDO="sudo" || SUDO=""
-
           # This test installs release packages or binaries that are a result of the CI and release builds.
           # It runs '... --version' commands to verify that the binaries are correctly installed
           # and finally uninstalls the packages.
@@ -426,11 +365,8 @@ spec:
         nodeRegistration:
           kubeletExtraArgs:
             cloud-provider: external
-            image-credential-provider-bin-dir: /var/lib/kubelet/credential-provider
-            image-credential-provider-config: /var/lib/kubelet/credential-provider-config.yaml
           name: '{{ ds.meta_data["local_hostname"] }}'
       preKubeadmCommands:
-      - bash -c /tmp/oot-cred-provider.sh
       - bash -c /tmp/kubeadm-bootstrap.sh
       verbosity: 5
 ---
@@ -606,36 +542,6 @@ spec:
     cloudControllerManager:
       clusterCIDR: {{ .Cluster.spec.clusterNetwork.pods.cidrBlocks | join "," }}
       logVerbosity: 4
----
-apiVersion: addons.cluster.x-k8s.io/v1alpha1
-kind: HelmChartProxy
-metadata:
-  name: cloud-provider-azure-chart-ci
-  namespace: default
-spec:
-  chartName: cloud-provider-azure
-  clusterSelector:
-    matchLabels:
-      cloud-provider: azure-ci
-  releaseName: cloud-provider-azure-oot
-  repoURL: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/helm/repo
-  valuesTemplate: |
-    infra:
-      clusterName: {{ .Cluster.metadata.name }}
-    cloudControllerManager:
-      cloudConfig: ${CLOUD_CONFIG:-"/etc/kubernetes/azure.json"}
-      cloudConfigSecretName: ${CONFIG_SECRET_NAME:-""}
-      clusterCIDR: {{ .Cluster.spec.clusterNetwork.pods.cidrBlocks | join "," }}
-      imageName: "${CCM_IMAGE_NAME:-""}"
-      imageRepository: "${IMAGE_REGISTRY:-""}"
-      imageTag: "${IMAGE_TAG_CCM:-""}"
-      logVerbosity: ${CCM_LOG_VERBOSITY:-4}
-      replicas: ${CCM_COUNT:-1}
-      enableDynamicReloading: ${ENABLE_DYNAMIC_RELOADING:-false}
-    cloudNodeManager:
-      imageName: "${CNM_IMAGE_NAME:-""}"
-      imageRepository: "${IMAGE_REGISTRY:-""}"
-      imageTag: "${IMAGE_TAG_CNM:-""}"
 ---
 apiVersion: addons.cluster.x-k8s.io/v1beta1
 kind: ClusterResourceSet

--- a/templates/test/ci/cluster-template-prow-ci-version-native-scheduling.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version-native-scheduling.yaml
@@ -1,0 +1,868 @@
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  labels:
+    cloud-provider: ${CLOUD_PROVIDER_AZURE_LABEL:=azure}
+    cni: calico
+    metrics-server: enabled
+  name: ${CLUSTER_NAME}
+  namespace: default
+spec:
+  clusterNetwork:
+    pods:
+      cidrBlocks:
+      - 192.168.0.0/16
+  controlPlaneRef:
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    kind: KubeadmControlPlane
+    name: ${CLUSTER_NAME}-control-plane
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    kind: AzureCluster
+    name: ${CLUSTER_NAME}
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: AzureCluster
+metadata:
+  name: ${CLUSTER_NAME}
+  namespace: default
+spec:
+  additionalTags:
+    buildProvenance: ${BUILD_PROVENANCE}
+    creationTimestamp: ${TIMESTAMP}
+    jobName: ${JOB_NAME}
+  identityRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    kind: AzureClusterIdentity
+    name: ${CLUSTER_IDENTITY_NAME}
+  location: ${AZURE_LOCATION}
+  networkSpec:
+    subnets:
+    - name: control-plane-subnet
+      role: control-plane
+    - name: node-subnet
+      role: node
+    vnet:
+      name: ${AZURE_VNET_NAME:=${CLUSTER_NAME}-vnet}
+  resourceGroup: ${AZURE_RESOURCE_GROUP:=${CLUSTER_NAME}}
+  subscriptionID: ${AZURE_SUBSCRIPTION_ID}
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+kind: KubeadmControlPlane
+metadata:
+  name: ${CLUSTER_NAME}-control-plane
+  namespace: default
+spec:
+  kubeadmConfigSpec:
+    clusterConfiguration:
+      apiServer:
+        extraArgs:
+          feature-gates: ${K8S_FEATURE_GATES:-"GenericWorkload=true"}
+          runtime-config: scheduling.k8s.io/v1alpha2=true
+        timeoutForControlPlane: 20m
+      controllerManager:
+        extraArgs:
+          allocate-node-cidrs: "false"
+          cloud-provider: external
+          cluster-name: ${CLUSTER_NAME}
+          feature-gates: GenericWorkload=true
+          v: "4"
+      scheduler:
+        extraArgs:
+          feature-gates: GenericWorkload=true,GangScheduling=true
+      etcd:
+        local:
+          dataDir: /var/lib/etcddisk/etcd
+          extraArgs:
+            quota-backend-bytes: "8589934592"
+      kubernetesVersion: ci/${CI_VERSION}
+    diskSetup:
+      filesystems:
+      - device: /dev/disk/azure/scsi1/lun0
+        extraOpts:
+        - -E
+        - lazy_itable_init=1,lazy_journal_init=1
+        filesystem: ext4
+        label: etcd_disk
+      - device: ephemeral0.1
+        filesystem: ext4
+        label: ephemeral0
+        replaceFS: ntfs
+      partitions:
+      - device: /dev/disk/azure/scsi1/lun0
+        layout: true
+        overwrite: false
+        tableType: gpt
+    files:
+    - contentFrom:
+        secret:
+          key: control-plane-azure.json
+          name: ${CLUSTER_NAME}-control-plane-azure-json
+      owner: root:root
+      path: /etc/kubernetes/azure.json
+      permissions: "0644"
+    - content: |
+        #!/bin/bash
+
+        set -o nounset
+        set -o pipefail
+        set -o errexit
+        [[ $(id -u) != 0 ]] && SUDO="sudo" || SUDO=""
+
+        # Run the az login command with managed identity
+        if az login --identity > /dev/null 2>&1; then
+          echo "Logged in Azure with managed identity"
+          echo "Use OOT credential provider"
+          mkdir -p /var/lib/kubelet/credential-provider
+          az storage blob download --blob-url "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${IMAGE_TAG_ACR_CREDENTIAL_PROVIDER}/azure-acr-credential-provider" -f /var/lib/kubelet/credential-provider/acr-credential-provider --auth-mode login
+          chmod 755 /var/lib/kubelet/credential-provider/acr-credential-provider
+          az storage blob download --blob-url "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${IMAGE_TAG_ACR_CREDENTIAL_PROVIDER}/credential-provider-config.yaml" -f /var/lib/kubelet/credential-provider-config.yaml --auth-mode login
+          chmod 644 /var/lib/kubelet/credential-provider-config.yaml
+        else
+          echo "Using curl to download the OOT credential provider"
+          mkdir -p /var/lib/kubelet/credential-provider
+          curl --retry 10 --retry-delay 5 -w "response status code is %{http_code}" -Lo /var/lib/kubelet/credential-provider/acr-credential-provider "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${IMAGE_TAG_ACR_CREDENTIAL_PROVIDER}/azure-acr-credential-provider"
+          chmod 755 /var/lib/kubelet/credential-provider/acr-credential-provider
+          curl --retry 10 --retry-delay 5 -w "response status code is %{http_code}" -Lo /var/lib/kubelet/credential-provider-config.yaml "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${IMAGE_TAG_ACR_CREDENTIAL_PROVIDER}/credential-provider-config.yaml"
+          chmod 644 /var/lib/kubelet/credential-provider-config.yaml
+        fi
+      owner: root:root
+      path: /tmp/oot-cred-provider.sh
+      permissions: "0744"
+    - content: |
+        #!/bin/bash
+
+        set -o nounset
+        set -o pipefail
+        set -o errexit
+        [[ $(id -u) != 0 ]] && SUDO="sudo" || SUDO=""
+
+        # This test installs release packages or binaries that are a result of the CI and release builds.
+        # It runs '... --version' commands to verify that the binaries are correctly installed
+        # and finally uninstalls the packages.
+        # For the release packages it tests all versions in the support skew.
+        LINE_SEPARATOR="*************************************************"
+        echo "$${LINE_SEPARATOR}"
+        CI_VERSION=${CI_VERSION}
+
+        # Note: We assume if kubectl has the right version, everything else has as well
+        if [[ $(kubectl version --client=true -o json | jq '.clientVersion.gitVersion' -r) = "$${CI_VERSION}" ]]; then
+          echo "Detected Kubernetes $${CI_VERSION} via kubectl version, nothing to do"
+          exit 0
+        fi
+        if [[ "$${CI_VERSION}" != "" ]]; then
+          CI_DIR=/tmp/k8s-ci
+          mkdir -p "$${CI_DIR}"
+          declare -a PACKAGES_TO_TEST=("kubectl" "kubelet" "kubeadm")
+          # Let's just also download the control plane images for worker nodes. It's easier then optimizing it.
+          declare -a CONTAINERS_TO_TEST=("kube-apiserver" "kube-controller-manager" "kube-proxy" "kube-scheduler")
+          CONTAINER_EXT="tar"
+          echo "* testing version $${CI_VERSION}"
+          CI_URL="https://dl.k8s.io/ci/$${CI_VERSION}/bin/linux/amd64"
+          # Set CI_URL to the released binaries for actually released versions.
+          if [[ "$${CI_VERSION}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || [[ "$${CI_VERSION}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+-(beta|rc).[0-9]+$ ]]; then
+            CI_URL="https://dl.k8s.io/release/$${CI_VERSION}/bin/linux/amd64"
+          fi
+          for CI_PACKAGE in "$${PACKAGES_TO_TEST[@]}"; do
+            # Browser: https://console.cloud.google.com/storage/browser/k8s-release-dev?project=k8s-release-dev
+            # e.g.: https://storage.googleapis.com/k8s-release-dev/ci/v1.21.0-beta.1.378+cf3374e43491c5/bin/linux/amd64/kubectl
+            echo "* downloading binary: $${CI_URL}/$${CI_PACKAGE}"
+            wget --inet4-only "$${CI_URL}/$${CI_PACKAGE}" -O "$${CI_DIR}/$${CI_PACKAGE}"
+            chmod +x "$${CI_DIR}/$${CI_PACKAGE}"
+            mv "$${CI_DIR}/$${CI_PACKAGE}" "/usr/bin/$${CI_PACKAGE}"
+          done
+
+          systemctl restart kubelet
+          IMAGE_REGISTRY_PREFIX=registry.k8s.io
+          # Kubernetes builds from 1.20 through 1.24 are tagged with k8s.gcr.io
+          if [[ "$${CI_VERSION}" =~ ^v1\.(1[0-9]|2[0-4])[\.[0-9]+ ]]; then
+            IMAGE_REGISTRY_PREFIX=k8s.gcr.io
+          fi
+          for CI_CONTAINER in "$${CONTAINERS_TO_TEST[@]}"; do
+            echo "* downloading package: $${CI_URL}/$${CI_CONTAINER}.$${CONTAINER_EXT}"
+            wget --inet4-only "$${CI_URL}/$${CI_CONTAINER}.$${CONTAINER_EXT}" -O "$${CI_DIR}/$${CI_CONTAINER}.$${CONTAINER_EXT}"
+            $${SUDO} ctr -n k8s.io images import "$${CI_DIR}/$${CI_CONTAINER}.$${CONTAINER_EXT}" || echo "* ignoring expected 'ctr images import' result"
+            $${SUDO} ctr -n k8s.io images tag "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}-amd64:$${CI_VERSION//+/_}" "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}:$${CI_VERSION//+/_}"
+            $${SUDO} ctr -n k8s.io images tag "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}-amd64:$${CI_VERSION//+/_}" "gcr.io/k8s-staging-ci-images/$${CI_CONTAINER}:$${CI_VERSION//+/_}"
+          done
+        fi
+        echo "* checking binary versions"
+        echo "ctr version: " "$(ctr version)"
+        echo "kubeadm version: " "$(kubeadm version -o=short)"
+        echo "kubectl version: " "$(kubectl version --client=true)"
+        echo "kubelet version: " "$(kubelet --version)"
+        echo "$${LINE_SEPARATOR}"
+      owner: root:root
+      path: /tmp/kubeadm-bootstrap.sh
+      permissions: "0744"
+    initConfiguration:
+      nodeRegistration:
+        kubeletExtraArgs:
+          cloud-provider: external
+          image-credential-provider-bin-dir: /var/lib/kubelet/credential-provider
+          image-credential-provider-config: /var/lib/kubelet/credential-provider-config.yaml
+        name: '{{ ds.meta_data["local_hostname"] }}'
+    joinConfiguration:
+      nodeRegistration:
+        kubeletExtraArgs:
+          cloud-provider: external
+          image-credential-provider-bin-dir: /var/lib/kubelet/credential-provider
+          image-credential-provider-config: /var/lib/kubelet/credential-provider-config.yaml
+        name: '{{ ds.meta_data["local_hostname"] }}'
+    mounts:
+    - - LABEL=etcd_disk
+      - /var/lib/etcddisk
+    postKubeadmCommands: []
+    preKubeadmCommands:
+    - bash -c /tmp/oot-cred-provider.sh
+    - bash -c /tmp/kubeadm-bootstrap.sh
+    verbosity: 5
+  machineTemplate:
+    infrastructureRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+      kind: AzureMachineTemplate
+      name: ${CLUSTER_NAME}-control-plane
+  replicas: ${CONTROL_PLANE_MACHINE_COUNT:=1}
+  version: ${KUBERNETES_VERSION}
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: AzureMachineTemplate
+metadata:
+  name: ${CLUSTER_NAME}-control-plane
+  namespace: default
+spec:
+  template:
+    spec:
+      additionalTags:
+        monitoring: virtualmachine
+      dataDisks:
+      - diskSizeGB: 256
+        lun: 0
+        nameSuffix: etcddisk
+      identity: UserAssigned
+      image:
+        computeGallery:
+          gallery: ClusterAPI-f72ceb4f-5159-4c26-a0fe-2ea738f0d019
+          name: capi-ubun2-2404
+          version: latest
+      osDisk:
+        diskSizeGB: 128
+        osType: Linux
+      sshPublicKey: ${AZURE_SSH_PUBLIC_KEY_B64:=""}
+      userAssignedIdentities:
+      - providerID: azure:///subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${CI_RG}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER_IDENTITY}
+      vmSize: ${AZURE_CONTROL_PLANE_MACHINE_TYPE}
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineDeployment
+metadata:
+  name: ${CLUSTER_NAME}-md-0
+  namespace: default
+spec:
+  clusterName: ${CLUSTER_NAME}
+  replicas: ${WORKER_MACHINE_COUNT:=2}
+  selector: {}
+  template:
+    metadata:
+      labels:
+        nodepool: pool1
+    spec:
+      bootstrap:
+        configRef:
+          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+          kind: KubeadmConfigTemplate
+          name: ${CLUSTER_NAME}-md-0
+      clusterName: ${CLUSTER_NAME}
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: AzureMachineTemplate
+        name: ${CLUSTER_NAME}-md-0
+      version: ${KUBERNETES_VERSION}
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: AzureMachineTemplate
+metadata:
+  name: ${CLUSTER_NAME}-md-0
+  namespace: default
+spec:
+  template:
+    spec:
+      additionalTags:
+        monitoring: virtualmachine
+      identity: UserAssigned
+      image:
+        computeGallery:
+          gallery: ClusterAPI-f72ceb4f-5159-4c26-a0fe-2ea738f0d019
+          name: capi-ubun2-2404
+          version: latest
+      osDisk:
+        diskSizeGB: 128
+        osType: Linux
+      sshPublicKey: ${AZURE_SSH_PUBLIC_KEY_B64:=""}
+      userAssignedIdentities:
+      - providerID: azure:///subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${CI_RG:=capz-ci}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${USER_IDENTITY:=cloud-provider-user-identity}
+      vmExtensions:
+      - name: CustomScript
+        protectedSettings:
+          commandToExecute: |
+            #!/bin/sh
+            echo "This script is a no-op used for extension testing purposes ..."
+            touch test_file
+        publisher: Microsoft.Azure.Extensions
+        version: "2.1"
+      vmSize: ${AZURE_NODE_MACHINE_TYPE}
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+kind: KubeadmConfigTemplate
+metadata:
+  name: ${CLUSTER_NAME}-md-0
+  namespace: default
+spec:
+  template:
+    spec:
+      files:
+      - contentFrom:
+          secret:
+            key: worker-node-azure.json
+            name: ${CLUSTER_NAME}-md-0-azure-json
+        owner: root:root
+        path: /etc/kubernetes/azure.json
+        permissions: "0644"
+      - content: |
+          #!/bin/bash
+
+          set -o nounset
+          set -o pipefail
+          set -o errexit
+          [[ $(id -u) != 0 ]] && SUDO="sudo" || SUDO=""
+
+          # Run the az login command with managed identity
+          if az login --identity > /dev/null 2>&1; then
+            echo "Logged in Azure with managed identity"
+            echo "Use OOT credential provider"
+            mkdir -p /var/lib/kubelet/credential-provider
+            az storage blob download --blob-url "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${IMAGE_TAG_ACR_CREDENTIAL_PROVIDER}/azure-acr-credential-provider" -f /var/lib/kubelet/credential-provider/acr-credential-provider --auth-mode login
+            chmod 755 /var/lib/kubelet/credential-provider/acr-credential-provider
+            az storage blob download --blob-url "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${IMAGE_TAG_ACR_CREDENTIAL_PROVIDER}/credential-provider-config.yaml" -f /var/lib/kubelet/credential-provider-config.yaml --auth-mode login
+            chmod 644 /var/lib/kubelet/credential-provider-config.yaml
+          else
+            echo "Use OOT credential provider"
+            mkdir -p /var/lib/kubelet/credential-provider
+            curl --retry 10 --retry-delay 5 -w "response status code is %{http_code}" -Lo /var/lib/kubelet/credential-provider/acr-credential-provider "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${IMAGE_TAG_ACR_CREDENTIAL_PROVIDER}/azure-acr-credential-provider"
+            chmod 755 /var/lib/kubelet/credential-provider/acr-credential-provider
+            curl --retry 10 --retry-delay 5 -w "response status code is %{http_code}" -Lo /var/lib/kubelet/credential-provider-config.yaml "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_BLOB_CONTAINER_NAME}/${IMAGE_TAG_ACR_CREDENTIAL_PROVIDER}/credential-provider-config.yaml"
+            chmod 644 /var/lib/kubelet/credential-provider-config.yaml
+          fi
+        owner: root:root
+        path: /tmp/oot-cred-provider.sh
+        permissions: "0744"
+      - content: |
+          #!/bin/bash
+
+          set -o nounset
+          set -o pipefail
+          set -o errexit
+          [[ $(id -u) != 0 ]] && SUDO="sudo" || SUDO=""
+
+          # This test installs release packages or binaries that are a result of the CI and release builds.
+          # It runs '... --version' commands to verify that the binaries are correctly installed
+          # and finally uninstalls the packages.
+          # For the release packages it tests all versions in the support skew.
+          LINE_SEPARATOR="*************************************************"
+          echo "$${LINE_SEPARATOR}"
+          CI_VERSION=${CI_VERSION}
+
+          # Note: We assume if kubectl has the right version, everything else has as well
+          if [[ $(kubectl version --client=true -o json | jq '.clientVersion.gitVersion' -r) = "$${CI_VERSION}" ]]; then
+            echo "Detected Kubernetes $${CI_VERSION} via kubectl version, nothing to do"
+            exit 0
+          fi
+          if [[ "$${CI_VERSION}" != "" ]]; then
+            CI_DIR=/tmp/k8s-ci
+            mkdir -p "$${CI_DIR}"
+            declare -a PACKAGES_TO_TEST=("kubectl" "kubelet" "kubeadm")
+            # Let's just also download the control plane images for worker nodes. It's easier then optimizing it.
+            declare -a CONTAINERS_TO_TEST=("kube-apiserver" "kube-controller-manager" "kube-proxy" "kube-scheduler")
+            CONTAINER_EXT="tar"
+            echo "* testing version $${CI_VERSION}"
+            CI_URL="https://dl.k8s.io/ci/$${CI_VERSION}/bin/linux/amd64"
+            # Set CI_URL to the released binaries for actually released versions.
+            if [[ "$${CI_VERSION}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || [[ "$${CI_VERSION}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+-(beta|rc).[0-9]+$ ]]; then
+              CI_URL="https://dl.k8s.io/release/$${CI_VERSION}/bin/linux/amd64"
+            fi
+            for CI_PACKAGE in "$${PACKAGES_TO_TEST[@]}"; do
+              # Browser: https://console.cloud.google.com/storage/browser/k8s-release-dev?project=k8s-release-dev
+              # e.g.: https://storage.googleapis.com/k8s-release-dev/ci/v1.21.0-beta.1.378+cf3374e43491c5/bin/linux/amd64/kubectl
+              echo "* downloading binary: $${CI_URL}/$${CI_PACKAGE}"
+              wget --inet4-only "$${CI_URL}/$${CI_PACKAGE}" -O "$${CI_DIR}/$${CI_PACKAGE}"
+              chmod +x "$${CI_DIR}/$${CI_PACKAGE}"
+              mv "$${CI_DIR}/$${CI_PACKAGE}" "/usr/bin/$${CI_PACKAGE}"
+            done
+
+            systemctl restart kubelet
+            IMAGE_REGISTRY_PREFIX=registry.k8s.io
+            # Kubernetes builds from 1.20 through 1.24 are tagged with k8s.gcr.io
+            if [[ "$${CI_VERSION}" =~ ^v1\.(1[0-9]|2[0-4])[\.[0-9]+ ]]; then
+              IMAGE_REGISTRY_PREFIX=k8s.gcr.io
+            fi
+            for CI_CONTAINER in "$${CONTAINERS_TO_TEST[@]}"; do
+              echo "* downloading package: $${CI_URL}/$${CI_CONTAINER}.$${CONTAINER_EXT}"
+              wget --inet4-only "$${CI_URL}/$${CI_CONTAINER}.$${CONTAINER_EXT}" -O "$${CI_DIR}/$${CI_CONTAINER}.$${CONTAINER_EXT}"
+              $${SUDO} ctr -n k8s.io images import "$${CI_DIR}/$${CI_CONTAINER}.$${CONTAINER_EXT}" || echo "* ignoring expected 'ctr images import' result"
+              $${SUDO} ctr -n k8s.io images tag "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}-amd64:$${CI_VERSION//+/_}" "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}:$${CI_VERSION//+/_}"
+              $${SUDO} ctr -n k8s.io images tag "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}-amd64:$${CI_VERSION//+/_}" "gcr.io/k8s-staging-ci-images/$${CI_CONTAINER}:$${CI_VERSION//+/_}"
+            done
+          fi
+          echo "* checking binary versions"
+          echo "ctr version: " "$(ctr version)"
+          echo "kubeadm version: " "$(kubeadm version -o=short)"
+          echo "kubectl version: " "$(kubectl version --client=true)"
+          echo "kubelet version: " "$(kubelet --version)"
+          echo "$${LINE_SEPARATOR}"
+        owner: root:root
+        path: /tmp/kubeadm-bootstrap.sh
+        permissions: "0744"
+      joinConfiguration:
+        nodeRegistration:
+          kubeletExtraArgs:
+            cloud-provider: external
+            image-credential-provider-bin-dir: /var/lib/kubelet/credential-provider
+            image-credential-provider-config: /var/lib/kubelet/credential-provider-config.yaml
+          name: '{{ ds.meta_data["local_hostname"] }}'
+      preKubeadmCommands:
+      - bash -c /tmp/oot-cred-provider.sh
+      - bash -c /tmp/kubeadm-bootstrap.sh
+      verbosity: 5
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineHealthCheck
+metadata:
+  name: ${CLUSTER_NAME}-control-plane
+  namespace: default
+spec:
+  clusterName: ${CLUSTER_NAME}
+  maxUnhealthy: 100%
+  selector:
+    matchLabels:
+      cluster.x-k8s.io/control-plane: ""
+  unhealthyConditions:
+  - status: Unknown
+    timeout: 300s
+    type: Ready
+  - status: "False"
+    timeout: 300s
+    type: Ready
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineHealthCheck
+metadata:
+  name: ${CLUSTER_NAME}-mhc-0
+  namespace: default
+spec:
+  clusterName: ${CLUSTER_NAME}
+  maxUnhealthy: 100%
+  selector:
+    matchLabels:
+      nodepool: pool1
+  unhealthyConditions:
+  - status: "True"
+    timeout: 30s
+    type: E2ENodeUnhealthy
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: AzureClusterIdentity
+metadata:
+  labels:
+    clusterctl.cluster.x-k8s.io/move-hierarchy: "true"
+  name: ${CLUSTER_IDENTITY_NAME}
+  namespace: default
+spec:
+  allowedNamespaces: {}
+  clientID: ${AZURE_CLIENT_ID_USER_ASSIGNED_IDENTITY}
+  tenantID: ${AZURE_TENANT_ID}
+  type: ${CLUSTER_IDENTITY_TYPE:=WorkloadIdentity}
+---
+apiVersion: addons.cluster.x-k8s.io/v1alpha1
+kind: HelmChartProxy
+metadata:
+  name: calico
+  namespace: default
+spec:
+  chartName: tigera-operator
+  clusterSelector:
+    matchLabels:
+      cni: calico
+  namespace: tigera-operator
+  releaseName: projectcalico
+  repoURL: https://docs.tigera.io/calico/charts
+  valuesTemplate: |
+    installation:
+      cni:
+        type: Calico
+        ipam:
+          type: Calico
+      calicoNetwork:
+        bgp: Disabled
+        windowsDataplane: HNS
+        mtu: 1350
+        ipPools:{{range $i, $cidr := .Cluster.spec.clusterNetwork.pods.cidrBlocks }}
+        - cidr: {{ $cidr }}
+          encapsulation: VXLAN{{end}}
+      typhaDeployment:
+        spec:
+          template:
+            spec:
+              # By default, typha tolerates all NoSchedule taints. This breaks
+              # scale-ins when it continuously gets scheduled onto an
+              # out-of-date Node that is being deleted. Tolerate only the
+              # NoSchedule taints that are expected.
+              tolerations:
+                - effect: NoExecute
+                  operator: Exists
+                - effect: NoSchedule
+                  key: node-role.kubernetes.io/control-plane
+                  operator: Exists
+                - effect: NoSchedule
+                  key: node.kubernetes.io/not-ready
+                  operator: Exists
+              affinity:
+                nodeAffinity:
+                  preferredDuringSchedulingIgnoredDuringExecution:
+                  - weight: 50
+                    preference:
+                      matchExpressions:
+                      - key: node-role.kubernetes.io/control-plane
+                        operator: Exists
+      registry: capzcicommunity.azurecr.io
+      serviceCIDRs:
+        - 10.96.0.0/12 # must match cluster service CIDR (this is the default)
+    # Image and registry configuration for the tigera/operator pod
+    tigeraOperator:
+      image: tigera/operator
+      registry: capzcicommunity.azurecr.io
+    calicoctl:
+      image: capzcicommunity.azurecr.io/calico/ctl
+    # when kubernetesServiceEndpoint (required for windows) is added
+    # DNS configuration is needed to look up the api server name properly
+    # https://github.com/projectcalico/calico/issues/9536
+    dnsConfig:
+      nameservers:
+        - 127.0.0.53
+      options:
+        - name: edns0
+        - name: trust-ad
+    kubernetesServiceEndpoint:
+      host: "{{ .Cluster.spec.controlPlaneEndpoint.host }}"
+      port: "{{ .Cluster.spec.controlPlaneEndpoint.port }}"
+    # By default, tigera tolerates all NoSchedule taints. This breaks upgrades
+    # when it continuously gets scheduled onto an out-of-date Node that is being
+    # deleted. Tolerate only the NoSchedule taints that are expected.
+    tolerations:
+      - effect: NoExecute
+        operator: Exists
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/control-plane
+        operator: Exists
+      - effect: NoSchedule
+        key: node.kubernetes.io/not-ready
+        operator: Exists
+  version: ${CALICO_VERSION}
+---
+apiVersion: addons.cluster.x-k8s.io/v1alpha1
+kind: HelmChartProxy
+metadata:
+  name: azuredisk-csi-driver-chart
+  namespace: default
+spec:
+  chartName: azuredisk-csi-driver
+  clusterSelector:
+    matchLabels:
+      azuredisk-csi: "true"
+  namespace: kube-system
+  releaseName: azuredisk-csi-driver-oot
+  repoURL: https://raw.githubusercontent.com/kubernetes-sigs/azuredisk-csi-driver/master/charts
+  valuesTemplate: |-
+    controller:
+      replicas: 1
+      runOnControlPlane: true
+    windows:
+      useHostProcessContainers: {{ hasKey .Cluster.metadata.labels "cni-windows" }}
+---
+apiVersion: addons.cluster.x-k8s.io/v1alpha1
+kind: HelmChartProxy
+metadata:
+  name: cloud-provider-azure-chart
+  namespace: default
+spec:
+  chartName: cloud-provider-azure
+  clusterSelector:
+    matchLabels:
+      cloud-provider: azure
+  releaseName: cloud-provider-azure-oot
+  repoURL: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/helm/repo
+  valuesTemplate: |
+    infra:
+      clusterName: {{ .Cluster.metadata.name }}
+    cloudControllerManager:
+      clusterCIDR: {{ .Cluster.spec.clusterNetwork.pods.cidrBlocks | join "," }}
+      logVerbosity: 4
+---
+apiVersion: addons.cluster.x-k8s.io/v1alpha1
+kind: HelmChartProxy
+metadata:
+  name: cloud-provider-azure-chart-ci
+  namespace: default
+spec:
+  chartName: cloud-provider-azure
+  clusterSelector:
+    matchLabels:
+      cloud-provider: azure-ci
+  releaseName: cloud-provider-azure-oot
+  repoURL: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/helm/repo
+  valuesTemplate: |
+    infra:
+      clusterName: {{ .Cluster.metadata.name }}
+    cloudControllerManager:
+      cloudConfig: ${CLOUD_CONFIG:-"/etc/kubernetes/azure.json"}
+      cloudConfigSecretName: ${CONFIG_SECRET_NAME:-""}
+      clusterCIDR: {{ .Cluster.spec.clusterNetwork.pods.cidrBlocks | join "," }}
+      imageName: "${CCM_IMAGE_NAME:-""}"
+      imageRepository: "${IMAGE_REGISTRY:-""}"
+      imageTag: "${IMAGE_TAG_CCM:-""}"
+      logVerbosity: ${CCM_LOG_VERBOSITY:-4}
+      replicas: ${CCM_COUNT:-1}
+      enableDynamicReloading: ${ENABLE_DYNAMIC_RELOADING:-false}
+    cloudNodeManager:
+      imageName: "${CNM_IMAGE_NAME:-""}"
+      imageRepository: "${IMAGE_REGISTRY:-""}"
+      imageTag: "${IMAGE_TAG_CNM:-""}"
+---
+apiVersion: addons.cluster.x-k8s.io/v1beta1
+kind: ClusterResourceSet
+metadata:
+  name: metrics-server-${CLUSTER_NAME}
+  namespace: default
+spec:
+  clusterSelector:
+    matchLabels:
+      metrics-server: enabled
+  resources:
+  - kind: ConfigMap
+    name: metrics-server-${CLUSTER_NAME}
+  strategy: ApplyOnce
+---
+apiVersion: v1
+data:
+  metrics-server: |
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      labels:
+        k8s-app: metrics-server
+      name: metrics-server
+      namespace: kube-system
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      labels:
+        k8s-app: metrics-server
+        rbac.authorization.k8s.io/aggregate-to-admin: "true"
+        rbac.authorization.k8s.io/aggregate-to-edit: "true"
+        rbac.authorization.k8s.io/aggregate-to-view: "true"
+      name: system:aggregated-metrics-reader
+    rules:
+    - apiGroups:
+      - metrics.k8s.io
+      resources:
+      - pods
+      - nodes
+      verbs:
+      - get
+      - list
+      - watch
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      labels:
+        k8s-app: metrics-server
+      name: system:metrics-server
+    rules:
+    - apiGroups:
+      - ""
+      resources:
+      - nodes/metrics
+      verbs:
+      - get
+    - apiGroups:
+      - ""
+      resources:
+      - pods
+      - nodes
+      verbs:
+      - get
+      - list
+      - watch
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      labels:
+        k8s-app: metrics-server
+      name: metrics-server-auth-reader
+      namespace: kube-system
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: Role
+      name: extension-apiserver-authentication-reader
+    subjects:
+    - kind: ServiceAccount
+      name: metrics-server
+      namespace: kube-system
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      labels:
+        k8s-app: metrics-server
+      name: metrics-server:system:auth-delegator
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: system:auth-delegator
+    subjects:
+    - kind: ServiceAccount
+      name: metrics-server
+      namespace: kube-system
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      labels:
+        k8s-app: metrics-server
+      name: system:metrics-server
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: system:metrics-server
+    subjects:
+    - kind: ServiceAccount
+      name: metrics-server
+      namespace: kube-system
+    ---
+    apiVersion: v1
+    kind: Service
+    metadata:
+      labels:
+        k8s-app: metrics-server
+      name: metrics-server
+      namespace: kube-system
+    spec:
+      ports:
+      - name: https
+        port: 443
+        protocol: TCP
+        targetPort: https
+      selector:
+        k8s-app: metrics-server
+    ---
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      labels:
+        k8s-app: metrics-server
+      name: metrics-server
+      namespace: kube-system
+    spec:
+      selector:
+        matchLabels:
+          k8s-app: metrics-server
+      strategy:
+        rollingUpdate:
+          maxUnavailable: 0
+      template:
+        metadata:
+          labels:
+            k8s-app: metrics-server
+        spec:
+          containers:
+          - args:
+            - --cert-dir=/tmp
+            - --secure-port=4443
+            - --kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname
+            - --kubelet-use-node-status-port
+            - --metric-resolution=15s
+            - --kubelet-insecure-tls
+            image: registry.k8s.io/metrics-server/metrics-server:v0.6.3
+            imagePullPolicy: IfNotPresent
+            livenessProbe:
+              failureThreshold: 3
+              httpGet:
+                path: /livez
+                port: https
+                scheme: HTTPS
+              periodSeconds: 10
+            name: metrics-server
+            ports:
+            - containerPort: 4443
+              name: https
+              protocol: TCP
+            readinessProbe:
+              failureThreshold: 3
+              httpGet:
+                path: /readyz
+                port: https
+                scheme: HTTPS
+              initialDelaySeconds: 20
+              periodSeconds: 10
+            resources:
+              requests:
+                cpu: 100m
+                memory: 200Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              runAsNonRoot: true
+              runAsUser: 1000
+            volumeMounts:
+            - mountPath: /tmp
+              name: tmp-dir
+          nodeSelector:
+            kubernetes.io/os: linux
+          priorityClassName: system-cluster-critical
+          serviceAccountName: metrics-server
+          tolerations:
+          - effect: NoSchedule
+            key: node-role.kubernetes.io/master
+            operator: Exists
+          - effect: NoSchedule
+            key: node-role.kubernetes.io/control-plane
+            operator: Exists
+          volumes:
+          - emptyDir: {}
+            name: tmp-dir
+    ---
+    apiVersion: apiregistration.k8s.io/v1
+    kind: APIService
+    metadata:
+      labels:
+        k8s-app: metrics-server
+      name: v1beta1.metrics.k8s.io
+    spec:
+      group: metrics.k8s.io
+      groupPriorityMinimum: 100
+      insecureSkipTLSVerify: true
+      service:
+        name: metrics-server
+        namespace: kube-system
+      version: v1beta1
+      versionPriority: 100
+kind: ConfigMap
+metadata:
+  annotations:
+    note: generated
+  labels:
+    type: generated
+  name: metrics-server-${CLUSTER_NAME}
+  namespace: default

--- a/templates/test/ci/cluster-template-prow-ci-version-native-scheduling.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version-native-scheduling.yaml
@@ -58,7 +58,7 @@ spec:
       apiServer:
         extraArgs:
           feature-gates: GenericWorkload=true
-          runtime-config: scheduling.k8s.io/v1alpha2=true
+          runtime-config: scheduling.k8s.io/v1alpha3=true
         timeoutForControlPlane: 20m
       controllerManager:
         extraArgs:

--- a/templates/test/ci/cluster-template-prow-ci-version-native-scheduling.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version-native-scheduling.yaml
@@ -69,7 +69,7 @@ spec:
           v: "4"
       scheduler:
         extraArgs:
-          feature-gates: GenericWorkload=true,GangScheduling=true
+          feature-gates: GenericWorkload=true
       etcd:
         local:
           dataDir: /var/lib/etcddisk/etcd

--- a/test/e2e/azure_kuberay.go
+++ b/test/e2e/azure_kuberay.go
@@ -296,13 +296,60 @@ func InstallHelmChartFromPath(ctx context.Context, clusterProxy framework.Cluste
 		"--create-namespace",
 		"--wait",
 		"--timeout", "10m0s",
+		"--debug",
 	}
 	helmArgs = append(helmArgs, extraArgs...)
 	installCmd := exec.CommandContext(ctx, "helm", helmArgs...) //nolint:gosec
 	installCmd.Env = append(installCmd.Environ(), fmt.Sprintf("KUBECONFIG=%s", kubeconfigPath))
 	output, err := installCmd.CombinedOutput()
 	Logf("helm install output: %s", string(output))
+	if err != nil {
+		dumpHelmInstallDiagnostics(ctx, clusterProxy, namespace, releaseName)
+	}
 	Expect(err).NotTo(HaveOccurred(), "failed to install Helm chart from path: %s", string(output))
+}
+
+// dumpHelmInstallDiagnostics logs pod status and events in the target namespace to help diagnose Helm install failures.
+func dumpHelmInstallDiagnostics(ctx context.Context, clusterProxy framework.ClusterProxy, namespace, releaseName string) {
+	clientset := clusterProxy.GetClientSet()
+	if clientset == nil {
+		Logf("WARNING: could not get clientset for diagnostics")
+		return
+	}
+
+	Logf("=== Helm install diagnostics for release %s in namespace %s ===", releaseName, namespace)
+
+	// List pods in the namespace
+	pods, err := clientset.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		Logf("WARNING: failed to list pods in namespace %s: %v", namespace, err)
+	} else {
+		for i := range pods.Items {
+			pod := &pods.Items[i]
+			Logf("Pod %s: Phase=%s", pod.Name, pod.Status.Phase)
+			for _, cs := range pod.Status.ContainerStatuses {
+				Logf("  Container %s: Ready=%v, RestartCount=%d, State=%+v", cs.Name, cs.Ready, cs.RestartCount, cs.State)
+			}
+			for _, cond := range pod.Status.Conditions {
+				if cond.Status != corev1.ConditionTrue {
+					Logf("  Condition %s=%s: %s", cond.Type, cond.Status, cond.Message)
+				}
+			}
+			Logf("  Events:\n%s", describeEvents(ctx, clientset, namespace, pod.Name))
+			Logf("  Logs:\n%s", getPodLogs(ctx, clientset, *pod))
+		}
+	}
+
+	// Check for CRD readiness
+	Logf("=== CRD status ===")
+	kubeconfigPath := clusterProxy.GetKubeconfigPath()
+	crdCmd := exec.CommandContext(ctx, "kubectl", "--kubeconfig", kubeconfigPath, "get", "crds", "-o", "wide") //nolint:gosec
+	crdOutput, crdErr := crdCmd.CombinedOutput()
+	if crdErr != nil {
+		Logf("WARNING: failed to list CRDs: %v", crdErr)
+	} else {
+		Logf("CRDs:\n%s", string(crdOutput))
+	}
 }
 
 // InstallKubeRayOperatorFromSource installs the KubeRay operator Helm chart from a local kuberay source tree,

--- a/test/e2e/azure_kuberay.go
+++ b/test/e2e/azure_kuberay.go
@@ -22,7 +22,9 @@ package e2e
 import (
 	"context"
 	"fmt"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -57,6 +59,18 @@ var rayJobGVR = schema.GroupVersionResource{
 	Group:    "ray.io",
 	Version:  "v1",
 	Resource: "rayjobs",
+}
+
+var workloadGVR = schema.GroupVersionResource{
+	Group:    "scheduling.k8s.io",
+	Version:  "v1alpha2",
+	Resource: "workloads",
+}
+
+var podGroupGVR = schema.GroupVersionResource{
+	Group:    "scheduling.k8s.io",
+	Version:  "v1alpha2",
+	Resource: "podgroups",
 }
 
 // KubeRayClusterSpecInput is the input for KubeRayClusterSpec.
@@ -267,6 +281,223 @@ func InstallHelmChart(ctx context.Context, clusterProxy framework.ClusterProxy, 
 	output, err = installCmd.CombinedOutput()
 	Logf("helm install output: %s", string(output))
 	Expect(err).NotTo(HaveOccurred(), "failed to install Helm chart: %s", string(output))
+}
+
+// InstallHelmChartFromPath installs a Helm chart from a local directory path onto a cluster
+// via the given ClusterProxy. This is used when installing charts built from source rather
+// than from a remote Helm repository.
+func InstallHelmChartFromPath(ctx context.Context, clusterProxy framework.ClusterProxy, namespace, chartPath, releaseName string, extraArgs ...string) {
+	kubeconfigPath := clusterProxy.GetKubeconfigPath()
+	By(fmt.Sprintf("Installing Helm chart from %s as release %s using kubeconfig %s", chartPath, releaseName, kubeconfigPath))
+
+	helmArgs := []string{"install", releaseName,
+		chartPath,
+		"--namespace", namespace,
+		"--create-namespace",
+		"--wait",
+		"--timeout", "5m0s",
+	}
+	helmArgs = append(helmArgs, extraArgs...)
+	installCmd := exec.CommandContext(ctx, "helm", helmArgs...) //nolint:gosec
+	installCmd.Env = append(installCmd.Environ(), fmt.Sprintf("KUBECONFIG=%s", kubeconfigPath))
+	output, err := installCmd.CombinedOutput()
+	Logf("helm install output: %s", string(output))
+	Expect(err).NotTo(HaveOccurred(), "failed to install Helm chart from path: %s", string(output))
+}
+
+// InstallKubeRayOperatorFromSource installs the KubeRay operator Helm chart from a local kuberay source tree,
+// using a custom-built operator image. This is used for testing unreleased kuberay features like NativeWorkloadScheduling.
+// The kuberay source directory must contain the helm-chart/kuberay-operator chart and the image must already
+// be built and pushed to the registry (see scripts/ci-build-kuberay-operator.sh).
+func InstallKubeRayOperatorFromSource(ctx context.Context, clusterProxy framework.ClusterProxy, specName string) {
+	By("Installing the KubeRay operator from source with NativeWorkloadScheduling enabled")
+	clientset := clusterProxy.GetClientSet()
+	Expect(clientset).NotTo(BeNil())
+
+	kuberaySourceDir := os.Getenv("KUBERAY_SOURCE_DIR")
+	Expect(kuberaySourceDir).NotTo(BeEmpty(), "KUBERAY_SOURCE_DIR must be set to the kuberay repo root")
+
+	chartPath := filepath.Join(kuberaySourceDir, "helm-chart", "kuberay-operator")
+	_, err := os.Stat(filepath.Join(chartPath, "Chart.yaml"))
+	Expect(err).NotTo(HaveOccurred(), "kuberay-operator Helm chart not found at %s", chartPath)
+
+	registry := os.Getenv("REGISTRY")
+	Expect(registry).NotTo(BeEmpty(), "REGISTRY must be set")
+	imageTag := os.Getenv("KUBERAY_OPERATOR_IMAGE_TAG")
+	Expect(imageTag).NotTo(BeEmpty(), "KUBERAY_OPERATOR_IMAGE_TAG must be set")
+
+	operatorImage := fmt.Sprintf("%s/kuberay-operator", registry)
+
+	InstallHelmChartFromPath(ctx, clusterProxy, kubeRayOperatorNamespace, chartPath, kubeRayOperatorHelmReleaseName,
+		"--set", fmt.Sprintf("image.repository=%s", operatorImage),
+		"--set", fmt.Sprintf("image.tag=%s", imageTag),
+		"--set", "image.pullPolicy=Always",
+		"--set", "nodeSelector.kubernetes\\.io/os=linux",
+		"--set", "featureGates[0].name=RayClusterStatusConditions",
+		"--set-string", "featureGates[0].enabled=true",
+		"--set", "featureGates[1].name=RayJobDeletionPolicy",
+		"--set-string", "featureGates[1].enabled=true",
+		"--set", "featureGates[2].name=NativeWorkloadScheduling",
+		"--set-string", "featureGates[2].enabled=true",
+	)
+
+	By("waiting for the KubeRay operator deployment to become available")
+	waitInput := GetWaitForDeploymentsAvailableInput(ctx, clusterProxy, kubeRayOperatorHelmReleaseName, kubeRayOperatorNamespace, specName)
+	WaitForDeploymentsAvailable(ctx, waitInput, e2eConfig.GetIntervals(specName, "wait-deployment")...)
+}
+
+// KubeRayNativeSchedulingSpecInput is the input for KubeRayNativeSchedulingSpec.
+type KubeRayNativeSchedulingSpecInput struct {
+	BootstrapClusterProxy framework.ClusterProxy
+	Namespace             *corev1.Namespace
+	ClusterName           string
+	SkipCleanup           bool
+}
+
+// KubeRayNativeSchedulingSpec implements a test that verifies the NativeWorkloadScheduling feature
+// of the KubeRay operator. It creates a RayCluster with the opt-in annotation, verifies that
+// Workload and PodGroup resources are created by the operator, and confirms that all pods are
+// scheduled and running via the native gang scheduling mechanism.
+func KubeRayNativeSchedulingSpec(ctx context.Context, inputGetter func() KubeRayNativeSchedulingSpecInput) {
+	var (
+		specName = "kuberay-native-scheduling"
+		input    KubeRayNativeSchedulingSpecInput
+	)
+
+	input = inputGetter()
+	Expect(input.BootstrapClusterProxy).NotTo(BeNil(), "Invalid argument. input.BootstrapClusterProxy can't be nil when calling %s spec", specName)
+	Expect(input.Namespace).NotTo(BeNil(), "Invalid argument. input.Namespace can't be nil when calling %s spec", specName)
+	Expect(input.ClusterName).NotTo(BeEmpty(), "Invalid argument. input.ClusterName can't be empty when calling %s spec", specName)
+
+	By("creating a Kubernetes client to the workload cluster")
+	clusterProxy := input.BootstrapClusterProxy.GetWorkloadCluster(ctx, input.Namespace.Name, input.ClusterName)
+	Expect(clusterProxy).NotTo(BeNil())
+	clientset := clusterProxy.GetClientSet()
+	Expect(clientset).NotTo(BeNil())
+
+	By("installing the KubeRay operator from source with NativeWorkloadScheduling enabled")
+	InstallKubeRayOperatorFromSource(ctx, clusterProxy, specName)
+
+	By("creating a RayCluster with native workload scheduling annotation")
+	dynamicClient := newDynamicClient(clusterProxy)
+	rayCluster := newRayClusterWithNativeScheduling("raycluster-scheduling-e2e", corev1.NamespaceDefault)
+	_, err := dynamicClient.Resource(rayClusterGVR).Namespace(corev1.NamespaceDefault).Create(ctx, rayCluster, metav1.CreateOptions{})
+	Expect(err).NotTo(HaveOccurred())
+
+	By("waiting for the RayCluster to become ready")
+	Eventually(func() bool {
+		rc, err := dynamicClient.Resource(rayClusterGVR).Namespace(corev1.NamespaceDefault).Get(ctx, "raycluster-scheduling-e2e", metav1.GetOptions{})
+		if err != nil {
+			return false
+		}
+		state, found, err := unstructured.NestedString(rc.Object, "status", "state")
+		if err != nil || !found {
+			return false
+		}
+		return state == "ready"
+	}, e2eConfig.GetIntervals(specName, "wait-raycluster-ready")...).Should(BeTrue(), func() string {
+		return describeKubeRayOperatorLogs(ctx, clientset)
+	})
+
+	By("verifying a Workload resource was created for the RayCluster")
+	Eventually(func() bool {
+		workloads, err := dynamicClient.Resource(workloadGVR).Namespace(corev1.NamespaceDefault).List(ctx, metav1.ListOptions{})
+		if err != nil || len(workloads.Items) == 0 {
+			return false
+		}
+		for _, w := range workloads.Items {
+			ownerRefs, _, _ := unstructured.NestedSlice(w.Object, "metadata", "ownerReferences")
+			for _, ref := range ownerRefs {
+				refMap, ok := ref.(map[string]interface{})
+				if !ok {
+					continue
+				}
+				if refMap["name"] == "raycluster-scheduling-e2e" && refMap["kind"] == "RayCluster" {
+					Logf("Found Workload %s owned by RayCluster raycluster-scheduling-e2e", w.GetName())
+					return true
+				}
+			}
+		}
+		return false
+	}, e2eConfig.GetIntervals(specName, "wait-workload-ready")...).Should(BeTrue(), "Workload resource was not created for the RayCluster")
+
+	By("verifying PodGroup resources were created for the RayCluster")
+	Eventually(func() bool {
+		podGroups, err := dynamicClient.Resource(podGroupGVR).Namespace(corev1.NamespaceDefault).List(ctx, metav1.ListOptions{})
+		if err != nil {
+			return false
+		}
+		// Expect at least 2 PodGroups: one for head, one for the worker group
+		expectedPrefixes := []string{"raycluster-scheduling-e2e-head", "raycluster-scheduling-e2e-worker"}
+		found := make(map[string]bool)
+		for _, pg := range podGroups.Items {
+			for _, prefix := range expectedPrefixes {
+				if strings.HasPrefix(pg.GetName(), prefix) {
+					found[prefix] = true
+					Logf("Found PodGroup %s", pg.GetName())
+				}
+			}
+		}
+		return len(found) == len(expectedPrefixes)
+	}, e2eConfig.GetIntervals(specName, "wait-workload-ready")...).Should(BeTrue(), "PodGroup resources were not created for the RayCluster")
+
+	By("verifying the head pod is running")
+	Eventually(func() bool {
+		pods, err := clientset.CoreV1().Pods(corev1.NamespaceDefault).List(ctx, metav1.ListOptions{
+			LabelSelector: "ray.io/node-type=head",
+		})
+		if err != nil || len(pods.Items) == 0 {
+			return false
+		}
+		for _, pod := range pods.Items {
+			if pod.Status.Phase == corev1.PodRunning {
+				return true
+			}
+		}
+		return false
+	}, e2eConfig.GetIntervals(specName, "wait-deployment")...).Should(BeTrue(), "head pod did not reach Running state")
+
+	By("verifying the worker pod is running")
+	Eventually(func() bool {
+		pods, err := clientset.CoreV1().Pods(corev1.NamespaceDefault).List(ctx, metav1.ListOptions{
+			LabelSelector: "ray.io/node-type=worker",
+		})
+		if err != nil || len(pods.Items) == 0 {
+			return false
+		}
+		for _, pod := range pods.Items {
+			if pod.Status.Phase == corev1.PodRunning {
+				return true
+			}
+		}
+		return false
+	}, e2eConfig.GetIntervals(specName, "wait-deployment")...).Should(BeTrue(), "worker pod did not reach Running state")
+
+	if !input.SkipCleanup {
+		By("deleting the RayCluster")
+		err = dynamicClient.Resource(rayClusterGVR).Namespace(corev1.NamespaceDefault).Delete(ctx, "raycluster-scheduling-e2e", metav1.DeleteOptions{})
+		Expect(err).NotTo(HaveOccurred())
+	}
+}
+
+// newRayClusterWithNativeScheduling creates a RayCluster with the native workload scheduling
+// opt-in annotation. This triggers the KubeRay operator to create Workload and PodGroup resources
+// for gang scheduling via the Kubernetes-native scheduling.k8s.io/v1alpha2 API.
+func newRayClusterWithNativeScheduling(name, namespace string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "ray.io/v1",
+			"kind":       "RayCluster",
+			"metadata": map[string]interface{}{
+				"name":      name,
+				"namespace": namespace,
+				"annotations": map[string]interface{}{
+					"ray.io/native-workload-scheduling": "true",
+				},
+			},
+			"spec": rayClusterSpec(),
+		},
+	}
 }
 
 // newDynamicClient creates a dynamic Kubernetes client from a ClusterProxy.

--- a/test/e2e/azure_kuberay.go
+++ b/test/e2e/azure_kuberay.go
@@ -295,7 +295,7 @@ func InstallHelmChartFromPath(ctx context.Context, clusterProxy framework.Cluste
 		"--namespace", namespace,
 		"--create-namespace",
 		"--wait",
-		"--timeout", "5m0s",
+		"--timeout", "10m0s",
 	}
 	helmArgs = append(helmArgs, extraArgs...)
 	installCmd := exec.CommandContext(ctx, "helm", helmArgs...) //nolint:gosec

--- a/test/e2e/azure_kuberay.go
+++ b/test/e2e/azure_kuberay.go
@@ -34,6 +34,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/cluster-api/test/framework"
@@ -592,6 +593,73 @@ func KubeRayNativeSchedulingSpec(ctx context.Context, inputGetter func() KubeRay
 	workerSchedulingGroup, _, _ := unstructured.NestedString(workerPods.Items[0].Object, "spec", "schedulingGroup", "podGroupName")
 	Expect(workerSchedulingGroup).To(Equal("raycluster-scheduling-e2e-worker-small-group"), "worker pod should reference its PodGroup via schedulingGroup")
 	Logf("Worker pod %s has schedulingGroup.podGroupName=%s", workerPods.Items[0].GetName(), workerSchedulingGroup)
+
+	By("testing gang scheduling: scaling workers beyond available resources")
+	scaleUpPatch := []byte(`[
+		{"op": "replace", "path": "/spec/workerGroupSpecs/0/replicas", "value": 20},
+		{"op": "replace", "path": "/spec/workerGroupSpecs/0/minReplicas", "value": 20},
+		{"op": "replace", "path": "/spec/workerGroupSpecs/0/maxReplicas", "value": 20}
+	]`)
+	_, err = dynamicClient.Resource(rayClusterGVR).Namespace(corev1.NamespaceDefault).Patch(ctx, "raycluster-scheduling-e2e", types.JSONPatchType, scaleUpPatch, metav1.PatchOptions{})
+	Expect(err).NotTo(HaveOccurred())
+
+	By("verifying the worker PodGroup minCount is updated to 20")
+	Eventually(func() int64 {
+		pg, err := dynamicClient.Resource(podGroupGVR).Namespace(corev1.NamespaceDefault).Get(ctx, "raycluster-scheduling-e2e-worker-small-group", metav1.GetOptions{})
+		if err != nil {
+			return 0
+		}
+		minCount, found, _ := unstructured.NestedInt64(pg.Object, "spec", "schedulingPolicy", "gang", "minCount")
+		if !found {
+			return 0
+		}
+		return minCount
+	}, e2eConfig.GetIntervals(specName, "wait-workload-ready")...).Should(Equal(int64(20)), "worker PodGroup minCount should be updated to 20")
+
+	By("verifying worker pods are Pending due to gang scheduling (all-or-nothing)")
+	Eventually(func() bool {
+		pods, err := clientset.CoreV1().Pods(corev1.NamespaceDefault).List(ctx, metav1.ListOptions{
+			LabelSelector: "ray.io/node-type=worker",
+		})
+		if err != nil {
+			return false
+		}
+		pendingCount := 0
+		for _, pod := range pods.Items {
+			if pod.Status.Phase == corev1.PodPending {
+				pendingCount++
+			}
+		}
+		Logf("Worker pods: %d total, %d Pending", len(pods.Items), pendingCount)
+		return pendingCount > 0
+	}, e2eConfig.GetIntervals(specName, "wait-workload-ready")...).Should(BeTrue(), "expected Pending worker pods when scaled beyond cluster capacity")
+	Logf("Gang scheduling verified: worker pods are Pending when replicas exceed available resources")
+
+	By("scaling workers back to 1 replica to verify recovery")
+	scaleDownPatch := []byte(`[
+		{"op": "replace", "path": "/spec/workerGroupSpecs/0/replicas", "value": 1},
+		{"op": "replace", "path": "/spec/workerGroupSpecs/0/minReplicas", "value": 1},
+		{"op": "replace", "path": "/spec/workerGroupSpecs/0/maxReplicas", "value": 1}
+	]`)
+	_, err = dynamicClient.Resource(rayClusterGVR).Namespace(corev1.NamespaceDefault).Patch(ctx, "raycluster-scheduling-e2e", types.JSONPatchType, scaleDownPatch, metav1.PatchOptions{})
+	Expect(err).NotTo(HaveOccurred())
+
+	By("verifying worker pod is Running again after scaling back down")
+	Eventually(func() bool {
+		pods, err := clientset.CoreV1().Pods(corev1.NamespaceDefault).List(ctx, metav1.ListOptions{
+			LabelSelector: "ray.io/node-type=worker",
+		})
+		if err != nil || len(pods.Items) == 0 {
+			return false
+		}
+		for _, pod := range pods.Items {
+			if pod.Status.Phase == corev1.PodRunning {
+				return true
+			}
+		}
+		return false
+	}, e2eConfig.GetIntervals(specName, "wait-deployment")...).Should(BeTrue(), "worker pod did not become Running after scaling back to 1")
+	Logf("Gang scheduling recovery verified: worker pod is Running after scaling back to 1 replica")
 
 	if !input.SkipCleanup {
 		By("deleting the RayCluster")

--- a/test/e2e/azure_kuberay.go
+++ b/test/e2e/azure_kuberay.go
@@ -30,6 +30,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -468,6 +469,34 @@ func KubeRayNativeSchedulingSpec(ctx context.Context, inputGetter func() KubeRay
 		return false
 	}, e2eConfig.GetIntervals(specName, "wait-workload-ready")...).Should(BeTrue(), "Workload resource was not created for the RayCluster")
 
+	By("validating Workload .spec fields")
+	workload, err := dynamicClient.Resource(workloadGVR).Namespace(corev1.NamespaceDefault).Get(ctx, "raycluster-scheduling-e2e", metav1.GetOptions{})
+	Expect(err).NotTo(HaveOccurred(), "failed to get Workload resource")
+
+	// Validate controllerRef points to the RayCluster
+	controllerRefAPIGroup, _, _ := unstructured.NestedString(workload.Object, "spec", "controllerRef", "apiGroup")
+	Expect(controllerRefAPIGroup).To(Equal("ray.io"), "Workload controllerRef.apiGroup should be ray.io")
+	controllerRefKind, _, _ := unstructured.NestedString(workload.Object, "spec", "controllerRef", "kind")
+	Expect(controllerRefKind).To(Equal("RayCluster"), "Workload controllerRef.kind should be RayCluster")
+	controllerRefName, _, _ := unstructured.NestedString(workload.Object, "spec", "controllerRef", "name")
+	Expect(controllerRefName).To(Equal("raycluster-scheduling-e2e"), "Workload controllerRef.name should match RayCluster name")
+
+	// Validate podGroupTemplates: expect 2 entries (head + 1 worker group)
+	podGroupTemplates, found, err := unstructured.NestedSlice(workload.Object, "spec", "podGroupTemplates")
+	Expect(err).NotTo(HaveOccurred())
+	Expect(found).To(BeTrue(), "Workload should have podGroupTemplates")
+	Expect(podGroupTemplates).To(HaveLen(2), "Workload should have 2 podGroupTemplates (head + 1 worker group)")
+
+	templateNames := make([]string, 0, len(podGroupTemplates))
+	for _, t := range podGroupTemplates {
+		tMap, ok := t.(map[string]interface{})
+		Expect(ok).To(BeTrue())
+		name, _, _ := unstructured.NestedString(tMap, "name")
+		templateNames = append(templateNames, name)
+	}
+	Expect(templateNames).To(ConsistOf("head", "worker-small-group"), "Workload podGroupTemplates should contain head and worker-small-group")
+	Logf("Workload .spec validated: controllerRef=%s/%s/%s, podGroupTemplates=%v", controllerRefAPIGroup, controllerRefKind, controllerRefName, templateNames)
+
 	By("verifying PodGroup resources were created for the RayCluster")
 	Eventually(func() bool {
 		podGroups, err := dynamicClient.Resource(podGroupGVR).Namespace(corev1.NamespaceDefault).List(ctx, metav1.ListOptions{})
@@ -487,6 +516,29 @@ func KubeRayNativeSchedulingSpec(ctx context.Context, inputGetter func() KubeRay
 		}
 		return len(found) == len(expectedPrefixes)
 	}, e2eConfig.GetIntervals(specName, "wait-workload-ready")...).Should(BeTrue(), "PodGroup resources were not created for the RayCluster")
+
+	By("validating PodGroup .spec fields")
+	headPG, err := dynamicClient.Resource(podGroupGVR).Namespace(corev1.NamespaceDefault).Get(ctx, "raycluster-scheduling-e2e-head", metav1.GetOptions{})
+	Expect(err).NotTo(HaveOccurred(), "failed to get head PodGroup")
+	headWorkloadName, _, _ := unstructured.NestedString(headPG.Object, "spec", "podGroupTemplateRef", "workload", "workloadName")
+	Expect(headWorkloadName).To(Equal("raycluster-scheduling-e2e"), "head PodGroup should reference the Workload")
+	headTemplateName, _, _ := unstructured.NestedString(headPG.Object, "spec", "podGroupTemplateRef", "workload", "podGroupTemplateName")
+	Expect(headTemplateName).To(Equal("head"), "head PodGroup should reference the 'head' template")
+	Logf("Head PodGroup validated: workloadName=%s, podGroupTemplateName=%s", headWorkloadName, headTemplateName)
+
+	workerPG, err := dynamicClient.Resource(podGroupGVR).Namespace(corev1.NamespaceDefault).Get(ctx, "raycluster-scheduling-e2e-worker-small-group", metav1.GetOptions{})
+	Expect(err).NotTo(HaveOccurred(), "failed to get worker PodGroup")
+	workerWorkloadName, _, _ := unstructured.NestedString(workerPG.Object, "spec", "podGroupTemplateRef", "workload", "workloadName")
+	Expect(workerWorkloadName).To(Equal("raycluster-scheduling-e2e"), "worker PodGroup should reference the Workload")
+	workerTemplateName, _, _ := unstructured.NestedString(workerPG.Object, "spec", "podGroupTemplateRef", "workload", "podGroupTemplateName")
+	Expect(workerTemplateName).To(Equal("worker-small-group"), "worker PodGroup should reference the 'worker-small-group' template")
+
+	// Validate worker PodGroup has gang scheduling policy with correct minCount
+	workerGangMinCount, found, err := unstructured.NestedFieldNoCopy(workerPG.Object, "spec", "schedulingPolicy", "gang", "minCount")
+	Expect(err).NotTo(HaveOccurred())
+	Expect(found).To(BeTrue(), "worker PodGroup should have gang scheduling policy with minCount")
+	Expect(workerGangMinCount).To(BeNumerically("==", 1), "worker PodGroup gang minCount should be 1 (matching replicas)")
+	Logf("Worker PodGroup validated: workloadName=%s, podGroupTemplateName=%s, gang.minCount=%v", workerWorkloadName, workerTemplateName, workerGangMinCount)
 
 	By("verifying the head pod is running")
 	Eventually(func() bool {
@@ -524,6 +576,21 @@ func KubeRayNativeSchedulingSpec(ctx context.Context, inputGetter func() KubeRay
 		By("deleting the RayCluster")
 		err = dynamicClient.Resource(rayClusterGVR).Namespace(corev1.NamespaceDefault).Delete(ctx, "raycluster-scheduling-e2e", metav1.DeleteOptions{})
 		Expect(err).NotTo(HaveOccurred())
+
+		By("verifying the Workload is cleaned up after RayCluster deletion")
+		Eventually(func() bool {
+			_, err := dynamicClient.Resource(workloadGVR).Namespace(corev1.NamespaceDefault).Get(ctx, "raycluster-scheduling-e2e", metav1.GetOptions{})
+			return apierrors.IsNotFound(err)
+		}, e2eConfig.GetIntervals(specName, "wait-workload-ready")...).Should(BeTrue(), "Workload was not cleaned up after RayCluster deletion")
+
+		By("verifying PodGroups are cleaned up after RayCluster deletion")
+		Eventually(func() bool {
+			_, headErr := dynamicClient.Resource(podGroupGVR).Namespace(corev1.NamespaceDefault).Get(ctx, "raycluster-scheduling-e2e-head", metav1.GetOptions{})
+			_, workerErr := dynamicClient.Resource(podGroupGVR).Namespace(corev1.NamespaceDefault).Get(ctx, "raycluster-scheduling-e2e-worker-small-group", metav1.GetOptions{})
+			return apierrors.IsNotFound(headErr) && apierrors.IsNotFound(workerErr)
+		}, e2eConfig.GetIntervals(specName, "wait-workload-ready")...).Should(BeTrue(), "PodGroups were not cleaned up after RayCluster deletion")
+
+		Logf("Cleanup cascade verified: Workload and PodGroups deleted with RayCluster")
 	}
 }
 

--- a/test/e2e/azure_kuberay.go
+++ b/test/e2e/azure_kuberay.go
@@ -381,11 +381,11 @@ func InstallKubeRayOperatorFromSource(ctx context.Context, clusterProxy framewor
 		"--set", "image.pullPolicy=Always",
 		"--set", "nodeSelector.kubernetes\\.io/os=linux",
 		"--set", "featureGates[0].name=RayClusterStatusConditions",
-		"--set-string", "featureGates[0].enabled=true",
+		"--set", "featureGates[0].enabled=true",
 		"--set", "featureGates[1].name=RayJobDeletionPolicy",
-		"--set-string", "featureGates[1].enabled=true",
+		"--set", "featureGates[1].enabled=true",
 		"--set", "featureGates[2].name=NativeWorkloadScheduling",
-		"--set-string", "featureGates[2].enabled=true",
+		"--set", "featureGates[2].enabled=true",
 	)
 
 	By("waiting for the KubeRay operator deployment to become available")

--- a/test/e2e/azure_kuberay.go
+++ b/test/e2e/azure_kuberay.go
@@ -75,8 +75,14 @@ var podGroupGVR = schema.GroupVersionResource{
 	Resource: "podgroups",
 }
 
-// KubeRayClusterSpecInput is the input for KubeRayClusterSpec.
-type KubeRayClusterSpecInput struct {
+var podGVR = schema.GroupVersionResource{
+	Group:    "",
+	Version:  "v1",
+	Resource: "pods",
+}
+
+// KubeRaySpecInput is the shared input type for all KubeRay test specs.
+type KubeRaySpecInput struct {
 	BootstrapClusterProxy framework.ClusterProxy
 	Namespace             *corev1.Namespace
 	ClusterName           string
@@ -86,10 +92,10 @@ type KubeRayClusterSpecInput struct {
 // KubeRayClusterSpec implements a test that verifies the KubeRay operator can be installed
 // on a workload cluster and a RayCluster can be created and become ready.
 // This corresponds to the "Test RayCluster and GCS E2E" case from the KubeRay buildkite CI.
-func KubeRayClusterSpec(ctx context.Context, inputGetter func() KubeRayClusterSpecInput) {
+func KubeRayClusterSpec(ctx context.Context, inputGetter func() KubeRaySpecInput) {
 	var (
 		specName = "kuberay-cluster"
-		input    KubeRayClusterSpecInput
+		input    KubeRaySpecInput
 	)
 
 	input = inputGetter()
@@ -112,52 +118,9 @@ func KubeRayClusterSpec(ctx context.Context, inputGetter func() KubeRayClusterSp
 	_, err := dynamicClient.Resource(rayClusterGVR).Namespace(corev1.NamespaceDefault).Create(ctx, rayCluster, metav1.CreateOptions{})
 	Expect(err).NotTo(HaveOccurred())
 
-	By("waiting for the RayCluster to become ready")
-	Eventually(func() bool {
-		rc, err := dynamicClient.Resource(rayClusterGVR).Namespace(corev1.NamespaceDefault).Get(ctx, "raycluster-e2e", metav1.GetOptions{})
-		if err != nil {
-			return false
-		}
-		state, found, err := unstructured.NestedString(rc.Object, "status", "state")
-		if err != nil || !found {
-			return false
-		}
-		return state == "ready"
-	}, e2eConfig.GetIntervals(specName, "wait-raycluster-ready")...).Should(BeTrue(), func() string {
-		return describeKubeRayOperatorLogs(ctx, clientset)
-	})
-
-	By("verifying the head pod is running")
-	Eventually(func() bool {
-		pods, err := clientset.CoreV1().Pods(corev1.NamespaceDefault).List(ctx, metav1.ListOptions{
-			LabelSelector: "ray.io/node-type=head",
-		})
-		if err != nil || len(pods.Items) == 0 {
-			return false
-		}
-		for _, pod := range pods.Items {
-			if pod.Status.Phase == corev1.PodRunning {
-				return true
-			}
-		}
-		return false
-	}, e2eConfig.GetIntervals(specName, "wait-deployment")...).Should(BeTrue(), "head pod did not reach Running state")
-
-	By("verifying the worker pod is running")
-	Eventually(func() bool {
-		pods, err := clientset.CoreV1().Pods(corev1.NamespaceDefault).List(ctx, metav1.ListOptions{
-			LabelSelector: "ray.io/node-type=worker",
-		})
-		if err != nil || len(pods.Items) == 0 {
-			return false
-		}
-		for _, pod := range pods.Items {
-			if pod.Status.Phase == corev1.PodRunning {
-				return true
-			}
-		}
-		return false
-	}, e2eConfig.GetIntervals(specName, "wait-deployment")...).Should(BeTrue(), "worker pod did not reach Running state")
+	waitForRayClusterReady(ctx, dynamicClient, "raycluster-e2e", specName, clientset)
+	waitForRayPodRunning(ctx, clientset, "ray.io/node-type=head", specName, "head pod did not reach Running state")
+	waitForRayPodRunning(ctx, clientset, "ray.io/node-type=worker", specName, "worker pod did not reach Running state")
 
 	if !input.SkipCleanup {
 		By("deleting the RayCluster")
@@ -166,21 +129,13 @@ func KubeRayClusterSpec(ctx context.Context, inputGetter func() KubeRayClusterSp
 	}
 }
 
-// KubeRayJobSpecInput is the input for KubeRayJobSpec.
-type KubeRayJobSpecInput struct {
-	BootstrapClusterProxy framework.ClusterProxy
-	Namespace             *corev1.Namespace
-	ClusterName           string
-	SkipCleanup           bool
-}
-
 // KubeRayJobSpec implements a test that verifies the KubeRay operator can be installed
 // on a workload cluster and a RayJob can be created and completed successfully.
 // This corresponds to the "Test RayJob E2E" case from the KubeRay buildkite CI.
-func KubeRayJobSpec(ctx context.Context, inputGetter func() KubeRayJobSpecInput) {
+func KubeRayJobSpec(ctx context.Context, inputGetter func() KubeRaySpecInput) {
 	var (
 		specName = "kuberay-job"
-		input    KubeRayJobSpecInput
+		input    KubeRaySpecInput
 	)
 
 	input = inputGetter()
@@ -395,22 +350,15 @@ func InstallKubeRayOperatorFromSource(ctx context.Context, clusterProxy framewor
 	WaitForDeploymentsAvailable(ctx, waitInput, e2eConfig.GetIntervals(specName, "wait-deployment")...)
 }
 
-// KubeRayNativeSchedulingSpecInput is the input for KubeRayNativeSchedulingSpec.
-type KubeRayNativeSchedulingSpecInput struct {
-	BootstrapClusterProxy framework.ClusterProxy
-	Namespace             *corev1.Namespace
-	ClusterName           string
-	SkipCleanup           bool
-}
-
 // KubeRayNativeSchedulingSpec implements a test that verifies the NativeWorkloadScheduling feature
 // of the KubeRay operator. It creates a RayCluster with the opt-in annotation, verifies that
 // Workload and PodGroup resources are created by the operator, and confirms that all pods are
 // scheduled and running via the native gang scheduling mechanism.
-func KubeRayNativeSchedulingSpec(ctx context.Context, inputGetter func() KubeRayNativeSchedulingSpecInput) {
+func KubeRayNativeSchedulingSpec(ctx context.Context, inputGetter func() KubeRaySpecInput) {
 	var (
-		specName = "kuberay-native-scheduling"
-		input    KubeRayNativeSchedulingSpecInput
+		specName       = "kuberay-native-scheduling"
+		input          KubeRaySpecInput
+		rayClusterName = "raycluster-scheduling-e2e"
 	)
 
 	input = inputGetter()
@@ -429,50 +377,22 @@ func KubeRayNativeSchedulingSpec(ctx context.Context, inputGetter func() KubeRay
 
 	By("creating a RayCluster with native workload scheduling annotation")
 	dynamicClient := newDynamicClient(clusterProxy)
-	rayCluster := newRayClusterWithNativeScheduling("raycluster-scheduling-e2e", corev1.NamespaceDefault)
+	rayCluster := newRayClusterWithNativeScheduling(rayClusterName, corev1.NamespaceDefault)
 	_, err := dynamicClient.Resource(rayClusterGVR).Namespace(corev1.NamespaceDefault).Create(ctx, rayCluster, metav1.CreateOptions{})
 	Expect(err).NotTo(HaveOccurred())
 
-	By("waiting for the RayCluster to become ready")
-	Eventually(func() bool {
-		rc, err := dynamicClient.Resource(rayClusterGVR).Namespace(corev1.NamespaceDefault).Get(ctx, "raycluster-scheduling-e2e", metav1.GetOptions{})
-		if err != nil {
-			return false
-		}
-		state, found, err := unstructured.NestedString(rc.Object, "status", "state")
-		if err != nil || !found {
-			return false
-		}
-		return state == "ready"
-	}, e2eConfig.GetIntervals(specName, "wait-raycluster-ready")...).Should(BeTrue(), func() string {
-		return describeKubeRayOperatorLogs(ctx, clientset)
-	})
+	waitForRayClusterReady(ctx, dynamicClient, rayClusterName, specName, clientset)
 
 	By("verifying a Workload resource was created for the RayCluster")
-	Eventually(func() bool {
-		workloads, err := dynamicClient.Resource(workloadGVR).Namespace(corev1.NamespaceDefault).List(ctx, metav1.ListOptions{})
-		if err != nil || len(workloads.Items) == 0 {
-			return false
-		}
-		for _, w := range workloads.Items {
-			ownerRefs, _, _ := unstructured.NestedSlice(w.Object, "metadata", "ownerReferences")
-			for _, ref := range ownerRefs {
-				refMap, ok := ref.(map[string]interface{})
-				if !ok {
-					continue
-				}
-				if refMap["name"] == "raycluster-scheduling-e2e" && refMap["kind"] == "RayCluster" {
-					Logf("Found Workload %s owned by RayCluster raycluster-scheduling-e2e", w.GetName())
-					return true
-				}
-			}
-		}
-		return false
-	}, e2eConfig.GetIntervals(specName, "wait-workload-ready")...).Should(BeTrue(), "Workload resource was not created for the RayCluster")
+	var workload *unstructured.Unstructured
+	Eventually(func() error {
+		var err error
+		workload, err = dynamicClient.Resource(workloadGVR).Namespace(corev1.NamespaceDefault).Get(ctx, rayClusterName, metav1.GetOptions{})
+		return err
+	}, e2eConfig.GetIntervals(specName, "wait-workload-ready")...).Should(Succeed(), "Workload resource was not created for the RayCluster")
+	Logf("Found Workload %s for RayCluster %s", workload.GetName(), rayClusterName)
 
 	By("validating Workload .spec fields")
-	workload, err := dynamicClient.Resource(workloadGVR).Namespace(corev1.NamespaceDefault).Get(ctx, "raycluster-scheduling-e2e", metav1.GetOptions{})
-	Expect(err).NotTo(HaveOccurred(), "failed to get Workload resource")
 
 	// Validate controllerRef points to the RayCluster
 	controllerRefAPIGroup, _, _ := unstructured.NestedString(workload.Object, "spec", "controllerRef", "apiGroup")
@@ -480,7 +400,7 @@ func KubeRayNativeSchedulingSpec(ctx context.Context, inputGetter func() KubeRay
 	controllerRefKind, _, _ := unstructured.NestedString(workload.Object, "spec", "controllerRef", "kind")
 	Expect(controllerRefKind).To(Equal("RayCluster"), "Workload controllerRef.kind should be RayCluster")
 	controllerRefName, _, _ := unstructured.NestedString(workload.Object, "spec", "controllerRef", "name")
-	Expect(controllerRefName).To(Equal("raycluster-scheduling-e2e"), "Workload controllerRef.name should match RayCluster name")
+	Expect(controllerRefName).To(Equal(rayClusterName), "Workload controllerRef.name should match RayCluster name")
 
 	// Validate podGroupTemplates: expect 2 entries (head + 1 worker group)
 	podGroupTemplates, found, err := unstructured.NestedSlice(workload.Object, "spec", "podGroupTemplates")
@@ -498,39 +418,30 @@ func KubeRayNativeSchedulingSpec(ctx context.Context, inputGetter func() KubeRay
 	Expect(templateNames).To(ConsistOf("head", "worker-small-group"), "Workload podGroupTemplates should contain head and worker-small-group")
 	Logf("Workload .spec validated: controllerRef=%s/%s/%s, podGroupTemplates=%v", controllerRefAPIGroup, controllerRefKind, controllerRefName, templateNames)
 
+	headPGName := rayClusterName + "-head"
+	workerPGName := rayClusterName + "-worker-small-group"
+
 	By("verifying PodGroup resources were created for the RayCluster")
 	Eventually(func() bool {
-		podGroups, err := dynamicClient.Resource(podGroupGVR).Namespace(corev1.NamespaceDefault).List(ctx, metav1.ListOptions{})
-		if err != nil {
-			return false
-		}
-		// Expect at least 2 PodGroups: one for head, one for the worker group
-		expectedPrefixes := []string{"raycluster-scheduling-e2e-head", "raycluster-scheduling-e2e-worker"}
-		found := make(map[string]bool)
-		for _, pg := range podGroups.Items {
-			for _, prefix := range expectedPrefixes {
-				if strings.HasPrefix(pg.GetName(), prefix) {
-					found[prefix] = true
-					Logf("Found PodGroup %s", pg.GetName())
-				}
-			}
-		}
-		return len(found) == len(expectedPrefixes)
+		_, headErr := dynamicClient.Resource(podGroupGVR).Namespace(corev1.NamespaceDefault).Get(ctx, headPGName, metav1.GetOptions{})
+		_, workerErr := dynamicClient.Resource(podGroupGVR).Namespace(corev1.NamespaceDefault).Get(ctx, workerPGName, metav1.GetOptions{})
+		return headErr == nil && workerErr == nil
 	}, e2eConfig.GetIntervals(specName, "wait-workload-ready")...).Should(BeTrue(), "PodGroup resources were not created for the RayCluster")
+	Logf("Found PodGroups %s and %s", headPGName, workerPGName)
 
 	By("validating PodGroup .spec fields")
-	headPG, err := dynamicClient.Resource(podGroupGVR).Namespace(corev1.NamespaceDefault).Get(ctx, "raycluster-scheduling-e2e-head", metav1.GetOptions{})
+	headPG, err := dynamicClient.Resource(podGroupGVR).Namespace(corev1.NamespaceDefault).Get(ctx, headPGName, metav1.GetOptions{})
 	Expect(err).NotTo(HaveOccurred(), "failed to get head PodGroup")
 	headWorkloadName, _, _ := unstructured.NestedString(headPG.Object, "spec", "podGroupTemplateRef", "workload", "workloadName")
-	Expect(headWorkloadName).To(Equal("raycluster-scheduling-e2e"), "head PodGroup should reference the Workload")
+	Expect(headWorkloadName).To(Equal(rayClusterName), "head PodGroup should reference the Workload")
 	headTemplateName, _, _ := unstructured.NestedString(headPG.Object, "spec", "podGroupTemplateRef", "workload", "podGroupTemplateName")
 	Expect(headTemplateName).To(Equal("head"), "head PodGroup should reference the 'head' template")
 	Logf("Head PodGroup validated: workloadName=%s, podGroupTemplateName=%s", headWorkloadName, headTemplateName)
 
-	workerPG, err := dynamicClient.Resource(podGroupGVR).Namespace(corev1.NamespaceDefault).Get(ctx, "raycluster-scheduling-e2e-worker-small-group", metav1.GetOptions{})
+	workerPG, err := dynamicClient.Resource(podGroupGVR).Namespace(corev1.NamespaceDefault).Get(ctx, workerPGName, metav1.GetOptions{})
 	Expect(err).NotTo(HaveOccurred(), "failed to get worker PodGroup")
 	workerWorkloadName, _, _ := unstructured.NestedString(workerPG.Object, "spec", "podGroupTemplateRef", "workload", "workloadName")
-	Expect(workerWorkloadName).To(Equal("raycluster-scheduling-e2e"), "worker PodGroup should reference the Workload")
+	Expect(workerWorkloadName).To(Equal(rayClusterName), "worker PodGroup should reference the Workload")
 	workerTemplateName, _, _ := unstructured.NestedString(workerPG.Object, "spec", "podGroupTemplateRef", "workload", "podGroupTemplateName")
 	Expect(workerTemplateName).To(Equal("worker-small-group"), "worker PodGroup should reference the 'worker-small-group' template")
 
@@ -541,47 +452,17 @@ func KubeRayNativeSchedulingSpec(ctx context.Context, inputGetter func() KubeRay
 	Expect(workerGangMinCount).To(BeNumerically("==", 1), "worker PodGroup gang minCount should be 1 (matching replicas)")
 	Logf("Worker PodGroup validated: workloadName=%s, podGroupTemplateName=%s, gang.minCount=%v", workerWorkloadName, workerTemplateName, workerGangMinCount)
 
-	By("verifying the head pod is running")
-	Eventually(func() bool {
-		pods, err := clientset.CoreV1().Pods(corev1.NamespaceDefault).List(ctx, metav1.ListOptions{
-			LabelSelector: "ray.io/node-type=head",
-		})
-		if err != nil || len(pods.Items) == 0 {
-			return false
-		}
-		for _, pod := range pods.Items {
-			if pod.Status.Phase == corev1.PodRunning {
-				return true
-			}
-		}
-		return false
-	}, e2eConfig.GetIntervals(specName, "wait-deployment")...).Should(BeTrue(), "head pod did not reach Running state")
-
-	By("verifying the worker pod is running")
-	Eventually(func() bool {
-		pods, err := clientset.CoreV1().Pods(corev1.NamespaceDefault).List(ctx, metav1.ListOptions{
-			LabelSelector: "ray.io/node-type=worker",
-		})
-		if err != nil || len(pods.Items) == 0 {
-			return false
-		}
-		for _, pod := range pods.Items {
-			if pod.Status.Phase == corev1.PodRunning {
-				return true
-			}
-		}
-		return false
-	}, e2eConfig.GetIntervals(specName, "wait-deployment")...).Should(BeTrue(), "worker pod did not reach Running state")
+	waitForRayPodRunning(ctx, clientset, "ray.io/node-type=head", specName, "head pod did not reach Running state")
+	waitForRayPodRunning(ctx, clientset, "ray.io/node-type=worker", specName, "worker pod did not reach Running state")
 
 	By("verifying head pod has schedulingGroup referencing its PodGroup")
-	podGVR := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}
 	headPods, err := dynamicClient.Resource(podGVR).Namespace(corev1.NamespaceDefault).List(ctx, metav1.ListOptions{
 		LabelSelector: "ray.io/node-type=head",
 	})
 	Expect(err).NotTo(HaveOccurred())
 	Expect(headPods.Items).NotTo(BeEmpty(), "expected at least one head pod")
 	headSchedulingGroup, _, _ := unstructured.NestedString(headPods.Items[0].Object, "spec", "schedulingGroup", "podGroupName")
-	Expect(headSchedulingGroup).To(Equal("raycluster-scheduling-e2e-head"), "head pod should reference its PodGroup via schedulingGroup")
+	Expect(headSchedulingGroup).To(Equal(rayClusterName+"-head"), "head pod should reference its PodGroup via schedulingGroup")
 	Logf("Head pod %s has schedulingGroup.podGroupName=%s", headPods.Items[0].GetName(), headSchedulingGroup)
 
 	By("verifying worker pod has schedulingGroup referencing its PodGroup")
@@ -591,7 +472,7 @@ func KubeRayNativeSchedulingSpec(ctx context.Context, inputGetter func() KubeRay
 	Expect(err).NotTo(HaveOccurred())
 	Expect(workerPods.Items).NotTo(BeEmpty(), "expected at least one worker pod")
 	workerSchedulingGroup, _, _ := unstructured.NestedString(workerPods.Items[0].Object, "spec", "schedulingGroup", "podGroupName")
-	Expect(workerSchedulingGroup).To(Equal("raycluster-scheduling-e2e-worker-small-group"), "worker pod should reference its PodGroup via schedulingGroup")
+	Expect(workerSchedulingGroup).To(Equal(rayClusterName+"-worker-small-group"), "worker pod should reference its PodGroup via schedulingGroup")
 	Logf("Worker pod %s has schedulingGroup.podGroupName=%s", workerPods.Items[0].GetName(), workerSchedulingGroup)
 
 	By("testing gang scheduling: scaling workers beyond available resources")
@@ -600,12 +481,14 @@ func KubeRayNativeSchedulingSpec(ctx context.Context, inputGetter func() KubeRay
 		{"op": "replace", "path": "/spec/workerGroupSpecs/0/minReplicas", "value": 20},
 		{"op": "replace", "path": "/spec/workerGroupSpecs/0/maxReplicas", "value": 20}
 	]`)
-	_, err = dynamicClient.Resource(rayClusterGVR).Namespace(corev1.NamespaceDefault).Patch(ctx, "raycluster-scheduling-e2e", types.JSONPatchType, scaleUpPatch, metav1.PatchOptions{})
+	_, err = dynamicClient.Resource(rayClusterGVR).Namespace(corev1.NamespaceDefault).Patch(ctx, rayClusterName, types.JSONPatchType, scaleUpPatch, metav1.PatchOptions{})
 	Expect(err).NotTo(HaveOccurred())
+
+	workerPGName = rayClusterName + "-worker-small-group"
 
 	By("verifying the worker PodGroup minCount is updated to 20")
 	Eventually(func() int64 {
-		pg, err := dynamicClient.Resource(podGroupGVR).Namespace(corev1.NamespaceDefault).Get(ctx, "raycluster-scheduling-e2e-worker-small-group", metav1.GetOptions{})
+		pg, err := dynamicClient.Resource(podGroupGVR).Namespace(corev1.NamespaceDefault).Get(ctx, workerPGName, metav1.GetOptions{})
 		if err != nil {
 			return 0
 		}
@@ -641,41 +524,28 @@ func KubeRayNativeSchedulingSpec(ctx context.Context, inputGetter func() KubeRay
 		{"op": "replace", "path": "/spec/workerGroupSpecs/0/minReplicas", "value": 1},
 		{"op": "replace", "path": "/spec/workerGroupSpecs/0/maxReplicas", "value": 1}
 	]`)
-	_, err = dynamicClient.Resource(rayClusterGVR).Namespace(corev1.NamespaceDefault).Patch(ctx, "raycluster-scheduling-e2e", types.JSONPatchType, scaleDownPatch, metav1.PatchOptions{})
+	_, err = dynamicClient.Resource(rayClusterGVR).Namespace(corev1.NamespaceDefault).Patch(ctx, rayClusterName, types.JSONPatchType, scaleDownPatch, metav1.PatchOptions{})
 	Expect(err).NotTo(HaveOccurred())
 
 	By("verifying worker pod is Running again after scaling back down")
-	Eventually(func() bool {
-		pods, err := clientset.CoreV1().Pods(corev1.NamespaceDefault).List(ctx, metav1.ListOptions{
-			LabelSelector: "ray.io/node-type=worker",
-		})
-		if err != nil || len(pods.Items) == 0 {
-			return false
-		}
-		for _, pod := range pods.Items {
-			if pod.Status.Phase == corev1.PodRunning {
-				return true
-			}
-		}
-		return false
-	}, e2eConfig.GetIntervals(specName, "wait-deployment")...).Should(BeTrue(), "worker pod did not become Running after scaling back to 1")
+	waitForRayPodRunning(ctx, clientset, "ray.io/node-type=worker", specName, "worker pod did not become Running after scaling back to 1")
 	Logf("Gang scheduling recovery verified: worker pod is Running after scaling back to 1 replica")
 
 	if !input.SkipCleanup {
 		By("deleting the RayCluster")
-		err = dynamicClient.Resource(rayClusterGVR).Namespace(corev1.NamespaceDefault).Delete(ctx, "raycluster-scheduling-e2e", metav1.DeleteOptions{})
+		err = dynamicClient.Resource(rayClusterGVR).Namespace(corev1.NamespaceDefault).Delete(ctx, rayClusterName, metav1.DeleteOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
 		By("verifying the Workload is cleaned up after RayCluster deletion")
 		Eventually(func() bool {
-			_, err := dynamicClient.Resource(workloadGVR).Namespace(corev1.NamespaceDefault).Get(ctx, "raycluster-scheduling-e2e", metav1.GetOptions{})
+			_, err := dynamicClient.Resource(workloadGVR).Namespace(corev1.NamespaceDefault).Get(ctx, rayClusterName, metav1.GetOptions{})
 			return apierrors.IsNotFound(err)
 		}, e2eConfig.GetIntervals(specName, "wait-workload-ready")...).Should(BeTrue(), "Workload was not cleaned up after RayCluster deletion")
 
 		By("verifying PodGroups are cleaned up after RayCluster deletion")
 		Eventually(func() bool {
-			_, headErr := dynamicClient.Resource(podGroupGVR).Namespace(corev1.NamespaceDefault).Get(ctx, "raycluster-scheduling-e2e-head", metav1.GetOptions{})
-			_, workerErr := dynamicClient.Resource(podGroupGVR).Namespace(corev1.NamespaceDefault).Get(ctx, "raycluster-scheduling-e2e-worker-small-group", metav1.GetOptions{})
+			_, headErr := dynamicClient.Resource(podGroupGVR).Namespace(corev1.NamespaceDefault).Get(ctx, rayClusterName+"-head", metav1.GetOptions{})
+			_, workerErr := dynamicClient.Resource(podGroupGVR).Namespace(corev1.NamespaceDefault).Get(ctx, workerPGName, metav1.GetOptions{})
 			return apierrors.IsNotFound(headErr) && apierrors.IsNotFound(workerErr)
 		}, e2eConfig.GetIntervals(specName, "wait-workload-ready")...).Should(BeTrue(), "PodGroups were not cleaned up after RayCluster deletion")
 
@@ -683,22 +553,14 @@ func KubeRayNativeSchedulingSpec(ctx context.Context, inputGetter func() KubeRay
 	}
 }
 
-// KubeRayNativeSchedulingNegativeSpecInput is the input for KubeRayNativeSchedulingNegativeSpec.
-type KubeRayNativeSchedulingNegativeSpecInput struct {
-	BootstrapClusterProxy framework.ClusterProxy
-	Namespace             *corev1.Namespace
-	ClusterName           string
-	SkipCleanup           bool
-}
-
 // KubeRayNativeSchedulingNegativeSpec implements a negative test that verifies the NativeWorkloadScheduling
 // feature does NOT create Workload or PodGroup resources when the opt-in annotation is absent.
 // It creates a RayCluster without the ray.io/native-workload-scheduling annotation, waits for
 // the cluster to become ready, and confirms that no scheduling.k8s.io/v1alpha2 resources exist.
-func KubeRayNativeSchedulingNegativeSpec(ctx context.Context, inputGetter func() KubeRayNativeSchedulingNegativeSpecInput) {
+func KubeRayNativeSchedulingNegativeSpec(ctx context.Context, inputGetter func() KubeRaySpecInput) {
 	var (
 		specName       = "kuberay-native-scheduling"
-		input          KubeRayNativeSchedulingNegativeSpecInput
+		input          KubeRaySpecInput
 		rayClusterName = "raycluster-no-scheduling-e2e"
 	)
 
@@ -722,40 +584,9 @@ func KubeRayNativeSchedulingNegativeSpec(ctx context.Context, inputGetter func()
 	_, err := dynamicClient.Resource(rayClusterGVR).Namespace(corev1.NamespaceDefault).Create(ctx, rayCluster, metav1.CreateOptions{})
 	Expect(err).NotTo(HaveOccurred())
 
-	By("waiting for the RayCluster to become ready")
-	Eventually(func() bool {
-		rc, err := dynamicClient.Resource(rayClusterGVR).Namespace(corev1.NamespaceDefault).Get(ctx, rayClusterName, metav1.GetOptions{})
-		if err != nil {
-			return false
-		}
-		state, found, err := unstructured.NestedString(rc.Object, "status", "state")
-		if err != nil || !found {
-			return false
-		}
-		return state == "ready"
-	}, e2eConfig.GetIntervals(specName, "wait-raycluster-ready")...).Should(BeTrue(), func() string {
-		return describeKubeRayOperatorLogs(ctx, clientset)
-	})
-
-	By("verifying the head and worker pods are Running")
-	Eventually(func() bool {
-		pods, err := clientset.CoreV1().Pods(corev1.NamespaceDefault).List(ctx, metav1.ListOptions{
-			LabelSelector: "ray.io/node-type=head",
-		})
-		if err != nil || len(pods.Items) == 0 {
-			return false
-		}
-		return pods.Items[0].Status.Phase == corev1.PodRunning
-	}, e2eConfig.GetIntervals(specName, "wait-deployment")...).Should(BeTrue(), "head pod did not reach Running state")
-	Eventually(func() bool {
-		pods, err := clientset.CoreV1().Pods(corev1.NamespaceDefault).List(ctx, metav1.ListOptions{
-			LabelSelector: "ray.io/node-type=worker",
-		})
-		if err != nil || len(pods.Items) == 0 {
-			return false
-		}
-		return pods.Items[0].Status.Phase == corev1.PodRunning
-	}, e2eConfig.GetIntervals(specName, "wait-deployment")...).Should(BeTrue(), "worker pod did not reach Running state")
+	waitForRayClusterReady(ctx, dynamicClient, rayClusterName, specName, clientset)
+	waitForRayPodRunning(ctx, clientset, "ray.io/node-type=head", specName, "head pod did not reach Running state")
+	waitForRayPodRunning(ctx, clientset, "ray.io/node-type=worker", specName, "worker pod did not reach Running state")
 
 	By("verifying NO Workload resources were created")
 	workloads, err := dynamicClient.Resource(workloadGVR).Namespace(corev1.NamespaceDefault).List(ctx, metav1.ListOptions{})
@@ -770,22 +601,21 @@ func KubeRayNativeSchedulingNegativeSpec(ctx context.Context, inputGetter func()
 	Logf("Negative test verified: no PodGroup resources created without annotation")
 
 	By("verifying pods do NOT have schedulingGroup set")
-	podGVR := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}
 	headPods, err := dynamicClient.Resource(podGVR).Namespace(corev1.NamespaceDefault).List(ctx, metav1.ListOptions{
 		LabelSelector: "ray.io/node-type=head",
 	})
 	Expect(err).NotTo(HaveOccurred())
 	Expect(headPods.Items).NotTo(BeEmpty())
-	headSchedulingGroup, found, _ := unstructured.NestedString(headPods.Items[0].Object, "spec", "schedulingGroup", "podGroupName")
-	Expect(found).To(BeFalse(), "head pod should not have schedulingGroup when annotation is absent, but found podGroupName=%s", headSchedulingGroup)
+	_, found, _ := unstructured.NestedString(headPods.Items[0].Object, "spec", "schedulingGroup", "podGroupName")
+	Expect(found).To(BeFalse(), "head pod should not have schedulingGroup when annotation is absent")
 
 	workerPods, err := dynamicClient.Resource(podGVR).Namespace(corev1.NamespaceDefault).List(ctx, metav1.ListOptions{
 		LabelSelector: "ray.io/node-type=worker",
 	})
 	Expect(err).NotTo(HaveOccurred())
 	Expect(workerPods.Items).NotTo(BeEmpty())
-	workerSchedulingGroup, found, _ := unstructured.NestedString(workerPods.Items[0].Object, "spec", "schedulingGroup", "podGroupName")
-	Expect(found).To(BeFalse(), "worker pod should not have schedulingGroup when annotation is absent, but found podGroupName=%s", workerSchedulingGroup)
+	_, found, _ = unstructured.NestedString(workerPods.Items[0].Object, "spec", "schedulingGroup", "podGroupName")
+	Expect(found).To(BeFalse(), "worker pod should not have schedulingGroup when annotation is absent")
 	Logf("Negative test verified: pods do not have schedulingGroup without annotation")
 
 	if !input.SkipCleanup {
@@ -799,20 +629,50 @@ func KubeRayNativeSchedulingNegativeSpec(ctx context.Context, inputGetter func()
 // opt-in annotation. This triggers the KubeRay operator to create Workload and PodGroup resources
 // for gang scheduling via the Kubernetes-native scheduling.k8s.io/v1alpha2 API.
 func newRayClusterWithNativeScheduling(name, namespace string) *unstructured.Unstructured {
-	return &unstructured.Unstructured{
-		Object: map[string]interface{}{
-			"apiVersion": "ray.io/v1",
-			"kind":       "RayCluster",
-			"metadata": map[string]interface{}{
-				"name":      name,
-				"namespace": namespace,
-				"annotations": map[string]interface{}{
-					"ray.io/native-workload-scheduling": "true",
-				},
-			},
-			"spec": rayClusterSpec(),
-		},
+	rc := newRayClusterUnstructured(name, namespace)
+	annotations := map[string]interface{}{
+		"ray.io/native-workload-scheduling": "true",
 	}
+	err := unstructured.SetNestedField(rc.Object, annotations, "metadata", "annotations")
+	Expect(err).NotTo(HaveOccurred())
+	return rc
+}
+
+// waitForRayClusterReady polls until the RayCluster's status.state is "ready".
+func waitForRayClusterReady(ctx context.Context, dynamicClient dynamic.Interface, name, specName string, clientset *kubernetes.Clientset) {
+	By("waiting for the RayCluster to become ready")
+	Eventually(func() bool {
+		rc, err := dynamicClient.Resource(rayClusterGVR).Namespace(corev1.NamespaceDefault).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			return false
+		}
+		state, found, err := unstructured.NestedString(rc.Object, "status", "state")
+		if err != nil || !found {
+			return false
+		}
+		return state == "ready"
+	}, e2eConfig.GetIntervals(specName, "wait-raycluster-ready")...).Should(BeTrue(), func() string {
+		return describeKubeRayOperatorLogs(ctx, clientset)
+	})
+}
+
+// waitForRayPodRunning polls until at least one pod matching the label selector is Running.
+func waitForRayPodRunning(ctx context.Context, clientset *kubernetes.Clientset, labelSelector, specName, failMessage string) {
+	By(fmt.Sprintf("verifying a %s pod is running", labelSelector))
+	Eventually(func() bool {
+		pods, err := clientset.CoreV1().Pods(corev1.NamespaceDefault).List(ctx, metav1.ListOptions{
+			LabelSelector: labelSelector,
+		})
+		if err != nil || len(pods.Items) == 0 {
+			return false
+		}
+		for _, pod := range pods.Items {
+			if pod.Status.Phase == corev1.PodRunning {
+				return true
+			}
+		}
+		return false
+	}, e2eConfig.GetIntervals(specName, "wait-deployment")...).Should(BeTrue(), failMessage)
 }
 
 // newDynamicClient creates a dynamic Kubernetes client from a ClusterProxy.

--- a/test/e2e/azure_kuberay.go
+++ b/test/e2e/azure_kuberay.go
@@ -683,6 +683,118 @@ func KubeRayNativeSchedulingSpec(ctx context.Context, inputGetter func() KubeRay
 	}
 }
 
+// KubeRayNativeSchedulingNegativeSpecInput is the input for KubeRayNativeSchedulingNegativeSpec.
+type KubeRayNativeSchedulingNegativeSpecInput struct {
+	BootstrapClusterProxy framework.ClusterProxy
+	Namespace             *corev1.Namespace
+	ClusterName           string
+	SkipCleanup           bool
+}
+
+// KubeRayNativeSchedulingNegativeSpec implements a negative test that verifies the NativeWorkloadScheduling
+// feature does NOT create Workload or PodGroup resources when the opt-in annotation is absent.
+// It creates a RayCluster without the ray.io/native-workload-scheduling annotation, waits for
+// the cluster to become ready, and confirms that no scheduling.k8s.io/v1alpha2 resources exist.
+func KubeRayNativeSchedulingNegativeSpec(ctx context.Context, inputGetter func() KubeRayNativeSchedulingNegativeSpecInput) {
+	var (
+		specName       = "kuberay-native-scheduling"
+		input          KubeRayNativeSchedulingNegativeSpecInput
+		rayClusterName = "raycluster-no-scheduling-e2e"
+	)
+
+	input = inputGetter()
+	Expect(input.BootstrapClusterProxy).NotTo(BeNil(), "Invalid argument. input.BootstrapClusterProxy can't be nil when calling %s spec", specName)
+	Expect(input.Namespace).NotTo(BeNil(), "Invalid argument. input.Namespace can't be nil when calling %s spec", specName)
+	Expect(input.ClusterName).NotTo(BeEmpty(), "Invalid argument. input.ClusterName can't be empty when calling %s spec", specName)
+
+	By("creating a Kubernetes client to the workload cluster")
+	clusterProxy := input.BootstrapClusterProxy.GetWorkloadCluster(ctx, input.Namespace.Name, input.ClusterName)
+	Expect(clusterProxy).NotTo(BeNil())
+	clientset := clusterProxy.GetClientSet()
+	Expect(clientset).NotTo(BeNil())
+
+	By("installing the KubeRay operator from source with NativeWorkloadScheduling enabled")
+	InstallKubeRayOperatorFromSource(ctx, clusterProxy, specName)
+
+	By("creating a RayCluster WITHOUT the native workload scheduling annotation")
+	dynamicClient := newDynamicClient(clusterProxy)
+	rayCluster := newRayClusterUnstructured(rayClusterName, corev1.NamespaceDefault)
+	_, err := dynamicClient.Resource(rayClusterGVR).Namespace(corev1.NamespaceDefault).Create(ctx, rayCluster, metav1.CreateOptions{})
+	Expect(err).NotTo(HaveOccurred())
+
+	By("waiting for the RayCluster to become ready")
+	Eventually(func() bool {
+		rc, err := dynamicClient.Resource(rayClusterGVR).Namespace(corev1.NamespaceDefault).Get(ctx, rayClusterName, metav1.GetOptions{})
+		if err != nil {
+			return false
+		}
+		state, found, err := unstructured.NestedString(rc.Object, "status", "state")
+		if err != nil || !found {
+			return false
+		}
+		return state == "ready"
+	}, e2eConfig.GetIntervals(specName, "wait-raycluster-ready")...).Should(BeTrue(), func() string {
+		return describeKubeRayOperatorLogs(ctx, clientset)
+	})
+
+	By("verifying the head and worker pods are Running")
+	Eventually(func() bool {
+		pods, err := clientset.CoreV1().Pods(corev1.NamespaceDefault).List(ctx, metav1.ListOptions{
+			LabelSelector: "ray.io/node-type=head",
+		})
+		if err != nil || len(pods.Items) == 0 {
+			return false
+		}
+		return pods.Items[0].Status.Phase == corev1.PodRunning
+	}, e2eConfig.GetIntervals(specName, "wait-deployment")...).Should(BeTrue(), "head pod did not reach Running state")
+	Eventually(func() bool {
+		pods, err := clientset.CoreV1().Pods(corev1.NamespaceDefault).List(ctx, metav1.ListOptions{
+			LabelSelector: "ray.io/node-type=worker",
+		})
+		if err != nil || len(pods.Items) == 0 {
+			return false
+		}
+		return pods.Items[0].Status.Phase == corev1.PodRunning
+	}, e2eConfig.GetIntervals(specName, "wait-deployment")...).Should(BeTrue(), "worker pod did not reach Running state")
+
+	By("verifying NO Workload resources were created")
+	workloads, err := dynamicClient.Resource(workloadGVR).Namespace(corev1.NamespaceDefault).List(ctx, metav1.ListOptions{})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(workloads.Items).To(BeEmpty(), "expected no Workload resources when annotation is absent, but found %d", len(workloads.Items))
+	Logf("Negative test verified: no Workload resources created without annotation")
+
+	By("verifying NO PodGroup resources were created")
+	podGroups, err := dynamicClient.Resource(podGroupGVR).Namespace(corev1.NamespaceDefault).List(ctx, metav1.ListOptions{})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(podGroups.Items).To(BeEmpty(), "expected no PodGroup resources when annotation is absent, but found %d", len(podGroups.Items))
+	Logf("Negative test verified: no PodGroup resources created without annotation")
+
+	By("verifying pods do NOT have schedulingGroup set")
+	podGVR := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}
+	headPods, err := dynamicClient.Resource(podGVR).Namespace(corev1.NamespaceDefault).List(ctx, metav1.ListOptions{
+		LabelSelector: "ray.io/node-type=head",
+	})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(headPods.Items).NotTo(BeEmpty())
+	headSchedulingGroup, found, _ := unstructured.NestedString(headPods.Items[0].Object, "spec", "schedulingGroup", "podGroupName")
+	Expect(found).To(BeFalse(), "head pod should not have schedulingGroup when annotation is absent, but found podGroupName=%s", headSchedulingGroup)
+
+	workerPods, err := dynamicClient.Resource(podGVR).Namespace(corev1.NamespaceDefault).List(ctx, metav1.ListOptions{
+		LabelSelector: "ray.io/node-type=worker",
+	})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(workerPods.Items).NotTo(BeEmpty())
+	workerSchedulingGroup, found, _ := unstructured.NestedString(workerPods.Items[0].Object, "spec", "schedulingGroup", "podGroupName")
+	Expect(found).To(BeFalse(), "worker pod should not have schedulingGroup when annotation is absent, but found podGroupName=%s", workerSchedulingGroup)
+	Logf("Negative test verified: pods do not have schedulingGroup without annotation")
+
+	if !input.SkipCleanup {
+		By("deleting the RayCluster")
+		err = dynamicClient.Resource(rayClusterGVR).Namespace(corev1.NamespaceDefault).Delete(ctx, rayClusterName, metav1.DeleteOptions{})
+		Expect(err).NotTo(HaveOccurred())
+	}
+}
+
 // newRayClusterWithNativeScheduling creates a RayCluster with the native workload scheduling
 // opt-in annotation. This triggers the KubeRay operator to create Workload and PodGroup resources
 // for gang scheduling via the Kubernetes-native scheduling.k8s.io/v1alpha2 API.

--- a/test/e2e/azure_kuberay.go
+++ b/test/e2e/azure_kuberay.go
@@ -487,17 +487,17 @@ func KubeRayNativeSchedulingSpec(ctx context.Context, inputGetter func() KubeRay
 	workerPGName = rayClusterName + "-worker-small-group"
 
 	By("verifying the worker PodGroup minCount is updated to 20")
-	Eventually(func() int64 {
+	Eventually(func() interface{} {
 		pg, err := dynamicClient.Resource(podGroupGVR).Namespace(corev1.NamespaceDefault).Get(ctx, workerPGName, metav1.GetOptions{})
 		if err != nil {
-			return 0
+			return nil
 		}
-		minCount, found, _ := unstructured.NestedInt64(pg.Object, "spec", "schedulingPolicy", "gang", "minCount")
+		minCount, found, _ := unstructured.NestedFieldNoCopy(pg.Object, "spec", "schedulingPolicy", "gang", "minCount")
 		if !found {
-			return 0
+			return nil
 		}
 		return minCount
-	}, e2eConfig.GetIntervals(specName, "wait-workload-ready")...).Should(Equal(int64(20)), "worker PodGroup minCount should be updated to 20")
+	}, e2eConfig.GetIntervals(specName, "wait-workload-ready")...).Should(BeNumerically("==", 20), "worker PodGroup minCount should be updated to 20")
 
 	By("verifying worker pods are Pending due to gang scheduling (all-or-nothing)")
 	Eventually(func() bool {
@@ -507,16 +507,23 @@ func KubeRayNativeSchedulingSpec(ctx context.Context, inputGetter func() KubeRay
 		if err != nil {
 			return false
 		}
+		runningCount := 0
 		pendingCount := 0
 		for _, pod := range pods.Items {
-			if pod.Status.Phase == corev1.PodPending {
+			switch pod.Status.Phase {
+			case corev1.PodRunning:
+				runningCount++
+			case corev1.PodPending:
 				pendingCount++
 			}
 		}
-		Logf("Worker pods: %d total, %d Pending", len(pods.Items), pendingCount)
-		return pendingCount > 0
-	}, e2eConfig.GetIntervals(specName, "wait-workload-ready")...).Should(BeTrue(), "expected Pending worker pods when scaled beyond cluster capacity")
-	Logf("Gang scheduling verified: worker pods are Pending when replicas exceed available resources")
+		Logf("Worker pods: %d total, %d Running, %d Pending", len(pods.Items), runningCount, pendingCount)
+		// Gang scheduling all-or-nothing: with minCount=20 and insufficient resources,
+		// the scheduler should not schedule any new pods in the gang. At most 1 worker
+		// may remain Running from before the scale-up.
+		return runningCount <= 1 && pendingCount >= 19
+	}, e2eConfig.GetIntervals(specName, "wait-workload-ready")...).Should(BeTrue(), "expected gang scheduling to prevent new workers from Running (all-or-nothing)")
+	Logf("Gang scheduling verified: at most 1 worker Running, rest Pending (all-or-nothing)")
 
 	By("scaling workers back to 1 replica to verify recovery")
 	scaleDownPatch := []byte(`[

--- a/test/e2e/azure_kuberay.go
+++ b/test/e2e/azure_kuberay.go
@@ -572,6 +572,27 @@ func KubeRayNativeSchedulingSpec(ctx context.Context, inputGetter func() KubeRay
 		return false
 	}, e2eConfig.GetIntervals(specName, "wait-deployment")...).Should(BeTrue(), "worker pod did not reach Running state")
 
+	By("verifying head pod has schedulingGroup referencing its PodGroup")
+	podGVR := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}
+	headPods, err := dynamicClient.Resource(podGVR).Namespace(corev1.NamespaceDefault).List(ctx, metav1.ListOptions{
+		LabelSelector: "ray.io/node-type=head",
+	})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(headPods.Items).NotTo(BeEmpty(), "expected at least one head pod")
+	headSchedulingGroup, _, _ := unstructured.NestedString(headPods.Items[0].Object, "spec", "schedulingGroup", "podGroupName")
+	Expect(headSchedulingGroup).To(Equal("raycluster-scheduling-e2e-head"), "head pod should reference its PodGroup via schedulingGroup")
+	Logf("Head pod %s has schedulingGroup.podGroupName=%s", headPods.Items[0].GetName(), headSchedulingGroup)
+
+	By("verifying worker pod has schedulingGroup referencing its PodGroup")
+	workerPods, err := dynamicClient.Resource(podGVR).Namespace(corev1.NamespaceDefault).List(ctx, metav1.ListOptions{
+		LabelSelector: "ray.io/node-type=worker",
+	})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(workerPods.Items).NotTo(BeEmpty(), "expected at least one worker pod")
+	workerSchedulingGroup, _, _ := unstructured.NestedString(workerPods.Items[0].Object, "spec", "schedulingGroup", "podGroupName")
+	Expect(workerSchedulingGroup).To(Equal("raycluster-scheduling-e2e-worker-small-group"), "worker pod should reference its PodGroup via schedulingGroup")
+	Logf("Worker pod %s has schedulingGroup.podGroupName=%s", workerPods.Items[0].GetName(), workerSchedulingGroup)
+
 	if !input.SkipCleanup {
 		By("deleting the RayCluster")
 		err = dynamicClient.Resource(rayClusterGVR).Namespace(corev1.NamespaceDefault).Delete(ctx, "raycluster-scheduling-e2e", metav1.DeleteOptions{})

--- a/test/e2e/azure_kuberay.go
+++ b/test/e2e/azure_kuberay.go
@@ -65,13 +65,13 @@ var rayJobGVR = schema.GroupVersionResource{
 
 var workloadGVR = schema.GroupVersionResource{
 	Group:    "scheduling.k8s.io",
-	Version:  "v1alpha2",
+	Version:  "v1alpha3",
 	Resource: "workloads",
 }
 
 var podGroupGVR = schema.GroupVersionResource{
 	Group:    "scheduling.k8s.io",
-	Version:  "v1alpha2",
+	Version:  "v1alpha3",
 	Resource: "podgroups",
 }
 
@@ -563,7 +563,7 @@ func KubeRayNativeSchedulingSpec(ctx context.Context, inputGetter func() KubeRay
 // KubeRayNativeSchedulingNegativeSpec implements a negative test that verifies the NativeWorkloadScheduling
 // feature does NOT create Workload or PodGroup resources when the opt-in annotation is absent.
 // It creates a RayCluster without the ray.io/native-workload-scheduling annotation, waits for
-// the cluster to become ready, and confirms that no scheduling.k8s.io/v1alpha2 resources exist.
+// the cluster to become ready, and confirms that no scheduling.k8s.io/v1alpha3 resources exist.
 func KubeRayNativeSchedulingNegativeSpec(ctx context.Context, inputGetter func() KubeRaySpecInput) {
 	var (
 		specName       = "kuberay-native-scheduling"
@@ -634,7 +634,7 @@ func KubeRayNativeSchedulingNegativeSpec(ctx context.Context, inputGetter func()
 
 // newRayClusterWithNativeScheduling creates a RayCluster with the native workload scheduling
 // opt-in annotation. This triggers the KubeRay operator to create Workload and PodGroup resources
-// for gang scheduling via the Kubernetes-native scheduling.k8s.io/v1alpha2 API.
+// for gang scheduling via the Kubernetes-native scheduling.k8s.io/v1alpha3 API.
 func newRayClusterWithNativeScheduling(name, namespace string) *unstructured.Unstructured {
 	rc := newRayClusterUnstructured(name, namespace)
 	annotations := map[string]interface{}{

--- a/test/e2e/azure_kuberay.go
+++ b/test/e2e/azure_kuberay.go
@@ -45,8 +45,8 @@ const (
 	kubeRayOperatorHelmChartName   = "kuberay-operator"
 	kubeRayOperatorHelmReleaseName = "kuberay-operator"
 	kubeRayOperatorNamespace       = "default"
-	kubeRayVersion                 = "1.6.1"
-	rayVersion                     = "2.55.1"
+	kubeRayVersion                 = "1.6.2"
+	rayVersion                     = "2.56.0"
 	rayImage                       = "rayproject/ray:" + rayVersion
 	objectStoreMemory              = "200000000" // ~200MB, prevents Ray from consuming all of /dev/shm
 )

--- a/test/e2e/azure_kuberay.go
+++ b/test/e2e/azure_kuberay.go
@@ -341,7 +341,7 @@ func InstallKubeRayOperatorFromSource(ctx context.Context, clusterProxy framewor
 		"--set", "featureGates[0].enabled=true",
 		"--set", "featureGates[1].name=RayJobDeletionPolicy",
 		"--set", "featureGates[1].enabled=true",
-		"--set", "featureGates[2].name=NativeWorkloadScheduling",
+		"--set", "featureGates[2].name=K8sWorkloadScheduling",
 		"--set", "featureGates[2].enabled=true",
 	)
 
@@ -562,7 +562,7 @@ func KubeRayNativeSchedulingSpec(ctx context.Context, inputGetter func() KubeRay
 
 // KubeRayNativeSchedulingNegativeSpec implements a negative test that verifies the NativeWorkloadScheduling
 // feature does NOT create Workload or PodGroup resources when the opt-in annotation is absent.
-// It creates a RayCluster without the ray.io/native-workload-scheduling annotation, waits for
+// It creates a RayCluster without the ray.io/k8s-workload-scheduling annotation, waits for
 // the cluster to become ready, and confirms that no scheduling.k8s.io/v1alpha3 resources exist.
 func KubeRayNativeSchedulingNegativeSpec(ctx context.Context, inputGetter func() KubeRaySpecInput) {
 	var (
@@ -638,7 +638,7 @@ func KubeRayNativeSchedulingNegativeSpec(ctx context.Context, inputGetter func()
 func newRayClusterWithNativeScheduling(name, namespace string) *unstructured.Unstructured {
 	rc := newRayClusterUnstructured(name, namespace)
 	annotations := map[string]interface{}{
-		"ray.io/native-workload-scheduling": "true",
+		"ray.io/k8s-workload-scheduling": "true",
 	}
 	err := unstructured.SetNestedField(rc.Object, annotations, "metadata", "annotations")
 	Expect(err).NotTo(HaveOccurred())

--- a/test/e2e/azure_test.go
+++ b/test/e2e/azure_test.go
@@ -1464,7 +1464,8 @@ spec:
 
 	// KubeRay tests deploy the KubeRay operator and verify Ray workloads run on a CAPZ cluster.
 	// These correspond to the RayCluster and RayJob E2E test cases from the KubeRay buildkite CI.
-	Context("Creating an AKS cluster and deploying KubeRay [KubeRay]", func() {
+	// TODO: Re-enable once NativeScheduling tests are validated in CI.
+	PContext("Creating an AKS cluster and deploying KubeRay [KubeRay]", func() {
 		It("Creates a RayCluster and verifies it becomes ready", func() {
 			clusterName = getClusterName(clusterNamePrefix, "kuberay")
 			kubernetesVersion, err := GetAKSKubernetesVersion(ctx, e2eConfig, AKSKubernetesVersion)
@@ -1533,7 +1534,8 @@ spec:
 	})
 
 	// KubeRay tests on a self-managed VM-based cluster.
-	Context("Creating a self-managed cluster and deploying KubeRay [KubeRay]", func() {
+	// TODO: Re-enable once NativeScheduling tests are validated in CI.
+	PContext("Creating a self-managed cluster and deploying KubeRay [KubeRay]", func() {
 		It("Creates a RayCluster and verifies it becomes ready", func() {
 			clusterName = getClusterName(clusterNamePrefix, "vm-kuberay")
 			kubernetesVersion, err := resolveCIVersion("latest")

--- a/test/e2e/azure_test.go
+++ b/test/e2e/azure_test.go
@@ -1635,6 +1635,7 @@ spec:
 			kubernetesVersion, err := resolveCIVersion("latest")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(os.Setenv("CI_VERSION", kubernetesVersion)).To(Succeed())
+			Expect(os.Setenv("CLOUD_PROVIDER_AZURE_LABEL", "azure-ci")).To(Succeed())
 
 			clusterctl.ApplyClusterTemplateAndWait(ctx, createApplyClusterTemplateInput(
 				specName,

--- a/test/e2e/azure_test.go
+++ b/test/e2e/azure_test.go
@@ -1675,4 +1675,52 @@ spec:
 			By("PASSED!")
 		})
 	})
+
+	// Negative test: verify that the NativeWorkloadScheduling feature does NOT create
+	// Workload or PodGroup resources when the opt-in annotation is absent.
+	// This runs on a separate cluster in parallel with the positive test above.
+	Context("Creating a self-managed cluster with native scheduling and deploying KubeRay from source (negative test) [KubeRay] [NativeScheduling]", func() {
+		It("Verifies no Workload/PodGroup resources are created without the annotation", func() {
+			clusterName = getClusterName(clusterNamePrefix, "vm-nonatsched")
+			kubernetesVersion, err := resolveCIVersion("latest")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(os.Setenv("CI_VERSION", kubernetesVersion)).To(Succeed())
+			Expect(os.Setenv("CLOUD_PROVIDER_AZURE_LABEL", "azure-ci")).To(Succeed())
+
+			clusterctl.ApplyClusterTemplateAndWait(ctx, createApplyClusterTemplateInput(
+				specName,
+				withFlavor("ci-version-native-scheduling"),
+				withNamespace(namespace.Name),
+				withClusterName(clusterName),
+				withKubernetesVersion(kubernetesVersion),
+				withControlPlaneMachineCount(1),
+				withWorkerMachineCount(1),
+				withControlPlaneWaiters(clusterctl.ControlPlaneWaiters{
+					WaitForControlPlaneInitialized: EnsureControlPlaneInitialized,
+				}),
+				withPostMachinesProvisioned(func() {
+					EnsureDaemonsets(ctx, func() DaemonsetsSpecInput {
+						return DaemonsetsSpecInput{
+							BootstrapClusterProxy: bootstrapClusterProxy,
+							Namespace:             namespace,
+							ClusterName:           clusterName,
+						}
+					})
+				}),
+			), result)
+
+			By("Running the KubeRay NativeScheduling negative spec", func() {
+				KubeRayNativeSchedulingNegativeSpec(ctx, func() KubeRayNativeSchedulingNegativeSpecInput {
+					return KubeRayNativeSchedulingNegativeSpecInput{
+						BootstrapClusterProxy: bootstrapClusterProxy,
+						Namespace:             namespace,
+						ClusterName:           clusterName,
+						SkipCleanup:           skipCleanup,
+					}
+				})
+			})
+
+			By("PASSED!")
+		})
+	})
 })

--- a/test/e2e/azure_test.go
+++ b/test/e2e/azure_test.go
@@ -1486,8 +1486,8 @@ spec:
 			), result)
 
 			By("Running the KubeRay RayCluster spec", func() {
-				KubeRayClusterSpec(ctx, func() KubeRayClusterSpecInput {
-					return KubeRayClusterSpecInput{
+				KubeRayClusterSpec(ctx, func() KubeRaySpecInput {
+					return KubeRaySpecInput{
 						BootstrapClusterProxy: bootstrapClusterProxy,
 						Namespace:             namespace,
 						ClusterName:           clusterName,
@@ -1519,8 +1519,8 @@ spec:
 			), result)
 
 			By("Running the KubeRay RayJob spec", func() {
-				KubeRayJobSpec(ctx, func() KubeRayJobSpecInput {
-					return KubeRayJobSpecInput{
+				KubeRayJobSpec(ctx, func() KubeRaySpecInput {
+					return KubeRaySpecInput{
 						BootstrapClusterProxy: bootstrapClusterProxy,
 						Namespace:             namespace,
 						ClusterName:           clusterName,
@@ -1566,8 +1566,8 @@ spec:
 			), result)
 
 			By("Running the KubeRay RayCluster spec", func() {
-				KubeRayClusterSpec(ctx, func() KubeRayClusterSpecInput {
-					return KubeRayClusterSpecInput{
+				KubeRayClusterSpec(ctx, func() KubeRaySpecInput {
+					return KubeRaySpecInput{
 						BootstrapClusterProxy: bootstrapClusterProxy,
 						Namespace:             namespace,
 						ClusterName:           clusterName,
@@ -1609,8 +1609,8 @@ spec:
 			), result)
 
 			By("Running the KubeRay RayJob spec", func() {
-				KubeRayJobSpec(ctx, func() KubeRayJobSpecInput {
-					return KubeRayJobSpecInput{
+				KubeRayJobSpec(ctx, func() KubeRaySpecInput {
+					return KubeRaySpecInput{
 						BootstrapClusterProxy: bootstrapClusterProxy,
 						Namespace:             namespace,
 						ClusterName:           clusterName,
@@ -1662,8 +1662,8 @@ spec:
 			), result)
 
 			By("Running the KubeRay NativeScheduling spec", func() {
-				KubeRayNativeSchedulingSpec(ctx, func() KubeRayNativeSchedulingSpecInput {
-					return KubeRayNativeSchedulingSpecInput{
+				KubeRayNativeSchedulingSpec(ctx, func() KubeRaySpecInput {
+					return KubeRaySpecInput{
 						BootstrapClusterProxy: bootstrapClusterProxy,
 						Namespace:             namespace,
 						ClusterName:           clusterName,
@@ -1710,8 +1710,8 @@ spec:
 			), result)
 
 			By("Running the KubeRay NativeScheduling negative spec", func() {
-				KubeRayNativeSchedulingNegativeSpec(ctx, func() KubeRayNativeSchedulingNegativeSpecInput {
-					return KubeRayNativeSchedulingNegativeSpecInput{
+				KubeRayNativeSchedulingNegativeSpec(ctx, func() KubeRaySpecInput {
+					return KubeRaySpecInput{
 						BootstrapClusterProxy: bootstrapClusterProxy,
 						Namespace:             namespace,
 						ClusterName:           clusterName,

--- a/test/e2e/azure_test.go
+++ b/test/e2e/azure_test.go
@@ -1635,7 +1635,6 @@ spec:
 			kubernetesVersion, err := resolveCIVersion("latest")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(os.Setenv("CI_VERSION", kubernetesVersion)).To(Succeed())
-			Expect(os.Setenv("CLOUD_PROVIDER_AZURE_LABEL", "azure-ci")).To(Succeed())
 
 			clusterctl.ApplyClusterTemplateAndWait(ctx, createApplyClusterTemplateInput(
 				specName,

--- a/test/e2e/azure_test.go
+++ b/test/e2e/azure_test.go
@@ -1620,4 +1620,57 @@ spec:
 			By("PASSED!")
 		})
 	})
+
+	// KubeRay NativeWorkloadScheduling tests on a self-managed VM-based cluster with K8s 1.36+.
+	// This tests the unreleased NativeWorkloadScheduling feature from the kuberay workload-poc branch,
+	// which uses the Kubernetes-native scheduling.k8s.io/v1alpha2 API for gang scheduling of Ray pods.
+	// The test requires:
+	//   - KUBERAY_SOURCE_DIR: path to the kuberay repo checked out at the workload-poc branch
+	//   - KUBERAY_OPERATOR_IMAGE_TAG: tag of the kuberay operator image built from source
+	//   - REGISTRY: container registry where the kuberay operator image has been pushed
+	// See scripts/ci-build-kuberay-operator.sh for building and pushing the image.
+	Context("Creating a self-managed cluster with native scheduling and deploying KubeRay from source [KubeRay] [NativeScheduling]", func() {
+		It("Creates a RayCluster with NativeWorkloadScheduling and verifies Workload/PodGroup resources", func() {
+			clusterName = getClusterName(clusterNamePrefix, "vm-natsched")
+			kubernetesVersion, err := resolveCIVersion("latest")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(os.Setenv("CI_VERSION", kubernetesVersion)).To(Succeed())
+			Expect(os.Setenv("CLOUD_PROVIDER_AZURE_LABEL", "azure-ci")).To(Succeed())
+
+			clusterctl.ApplyClusterTemplateAndWait(ctx, createApplyClusterTemplateInput(
+				specName,
+				withFlavor("ci-version-native-scheduling"),
+				withNamespace(namespace.Name),
+				withClusterName(clusterName),
+				withKubernetesVersion(kubernetesVersion),
+				withControlPlaneMachineCount(1),
+				withWorkerMachineCount(1),
+				withControlPlaneWaiters(clusterctl.ControlPlaneWaiters{
+					WaitForControlPlaneInitialized: EnsureControlPlaneInitialized,
+				}),
+				withPostMachinesProvisioned(func() {
+					EnsureDaemonsets(ctx, func() DaemonsetsSpecInput {
+						return DaemonsetsSpecInput{
+							BootstrapClusterProxy: bootstrapClusterProxy,
+							Namespace:             namespace,
+							ClusterName:           clusterName,
+						}
+					})
+				}),
+			), result)
+
+			By("Running the KubeRay NativeScheduling spec", func() {
+				KubeRayNativeSchedulingSpec(ctx, func() KubeRayNativeSchedulingSpecInput {
+					return KubeRayNativeSchedulingSpecInput{
+						BootstrapClusterProxy: bootstrapClusterProxy,
+						Namespace:             namespace,
+						ClusterName:           clusterName,
+						SkipCleanup:           skipCleanup,
+					}
+				})
+			})
+
+			By("PASSED!")
+		})
+	})
 })

--- a/test/e2e/azure_test.go
+++ b/test/e2e/azure_test.go
@@ -1473,7 +1473,8 @@ spec:
 
 	// KubeRay tests deploy the KubeRay operator and verify Ray workloads run on a CAPZ cluster.
 	// These correspond to the RayCluster and RayJob E2E test cases from the KubeRay buildkite CI.
-	Context("Creating an AKS cluster and deploying KubeRay [KubeRay]", func() {
+	// TODO: Re-enable once NativeScheduling tests are validated in CI.
+	PContext("Creating an AKS cluster and deploying KubeRay [KubeRay]", func() {
 		It("Creates a RayCluster and verifies it becomes ready", func() {
 			clusterName = getClusterName(clusterNamePrefix, "kuberay")
 			kubernetesVersion, err := GetAKSKubernetesVersion(ctx, e2eConfig, AKSKubernetesVersion)
@@ -1542,7 +1543,8 @@ spec:
 	})
 
 	// KubeRay tests on a self-managed VM-based cluster.
-	Context("Creating a self-managed cluster and deploying KubeRay [KubeRay]", func() {
+	// TODO: Re-enable once NativeScheduling tests are validated in CI.
+	PContext("Creating a self-managed cluster and deploying KubeRay [KubeRay]", func() {
 		It("Creates a RayCluster and verifies it becomes ready", func() {
 			clusterName = getClusterName(clusterNamePrefix, "vm-kuberay")
 			kubernetesVersion, err := resolveCIVersion("latest")

--- a/test/e2e/azure_test.go
+++ b/test/e2e/azure_test.go
@@ -1644,6 +1644,7 @@ spec:
 			kubernetesVersion, err := resolveCIVersion("latest")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(os.Setenv("CI_VERSION", kubernetesVersion)).To(Succeed())
+			Expect(os.Setenv("CLOUD_PROVIDER_AZURE_LABEL", "azure-ci")).To(Succeed())
 
 			clusterctl.ApplyClusterTemplateAndWait(ctx, createApplyClusterTemplateInput(
 				specName,

--- a/test/e2e/azure_test.go
+++ b/test/e2e/azure_test.go
@@ -1684,4 +1684,52 @@ spec:
 			By("PASSED!")
 		})
 	})
+
+	// Negative test: verify that the NativeWorkloadScheduling feature does NOT create
+	// Workload or PodGroup resources when the opt-in annotation is absent.
+	// This runs on a separate cluster in parallel with the positive test above.
+	Context("Creating a self-managed cluster with native scheduling and deploying KubeRay from source (negative test) [KubeRay] [NativeScheduling]", func() {
+		It("Verifies no Workload/PodGroup resources are created without the annotation", func() {
+			clusterName = getClusterName(clusterNamePrefix, "vm-nonatsched")
+			kubernetesVersion, err := resolveCIVersion("latest")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(os.Setenv("CI_VERSION", kubernetesVersion)).To(Succeed())
+			Expect(os.Setenv("CLOUD_PROVIDER_AZURE_LABEL", "azure-ci")).To(Succeed())
+
+			clusterctl.ApplyClusterTemplateAndWait(ctx, createApplyClusterTemplateInput(
+				specName,
+				withFlavor("ci-version-native-scheduling"),
+				withNamespace(namespace.Name),
+				withClusterName(clusterName),
+				withKubernetesVersion(kubernetesVersion),
+				withControlPlaneMachineCount(1),
+				withWorkerMachineCount(1),
+				withControlPlaneWaiters(clusterctl.ControlPlaneWaiters{
+					WaitForControlPlaneInitialized: EnsureControlPlaneInitialized,
+				}),
+				withPostMachinesProvisioned(func() {
+					EnsureDaemonsets(ctx, func() DaemonsetsSpecInput {
+						return DaemonsetsSpecInput{
+							BootstrapClusterProxy: bootstrapClusterProxy,
+							Namespace:             namespace,
+							ClusterName:           clusterName,
+						}
+					})
+				}),
+			), result)
+
+			By("Running the KubeRay NativeScheduling negative spec", func() {
+				KubeRayNativeSchedulingNegativeSpec(ctx, func() KubeRayNativeSchedulingNegativeSpecInput {
+					return KubeRayNativeSchedulingNegativeSpecInput{
+						BootstrapClusterProxy: bootstrapClusterProxy,
+						Namespace:             namespace,
+						ClusterName:           clusterName,
+						SkipCleanup:           skipCleanup,
+					}
+				})
+			})
+
+			By("PASSED!")
+		})
+	})
 })

--- a/test/e2e/azure_test.go
+++ b/test/e2e/azure_test.go
@@ -1644,7 +1644,6 @@ spec:
 			kubernetesVersion, err := resolveCIVersion("latest")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(os.Setenv("CI_VERSION", kubernetesVersion)).To(Succeed())
-			Expect(os.Setenv("CLOUD_PROVIDER_AZURE_LABEL", "azure-ci")).To(Succeed())
 
 			clusterctl.ApplyClusterTemplateAndWait(ctx, createApplyClusterTemplateInput(
 				specName,

--- a/test/e2e/azure_test.go
+++ b/test/e2e/azure_test.go
@@ -1495,8 +1495,8 @@ spec:
 			), result)
 
 			By("Running the KubeRay RayCluster spec", func() {
-				KubeRayClusterSpec(ctx, func() KubeRayClusterSpecInput {
-					return KubeRayClusterSpecInput{
+				KubeRayClusterSpec(ctx, func() KubeRaySpecInput {
+					return KubeRaySpecInput{
 						BootstrapClusterProxy: bootstrapClusterProxy,
 						Namespace:             namespace,
 						ClusterName:           clusterName,
@@ -1528,8 +1528,8 @@ spec:
 			), result)
 
 			By("Running the KubeRay RayJob spec", func() {
-				KubeRayJobSpec(ctx, func() KubeRayJobSpecInput {
-					return KubeRayJobSpecInput{
+				KubeRayJobSpec(ctx, func() KubeRaySpecInput {
+					return KubeRaySpecInput{
 						BootstrapClusterProxy: bootstrapClusterProxy,
 						Namespace:             namespace,
 						ClusterName:           clusterName,
@@ -1575,8 +1575,8 @@ spec:
 			), result)
 
 			By("Running the KubeRay RayCluster spec", func() {
-				KubeRayClusterSpec(ctx, func() KubeRayClusterSpecInput {
-					return KubeRayClusterSpecInput{
+				KubeRayClusterSpec(ctx, func() KubeRaySpecInput {
+					return KubeRaySpecInput{
 						BootstrapClusterProxy: bootstrapClusterProxy,
 						Namespace:             namespace,
 						ClusterName:           clusterName,
@@ -1618,8 +1618,8 @@ spec:
 			), result)
 
 			By("Running the KubeRay RayJob spec", func() {
-				KubeRayJobSpec(ctx, func() KubeRayJobSpecInput {
-					return KubeRayJobSpecInput{
+				KubeRayJobSpec(ctx, func() KubeRaySpecInput {
+					return KubeRaySpecInput{
 						BootstrapClusterProxy: bootstrapClusterProxy,
 						Namespace:             namespace,
 						ClusterName:           clusterName,
@@ -1671,8 +1671,8 @@ spec:
 			), result)
 
 			By("Running the KubeRay NativeScheduling spec", func() {
-				KubeRayNativeSchedulingSpec(ctx, func() KubeRayNativeSchedulingSpecInput {
-					return KubeRayNativeSchedulingSpecInput{
+				KubeRayNativeSchedulingSpec(ctx, func() KubeRaySpecInput {
+					return KubeRaySpecInput{
 						BootstrapClusterProxy: bootstrapClusterProxy,
 						Namespace:             namespace,
 						ClusterName:           clusterName,
@@ -1719,8 +1719,8 @@ spec:
 			), result)
 
 			By("Running the KubeRay NativeScheduling negative spec", func() {
-				KubeRayNativeSchedulingNegativeSpec(ctx, func() KubeRayNativeSchedulingNegativeSpecInput {
-					return KubeRayNativeSchedulingNegativeSpecInput{
+				KubeRayNativeSchedulingNegativeSpec(ctx, func() KubeRaySpecInput {
+					return KubeRaySpecInput{
 						BootstrapClusterProxy: bootstrapClusterProxy,
 						Namespace:             namespace,
 						ClusterName:           clusterName,

--- a/test/e2e/azure_test.go
+++ b/test/e2e/azure_test.go
@@ -1629,4 +1629,57 @@ spec:
 			By("PASSED!")
 		})
 	})
+
+	// KubeRay NativeWorkloadScheduling tests on a self-managed VM-based cluster with K8s 1.36+.
+	// This tests the unreleased NativeWorkloadScheduling feature from the kuberay workload-poc branch,
+	// which uses the Kubernetes-native scheduling.k8s.io/v1alpha2 API for gang scheduling of Ray pods.
+	// The test requires:
+	//   - KUBERAY_SOURCE_DIR: path to the kuberay repo checked out at the workload-poc branch
+	//   - KUBERAY_OPERATOR_IMAGE_TAG: tag of the kuberay operator image built from source
+	//   - REGISTRY: container registry where the kuberay operator image has been pushed
+	// See scripts/ci-build-kuberay-operator.sh for building and pushing the image.
+	Context("Creating a self-managed cluster with native scheduling and deploying KubeRay from source [KubeRay] [NativeScheduling]", func() {
+		It("Creates a RayCluster with NativeWorkloadScheduling and verifies Workload/PodGroup resources", func() {
+			clusterName = getClusterName(clusterNamePrefix, "vm-natsched")
+			kubernetesVersion, err := resolveCIVersion("latest")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(os.Setenv("CI_VERSION", kubernetesVersion)).To(Succeed())
+			Expect(os.Setenv("CLOUD_PROVIDER_AZURE_LABEL", "azure-ci")).To(Succeed())
+
+			clusterctl.ApplyClusterTemplateAndWait(ctx, createApplyClusterTemplateInput(
+				specName,
+				withFlavor("ci-version-native-scheduling"),
+				withNamespace(namespace.Name),
+				withClusterName(clusterName),
+				withKubernetesVersion(kubernetesVersion),
+				withControlPlaneMachineCount(1),
+				withWorkerMachineCount(1),
+				withControlPlaneWaiters(clusterctl.ControlPlaneWaiters{
+					WaitForControlPlaneInitialized: EnsureControlPlaneInitialized,
+				}),
+				withPostMachinesProvisioned(func() {
+					EnsureDaemonsets(ctx, func() DaemonsetsSpecInput {
+						return DaemonsetsSpecInput{
+							BootstrapClusterProxy: bootstrapClusterProxy,
+							Namespace:             namespace,
+							ClusterName:           clusterName,
+						}
+					})
+				}),
+			), result)
+
+			By("Running the KubeRay NativeScheduling spec", func() {
+				KubeRayNativeSchedulingSpec(ctx, func() KubeRayNativeSchedulingSpecInput {
+					return KubeRayNativeSchedulingSpecInput{
+						BootstrapClusterProxy: bootstrapClusterProxy,
+						Namespace:             namespace,
+						ClusterName:           clusterName,
+						SkipCleanup:           skipCleanup,
+					}
+				})
+			})
+
+			By("PASSED!")
+		})
+	})
 })

--- a/test/e2e/azure_test.go
+++ b/test/e2e/azure_test.go
@@ -1634,7 +1634,7 @@ spec:
 
 	// KubeRay NativeWorkloadScheduling tests on a self-managed VM-based cluster with K8s 1.36+.
 	// This tests the unreleased NativeWorkloadScheduling feature from the kuberay workload-poc branch,
-	// which uses the Kubernetes-native scheduling.k8s.io/v1alpha2 API for gang scheduling of Ray pods.
+	// which uses the Kubernetes-native scheduling.k8s.io/v1alpha3 API for gang scheduling of Ray pods.
 	// The test requires:
 	//   - KUBERAY_SOURCE_DIR: path to the kuberay repo checked out at the workload-poc branch
 	//   - KUBERAY_OPERATOR_IMAGE_TAG: tag of the kuberay operator image built from source

--- a/test/e2e/config/azure-dev.yaml
+++ b/test/e2e/config/azure-dev.yaml
@@ -177,6 +177,8 @@ providers:
         targetName: "cluster-template-private.yaml"
       - sourcePath: "${PWD}/templates/test/ci/cluster-template-prow-ci-version.yaml"
         targetName: "cluster-template-ci-version.yaml"
+      - sourcePath: "${PWD}/templates/test/ci/cluster-template-prow-ci-version-native-scheduling.yaml"
+        targetName: "cluster-template-ci-version-native-scheduling.yaml"
       - sourcePath: "${PWD}/templates/test/ci/cluster-template-prow-ci-version-md-and-mp.yaml"
         targetName: "cluster-template-conformance-ci-artifacts.yaml"
       - sourcePath: "${PWD}/templates/test/ci/cluster-template-prow-ci-version-ipv6.yaml"
@@ -336,6 +338,9 @@ intervals:
   kuberay-cluster/wait-raycluster-ready: ["10m", "10s"]
   kuberay-job/wait-deployment: ["15m", "10s"]
   kuberay-job/wait-rayjob-complete: ["15m", "10s"]
+  kuberay-native-scheduling/wait-deployment: ["15m", "10s"]
+  kuberay-native-scheduling/wait-raycluster-ready: ["10m", "10s"]
+  kuberay-native-scheduling/wait-workload-ready: ["5m", "10s"]
   csi-migration/wait-controlplane-upgrade: ["60m", "10s"]
   csi-migration/wait-worker-nodes: ["60m", "10s"]
   csi-migration/wait-control-plane: ["60m", "10s"]

--- a/test/e2e/config/azure-dev.yaml
+++ b/test/e2e/config/azure-dev.yaml
@@ -177,6 +177,8 @@ providers:
         targetName: "cluster-template-private.yaml"
       - sourcePath: "${PWD}/templates/test/ci/cluster-template-prow-ci-version.yaml"
         targetName: "cluster-template-ci-version.yaml"
+      - sourcePath: "${PWD}/templates/test/ci/cluster-template-prow-ci-version-native-scheduling.yaml"
+        targetName: "cluster-template-ci-version-native-scheduling.yaml"
       - sourcePath: "${PWD}/templates/test/ci/cluster-template-prow-ci-version-md-and-mp.yaml"
         targetName: "cluster-template-conformance-ci-artifacts.yaml"
       - sourcePath: "${PWD}/templates/test/ci/cluster-template-prow-ci-version-ipv6.yaml"
@@ -337,6 +339,9 @@ intervals:
   kuberay-cluster/wait-raycluster-ready: ["10m", "10s"]
   kuberay-job/wait-deployment: ["15m", "10s"]
   kuberay-job/wait-rayjob-complete: ["15m", "10s"]
+  kuberay-native-scheduling/wait-deployment: ["15m", "10s"]
+  kuberay-native-scheduling/wait-raycluster-ready: ["10m", "10s"]
+  kuberay-native-scheduling/wait-workload-ready: ["5m", "10s"]
   csi-migration/wait-controlplane-upgrade: ["60m", "10s"]
   csi-migration/wait-worker-nodes: ["60m", "10s"]
   csi-migration/wait-control-plane: ["60m", "10s"]


### PR DESCRIPTION
**What type of PR is this?**

/kind feature


**What this PR does / why we need it**:

Add a new e2e test that exercises the unreleased NativeWorkloadScheduling feature from the kuberay workload-poc branch. This feature uses the Kubernetes-native scheduling.k8s.io/v1alpha2 API (Workload + PodGroup) for gang scheduling of Ray pods.

Changes:
- New cluster template ci-version-native-scheduling with K8s feature gates GenericWorkload, GangScheduling, and runtime config for scheduling.k8s.io/v1alpha2
- InstallHelmChartFromPath and InstallKubeRayOperatorFromSource helpers for installing kuberay from a local chart with custom image
- KubeRayNativeSchedulingSpec test that creates a RayCluster with the opt-in annotation, verifies Workload and PodGroup resources are created, and confirms all pods reach Running state
- New Ginkgo test case tagged [KubeRay] [NativeScheduling]

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:


**TODOs**:

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] cherry-pick candidate

**Release note**:

```release-note
NONE
```
