### PR TITLE
Dalec E2E: Use upstream k8s images if no artifacts are built

### DIFF
--- a/templates/test/ci/cluster-template-prow-dalec-custom-builds.yaml
+++ b/templates/test/ci/cluster-template-prow-dalec-custom-builds.yaml
@@ -204,7 +204,37 @@ spec:
         [[ -n "${KUBELET_REVISION}" ]] && ANY_REVISION_SET="true"
 
         if [[ "$${ANY_REVISION_SET}" != "true" ]]; then
-          echo "No *_REVISION variables set. Skipping binary replacement."
+          # No dalec revisions set — download official upstream binaries from
+          # dl.k8s.io to ensure binaries match the dalec container image version.
+          TARGET_VERSION="v$${VERSION}"
+
+          echo "============================================================"
+          echo "DALEC IMAGE-ONLY TEST: No dalec binary revisions set."
+          echo "Downloading official upstream binaries ($${TARGET_VERSION})"
+          echo "from dl.k8s.io for version consistency with dalec images."
+          echo "============================================================"
+
+          # Download all binaries to temp files first, then replace
+          DOWNLOAD_DIR=$$(mktemp -d)
+          ALL_UPSTREAM_BINARIES=("kubeadm" "kubectl" "kubelet")
+          for BINARY in "$${ALL_UPSTREAM_BINARIES[@]}"; do
+            DL_URL="https://dl.k8s.io/release/$${TARGET_VERSION}/bin/linux/amd64/$${BINARY}"
+            echo "* downloading $${BINARY} $${TARGET_VERSION} from $${DL_URL}"
+            curl --fail --location --retry 10 --retry-delay 5 "$${DL_URL}" --output "$${DOWNLOAD_DIR}/$${BINARY}"
+            chmod +x "$${DOWNLOAD_DIR}/$${BINARY}"
+          done
+
+          # All downloads succeeded — now stop kubelet and replace binaries
+          systemctl stop kubelet
+          for BINARY in "$${ALL_UPSTREAM_BINARIES[@]}"; do
+            mv "$${DOWNLOAD_DIR}/$${BINARY}" "/usr/bin/$${BINARY}"
+          done
+          rm -rf "$${DOWNLOAD_DIR}"
+          systemctl restart kubelet
+
+          echo "kubeadm version: $(kubeadm version -o=short)"
+          echo "kubectl version: $(kubectl version --client=true)"
+          echo "kubelet version: $(kubelet --version)"
           exit 0
         fi
 
@@ -453,7 +483,37 @@ spec:
           [[ -n "${KUBELET_REVISION}" ]] && ANY_REVISION_SET="true"
 
           if [[ "$${ANY_REVISION_SET}" != "true" ]]; then
-            echo "No *_REVISION variables set. Skipping binary replacement."
+            # No dalec revisions set — download official upstream binaries from
+            # dl.k8s.io to ensure binaries match the dalec container image version.
+            TARGET_VERSION="v$${VERSION}"
+
+            echo "============================================================"
+            echo "DALEC IMAGE-ONLY TEST: No dalec binary revisions set."
+            echo "Downloading official upstream binaries ($${TARGET_VERSION})"
+            echo "from dl.k8s.io for version consistency with dalec images."
+            echo "============================================================"
+
+            # Download all binaries to temp files first, then replace
+            DOWNLOAD_DIR=$$(mktemp -d)
+            ALL_UPSTREAM_BINARIES=("kubeadm" "kubectl" "kubelet")
+            for BINARY in "$${ALL_UPSTREAM_BINARIES[@]}"; do
+              DL_URL="https://dl.k8s.io/release/$${TARGET_VERSION}/bin/linux/amd64/$${BINARY}"
+              echo "* downloading $${BINARY} $${TARGET_VERSION} from $${DL_URL}"
+              curl --fail --location --retry 10 --retry-delay 5 "$${DL_URL}" --output "$${DOWNLOAD_DIR}/$${BINARY}"
+              chmod +x "$${DOWNLOAD_DIR}/$${BINARY}"
+            done
+
+            # All downloads succeeded — now stop kubelet and replace binaries
+            systemctl stop kubelet
+            for BINARY in "$${ALL_UPSTREAM_BINARIES[@]}"; do
+              mv "$${DOWNLOAD_DIR}/$${BINARY}" "/usr/bin/$${BINARY}"
+            done
+            rm -rf "$${DOWNLOAD_DIR}"
+            systemctl restart kubelet
+
+            echo "kubeadm version: $(kubeadm version -o=short)"
+            echo "kubectl version: $(kubectl version --client=true)"
+            echo "kubelet version: $(kubelet --version)"
             exit 0
           fi
 
@@ -817,7 +877,46 @@ spec:
           [[ -n "${KUBELET_REVISION}" ]] && ANY_REVISION_SET="true"
 
           if [[ "$${ANY_REVISION_SET}" != "true" ]]; then
-            echo "No *_REVISION variables set. Skipping binary replacement."
+            # No dalec revisions set — download official upstream binaries from
+            # dl.k8s.io to ensure binaries match the dalec container image version.
+            TARGET_VERSION="v$${VERSION}"
+
+            echo "============================================================"
+            echo "DALEC IMAGE-ONLY TEST: No dalec binary revisions set."
+            echo "Downloading official upstream binaries ($${TARGET_VERSION})"
+            echo "from dl.k8s.io for version consistency with dalec images."
+            echo "============================================================"
+
+            # Download all binaries to temp files first, then replace
+            DOWNLOAD_DIR=$$(mktemp -d)
+            ALL_UPSTREAM_BINARIES=("kubeadm" "kubectl" "kubelet")
+            for BINARY in "$${ALL_UPSTREAM_BINARIES[@]}"; do
+              DL_URL="https://dl.k8s.io/release/$${TARGET_VERSION}/bin/linux/amd64/$${BINARY}"
+              echo "* downloading $${BINARY} $${TARGET_VERSION} from $${DL_URL}"
+              curl --fail --location --retry 10 --retry-delay 5 "$${DL_URL}" --output "$${DOWNLOAD_DIR}/$${BINARY}"
+              chmod +x "$${DOWNLOAD_DIR}/$${BINARY}"
+            done
+
+            # All downloads succeeded — now stop kubelet and replace binaries
+            systemctl stop kubelet
+            for BINARY in "$${ALL_UPSTREAM_BINARIES[@]}"; do
+              mv "$${DOWNLOAD_DIR}/$${BINARY}" "/usr/bin/$${BINARY}"
+            done
+            rm -rf "$${DOWNLOAD_DIR}"
+
+            # Clean up stale kubelet flags in /etc/sysconfig/kubelet.
+            # The gallery image may ship flags removed in newer k8s versions
+            # (e.g. --pod-infra-container-image was removed in v1.35).
+            if [ -f /etc/sysconfig/kubelet ]; then
+              echo "Sanitizing /etc/sysconfig/kubelet for $${TARGET_VERSION}"
+              sed -i 's/--pod-infra-container-image=[^ ]*//g' /etc/sysconfig/kubelet
+            fi
+
+            systemctl restart kubelet
+
+            echo "kubeadm version: $(kubeadm version -o=short)"
+            echo "kubectl version: $(kubectl version --client=true)"
+            echo "kubelet version: $(kubelet --version)"
             exit 0
           fi
 

--- a/templates/test/ci/prow-dalec-custom-builds/patches/azl3-machine-deployment.yaml
+++ b/templates/test/ci/prow-dalec-custom-builds/patches/azl3-machine-deployment.yaml
@@ -110,7 +110,46 @@ spec:
           [[ -n "${KUBELET_REVISION}" ]] && ANY_REVISION_SET="true"
 
           if [[ "$${ANY_REVISION_SET}" != "true" ]]; then
-            echo "No *_REVISION variables set. Skipping binary replacement."
+            # No dalec revisions set — download official upstream binaries from
+            # dl.k8s.io to ensure binaries match the dalec container image version.
+            TARGET_VERSION="v$${VERSION}"
+
+            echo "============================================================"
+            echo "DALEC IMAGE-ONLY TEST: No dalec binary revisions set."
+            echo "Downloading official upstream binaries ($${TARGET_VERSION})"
+            echo "from dl.k8s.io for version consistency with dalec images."
+            echo "============================================================"
+
+            # Download all binaries to temp files first, then replace
+            DOWNLOAD_DIR=$$(mktemp -d)
+            ALL_UPSTREAM_BINARIES=("kubeadm" "kubectl" "kubelet")
+            for BINARY in "$${ALL_UPSTREAM_BINARIES[@]}"; do
+              DL_URL="https://dl.k8s.io/release/$${TARGET_VERSION}/bin/linux/amd64/$${BINARY}"
+              echo "* downloading $${BINARY} $${TARGET_VERSION} from $${DL_URL}"
+              curl --fail --location --retry 10 --retry-delay 5 "$${DL_URL}" --output "$${DOWNLOAD_DIR}/$${BINARY}"
+              chmod +x "$${DOWNLOAD_DIR}/$${BINARY}"
+            done
+
+            # All downloads succeeded — now stop kubelet and replace binaries
+            systemctl stop kubelet
+            for BINARY in "$${ALL_UPSTREAM_BINARIES[@]}"; do
+              mv "$${DOWNLOAD_DIR}/$${BINARY}" "/usr/bin/$${BINARY}"
+            done
+            rm -rf "$${DOWNLOAD_DIR}"
+
+            # Clean up stale kubelet flags in /etc/sysconfig/kubelet.
+            # The gallery image may ship flags removed in newer k8s versions
+            # (e.g. --pod-infra-container-image was removed in v1.35).
+            if [ -f /etc/sysconfig/kubelet ]; then
+              echo "Sanitizing /etc/sysconfig/kubelet for $${TARGET_VERSION}"
+              sed -i 's/--pod-infra-container-image=[^ ]*//g' /etc/sysconfig/kubelet
+            fi
+
+            systemctl restart kubelet
+
+            echo "kubeadm version: $(kubeadm version -o=short)"
+            echo "kubectl version: $(kubectl version --client=true)"
+            echo "kubelet version: $(kubelet --version)"
             exit 0
           fi
 

--- a/templates/test/ci/prow-dalec-custom-builds/patches/control-plane-custom-builds.yaml
+++ b/templates/test/ci/prow-dalec-custom-builds/patches/control-plane-custom-builds.yaml
@@ -25,7 +25,37 @@
       [[ -n "${KUBELET_REVISION}" ]] && ANY_REVISION_SET="true"
 
       if [[ "$${ANY_REVISION_SET}" != "true" ]]; then
-        echo "No *_REVISION variables set. Skipping binary replacement."
+        # No dalec revisions set — download official upstream binaries from
+        # dl.k8s.io to ensure binaries match the dalec container image version.
+        TARGET_VERSION="v$${VERSION}"
+
+        echo "============================================================"
+        echo "DALEC IMAGE-ONLY TEST: No dalec binary revisions set."
+        echo "Downloading official upstream binaries ($${TARGET_VERSION})"
+        echo "from dl.k8s.io for version consistency with dalec images."
+        echo "============================================================"
+
+        # Download all binaries to temp files first, then replace
+        DOWNLOAD_DIR=$$(mktemp -d)
+        ALL_UPSTREAM_BINARIES=("kubeadm" "kubectl" "kubelet")
+        for BINARY in "$${ALL_UPSTREAM_BINARIES[@]}"; do
+          DL_URL="https://dl.k8s.io/release/$${TARGET_VERSION}/bin/linux/amd64/$${BINARY}"
+          echo "* downloading $${BINARY} $${TARGET_VERSION} from $${DL_URL}"
+          curl --fail --location --retry 10 --retry-delay 5 "$${DL_URL}" --output "$${DOWNLOAD_DIR}/$${BINARY}"
+          chmod +x "$${DOWNLOAD_DIR}/$${BINARY}"
+        done
+
+        # All downloads succeeded — now stop kubelet and replace binaries
+        systemctl stop kubelet
+        for BINARY in "$${ALL_UPSTREAM_BINARIES[@]}"; do
+          mv "$${DOWNLOAD_DIR}/$${BINARY}" "/usr/bin/$${BINARY}"
+        done
+        rm -rf "$${DOWNLOAD_DIR}"
+        systemctl restart kubelet
+
+        echo "kubeadm version: $(kubeadm version -o=short)"
+        echo "kubectl version: $(kubectl version --client=true)"
+        echo "kubelet version: $(kubelet --version)"
         exit 0
       fi
 

--- a/templates/test/ci/prow-dalec-custom-builds/patches/kubeadm-bootstrap-custom-builds.yaml
+++ b/templates/test/ci/prow-dalec-custom-builds/patches/kubeadm-bootstrap-custom-builds.yaml
@@ -25,7 +25,37 @@
       [[ -n "${KUBELET_REVISION}" ]] && ANY_REVISION_SET="true"
 
       if [[ "$${ANY_REVISION_SET}" != "true" ]]; then
-        echo "No *_REVISION variables set. Skipping binary replacement."
+        # No dalec revisions set — download official upstream binaries from
+        # dl.k8s.io to ensure binaries match the dalec container image version.
+        TARGET_VERSION="v$${VERSION}"
+
+        echo "============================================================"
+        echo "DALEC IMAGE-ONLY TEST: No dalec binary revisions set."
+        echo "Downloading official upstream binaries ($${TARGET_VERSION})"
+        echo "from dl.k8s.io for version consistency with dalec images."
+        echo "============================================================"
+
+        # Download all binaries to temp files first, then replace
+        DOWNLOAD_DIR=$$(mktemp -d)
+        ALL_UPSTREAM_BINARIES=("kubeadm" "kubectl" "kubelet")
+        for BINARY in "$${ALL_UPSTREAM_BINARIES[@]}"; do
+          DL_URL="https://dl.k8s.io/release/$${TARGET_VERSION}/bin/linux/amd64/$${BINARY}"
+          echo "* downloading $${BINARY} $${TARGET_VERSION} from $${DL_URL}"
+          curl --fail --location --retry 10 --retry-delay 5 "$${DL_URL}" --output "$${DOWNLOAD_DIR}/$${BINARY}"
+          chmod +x "$${DOWNLOAD_DIR}/$${BINARY}"
+        done
+
+        # All downloads succeeded — now stop kubelet and replace binaries
+        systemctl stop kubelet
+        for BINARY in "$${ALL_UPSTREAM_BINARIES[@]}"; do
+          mv "$${DOWNLOAD_DIR}/$${BINARY}" "/usr/bin/$${BINARY}"
+        done
+        rm -rf "$${DOWNLOAD_DIR}"
+        systemctl restart kubelet
+
+        echo "kubeadm version: $(kubeadm version -o=short)"
+        echo "kubectl version: $(kubectl version --client=true)"
+        echo "kubelet version: $(kubelet --version)"
         exit 0
       fi
 


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind cleanup

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
This PR accounts for an edge case where a Dalec test is only testing images and a CAPZ community gallery image does not yet exist for that version, the artifacts are set to the wrong version.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->


**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] cherry-pick candidate

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
