### PR TITLE
Honor AzureCluster ControlPlaneEndpoint.Port in API server LB

### DIFF
--- a/azure/scope/cluster.go
+++ b/azure/scope/cluster.go
@@ -256,24 +256,25 @@ func (s *ClusterScope) LBSpecs() []azure.ResourceSpecGetter {
 	if s.ControlPlaneEnabled() {
 		frontendLB := &loadbalancers.LBSpec{
 			// API Server LB
-			Name:                 s.APIServerLB().Name,
-			ResourceGroup:        s.ResourceGroup(),
-			SubscriptionID:       s.SubscriptionID(),
-			ClusterName:          s.ClusterName(),
-			Location:             s.Location(),
-			ExtendedLocation:     s.ExtendedLocation(),
-			VNetName:             s.Vnet().Name,
-			VNetResourceGroup:    s.Vnet().ResourceGroup,
-			SubnetName:           s.ControlPlaneSubnet().Name,
-			APIServerPort:        s.APIServerPort(),
-			Type:                 s.APIServerLB().Type,
-			SKU:                  s.APIServerLB().SKU,
-			Role:                 infrav1.APIServerRole,
-			BackendPoolName:      s.APIServerLB().BackendPool.Name,
-			IdleTimeoutInMinutes: s.APIServerLB().IdleTimeoutInMinutes,
-			AdditionalTags:       s.AdditionalTags(),
-			AdditionalPorts:      s.AdditionalAPIServerLBPorts(),
-			AvailabilityZones:    s.APIServerLB().AvailabilityZones,
+			Name:                  s.APIServerLB().Name,
+			ResourceGroup:         s.ResourceGroup(),
+			SubscriptionID:        s.SubscriptionID(),
+			ClusterName:           s.ClusterName(),
+			Location:              s.Location(),
+			ExtendedLocation:      s.ExtendedLocation(),
+			VNetName:              s.Vnet().Name,
+			VNetResourceGroup:     s.Vnet().ResourceGroup,
+			SubnetName:            s.ControlPlaneSubnet().Name,
+			APIServerPort:         s.APIServerPort(),
+			APIServerFrontendPort: s.APIServerFrontendPort(),
+			Type:                  s.APIServerLB().Type,
+			SKU:                   s.APIServerLB().SKU,
+			Role:                  infrav1.APIServerRole,
+			BackendPoolName:       s.APIServerLB().BackendPool.Name,
+			IdleTimeoutInMinutes:  s.APIServerLB().IdleTimeoutInMinutes,
+			AdditionalTags:        s.AdditionalTags(),
+			AdditionalPorts:       s.AdditionalAPIServerLBPorts(),
+			AvailabilityZones:     s.APIServerLB().AvailabilityZones,
 		}
 
 		if s.APIServerLB().FrontendIPs != nil {
@@ -291,24 +292,25 @@ func (s *ClusterScope) LBSpecs() []azure.ResourceSpecGetter {
 
 	if s.APIServerLB().Type != infrav1.Internal && feature.Gates.Enabled(feature.APIServerILB) {
 		internalLB := &loadbalancers.LBSpec{
-			Name:                 s.APIServerLB().Name + "-internal",
-			ResourceGroup:        s.ResourceGroup(),
-			SubscriptionID:       s.SubscriptionID(),
-			ClusterName:          s.ClusterName(),
-			Location:             s.Location(),
-			ExtendedLocation:     s.ExtendedLocation(),
-			VNetName:             s.Vnet().Name,
-			VNetResourceGroup:    s.Vnet().ResourceGroup,
-			SubnetName:           s.ControlPlaneSubnet().Name,
-			APIServerPort:        s.APIServerPort(),
-			Type:                 infrav1.Internal,
-			SKU:                  s.APIServerLB().SKU,
-			Role:                 infrav1.APIServerRoleInternal,
-			BackendPoolName:      s.APIServerLB().BackendPool.Name + "-internal",
-			IdleTimeoutInMinutes: s.APIServerLB().IdleTimeoutInMinutes,
-			AdditionalTags:       s.AdditionalTags(),
-			AdditionalPorts:      s.AdditionalAPIServerLBPorts(),
-			AvailabilityZones:    s.APIServerLB().AvailabilityZones,
+			Name:                  s.APIServerLB().Name + "-internal",
+			ResourceGroup:         s.ResourceGroup(),
+			SubscriptionID:        s.SubscriptionID(),
+			ClusterName:           s.ClusterName(),
+			Location:              s.Location(),
+			ExtendedLocation:      s.ExtendedLocation(),
+			VNetName:              s.Vnet().Name,
+			VNetResourceGroup:     s.Vnet().ResourceGroup,
+			SubnetName:            s.ControlPlaneSubnet().Name,
+			APIServerPort:         s.APIServerPort(),
+			APIServerFrontendPort: s.APIServerFrontendPort(),
+			Type:                  infrav1.Internal,
+			SKU:                   s.APIServerLB().SKU,
+			Role:                  infrav1.APIServerRoleInternal,
+			BackendPoolName:       s.APIServerLB().BackendPool.Name + "-internal",
+			IdleTimeoutInMinutes:  s.APIServerLB().IdleTimeoutInMinutes,
+			AdditionalTags:        s.AdditionalTags(),
+			AdditionalPorts:       s.AdditionalAPIServerLBPorts(),
+			AvailabilityZones:     s.APIServerLB().AvailabilityZones,
 		}
 
 		privateIPFound := false
@@ -989,12 +991,20 @@ func (s *ClusterScope) AdditionalTags() infrav1.Tags {
 	return tags
 }
 
-// APIServerPort returns the APIServerPort to use when creating the load balancer.
+// APIServerPort returns the port the API server binds to.
 func (s *ClusterScope) APIServerPort() int32 {
 	if s.Cluster.Spec.ClusterNetwork.APIServerPort != 0 {
 		return s.Cluster.Spec.ClusterNetwork.APIServerPort
 	}
 	return 6443
+}
+
+// APIServerFrontendPort returns the port used to reach the API server through the load balancer.
+func (s *ClusterScope) APIServerFrontendPort() int32 {
+	if s.AzureCluster.Spec.ControlPlaneEndpoint.Port != 0 {
+		return s.AzureCluster.Spec.ControlPlaneEndpoint.Port
+	}
+	return s.APIServerPort()
 }
 
 // APIServerHost returns the hostname used to reach the API server.

--- a/azure/scope/cluster_test.go
+++ b/azure/scope/cluster_test.go
@@ -2865,32 +2865,52 @@ func TestAdditionalTags(t *testing.T) {
 	}
 }
 
-func TestAPIServerPort(t *testing.T) {
+func TestAPIServerPorts(t *testing.T) {
 	tests := []struct {
-		name                string
-		clusterName         string
-		clusterNetowrk      clusterv1.ClusterNetwork
-		expectAPIServerPort int32
+		name                        string
+		clusterName                 string
+		clusterNetwork              clusterv1.ClusterNetwork
+		controlPlaneEndpoint        clusterv1beta1.APIEndpoint
+		expectAPIServerPort         int32
+		expectAPIServerFrontendPort int32
 	}{
 		{
-			name:                "Nil cluster network",
-			clusterName:         "my-cluster",
-			expectAPIServerPort: 6443,
+			name:                        "Nil cluster network",
+			clusterName:                 "my-cluster",
+			expectAPIServerPort:         6443,
+			expectAPIServerFrontendPort: 6443,
 		},
 
 		{
-			name:                "Non nil cluster network but nil apiserverport",
-			clusterName:         "my-cluster",
-			clusterNetowrk:      clusterv1.ClusterNetwork{},
-			expectAPIServerPort: 6443,
+			name:                        "Non nil cluster network but nil apiserverport",
+			clusterName:                 "my-cluster",
+			clusterNetwork:              clusterv1.ClusterNetwork{},
+			expectAPIServerPort:         6443,
+			expectAPIServerFrontendPort: 6443,
 		},
 		{
 			name:        "Non nil cluster network and non nil apiserverport",
 			clusterName: "my-cluster",
-			clusterNetowrk: clusterv1.ClusterNetwork{
+			clusterNetwork: clusterv1.ClusterNetwork{
 				APIServerPort: 7000,
 			},
-			expectAPIServerPort: 7000,
+			expectAPIServerPort:         7000,
+			expectAPIServerFrontendPort: 7000,
+		},
+		{
+			name:                        "ControlPlaneEndpoint.Port set",
+			clusterName:                 "my-cluster",
+			controlPlaneEndpoint:        clusterv1beta1.APIEndpoint{Port: 443},
+			expectAPIServerPort:         6443,
+			expectAPIServerFrontendPort: 443,
+		},
+		{
+			name:                        "ControlPlaneEndpoint.Port differs from ClusterNetwork.APIServerPort",
+			clusterName:                 "my-cluster",
+			clusterNetwork:              clusterv1.ClusterNetwork{APIServerPort: 7000},
+			controlPlaneEndpoint:        clusterv1beta1.APIEndpoint{Port: 443},
+			expectAPIServerPort:         7000,
+			expectAPIServerFrontendPort: 443,
 		},
 	}
 	for _, tc := range tests {
@@ -2903,12 +2923,16 @@ func TestAPIServerPort(t *testing.T) {
 					Namespace: "default",
 				},
 				Spec: clusterv1.ClusterSpec{
-					ClusterNetwork: tc.clusterNetowrk,
+					ClusterNetwork: tc.clusterNetwork,
 				},
 			}
 			azureCluster := &infrav1.AzureCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: tc.clusterName,
+				},
+				Spec: infrav1.AzureClusterSpec{
+					AzureClusterClassSpec: infrav1.AzureClusterClassSpec{},
+					ControlPlaneEndpoint:  tc.controlPlaneEndpoint,
 				},
 			}
 
@@ -2916,8 +2940,8 @@ func TestAPIServerPort(t *testing.T) {
 				Cluster:      cluster,
 				AzureCluster: azureCluster,
 			}
-			got := clusterScope.APIServerPort()
-			g.Expect(tc.expectAPIServerPort).Should(Equal(got))
+			g.Expect(clusterScope.APIServerPort()).To(Equal(tc.expectAPIServerPort))
+			g.Expect(clusterScope.APIServerFrontendPort()).To(Equal(tc.expectAPIServerFrontendPort))
 		})
 	}
 }
@@ -2999,8 +3023,9 @@ func TestClusterScope_LBSpecs(t *testing.T) {
 						SubscriptionID: "123",
 						Location:       "westus2",
 					},
-					ControlPlaneEnabled: true,
-					ResourceGroup:       "my-rg",
+					ControlPlaneEnabled:  true,
+					ControlPlaneEndpoint: clusterv1beta1.APIEndpoint{Port: 443},
+					ResourceGroup:        "my-rg",
 					NetworkSpec: infrav1.NetworkSpec{
 						Vnet: infrav1.VnetSpec{
 							Name:          "my-vnet",
@@ -3098,12 +3123,13 @@ func TestClusterScope_LBSpecs(t *testing.T) {
 							},
 						},
 					},
-					APIServerPort:        6443,
-					Type:                 infrav1.Public,
-					SKU:                  infrav1.SKUStandard,
-					Role:                 infrav1.APIServerRole,
-					BackendPoolName:      "api-server-lb-backend-pool",
-					IdleTimeoutInMinutes: ptr.To[int32](30),
+					APIServerPort:         6443,
+					APIServerFrontendPort: 443,
+					Type:                  infrav1.Public,
+					SKU:                   infrav1.SKUStandard,
+					Role:                  infrav1.APIServerRole,
+					BackendPoolName:       "api-server-lb-backend-pool",
+					IdleTimeoutInMinutes:  ptr.To[int32](30),
 					AdditionalTags: infrav1.Tags{
 						"foo": "bar",
 					},
@@ -3274,12 +3300,13 @@ func TestClusterScope_LBSpecs(t *testing.T) {
 							},
 						},
 					},
-					APIServerPort:        6443,
-					Type:                 infrav1.Public,
-					SKU:                  infrav1.SKUStandard,
-					Role:                 infrav1.APIServerRole,
-					BackendPoolName:      "api-server-lb-backend-pool",
-					IdleTimeoutInMinutes: ptr.To[int32](30),
+					APIServerPort:         6443,
+					APIServerFrontendPort: 6443,
+					Type:                  infrav1.Public,
+					SKU:                   infrav1.SKUStandard,
+					Role:                  infrav1.APIServerRole,
+					BackendPoolName:       "api-server-lb-backend-pool",
+					IdleTimeoutInMinutes:  ptr.To[int32](30),
 					AdditionalTags: infrav1.Tags{
 						"foo": "bar",
 					},
@@ -3301,12 +3328,13 @@ func TestClusterScope_LBSpecs(t *testing.T) {
 							},
 						},
 					},
-					APIServerPort:        6443,
-					Type:                 infrav1.Internal,
-					SKU:                  infrav1.SKUStandard,
-					Role:                 infrav1.APIServerRoleInternal,
-					BackendPoolName:      "api-server-lb-backend-pool-internal",
-					IdleTimeoutInMinutes: ptr.To[int32](30),
+					APIServerPort:         6443,
+					APIServerFrontendPort: 6443,
+					Type:                  infrav1.Internal,
+					SKU:                   infrav1.SKUStandard,
+					Role:                  infrav1.APIServerRoleInternal,
+					BackendPoolName:       "api-server-lb-backend-pool-internal",
+					IdleTimeoutInMinutes:  ptr.To[int32](30),
 					AdditionalTags: infrav1.Tags{
 						"foo": "bar",
 					},
@@ -3411,21 +3439,22 @@ func TestClusterScope_LBSpecs(t *testing.T) {
 			},
 			want: []azure.ResourceSpecGetter{
 				&loadbalancers.LBSpec{
-					Name:                 "api-server-lb",
-					ResourceGroup:        "my-rg",
-					SubscriptionID:       "123",
-					ClusterName:          "my-cluster",
-					Location:             "westus2",
-					VNetName:             "my-vnet",
-					VNetResourceGroup:    "my-rg",
-					SubnetName:           "cp-subnet",
-					APIServerPort:        6443,
-					Type:                 infrav1.Internal,
-					SKU:                  infrav1.SKUStandard,
-					Role:                 infrav1.APIServerRole,
-					BackendPoolName:      "api-server-lb-backend-pool",
-					IdleTimeoutInMinutes: ptr.To[int32](30),
-					AdditionalTags:       infrav1.Tags{},
+					Name:                  "api-server-lb",
+					ResourceGroup:         "my-rg",
+					SubscriptionID:        "123",
+					ClusterName:           "my-cluster",
+					Location:              "westus2",
+					VNetName:              "my-vnet",
+					VNetResourceGroup:     "my-rg",
+					SubnetName:            "cp-subnet",
+					APIServerPort:         6443,
+					APIServerFrontendPort: 6443,
+					Type:                  infrav1.Internal,
+					SKU:                   infrav1.SKUStandard,
+					Role:                  infrav1.APIServerRole,
+					BackendPoolName:       "api-server-lb-backend-pool",
+					IdleTimeoutInMinutes:  ptr.To[int32](30),
+					AdditionalTags:        infrav1.Tags{},
 				},
 			},
 		},
@@ -3478,21 +3507,22 @@ func TestClusterScope_LBSpecs(t *testing.T) {
 			},
 			want: []azure.ResourceSpecGetter{
 				&loadbalancers.LBSpec{
-					Name:                 "api-server-lb",
-					ResourceGroup:        "my-rg",
-					SubscriptionID:       "123",
-					ClusterName:          "my-cluster",
-					Location:             "westus2",
-					VNetName:             "my-vnet",
-					VNetResourceGroup:    "my-rg",
-					SubnetName:           "cp-subnet",
-					APIServerPort:        6443,
-					Type:                 infrav1.Internal,
-					SKU:                  infrav1.SKUStandard,
-					Role:                 infrav1.APIServerRole,
-					BackendPoolName:      "api-server-lb-backend-pool",
-					IdleTimeoutInMinutes: ptr.To[int32](30),
-					AdditionalTags:       infrav1.Tags{},
+					Name:                  "api-server-lb",
+					ResourceGroup:         "my-rg",
+					SubscriptionID:        "123",
+					ClusterName:           "my-cluster",
+					Location:              "westus2",
+					VNetName:              "my-vnet",
+					VNetResourceGroup:     "my-rg",
+					SubnetName:            "cp-subnet",
+					APIServerPort:         6443,
+					APIServerFrontendPort: 6443,
+					Type:                  infrav1.Internal,
+					SKU:                   infrav1.SKUStandard,
+					Role:                  infrav1.APIServerRole,
+					BackendPoolName:       "api-server-lb-backend-pool",
+					IdleTimeoutInMinutes:  ptr.To[int32](30),
+					AdditionalTags:        infrav1.Tags{},
 				},
 			},
 		},

--- a/azure/services/loadbalancers/loadbalancers_test.go
+++ b/azure/services/loadbalancers/loadbalancers_test.go
@@ -57,7 +57,8 @@ var (
 				},
 			},
 		},
-		APIServerPort: 6443,
+		APIServerPort:         6443,
+		APIServerFrontendPort: 6443,
 	}
 
 	fakePublicAPILBSpecWithAdditionalPorts = LBSpec{
@@ -81,7 +82,8 @@ var (
 				},
 			},
 		},
-		APIServerPort: 6443,
+		APIServerPort:         6443,
+		APIServerFrontendPort: 6443,
 		AdditionalPorts: []infrav1.LoadBalancerPort{{
 			Name: "rke2-agent",
 			Port: 9345,
@@ -108,7 +110,8 @@ var (
 				},
 			},
 		},
-		APIServerPort: 6443,
+		APIServerPort:         6443,
+		APIServerFrontendPort: 6443,
 	}
 
 	fakeInternalAPILBSpecWithZones = LBSpec{

--- a/azure/services/loadbalancers/spec.go
+++ b/azure/services/loadbalancers/spec.go
@@ -18,6 +18,7 @@ package loadbalancers
 
 import (
 	"context"
+	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v4"
 	"github.com/pkg/errors"
@@ -30,25 +31,26 @@ import (
 
 // LBSpec defines the specification for a Load Balancer.
 type LBSpec struct {
-	Name                 string
-	ResourceGroup        string
-	SubscriptionID       string
-	ClusterName          string
-	Location             string
-	ExtendedLocation     *infrav1.ExtendedLocationSpec
-	Role                 string
-	Type                 infrav1.LBType
-	SKU                  infrav1.SKU
-	VNetName             string
-	VNetResourceGroup    string
-	SubnetName           string
-	BackendPoolName      string
-	FrontendIPConfigs    []infrav1.FrontendIP
-	APIServerPort        int32
-	IdleTimeoutInMinutes *int32
-	AdditionalTags       map[string]string
-	AdditionalPorts      []infrav1.LoadBalancerPort
-	AvailabilityZones    []string
+	Name                  string
+	ResourceGroup         string
+	SubscriptionID        string
+	ClusterName           string
+	Location              string
+	ExtendedLocation      *infrav1.ExtendedLocationSpec
+	Role                  string
+	Type                  infrav1.LBType
+	SKU                   infrav1.SKU
+	VNetName              string
+	VNetResourceGroup     string
+	SubnetName            string
+	BackendPoolName       string
+	FrontendIPConfigs     []infrav1.FrontendIP
+	APIServerPort         int32
+	APIServerFrontendPort int32
+	IdleTimeoutInMinutes  *int32
+	AdditionalTags        map[string]string
+	AdditionalPorts       []infrav1.LoadBalancerPort
+	AvailabilityZones     []string
 }
 
 // ResourceName returns the name of the load balancer.
@@ -99,11 +101,9 @@ func (s *LBSpec) Parameters(_ context.Context, existing any) (parameters any, er
 		}
 
 		loadBalancingRules = existingLB.Properties.LoadBalancingRules
-		for _, rule := range getLoadBalancingRules(*s, wantedFrontendIDs) {
-			if !lbRuleExists(loadBalancingRules, *rule) {
-				update = true
-				loadBalancingRules = append(loadBalancingRules, rule)
-			}
+		if mergedRules, changed := mergeLoadBalancingRules(loadBalancingRules, getLoadBalancingRules(*s, wantedFrontendIDs)); changed {
+			update = true
+			loadBalancingRules = mergedRules
 		}
 
 		backendAddressPools = existingLB.Properties.BackendAddressPools
@@ -123,11 +123,9 @@ func (s *LBSpec) Parameters(_ context.Context, existing any) (parameters any, er
 		}
 
 		probes = existingLB.Properties.Probes
-		for _, probe := range getProbes(*s) {
-			if !probeExists(probes, *probe) {
-				update = true
-				probes = append(probes, probe)
-			}
+		if mergedProbes, changed := mergeProbes(probes, getProbes(*s)); changed {
+			update = true
+			probes = mergedProbes
 		}
 
 		if !update {
@@ -251,7 +249,7 @@ func getLoadBalancingRules(lbSpec LBSpec, frontendIDs []*armnetwork.SubResource)
 				Properties: &armnetwork.LoadBalancingRulePropertiesFormat{
 					DisableOutboundSnat:     ptr.To(true),
 					Protocol:                ptr.To(armnetwork.TransportProtocolTCP),
-					FrontendPort:            ptr.To(lbSpec.APIServerPort),
+					FrontendPort:            ptr.To(lbSpec.apiServerFrontendPort()),
 					BackendPort:             ptr.To(lbSpec.APIServerPort),
 					IdleTimeoutInMinutes:    lbSpec.IdleTimeoutInMinutes,
 					EnableFloatingIP:        ptr.To(false),
@@ -320,13 +318,47 @@ func getProbes(lbSpec LBSpec) []*armnetwork.Probe {
 	return []*armnetwork.Probe{}
 }
 
-func probeExists(probes []*armnetwork.Probe, probe armnetwork.Probe) bool {
-	for _, p := range probes {
-		if ptr.Deref(p.Name, "") == ptr.Deref(probe.Name, "") {
-			return true
+func (s LBSpec) apiServerFrontendPort() int32 {
+	if s.APIServerFrontendPort != 0 {
+		return s.APIServerFrontendPort
+	}
+	return s.APIServerPort
+}
+
+func mergeProbes(existing, desired []*armnetwork.Probe) ([]*armnetwork.Probe, bool) {
+	merged := append([]*armnetwork.Probe(nil), existing...)
+	changed := false
+	for _, desiredProbe := range desired {
+		found := false
+		for i, existingProbe := range merged {
+			if !strings.EqualFold(ptr.Deref(existingProbe.Name, ""), ptr.Deref(desiredProbe.Name, "")) {
+				continue
+			}
+			found = true
+			if !probeMatches(existingProbe, desiredProbe) {
+				merged[i] = desiredProbe
+				changed = true
+			}
+			break
+		}
+		if !found {
+			merged = append(merged, desiredProbe)
+			changed = true
 		}
 	}
-	return false
+	return merged, changed
+}
+
+func probeMatches(existing, desired *armnetwork.Probe) bool {
+	if existing == nil || desired == nil || existing.Properties == nil || desired.Properties == nil {
+		return existing == desired
+	}
+	return strings.EqualFold(ptr.Deref(existing.Name, ""), ptr.Deref(desired.Name, "")) &&
+		pointerMatches(existing.Properties.Protocol, desired.Properties.Protocol) &&
+		pointerMatches(existing.Properties.Port, desired.Properties.Port) &&
+		pointerMatches(existing.Properties.RequestPath, desired.Properties.RequestPath) &&
+		pointerMatches(existing.Properties.IntervalInSeconds, desired.Properties.IntervalInSeconds) &&
+		pointerMatches(existing.Properties.ProbeThreshold, desired.Properties.ProbeThreshold)
 }
 
 func outboundRuleExists(rules []*armnetwork.OutboundRule, rule armnetwork.OutboundRule) bool {
@@ -347,13 +379,53 @@ func poolExists(pools []*armnetwork.BackendAddressPool, pool armnetwork.BackendA
 	return false
 }
 
-func lbRuleExists(rules []*armnetwork.LoadBalancingRule, rule armnetwork.LoadBalancingRule) bool {
-	for _, r := range rules {
-		if ptr.Deref(r.Name, "") == ptr.Deref(rule.Name, "") {
-			return true
+func mergeLoadBalancingRules(existing, desired []*armnetwork.LoadBalancingRule) ([]*armnetwork.LoadBalancingRule, bool) {
+	merged := append([]*armnetwork.LoadBalancingRule(nil), existing...)
+	changed := false
+	for _, desiredRule := range desired {
+		found := false
+		for i, existingRule := range merged {
+			if !strings.EqualFold(ptr.Deref(existingRule.Name, ""), ptr.Deref(desiredRule.Name, "")) {
+				continue
+			}
+			found = true
+			if !loadBalancingRuleMatches(existingRule, desiredRule) {
+				merged[i] = desiredRule
+				changed = true
+			}
+			break
+		}
+		if !found {
+			merged = append(merged, desiredRule)
+			changed = true
 		}
 	}
-	return false
+	return merged, changed
+}
+
+func loadBalancingRuleMatches(existing, desired *armnetwork.LoadBalancingRule) bool {
+	if existing == nil || desired == nil || existing.Properties == nil || desired.Properties == nil {
+		return existing == desired
+	}
+	return strings.EqualFold(ptr.Deref(existing.Name, ""), ptr.Deref(desired.Name, "")) &&
+		pointerMatches(existing.Properties.DisableOutboundSnat, desired.Properties.DisableOutboundSnat) &&
+		pointerMatches(existing.Properties.Protocol, desired.Properties.Protocol) &&
+		pointerMatches(existing.Properties.FrontendPort, desired.Properties.FrontendPort) &&
+		pointerMatches(existing.Properties.BackendPort, desired.Properties.BackendPort) &&
+		pointerMatches(existing.Properties.IdleTimeoutInMinutes, desired.Properties.IdleTimeoutInMinutes) &&
+		pointerMatches(existing.Properties.EnableFloatingIP, desired.Properties.EnableFloatingIP) &&
+		pointerMatches(existing.Properties.LoadDistribution, desired.Properties.LoadDistribution) &&
+		subResourceMatches(existing.Properties.FrontendIPConfiguration, desired.Properties.FrontendIPConfiguration) &&
+		subResourceMatches(existing.Properties.BackendAddressPool, desired.Properties.BackendAddressPool) &&
+		subResourceMatches(existing.Properties.Probe, desired.Properties.Probe)
+}
+
+func pointerMatches[T comparable](existing, desired *T) bool {
+	return desired == nil || existing != nil && *existing == *desired
+}
+
+func subResourceMatches(existing, desired *armnetwork.SubResource) bool {
+	return desired == nil || existing != nil && strings.EqualFold(ptr.Deref(existing.ID, ""), ptr.Deref(desired.ID, ""))
 }
 
 func ipExists(configs []*armnetwork.FrontendIPConfiguration, config armnetwork.FrontendIPConfiguration) bool {

--- a/azure/services/loadbalancers/spec_test.go
+++ b/azure/services/loadbalancers/spec_test.go
@@ -61,6 +61,12 @@ func getExistingLBWithMissingOutboundRules() armnetwork.LoadBalancer {
 	return existingLB
 }
 
+func getPublicAPILBSpecWithFrontendPort(port int32) *LBSpec {
+	spec := fakePublicAPILBSpec
+	spec.APIServerFrontendPort = port
+	return &spec
+}
+
 func TestParameters(t *testing.T) {
 	testcases := []struct {
 		name          string
@@ -97,12 +103,32 @@ func TestParameters(t *testing.T) {
 			expectedError: "",
 		},
 		{
+			name:     "existing API server load balancer is updated to use the desired frontend port",
+			spec:     getPublicAPILBSpecWithFrontendPort(443),
+			existing: newSamplePublicAPIServerLB(false, false, false, false, false),
+			expect: func(g *WithT, result any) {
+				g.Expect(result).To(Equal(newSamplePublicAPIServerLB(false, false, false, false, false, func(lb *armnetwork.LoadBalancer) {
+					lb.Properties.LoadBalancingRules[0].Properties.FrontendPort = ptr.To[int32](443)
+				})))
+			},
+			expectedError: "",
+		},
+		{
+			name:     "existing API server rule and probe are updated when desired properties differ",
+			spec:     &fakePublicAPILBSpec,
+			existing: newSamplePublicAPIServerLB(false, false, true, true, false),
+			expect: func(g *WithT, result any) {
+				g.Expect(result).To(Equal(newSamplePublicAPIServerLB(false, false, false, false, false)))
+			},
+			expectedError: "",
+		},
+		{
 			name:     "load balancer exists with missing additional API server ports",
 			spec:     &fakePublicAPILBSpecWithAdditionalPorts,
 			existing: getExistingLBWithMissingFrontendIPConfigs(),
 			expect: func(g *WithT, result any) {
 				g.Expect(result).To(BeAssignableToTypeOf(armnetwork.LoadBalancer{}))
-				g.Expect(result.(armnetwork.LoadBalancer)).To(Equal(newSamplePublicAPIServerLB(false, true, true, true, true, func(lb *armnetwork.LoadBalancer) {
+				g.Expect(result.(armnetwork.LoadBalancer)).To(Equal(newSamplePublicAPIServerLB(false, true, false, false, true, func(lb *armnetwork.LoadBalancer) {
 					lb.Properties.LoadBalancingRules = append(lb.Properties.LoadBalancingRules, &armnetwork.LoadBalancingRule{
 						Name: ptr.To("rke2-agent"),
 						Properties: &armnetwork.LoadBalancingRulePropertiesFormat{
@@ -134,7 +160,7 @@ func TestParameters(t *testing.T) {
 			existing: getExistingLBWithMissingFrontendIPConfigs(),
 			expect: func(g *WithT, result any) {
 				g.Expect(result).To(BeAssignableToTypeOf(armnetwork.LoadBalancer{}))
-				g.Expect(result.(armnetwork.LoadBalancer)).To(Equal(newSamplePublicAPIServerLB(false, true, true, true, true)))
+				g.Expect(result.(armnetwork.LoadBalancer)).To(Equal(newSamplePublicAPIServerLB(false, true, false, false, true)))
 			},
 			expectedError: "",
 		},
@@ -144,7 +170,7 @@ func TestParameters(t *testing.T) {
 			existing: getExistingLBWithMissingBackendPool(),
 			expect: func(g *WithT, result any) {
 				g.Expect(result).To(BeAssignableToTypeOf(armnetwork.LoadBalancer{}))
-				g.Expect(result.(armnetwork.LoadBalancer)).To(Equal(newSamplePublicAPIServerLB(true, false, true, true, true)))
+				g.Expect(result.(armnetwork.LoadBalancer)).To(Equal(newSamplePublicAPIServerLB(true, false, false, false, true)))
 			},
 			expectedError: "",
 		},
@@ -154,7 +180,7 @@ func TestParameters(t *testing.T) {
 			existing: getExistingLBWithMissingLBRules(),
 			expect: func(g *WithT, result any) {
 				g.Expect(result).To(BeAssignableToTypeOf(armnetwork.LoadBalancer{}))
-				g.Expect(result.(armnetwork.LoadBalancer)).To(Equal(newSamplePublicAPIServerLB(true, true, false, true, true)))
+				g.Expect(result.(armnetwork.LoadBalancer)).To(Equal(newSamplePublicAPIServerLB(true, true, false, false, true)))
 			},
 			expectedError: "",
 		},
@@ -164,7 +190,7 @@ func TestParameters(t *testing.T) {
 			existing: getExistingLBWithMissingProbes(),
 			expect: func(g *WithT, result any) {
 				g.Expect(result).To(BeAssignableToTypeOf(armnetwork.LoadBalancer{}))
-				g.Expect(result.(armnetwork.LoadBalancer)).To(Equal(newSamplePublicAPIServerLB(true, true, true, false, true)))
+				g.Expect(result.(armnetwork.LoadBalancer)).To(Equal(newSamplePublicAPIServerLB(true, true, false, false, true)))
 			},
 			expectedError: "",
 		},
@@ -174,7 +200,7 @@ func TestParameters(t *testing.T) {
 			existing: getExistingLBWithMissingOutboundRules(),
 			expect: func(g *WithT, result any) {
 				g.Expect(result).To(BeAssignableToTypeOf(armnetwork.LoadBalancer{}))
-				g.Expect(result.(armnetwork.LoadBalancer)).To(Equal(newSamplePublicAPIServerLB(true, true, true, true, false)))
+				g.Expect(result.(armnetwork.LoadBalancer)).To(Equal(newSamplePublicAPIServerLB(true, true, false, false, false)))
 			},
 			expectedError: "",
 		},
@@ -227,6 +253,41 @@ func TestParameters(t *testing.T) {
 			tc.expect(g, result)
 		})
 	}
+}
+
+// TestAPIServerLBPortPropagation verifies that the API server LB uses the externally
+// reachable port for its frontend and the API server bind port for its backend and probe.
+func TestAPIServerLBPortPropagation(t *testing.T) {
+	g := NewWithT(t)
+
+	const (
+		frontendPort int32 = 443
+		backendPort  int32 = 6443
+	)
+	spec := LBSpec{
+		Name:                  "my-lb",
+		SubscriptionID:        "123",
+		ResourceGroup:         "my-rg",
+		BackendPoolName:       "my-lb-backendPool",
+		APIServerPort:         backendPort,
+		APIServerFrontendPort: frontendPort,
+		Role:                  infrav1.APIServerRole,
+		AdditionalPorts: []infrav1.LoadBalancerPort{
+			{Name: "https-alt", Port: 8443},
+		},
+	}
+	frontendIDs := []*armnetwork.SubResource{{ID: ptr.To("/some/frontend/id")}}
+
+	rules := getLoadBalancingRules(spec, frontendIDs)
+	g.Expect(rules).To(HaveLen(2))
+	g.Expect(rules[0].Properties.FrontendPort).To(Equal(ptr.To(frontendPort)))
+	g.Expect(rules[0].Properties.BackendPort).To(Equal(ptr.To(backendPort)))
+	g.Expect(rules[1].Properties.FrontendPort).To(Equal(ptr.To[int32](8443)))
+	g.Expect(rules[1].Properties.BackendPort).To(Equal(ptr.To[int32](8443)))
+
+	probes := getProbes(spec)
+	g.Expect(probes).To(HaveLen(1))
+	g.Expect(probes[0].Properties.Port).To(Equal(ptr.To(backendPort)))
 }
 
 func newDefaultNodeOutboundLB() armnetwork.LoadBalancer {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

`ClusterScope.APIServerPort()` only consulted `Cluster.Spec.ClusterNetwork.APIServerPort`, falling back to 6443. As a result, when a user set `AzureCluster.Spec.ControlPlaneEndpoint.Port` (e.g. to 443) the API server load balancer rule, health probe, and NSG rule were still constructed for port 6443, even though the AzureCluster spec doc string explicitly tells users they may set this field and CAPZ will honor it.

This change updates `APIServerPort()` to consult `AzureCluster.Spec.ControlPlaneEndpoint.Port` first, so a user-supplied port flows through to:

- the API server LB rule frontend/backend port (`getLoadBalancingRules`)
- the HTTPS health probe port (`getProbes`)
- the NSG rule for inbound API server traffic
- the back-fill of `ControlPlaneEndpoint.Port` in the AzureCluster reconciler (already idempotent — only writes when the field is 0)

**Which issue(s) this PR fixes**:
Fixes #5781

**Special notes for your reviewer**:

No e2e change is included. None of the existing flavors uses a non-6443 port. Modifying `prow-apiserver-ilb` (the closest candidate) would also require coordinating the API server bind port in the KubeadmControlPlane and updating the test's probe assertions, which is non-trivial. Coverage is provided at the unit level instead:

- `azure/scope/cluster_test.go::TestAPIServerPort` gains cases for the new precedence.
- `azure/services/loadbalancers/spec_test.go::TestAPIServerLBPortPropagation` verifies that a non-default `LBSpec.APIServerPort` propagates to LB rule ports and the probe port.

Adding a dedicated e2e flavor for non-default control plane port would be a reasonable follow-up.

**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests
- [ ] cherry-pick candidate

**Release note**:
```release-note
Honor `AzureCluster.spec.controlPlaneEndpoint.port` when configuring the API server load balancer rule, health probe, and NSG rule. Previously these were always created for port 6443 (or `Cluster.spec.clusterNetwork.apiServerPort` if set), ignoring the AzureCluster control plane endpoint port.
```
