### PR TITLE
Bump CAPI to v1.13.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -365,7 +365,7 @@ create-management-cluster: $(KUSTOMIZE) $(ENVSUBST) $(KUBECTL) $(KIND) ## Create
 	./hack/create-custom-cloud-provider-config.sh
 
 	# Deploy CAPI
-	timeout --foreground 300 bash -c "until curl --retry $(CURL_RETRIES) -sSL https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.13.0-rc.0/cluster-api-components.yaml | $(ENVSUBST) | $(KUBECTL) apply -f - --server-side=true; do sleep 5; done"
+	timeout --foreground 300 bash -c "until curl --retry $(CURL_RETRIES) -sSL https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.13.0/cluster-api-components.yaml | $(ENVSUBST) | $(KUBECTL) apply -f - --server-side=true; do sleep 5; done"
 
 	# Deploy CAAPH
 	timeout --foreground 300 bash -c "until curl --retry $(CURL_RETRIES) -sSL https://github.com/kubernetes-sigs/cluster-api-addon-provider-helm/releases/download/v0.6.2/addon-components.yaml | $(ENVSUBST) | $(KUBECTL) apply -f - --server-side=true; do sleep 5; done"

--- a/Tiltfile
+++ b/Tiltfile
@@ -22,7 +22,7 @@ settings = {
     "deploy_cert_manager": True,
     "preload_images_for_kind": True,
     "kind_cluster_name": "capz",
-    "capi_version": "v1.13.0-rc.0",
+    "capi_version": "v1.13.0",
     "caaph_version": "v0.6.2",
     "cert_manager_version": "v1.20.1",
     "kubernetes_version": "v1.35.4",

--- a/docs/book/src/developers/getting-started-with-capi-operator.md
+++ b/docs/book/src/developers/getting-started-with-capi-operator.md
@@ -120,7 +120,7 @@ helm install cert-manager jetstack/cert-manager --namespace cert-manager --creat
 Create a `values.yaml` file for the CAPI Operator Helm chart like so:
 
 ```yaml
-core: "cluster-api:v1.12.4"
+core: "cluster-api:v1.13.0"
 infrastructure: "azure:v1.17.2"
 addon: "helm:v0.6.2"
 manager:

--- a/go.mod
+++ b/go.mod
@@ -56,8 +56,8 @@ require (
 	k8s.io/kubectl v0.34.2
 	k8s.io/utils v0.0.0-20251002143259-bc988d571ff4
 	sigs.k8s.io/cloud-provider-azure v1.34.3
-	sigs.k8s.io/cluster-api v1.13.0-rc.1
-	sigs.k8s.io/cluster-api/test v1.13.0-rc.1
+	sigs.k8s.io/cluster-api v1.13.0
+	sigs.k8s.io/cluster-api/test v1.13.0
 	sigs.k8s.io/controller-runtime v0.23.3
 	sigs.k8s.io/kind v0.31.0
 )

--- a/go.sum
+++ b/go.sum
@@ -584,10 +584,10 @@ sigs.k8s.io/cloud-provider-azure/pkg/azclient v0.9.2 h1:7vEaYwdsvOz1OBAtEm6vyc4K
 sigs.k8s.io/cloud-provider-azure/pkg/azclient v0.9.2/go.mod h1:BgPOvGEdPTyaIWREF7pywm6teBhO3fNVQ+CTPYyr/5w=
 sigs.k8s.io/cloud-provider-azure/pkg/azclient/configloader v0.8.4 h1:Sy+dyfxemdQaz/UfJYWzALlbLdEaZ7IoKn93JXTqWYs=
 sigs.k8s.io/cloud-provider-azure/pkg/azclient/configloader v0.8.4/go.mod h1:RgIi9n/PhULbvPjYZGsjP2zWJf1ZEd1qyA0CYUuSgcE=
-sigs.k8s.io/cluster-api v1.13.0-rc.1 h1:AHzLoinv1AuuMkBwAfWeSDV+JsPubAB7BgaKqoQpSB4=
-sigs.k8s.io/cluster-api v1.13.0-rc.1/go.mod h1:DNgWpqSGIc8tWI4vwCbgLhDcnDNuDZ2L/FQur4ulAW0=
-sigs.k8s.io/cluster-api/test v1.13.0-rc.1 h1:QyrDjSShQILiOctO6NHYU67gl1qJoS3ypNHI4SVkQKo=
-sigs.k8s.io/cluster-api/test v1.13.0-rc.1/go.mod h1:uN9BzpjtzUwDr9nClw95VldtT3L97ZsKiA/z5Dde3Rk=
+sigs.k8s.io/cluster-api v1.13.0 h1:xX0vAQ/a9mv0OwW+Tlx/EqmIdPHQAMp+T+gxalSZ3gc=
+sigs.k8s.io/cluster-api v1.13.0/go.mod h1:DNgWpqSGIc8tWI4vwCbgLhDcnDNuDZ2L/FQur4ulAW0=
+sigs.k8s.io/cluster-api/test v1.13.0 h1:1MWOFmL4YzJDIvd3mPqOIIm0T/RSw6O7Ugge94vhBws=
+sigs.k8s.io/cluster-api/test v1.13.0/go.mod h1:uN9BzpjtzUwDr9nClw95VldtT3L97ZsKiA/z5Dde3Rk=
 sigs.k8s.io/controller-runtime v0.23.3 h1:VjB/vhoPoA9l1kEKZHBMnQF33tdCLQKJtydy4iqwZ80=
 sigs.k8s.io/controller-runtime v0.23.3/go.mod h1:B6COOxKptp+YaUT5q4l6LqUJTRpizbgf9KSRNdQGns0=
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 h1:IpInykpT6ceI+QxKBbEflcR5EXP7sU1kvOlxwZh5txg=

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 toolchain go1.25.9
 
-require sigs.k8s.io/cluster-api/hack/tools v0.0.0-20260414142840-70c3dad9facb
+require sigs.k8s.io/cluster-api/hack/tools v0.0.0-20260420175955-cf3d8f81e95c
 
 require (
 	github.com/fxamacker/cbor/v2 v2.9.0 // indirect

--- a/hack/tools/go.sum
+++ b/hack/tools/go.sum
@@ -82,8 +82,8 @@ k8s.io/kube-openapi v0.0.0-20250910181357-589584f1c912 h1:Y3gxNAuB0OBLImH611+UDZ
 k8s.io/kube-openapi v0.0.0-20250910181357-589584f1c912/go.mod h1:kdmbQkyfwUagLfXIad1y2TdrjPFWp2Q89B3qkRwf/pQ=
 k8s.io/utils v0.0.0-20251002143259-bc988d571ff4 h1:SjGebBtkBqHFOli+05xYbK8YF1Dzkbzn+gDM4X9T4Ck=
 k8s.io/utils v0.0.0-20251002143259-bc988d571ff4/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
-sigs.k8s.io/cluster-api/hack/tools v0.0.0-20260414142840-70c3dad9facb h1:A0OltmsbqI6u3v5/3nElz9/86VmGajHAUlIzG0r4Mug=
-sigs.k8s.io/cluster-api/hack/tools v0.0.0-20260414142840-70c3dad9facb/go.mod h1:/gNJAf/oJ+1MId6ydMeUIFntI1mng8ZH0HTdVuJCC7o=
+sigs.k8s.io/cluster-api/hack/tools v0.0.0-20260420175955-cf3d8f81e95c h1:1KWb+zphK3devFi/geiLps3VhB8/5qxCmEGaVFXA5HQ=
+sigs.k8s.io/cluster-api/hack/tools v0.0.0-20260420175955-cf3d8f81e95c/go.mod h1:/gNJAf/oJ+1MId6ydMeUIFntI1mng8ZH0HTdVuJCC7o=
 sigs.k8s.io/controller-tools v0.20.1 h1:gkfMt9YodI0K85oT8rVi80NTXO/kDmabKR5Ajn5GYxs=
 sigs.k8s.io/controller-tools v0.20.1/go.mod h1:b4qPmjGU3iZwqn34alUU5tILhNa9+VXK+J3QV0fT/uU=
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 h1:IpInykpT6ceI+QxKBbEflcR5EXP7sU1kvOlxwZh5txg=

--- a/test/e2e/config/azure-dev.yaml
+++ b/test/e2e/config/azure-dev.yaml
@@ -3,17 +3,17 @@ managementClusterName: capz-e2e
 images:
   - name: ${MANAGER_IMAGE}
     loadBehavior: mustLoad
-  - name: registry.k8s.io/cluster-api/cluster-api-controller:v1.12.4
+  - name: registry.k8s.io/cluster-api/cluster-api-controller:v1.12.7
     loadBehavior: tryLoad
-  - name: registry.k8s.io/cluster-api/cluster-api-controller:v1.13.0-rc.0
+  - name: registry.k8s.io/cluster-api/cluster-api-controller:v1.13.0
     loadBehavior: tryLoad
-  - name: registry.k8s.io/cluster-api/kubeadm-bootstrap-controller:v1.12.4
+  - name: registry.k8s.io/cluster-api/kubeadm-bootstrap-controller:v1.12.7
     loadBehavior: tryLoad
-  - name: registry.k8s.io/cluster-api/kubeadm-bootstrap-controller:v1.13.0-rc.0
+  - name: registry.k8s.io/cluster-api/kubeadm-bootstrap-controller:v1.13.0
     loadBehavior: tryLoad
-  - name: registry.k8s.io/cluster-api/kubeadm-control-plane-controller:v1.12.4
+  - name: registry.k8s.io/cluster-api/kubeadm-control-plane-controller:v1.12.7
     loadBehavior: tryLoad
-  - name: registry.k8s.io/cluster-api/kubeadm-control-plane-controller:v1.13.0-rc.0
+  - name: registry.k8s.io/cluster-api/kubeadm-control-plane-controller:v1.13.0
     loadBehavior: tryLoad
   - name: registry.k8s.io/cluster-api-helm/cluster-api-helm-controller:v0.6.2
     loadBehavior: tryLoad
@@ -31,8 +31,8 @@ providers:
           new: --metrics-addr=:8080
       files:
         - sourcePath: "../data/shared/v1beta1/metadata.yaml"
-    - name: v1.12.4
-      value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.12.4/core-components.yaml
+    - name: v1.12.7
+      value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.12.7/core-components.yaml
       type: url
       contract: v1beta2
       files:
@@ -42,8 +42,8 @@ providers:
         new: "imagePullPolicy: IfNotPresent"
       - old: "- --leader-elect"
         new: "- --leader-elect\n        - --remote-connection-grace-period=3m"
-    - name: v1.13.0-rc.0
-      value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.13.0-rc.0/core-components.yaml
+    - name: v1.13.0
+      value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.13.0/core-components.yaml
       type: url
       contract: v1beta2
       files:
@@ -66,8 +66,8 @@ providers:
           new: --metrics-addr=:8080
       files:
         - sourcePath: "../data/shared/v1beta1/metadata.yaml"
-    - name: v1.12.4
-      value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.12.4/bootstrap-components.yaml
+    - name: v1.12.7
+      value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.12.7/bootstrap-components.yaml
       type: url
       contract: v1beta2
       files:
@@ -75,8 +75,8 @@ providers:
       replacements:
       - old: "imagePullPolicy: Always"
         new: "imagePullPolicy: IfNotPresent"
-    - name: v1.13.0-rc.0
-      value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.13.0-rc.0/bootstrap-components.yaml
+    - name: v1.13.0
+      value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.13.0/bootstrap-components.yaml
       type: url
       contract: v1beta2
       files:
@@ -97,8 +97,8 @@ providers:
           new: --metrics-addr=:8080
       files:
         - sourcePath: "../data/shared/v1beta1/metadata.yaml"
-    - name: v1.12.4
-      value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.12.4/control-plane-components.yaml
+    - name: v1.12.7
+      value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.12.7/control-plane-components.yaml
       type: url
       contract: v1beta2
       files:
@@ -106,8 +106,8 @@ providers:
       replacements:
       - old: "imagePullPolicy: Always"
         new: "imagePullPolicy: IfNotPresent"
-    - name: v1.13.0-rc.0
-      value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.13.0-rc.0/control-plane-components.yaml
+    - name: v1.13.0
+      value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.13.0/control-plane-components.yaml
       type: url
       contract: v1beta2
       files:
@@ -296,7 +296,7 @@ variables:
   WINDOWS_CONTAINERD_URL: "${WINDOWS_CONTAINERD_URL:-}"
   AZURE_CNI_V1_MANIFEST_PATH: "${PWD}/templates/addons/azure-cni-v1.yaml"
   OLD_CAPI_UPGRADE_VERSION: "v1.11.7"
-  LATEST_CAPI_UPGRADE_VERSION: "v1.12.4"
+  LATEST_CAPI_UPGRADE_VERSION: "v1.12.7"
   OLD_PROVIDER_UPGRADE_VERSION: "v1.22.2"
   LATEST_PROVIDER_UPGRADE_VERSION: "v1.23.0"
   OLD_CAAPH_UPGRADE_VERSION: "v0.5.3"


### PR DESCRIPTION
[**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Updates the Cluster API dependency to [v1.13.0](https://github.com/kubernetes-sigs/cluster-api/releases/tag/v1.13.0).

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:


**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] cherry-pick candidate

**Release note**:

```release-note
Bump CAPI to v1.13.0
```
