### PR TITLE
Switch default Windows image to windows-2022

### DIFF
--- a/azure/defaults.go
+++ b/azure/defaults.go
@@ -54,7 +54,7 @@ const (
 	// DefaultLinuxGalleryImageName is the default Linux community gallery image definition.
 	DefaultLinuxGalleryImageName = "capi-ubun2-2404"
 	// DefaultWindowsGalleryImageName is the default Windows community gallery image definition.
-	DefaultWindowsGalleryImageName = "capi-win-2019-containerd"
+	DefaultWindowsGalleryImageName = "capi-win-2022-containerd"
 )
 
 const (
@@ -74,7 +74,7 @@ const (
 const (
 	// DefaultWindowsOsAndVersion is the default Windows Server version to use when
 	// generating default images for Windows nodes.
-	DefaultWindowsOsAndVersion = "windows-2019"
+	DefaultWindowsOsAndVersion = "windows-2022"
 )
 
 const (

--- a/azure/services/virtualmachineimages/images.go
+++ b/azure/services/virtualmachineimages/images.go
@@ -19,7 +19,6 @@ package virtualmachineimages
 import (
 	"context"
 	"regexp"
-	"strings"
 
 	"github.com/blang/semver"
 	"github.com/pkg/errors"
@@ -106,7 +105,8 @@ func (s *Service) GetDefaultWindowsImage(ctx context.Context, _, k8sVersion, run
 		if len(match) != 2 {
 			return nil, errors.Errorf("unsupported osAndVersion %s", osAndVersion)
 		}
-		imageName = strings.Replace(imageName, "2019", match[1], 1)
+		// Substitute the requested Windows Server year into the default image name.
+		imageName = regexp.MustCompile(`\d{4}`).ReplaceAllString(imageName, match[1])
 	}
 
 	// Use the Azure Marketplace for specific older versions, to keep "clusterctl upgrade" from rolling new machines.

--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -701,7 +701,7 @@ func resolveKubernetesVersions(config *clusterctl.E2EConfig) {
 	windowsRequired := testWindows == "true"
 
 	if windowsRequired {
-		windowsVersions := getVersionsInCommunityGallery(ctx, os.Getenv(AzureLocation), capiCommunityGallery, "capi-win-2019-containerd")
+		windowsVersions := getVersionsInCommunityGallery(ctx, os.Getenv(AzureLocation), capiCommunityGallery, "capi-win-2022-containerd")
 		for k, v := range linuxVersions {
 			if _, ok := windowsVersions[k]; ok {
 				versions = append(versions, v)


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Updates CAPZ's in-tree Windows defaults from `windows-2019` to `windows-2022`. Windows Server 2019 entered extended support in Jan 2024 and we no longer publish 2019 reference images, so any user creating an AzureMachine without explicitly setting `windowsServerVersion` would land on a stale, no-longer-published image.

CI scripts (`scripts/ci-e2e.sh`, `ci-conformance.sh`, `ci-entrypoint.sh`) already export `WINDOWS_SERVER_VERSION="${WINDOWS_SERVER_VERSION:-windows-2022}"` and the existing `[REQUIRED]` HA Windows worker e2e is consistently green at 2022, so the risk profile is low.

Changes:
- `azure/defaults.go`: `DefaultWindowsGalleryImageName` and `DefaultWindowsOsAndVersion` flipped to 2022
- `azure/services/virtualmachineimages/images.go`: the year-substitution in `GetDefaultWindowsImage` no longer assumes the default name contains `"2019"`. Switched the brittle `strings.Replace(imageName, "2019", match[1], 1)` to `regexp.ReplaceAllString(imageName, "\d{4}", match[1])`, so any future default-year flip won't require touching this code again.
- `test/e2e/helpers.go`: the Windows version-intersection check in `resolveKubernetesVersions` now queries `capi-win-2022-containerd` (only runs when `TEST_WINDOWS=true`).

Intentionally **not** changed:
- The deprecated marketplace fallback path for old Kubernetes versions (`oldWindows2019Versions` map and the `windows-2019-containerd-gen1` SKU) — those are hardcoded for k8s ≤ 1.28.12 etc. and reflect what was published to the Azure Marketplace at the time.
- Existing unit tests for `windows-2019` osAndVersion in `images_test.go` and `machine_test.go` — they now serve as regression coverage for the explicit-override path.

**Which issue(s) this PR fixes**:
Fixes #5357

**Special notes for your reviewer**:

None.

**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] cherry-pick candidate

**Release note**:
```release-note
Switch default Windows image to windows-2022
```
