### PR TITLE
Update RKE2 ClusterClass to v1beta2 and bump provider to v0.24.3

### DIFF
--- a/templates/cluster-template-clusterclass-rke2.yaml
+++ b/templates/cluster-template-clusterclass-rke2.yaml
@@ -11,7 +11,7 @@ spec:
         kind: AzureMachineTemplate
         name: ${CLUSTER_NAME}-control-plane
     ref:
-      apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+      apiVersion: controlplane.cluster.x-k8s.io/v1beta2
       kind: RKE2ControlPlaneTemplate
       name: ${CLUSTER_NAME}-control-plane
   infrastructure:
@@ -58,7 +58,7 @@ spec:
               path: /etc/kubernetes/azure.json
               permissions: "0644"
       selector:
-        apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+        apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
         kind: RKE2ConfigTemplate
         matchResources:
           machineDeploymentClass:
@@ -79,7 +79,7 @@ spec:
             path: /etc/kubernetes/azure.json
             permissions: "0644"
       selector:
-        apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+        apiVersion: controlplane.cluster.x-k8s.io/v1beta2
         kind: RKE2ControlPlaneTemplate
         matchResources:
           controlPlane: true
@@ -103,7 +103,7 @@ spec:
       template:
         bootstrap:
           ref:
-            apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+            apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
             kind: RKE2ConfigTemplate
             name: ${CLUSTER_NAME}-worker
         infrastructure:
@@ -172,7 +172,7 @@ spec:
         diskSizeGB: 30
         osType: Linux
 ---
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlaneTemplate
 metadata:
   name: ${CLUSTER_NAME}-control-plane
@@ -200,7 +200,7 @@ spec:
           extraArgs:
           - --anonymous-auth=true
 ---
-apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
 kind: RKE2ConfigTemplate
 metadata:
   name: ${CLUSTER_NAME}-worker

--- a/templates/flavors/clusterclass-rke2/clusterclass.yaml
+++ b/templates/flavors/clusterclass-rke2/clusterclass.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   controlPlane:
     ref:
-      apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+      apiVersion: controlplane.cluster.x-k8s.io/v1beta2
       kind: RKE2ControlPlaneTemplate
       name: ${CLUSTER_NAME}-control-plane
     machineInfrastructure:
@@ -24,7 +24,7 @@ spec:
         template:
           bootstrap:
             ref:
-              apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+              apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
               kind: RKE2ConfigTemplate
               name: ${CLUSTER_NAME}-worker
           infrastructure:
@@ -72,7 +72,7 @@ spec:
                 path: /etc/kubernetes/azure.json
                 permissions: "0644"
         selector:
-          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+          apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
           kind: RKE2ConfigTemplate
           matchResources:
             machineDeploymentClass:
@@ -81,7 +81,7 @@ spec:
     - name: azureMachineTemplate
       definitions:
         - selector:
-            apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+            apiVersion: controlplane.cluster.x-k8s.io/v1beta2
             kind: RKE2ControlPlaneTemplate
             matchResources:
               controlPlane: true

--- a/templates/flavors/clusterclass-rke2/rke2-config-template.yaml
+++ b/templates/flavors/clusterclass-rke2/rke2-config-template.yaml
@@ -1,4 +1,4 @@
-apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
 kind: RKE2ConfigTemplate
 metadata:
   name: ${CLUSTER_NAME}-worker

--- a/templates/flavors/clusterclass-rke2/rke2-controlplane-template.yaml
+++ b/templates/flavors/clusterclass-rke2/rke2-controlplane-template.yaml
@@ -1,4 +1,4 @@
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlaneTemplate
 metadata:
   name: ${CLUSTER_NAME}-control-plane

--- a/templates/test/ci/cluster-template-prow-clusterclass-ci-rke2.yaml
+++ b/templates/test/ci/cluster-template-prow-clusterclass-ci-rke2.yaml
@@ -11,7 +11,7 @@ spec:
         kind: AzureMachineTemplate
         name: ${CLUSTER_NAME}-control-plane
     ref:
-      apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+      apiVersion: controlplane.cluster.x-k8s.io/v1beta2
       kind: RKE2ControlPlaneTemplate
       name: ${CLUSTER_NAME}-control-plane
   infrastructure:
@@ -34,7 +34,7 @@ spec:
             path: /etc/kubernetes/azure.json
             permissions: "0644"
       selector:
-        apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+        apiVersion: controlplane.cluster.x-k8s.io/v1beta2
         kind: RKE2ControlPlaneTemplate
         matchResources:
           controlPlane: true
@@ -53,7 +53,7 @@ spec:
               path: /etc/kubernetes/azure.json
               permissions: "0644"
       selector:
-        apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+        apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
         kind: RKE2ConfigTemplate
         matchResources:
           machineDeploymentClass:
@@ -273,7 +273,7 @@ spec:
       template:
         bootstrap:
           ref:
-            apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+            apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
             kind: RKE2ConfigTemplate
             name: ${CLUSTER_NAME}-worker
         infrastructure:
@@ -282,7 +282,7 @@ spec:
             kind: AzureMachineTemplate
             name: ${CLUSTER_NAME}-worker
 ---
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlaneTemplate
 metadata:
   name: ${CLUSTER_NAME}-control-plane
@@ -372,7 +372,7 @@ spec:
         diskSizeGB: 30
         osType: Linux
 ---
-apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
 kind: RKE2ConfigTemplate
 metadata:
   name: ${CLUSTER_NAME}-worker

--- a/templates/test/ci/prow-clusterclass-ci-rke2/patches.yaml
+++ b/templates/test/ci/prow-clusterclass-ci-rke2/patches.yaml
@@ -15,7 +15,7 @@ spec:
         template:
           bootstrap:
             ref:
-              apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+              apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
               kind: RKE2ConfigTemplate
               name: ${CLUSTER_NAME}-worker
           infrastructure:
@@ -27,7 +27,7 @@ spec:
     - name: controlPlaneAzureJsonSecretName
       definitions:
         - selector:
-            apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+            apiVersion: controlplane.cluster.x-k8s.io/v1beta2
             kind: RKE2ControlPlaneTemplate
             matchResources:
               controlPlane: true
@@ -46,7 +46,7 @@ spec:
     - name: workerAzureJsonSecretName
       definitions:
         - selector:
-            apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+            apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
             kind: RKE2ConfigTemplate
             matchResources:
               machineDeploymentClass:

--- a/templates/test/ci/prow-clusterclass-ci-rke2/rke2-config-template.yaml
+++ b/templates/test/ci/prow-clusterclass-ci-rke2/rke2-config-template.yaml
@@ -1,4 +1,4 @@
-apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
 kind: RKE2ConfigTemplate
 metadata:
   name: ${CLUSTER_NAME}-worker

--- a/test/e2e/azure_test.go
+++ b/test/e2e/azure_test.go
@@ -1050,7 +1050,7 @@ var _ = Describe("Workload cluster creation", func() {
 			clusterName = getClusterName(clusterNamePrefix, "cc")
 
 			// Init rke2 CP and bootstrap providers
-			rke2Version := "v0.21.1"
+			rke2Version := "v0.24.3"
 			initInput := clusterctl.InitInput{
 				// pass reference to the management cluster hosting this test
 				KubeconfigPath: bootstrapClusterProxy.GetKubeconfigPath(),
@@ -1075,7 +1075,7 @@ var _ = Describe("Workload cluster creation", func() {
 			//
 			// If that issue is resolved then we can remove this workaround.
 			objects, err := yaml.ToUnstructured([]byte(`
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlaneTemplate
 metadata:
   name: dry-run
@@ -1085,7 +1085,7 @@ spec:
     spec:
       rolloutStrategy: {}
 ---
-apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
 kind: RKE2ConfigTemplate
 metadata:
   name: dry-run


### PR DESCRIPTION
**What type of PR is this?**

/kind failing-test

**What this PR does / why we need it**:

The RKE2 clusterclass e2e test is currently pinned to RKE2 provider `v0.21.1` because newer versions changed the schema for `RKE2ControlPlaneTemplate` and `RKE2ConfigTemplate`. Specifically, [`rancher/cluster-api-provider-rke2#793`](https://github.com/rancher/cluster-api-provider-rke2/pull/793) and [`#794`](https://github.com/rancher/cluster-api-provider-rke2/pull/794) (released in v0.22.0) introduced a `v1beta2` API and the v1beta2 contract: `RKE2ControlPlane.spec.machineTemplate` is no longer the InfrastructureRef container itself, but now wraps a `Spec` field that holds `infrastructureRef` (of type `ContractVersionedObjectReference`). CAPI v1.13's topology controller writes against this new contract and produced the schema error reported in #6081.

This PR updates our RKE2 clusterclass templates to use the `v1beta2` API for RKE2 types and bumps the pinned provider version to `v0.24.3` (latest stable):

- `RKE2ControlPlaneTemplate` and `RKE2ConfigTemplate` apiVersions changed from `v1beta1` to `v1beta2` in both base flavor (`templates/flavors/clusterclass-rke2/`) and the CI overlay (`templates/test/ci/prow-clusterclass-ci-rke2/`).
- ClusterClass `controlPlane.ref` and worker `bootstrap.ref` updated to `v1beta2` for the RKE2 types. The ClusterClass itself stays on `cluster.x-k8s.io/v1beta1`, matching the rest of CAPZ.
- All ClusterClass patch selectors targeting RKE2 types updated to `v1beta2`.
- Webhook-readiness dry-run snippet in `azure_test.go` updated to v1beta2.
- RKE2 provider pin bumped from `v0.21.1` to `v0.24.3`.
- Rendered cluster templates regenerated via `make generate-flavors`.

The patches that reference built-in topology variables (`{{ .builtin.controlPlane.machineTemplate.infrastructureRef.name }}`, `{{ .builtin.machineDeployment.infrastructureRef.name }}`) are unchanged — those built-in names persist across the contract version.

**Which issue(s) this PR fixes**:
Fixes #6081

**Special notes for your reviewer**:

The actual validation of this fix is `pull-cluster-api-provider-azure-e2e-optional`. Local checks (`go vet -tags=e2e`, `make lint`, `make generate`) all pass cleanly.

This effectively reverts the temporary pin in #6085 while raising the pin to a maintained release.

**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] cherry-pick candidate

**Release note**:
```release-note
NONE
```
