### PR TITLE
Add unit tests for azuremachine_validation

### DIFF
--- a/internal/webhooks/azuremachine_validation_test.go
+++ b/internal/webhooks/azuremachine_validation_test.go
@@ -443,12 +443,152 @@ func TestAzureMachine_ValidateDataDisks(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "nil LUN",
+			disks: []infrav1.DataDisk{
+				{
+					NameSuffix:  "my_disk",
+					DiskSizeGB:  64,
+					Lun:         nil,
+					CachingType: string(armcompute.PossibleCachingTypesValues()[0]),
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "LUN below valid range",
+			disks: []infrav1.DataDisk{
+				{
+					NameSuffix:  "my_disk",
+					DiskSizeGB:  64,
+					Lun:         ptr.To[int32](-1),
+					CachingType: string(armcompute.PossibleCachingTypesValues()[0]),
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "LUN above valid range",
+			disks: []infrav1.DataDisk{
+				{
+					NameSuffix:  "my_disk",
+					DiskSizeGB:  64,
+					Lun:         ptr.To[int32](64),
+					CachingType: string(armcompute.PossibleCachingTypesValues()[0]),
+				},
+			},
+			wantErr: true,
+		},
 	}
 
 	for _, test := range testcases {
 		t.Run(test.name, func(t *testing.T) {
 			g := NewWithT(t)
 			err := ValidateDataDisks(test.disks, field.NewPath("dataDisks"))
+			if test.wantErr {
+				g.Expect(err).NotTo(BeEmpty())
+			} else {
+				g.Expect(err).To(BeEmpty())
+			}
+		})
+	}
+}
+
+func TestAzureMachine_ValidateDiagnostics(t *testing.T) {
+	testcases := []struct {
+		name        string
+		diagnostics *infrav1.Diagnostics
+		wantErr     bool
+	}{
+		{
+			name:        "nil diagnostics",
+			diagnostics: nil,
+			wantErr:     false,
+		},
+		{
+			name:        "nil boot diagnostics",
+			diagnostics: &infrav1.Diagnostics{},
+			wantErr:     false,
+		},
+		{
+			name: "managed storage account type without user-managed config",
+			diagnostics: &infrav1.Diagnostics{
+				Boot: &infrav1.BootDiagnostics{
+					StorageAccountType: infrav1.ManagedDiagnosticsStorage,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "managed storage account type with user-managed StorageAccountURI",
+			diagnostics: &infrav1.Diagnostics{
+				Boot: &infrav1.BootDiagnostics{
+					StorageAccountType: infrav1.ManagedDiagnosticsStorage,
+					UserManaged: &infrav1.UserManagedBootDiagnostics{
+						StorageAccountURI: "https://example.blob.core.windows.net/",
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "disabled storage account type without user-managed config",
+			diagnostics: &infrav1.Diagnostics{
+				Boot: &infrav1.BootDiagnostics{
+					StorageAccountType: infrav1.DisabledDiagnosticsStorage,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "disabled storage account type with user-managed StorageAccountURI",
+			diagnostics: &infrav1.Diagnostics{
+				Boot: &infrav1.BootDiagnostics{
+					StorageAccountType: infrav1.DisabledDiagnosticsStorage,
+					UserManaged: &infrav1.UserManagedBootDiagnostics{
+						StorageAccountURI: "https://example.blob.core.windows.net/",
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "user-managed storage account type with valid URI",
+			diagnostics: &infrav1.Diagnostics{
+				Boot: &infrav1.BootDiagnostics{
+					StorageAccountType: infrav1.UserManagedDiagnosticsStorage,
+					UserManaged: &infrav1.UserManagedBootDiagnostics{
+						StorageAccountURI: "https://example.blob.core.windows.net/",
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "user-managed storage account type missing UserManaged",
+			diagnostics: &infrav1.Diagnostics{
+				Boot: &infrav1.BootDiagnostics{
+					StorageAccountType: infrav1.UserManagedDiagnosticsStorage,
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "user-managed storage account type with empty URI",
+			diagnostics: &infrav1.Diagnostics{
+				Boot: &infrav1.BootDiagnostics{
+					StorageAccountType: infrav1.UserManagedDiagnosticsStorage,
+					UserManaged:        &infrav1.UserManagedBootDiagnostics{},
+				},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, test := range testcases {
+		t.Run(test.name, func(t *testing.T) {
+			g := NewWithT(t)
+			err := ValidateDiagnostics(test.diagnostics, field.NewPath("diagnostics"))
 			if test.wantErr {
 				g.Expect(err).NotTo(BeEmpty())
 			} else {


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Adds the missing unit-test coverage for `internal/webhooks/azuremachine_validation.go` called out in the linked issue:

- `TestAzureMachine_ValidateDataDisks` gains cases for `disk.Lun` nil and out-of-range (`< 0`, `> 63`).
- New `TestAzureMachine_ValidateDiagnostics` covers all branches of `ValidateDiagnostics` (nil diagnostics, nil boot, the three `BootDiagnosticsStorageAccountType` values, and missing/empty `UserManaged.StorageAccountURI`).

After this change, both `ValidateDataDisks` and `ValidateDiagnostics` report 100% statement coverage.

The `ValidateDataDisksUpdate` / `validateManagedDisksUpdate` cases mentioned in the issue are no longer applicable — those functions were removed during the webhook refactor.

**Which issue(s) this PR fixes**:
Fixes #3374

**Special notes for your reviewer**:

None.

**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests
- [ ] cherry-pick candidate

**Release note**:
```release-note
NONE
```
