### PR TITLE
Fix: clean up stopped nodes in VMSS/MachinePool

### DIFF
--- a/azure/converters/vmss.go
+++ b/azure/converters/vmss.go
@@ -18,6 +18,7 @@ package converters
 
 import (
 	"regexp"
+	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
 	"k8s.io/utils/ptr"
@@ -89,6 +90,13 @@ func SDKVMToVMSSVM(sdkInstance armcompute.VirtualMachine, mode infrav1.Orchestra
 		instance.State = infrav1.ProvisioningState(ptr.Deref(sdkInstance.Properties.ProvisioningState, ""))
 	}
 
+	// A stopped/deallocated VM has ProvisioningState "Succeeded" but is not healthy.
+	// Override the state to Failed so that the machine pool controller detects and replaces it.
+	if sdkInstance.Properties.InstanceView != nil &&
+		isVMStoppedOrDeallocated(sdkInstance.Properties.InstanceView.Statuses) {
+		instance.State = infrav1.Failed
+	}
+
 	if sdkInstance.Properties.OSProfile != nil && sdkInstance.Properties.OSProfile.ComputerName != nil {
 		instance.Name = *sdkInstance.Properties.OSProfile.ComputerName
 	}
@@ -131,6 +139,13 @@ func SDKToVMSSVM(sdkInstance armcompute.VirtualMachineScaleSetVM) *azure.VMSSVM 
 		instance.State = infrav1.ProvisioningState(ptr.Deref(sdkInstance.Properties.ProvisioningState, ""))
 	}
 
+	// A stopped/deallocated VM has ProvisioningState "Succeeded" but is not healthy.
+	// Override the state to Failed so that the machine pool controller detects and replaces it.
+	if sdkInstance.Properties.InstanceView != nil &&
+		isVMStoppedOrDeallocated(sdkInstance.Properties.InstanceView.Statuses) {
+		instance.State = infrav1.Failed
+	}
+
 	if sdkInstance.Properties.OSProfile != nil && sdkInstance.Properties.OSProfile.ComputerName != nil {
 		instance.Name = *sdkInstance.Properties.OSProfile.ComputerName
 	}
@@ -156,6 +171,21 @@ func SDKToVMSSVM(sdkInstance armcompute.VirtualMachineScaleSetVM) *azure.VMSSVM 
 	}
 
 	return &instance
+}
+
+// isVMStoppedOrDeallocated returns true if the instance view statuses indicate
+// the VM is stopped or deallocated (i.e. not running).
+func isVMStoppedOrDeallocated(statuses []*armcompute.InstanceViewStatus) bool {
+	for _, status := range statuses {
+		if status == nil || status.Code == nil {
+			continue
+		}
+		switch strings.ToLower(*status.Code) {
+		case "powerstate/stopped", "powerstate/deallocated":
+			return true
+		}
+	}
+	return false
 }
 
 // SDKImageToImage converts a SDK image reference to infrav1.Image.

--- a/azure/converters/vmss_test.go
+++ b/azure/converters/vmss_test.go
@@ -202,6 +202,69 @@ func Test_SDKToVMSSVM(t *testing.T) {
 				State:            "Creating",
 			},
 		},
+		{
+			Name: "VM stopped is reported as Failed",
+			SDKInstance: armcompute.VirtualMachineScaleSetVM{
+				ID: ptr.To("/subscriptions/foo/resourceGroups/MY_RESOURCE_GROUP/providers/bar"),
+				Properties: &armcompute.VirtualMachineScaleSetVMProperties{
+					ProvisioningState: ptr.To("Succeeded"),
+					OSProfile:         &armcompute.OSProfile{ComputerName: ptr.To("instance-000003")},
+					InstanceView: &armcompute.VirtualMachineScaleSetVMInstanceView{
+						Statuses: []*armcompute.InstanceViewStatus{
+							{Code: ptr.To("ProvisioningState/succeeded")},
+							{Code: ptr.To("PowerState/stopped")},
+						},
+					},
+				},
+			},
+			VMSSVM: &azure.VMSSVM{
+				ID:    "/subscriptions/foo/resourceGroups/my_resource_group/providers/bar",
+				Name:  "instance-000003",
+				State: infrav1.Failed,
+			},
+		},
+		{
+			Name: "VM deallocated is reported as Failed",
+			SDKInstance: armcompute.VirtualMachineScaleSetVM{
+				ID: ptr.To("/subscriptions/foo/resourceGroups/MY_RESOURCE_GROUP/providers/bar"),
+				Properties: &armcompute.VirtualMachineScaleSetVMProperties{
+					ProvisioningState: ptr.To("Succeeded"),
+					OSProfile:         &armcompute.OSProfile{ComputerName: ptr.To("instance-000004")},
+					InstanceView: &armcompute.VirtualMachineScaleSetVMInstanceView{
+						Statuses: []*armcompute.InstanceViewStatus{
+							{Code: ptr.To("ProvisioningState/succeeded")},
+							{Code: ptr.To("PowerState/deallocated")},
+						},
+					},
+				},
+			},
+			VMSSVM: &azure.VMSSVM{
+				ID:    "/subscriptions/foo/resourceGroups/my_resource_group/providers/bar",
+				Name:  "instance-000004",
+				State: infrav1.Failed,
+			},
+		},
+		{
+			Name: "VM running preserves provisioning state",
+			SDKInstance: armcompute.VirtualMachineScaleSetVM{
+				ID: ptr.To("/subscriptions/foo/resourceGroups/MY_RESOURCE_GROUP/providers/bar"),
+				Properties: &armcompute.VirtualMachineScaleSetVMProperties{
+					ProvisioningState: ptr.To("Succeeded"),
+					OSProfile:         &armcompute.OSProfile{ComputerName: ptr.To("instance-000005")},
+					InstanceView: &armcompute.VirtualMachineScaleSetVMInstanceView{
+						Statuses: []*armcompute.InstanceViewStatus{
+							{Code: ptr.To("ProvisioningState/succeeded")},
+							{Code: ptr.To("PowerState/running")},
+						},
+					},
+				},
+			},
+			VMSSVM: &azure.VMSSVM{
+				ID:    "/subscriptions/foo/resourceGroups/my_resource_group/providers/bar",
+				Name:  "instance-000005",
+				State: "Succeeded",
+			},
+		},
 	}
 
 	for _, c := range cases {
@@ -392,6 +455,75 @@ func Test_SDKVMToVMSSVM(t *testing.T) {
 			Expected: &azure.VMSSVM{
 				ID:    "vmID4",
 				Name:  "vmwithstate",
+				State: "Succeeded",
+			},
+		},
+		{
+			Name: "VM stopped is reported as Failed",
+			Subject: armcompute.VirtualMachine{
+				ID: ptr.To("vmID5"),
+				Properties: &armcompute.VirtualMachineProperties{
+					OSProfile: &armcompute.OSProfile{
+						ComputerName: ptr.To("vmstopped"),
+					},
+					ProvisioningState: ptr.To("Succeeded"),
+					InstanceView: &armcompute.VirtualMachineInstanceView{
+						Statuses: []*armcompute.InstanceViewStatus{
+							{Code: ptr.To("ProvisioningState/succeeded")},
+							{Code: ptr.To("PowerState/stopped")},
+						},
+					},
+				},
+			},
+			Expected: &azure.VMSSVM{
+				ID:    "vmID5",
+				Name:  "vmstopped",
+				State: infrav1.Failed,
+			},
+		},
+		{
+			Name: "VM deallocated is reported as Failed",
+			Subject: armcompute.VirtualMachine{
+				ID: ptr.To("vmID6"),
+				Properties: &armcompute.VirtualMachineProperties{
+					OSProfile: &armcompute.OSProfile{
+						ComputerName: ptr.To("vmdeallocated"),
+					},
+					ProvisioningState: ptr.To("Succeeded"),
+					InstanceView: &armcompute.VirtualMachineInstanceView{
+						Statuses: []*armcompute.InstanceViewStatus{
+							{Code: ptr.To("ProvisioningState/succeeded")},
+							{Code: ptr.To("PowerState/deallocated")},
+						},
+					},
+				},
+			},
+			Expected: &azure.VMSSVM{
+				ID:    "vmID6",
+				Name:  "vmdeallocated",
+				State: infrav1.Failed,
+			},
+		},
+		{
+			Name: "VM running preserves provisioning state",
+			Subject: armcompute.VirtualMachine{
+				ID: ptr.To("vmID7"),
+				Properties: &armcompute.VirtualMachineProperties{
+					OSProfile: &armcompute.OSProfile{
+						ComputerName: ptr.To("vmrunning"),
+					},
+					ProvisioningState: ptr.To("Succeeded"),
+					InstanceView: &armcompute.VirtualMachineInstanceView{
+						Statuses: []*armcompute.InstanceViewStatus{
+							{Code: ptr.To("ProvisioningState/succeeded")},
+							{Code: ptr.To("PowerState/running")},
+						},
+					},
+				},
+			},
+			Expected: &azure.VMSSVM{
+				ID:    "vmID7",
+				Name:  "vmrunning",
 				State: "Succeeded",
 			},
 		},

--- a/azure/services/scalesets/client.go
+++ b/azure/services/scalesets/client.go
@@ -23,6 +23,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
 	"github.com/pkg/errors"
+	"k8s.io/utils/ptr"
 
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/services/async"
@@ -97,7 +98,9 @@ func (ac *AzureClient) ListInstances(ctx context.Context, resourceGroupName stri
 	defer done()
 
 	var instances []armcompute.VirtualMachineScaleSetVM
-	pager := ac.scalesetvms.NewListPager(resourceGroupName, resourceName, nil)
+	pager := ac.scalesetvms.NewListPager(resourceGroupName, resourceName, &armcompute.VirtualMachineScaleSetVMsClientListOptions{
+		Expand: ptr.To("instanceView"),
+	})
 	for pager.More() {
 		nextResult, err := pager.NextPage(ctx)
 		if err != nil {

--- a/azure/services/scalesetvms/client.go
+++ b/azure/services/scalesetvms/client.go
@@ -23,6 +23,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
 	"github.com/pkg/errors"
+	"k8s.io/utils/ptr"
 
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/services/async"
@@ -62,7 +63,9 @@ func (ac *azureClient) Get(ctx context.Context, spec azure.ResourceSpecGetter) (
 	ctx, _, done := tele.StartSpanWithLogger(ctx, "scalesetvms.azureClient.Get")
 	defer done()
 
-	resp, err := ac.scalesetvms.Get(ctx, spec.ResourceGroupName(), spec.OwnerResourceName(), spec.ResourceName(), nil)
+	resp, err := ac.scalesetvms.Get(ctx, spec.ResourceGroupName(), spec.OwnerResourceName(), spec.ResourceName(), &armcompute.VirtualMachineScaleSetVMsClientGetOptions{
+		Expand: ptr.To(armcompute.InstanceViewTypesInstanceView),
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/azure/services/virtualmachines/client.go
+++ b/azure/services/virtualmachines/client.go
@@ -65,7 +65,9 @@ func (ac *AzureClient) Get(ctx context.Context, spec azure.ResourceSpecGetter) (
 	ctx, _, done := tele.StartSpanWithLogger(ctx, "virtualmachines.AzureClient.Get")
 	defer done()
 
-	resp, err := ac.virtualmachines.Get(ctx, spec.ResourceGroupName(), spec.ResourceName(), nil)
+	resp, err := ac.virtualmachines.Get(ctx, spec.ResourceGroupName(), spec.ResourceName(), &armcompute.VirtualMachinesClientGetOptions{
+		Expand: ptr.To(armcompute.InstanceViewTypesInstanceView),
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/test/e2e/azure_machinepool_stopped_vm.go
+++ b/test/e2e/azure_machinepool_stopped_vm.go
@@ -1,0 +1,166 @@
+//go:build e2e
+// +build e2e
+
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"strings"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/utils/ptr"
+	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
+	"sigs.k8s.io/cluster-api/test/framework"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
+	infrav1exp "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1beta1"
+	azureutil "sigs.k8s.io/cluster-api-provider-azure/util/azure"
+)
+
+const (
+	AzureMachinePoolStoppedVMSpecName = "azure-machinepool-stopped-vm"
+)
+
+// AzureMachinePoolStoppedVMSpecInput is the input for AzureMachinePoolStoppedVMSpec.
+type AzureMachinePoolStoppedVMSpecInput struct {
+	Cluster               *clusterv1.Cluster
+	BootstrapClusterProxy framework.ClusterProxy
+	Namespace             *corev1.Namespace
+	ClusterName           string
+	WaitIntervals         []interface{}
+}
+
+// AzureMachinePoolStoppedVMSpec verifies that a VMSS instance that is stopped
+// (powered off) is detected by CAPZ and cleaned up.
+func AzureMachinePoolStoppedVMSpec(ctx context.Context, inputGetter func() AzureMachinePoolStoppedVMSpecInput) {
+	input := inputGetter()
+	Expect(input.Cluster).NotTo(BeNil(), "Invalid argument. input.Cluster can't be nil when calling %s spec", AzureMachinePoolStoppedVMSpecName)
+	Expect(input.BootstrapClusterProxy).NotTo(BeNil(), "Invalid argument. input.BootstrapClusterProxy can't be nil when calling %s spec", AzureMachinePoolStoppedVMSpecName)
+	Expect(input.Namespace).NotTo(BeNil(), "Invalid argument. input.Namespace can't be nil when calling %s spec", AzureMachinePoolStoppedVMSpecName)
+	Expect(input.ClusterName).NotTo(BeEmpty(), "Invalid argument. input.ClusterName can't be empty when calling %s spec", AzureMachinePoolStoppedVMSpecName)
+	Expect(input.WaitIntervals).NotTo(BeEmpty(), "Invalid argument. input.WaitIntervals can't be empty when calling %s spec", AzureMachinePoolStoppedVMSpecName)
+
+	mgmtClient := input.BootstrapClusterProxy.GetClient()
+	Expect(mgmtClient).NotTo(BeNil())
+
+	clusterLabels := map[string]string{clusterv1.ClusterNameLabel: input.ClusterName}
+
+	By("Listing AzureMachinePoolMachines for the cluster")
+	ampmList := &infrav1exp.AzureMachinePoolMachineList{}
+	Expect(mgmtClient.List(ctx, ampmList, client.InNamespace(input.Namespace.Name), client.MatchingLabels(clusterLabels))).To(Succeed())
+	Expect(ampmList.Items).NotTo(BeEmpty(), "expected at least one AzureMachinePoolMachine")
+
+	// Pick the first ready instance to stop.
+	var targetAMPM infrav1exp.AzureMachinePoolMachine
+	for _, ampm := range ampmList.Items {
+		if ampm.Status.Ready && ampm.Status.ProvisioningState != nil && *ampm.Status.ProvisioningState == infrav1.Succeeded {
+			targetAMPM = ampm
+			break
+		}
+	}
+	Expect(targetAMPM.Name).NotTo(BeEmpty(), "expected at least one ready AzureMachinePoolMachine")
+
+	// Parse the provider ID to extract VMSS name, instance ID, and resource group.
+	providerID := targetAMPM.Spec.ProviderID
+	Byf("Selected AzureMachinePoolMachine %s with provider ID %s", targetAMPM.Name, providerID)
+
+	// Provider ID format: azure:///subscriptions/.../resourceGroups/<rg>/providers/Microsoft.Compute/virtualMachineScaleSets/<vmss>/virtualMachines/<id>
+	resourceID := strings.TrimPrefix(providerID, "azure://")
+	parsed, err := azureutil.ParseResourceID(resourceID)
+	Expect(err).NotTo(HaveOccurred(), "failed to parse provider ID %s", providerID)
+
+	resourceGroup := parsed.ResourceGroupName
+
+	// Walk the parent chain to extract the VMSS name and instance ID.
+	// For Uniform VMSS: the resource type is "virtualMachines" under "virtualMachineScaleSets".
+	var vmssName, instanceID string
+	switch parsed.ResourceType.Type {
+	case "virtualMachineScaleSets/virtualMachines":
+		vmssName = parsed.Parent.Name
+		instanceID = parsed.Name
+	case "virtualMachines":
+		Skip("Stopping Flex VMSS VMs is not covered by this test")
+	default:
+		Fail("unexpected resource type in provider ID: " + parsed.ResourceType.Type)
+	}
+	Byf("VMSS: %s, Instance ID: %s, Resource Group: %s", vmssName, instanceID, resourceGroup)
+
+	// Find the AzureMachinePool that owns the target AzureMachinePoolMachine.
+	ampList := &infrav1exp.AzureMachinePoolList{}
+	Expect(mgmtClient.List(ctx, ampList, client.InNamespace(input.Namespace.Name), client.MatchingLabels(clusterLabels))).To(Succeed())
+	Expect(ampList.Items).NotTo(BeEmpty())
+	var amp *infrav1exp.AzureMachinePool
+	for i, candidate := range ampList.Items {
+		for _, ref := range targetAMPM.OwnerReferences {
+			if ref.Kind == "AzureMachinePool" && ref.Name == candidate.Name {
+				amp = &ampList.Items[i]
+				break
+			}
+		}
+		if amp != nil {
+			break
+		}
+	}
+	Expect(amp).NotTo(BeNil(), "expected to find AzureMachinePool owning %s", targetAMPM.Name)
+	mp, err := azureutil.FindParentMachinePool(amp.Name, mgmtClient)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(mp).NotTo(BeNil())
+	Byf("MachinePool %s has %d desired replicas", mp.Name, ptr.Deref(mp.Spec.Replicas, 0))
+
+	By("Stopping the VMSS instance via Azure API")
+	cred, err := azidentity.NewDefaultAzureCredential(nil)
+	Expect(err).NotTo(HaveOccurred())
+
+	vmssVMClient, err := armcompute.NewVirtualMachineScaleSetVMsClient(getSubscriptionID(Default), cred, nil)
+	Expect(err).NotTo(HaveOccurred())
+
+	poller, err := vmssVMClient.BeginPowerOff(ctx, resourceGroup, vmssName, instanceID, nil)
+	Expect(err).NotTo(HaveOccurred())
+	_, err = poller.PollUntilDone(ctx, nil)
+	Expect(err).NotTo(HaveOccurred())
+
+	Byf("Successfully stopped VMSS instance %s/%s/%s", resourceGroup, vmssName, instanceID)
+
+	By("Waiting for the stopped AzureMachinePoolMachine to be cleaned up")
+	Eventually(func(g Gomega) {
+		currentAMPM := &infrav1exp.AzureMachinePoolMachine{}
+		err := mgmtClient.Get(ctx, client.ObjectKeyFromObject(&targetAMPM), currentAMPM)
+		if apierrors.IsNotFound(err) {
+			// Object is gone — cleanup succeeded.
+			return
+		}
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(currentAMPM.Status.Ready).To(BeFalse(),
+			"expected stopped AzureMachinePoolMachine %s to be marked not ready", targetAMPM.Name)
+	}, input.WaitIntervals...).Should(Succeed())
+
+	By("Waiting for MachinePool to recover to the desired replica count")
+	framework.WaitForMachinePoolNodesToExist(ctx, framework.WaitForMachinePoolNodesToExistInput{
+		Getter:      mgmtClient,
+		MachinePool: mp,
+	}, input.WaitIntervals...)
+
+	Byf("MachinePool %s recovered to %d nodes", mp.Name, ptr.Deref(mp.Spec.Replicas, 0))
+}

--- a/test/e2e/azure_test.go
+++ b/test/e2e/azure_test.go
@@ -525,6 +525,18 @@ var _ = Describe("Workload cluster creation", func() {
 				})
 			})
 
+			By("Verifying stopped VMSS instances are cleaned up", func() {
+				AzureMachinePoolStoppedVMSpec(ctx, func() AzureMachinePoolStoppedVMSpecInput {
+					return AzureMachinePoolStoppedVMSpecInput{
+						Cluster:               result.Cluster,
+						BootstrapClusterProxy: bootstrapClusterProxy,
+						Namespace:             namespace,
+						ClusterName:           clusterName,
+						WaitIntervals:         e2eConfig.GetIntervals(specName, "wait-machine-pool-nodes"),
+					}
+				})
+			})
+
 			By("PASSED!")
 		})
 	})


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

CAPZ doesn't detect VMSS instances that have been stopped or deallocated outside of Kubernetes (for example, via the Azure portal or `az` CLI). These instances have `ProvisioningState: Succeeded` but a `PowerState` of `stopped` or `deallocated`, so CAPZ considers them healthy and never replaces them.

This PR fixes the issue by:

- Adding `$expand=instanceView` to VMSS VM List and Get API calls so that `PowerState` is available.
- In the converters, checking `InstanceView.Statuses` for `PowerState/stopped` or `PowerState/deallocated` and overriding the instance state to `Failed`, which triggers the existing machine replacement flow.
- Adding an e2e test that stops a VMSS instance via the Azure API and verifies CAPZ cleans it up and reconciles the MachinePool to the desired replica count.

**Which issue(s) this PR fixes**:
Fixes #5541

**Special notes for your reviewer**:

The `$expand=instanceView` parameter adds some modest extra data to every VMSS VM List/Get response. This is necessary for correctness — without it, stopped VMs are invisible to CAPZ. 

**TODOs**:

- [ ] squashed commits
- [ ] includes documentation
- [x] adds unit tests
- [ ] cherry-pick candidate

**Release note**:

```release-note
Fix: clean up stopped nodes in VMSS/MachinePool
```
