### PR TITLE
Bump Azure Service Operator from v2.16.1 to v2.17.0

### DIFF
--- a/azure/scope/managedcontrolplane.go
+++ b/azure/scope/managedcontrolplane.go
@@ -23,7 +23,7 @@ import (
 	"strings"
 	"time"
 
-	asocontainerservicev1preview "github.com/Azure/azure-service-operator/v2/api/containerservice/v1api20230315preview"
+	asocontainerservicev1 "github.com/Azure/azure-service-operator/v2/api/containerservice/v1api20250301"
 	asokubernetesconfigurationv1 "github.com/Azure/azure-service-operator/v2/api/kubernetesconfiguration/v1api20230501"
 	asonetworkv1api20201101 "github.com/Azure/azure-service-operator/v2/api/network/v1api20201101"
 	asonetworkv1api20220701 "github.com/Azure/azure-service-operator/v2/api/network/v1api20220701"
@@ -307,11 +307,11 @@ func (s *ManagedControlPlaneScope) VNetSpec() azure.ASOResourceSpecGetter[*asone
 }
 
 // AzureFleetsMemberSpec returns the fleet spec.
-func (s *ManagedControlPlaneScope) AzureFleetsMemberSpec() []azure.ASOResourceSpecGetter[*asocontainerservicev1preview.FleetsMember] {
+func (s *ManagedControlPlaneScope) AzureFleetsMemberSpec() []azure.ASOResourceSpecGetter[*asocontainerservicev1.FleetsMember] {
 	if s.AzureFleetMembership() == nil {
 		return nil
 	}
-	return []azure.ASOResourceSpecGetter[*asocontainerservicev1preview.FleetsMember]{&fleetsmembers.AzureFleetsMemberSpec{
+	return []azure.ASOResourceSpecGetter[*asocontainerservicev1.FleetsMember]{&fleetsmembers.AzureFleetsMemberSpec{
 		Name:                 s.AzureFleetMembership().Name,
 		ClusterName:          s.ClusterName(),
 		ClusterResourceGroup: s.ResourceGroup(),

--- a/azure/services/fleetsmembers/fleetsmembers.go
+++ b/azure/services/fleetsmembers/fleetsmembers.go
@@ -19,7 +19,7 @@ package fleetsmembers
 import (
 	"context"
 
-	asocontainerservicev1 "github.com/Azure/azure-service-operator/v2/api/containerservice/v1api20230315preview"
+	asocontainerservicev1 "github.com/Azure/azure-service-operator/v2/api/containerservice/v1api20250301"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"

--- a/azure/services/fleetsmembers/spec.go
+++ b/azure/services/fleetsmembers/spec.go
@@ -19,7 +19,7 @@ package fleetsmembers
 import (
 	"context"
 
-	asocontainerservicev1 "github.com/Azure/azure-service-operator/v2/api/containerservice/v1api20230315preview"
+	asocontainerservicev1 "github.com/Azure/azure-service-operator/v2/api/containerservice/v1api20250301"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"

--- a/azure/services/fleetsmembers/spec_test.go
+++ b/azure/services/fleetsmembers/spec_test.go
@@ -19,7 +19,7 @@ package fleetsmembers
 import (
 	"testing"
 
-	asocontainerservicev1 "github.com/Azure/azure-service-operator/v2/api/containerservice/v1api20230315preview"
+	asocontainerservicev1 "github.com/Azure/azure-service-operator/v2/api/containerservice/v1api20250301"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/config/aso/crds.yaml
+++ b/config/aso/crds.yaml
@@ -3,10 +3,10 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: azureserviceoperator-system/azureserviceoperator-serving-cert
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.19.0
   labels:
     app.kubernetes.io/name: azure-service-operator
-    app.kubernetes.io/version: v2.16.1
+    app.kubernetes.io/version: v2.17.0
   name: bastionhosts.network.azure.com
 spec:
   conversion:
@@ -1110,10 +1110,10 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: azureserviceoperator-system/azureserviceoperator-serving-cert
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.19.0
   labels:
     app.kubernetes.io/name: azure-service-operator
-    app.kubernetes.io/version: v2.16.1
+    app.kubernetes.io/version: v2.17.0
   name: extensions.kubernetesconfiguration.azure.com
 spec:
   conversion:
@@ -2727,10 +2727,10 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: azureserviceoperator-system/azureserviceoperator-serving-cert
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.19.0
   labels:
     app.kubernetes.io/name: azure-service-operator
-    app.kubernetes.io/version: v2.16.1
+    app.kubernetes.io/version: v2.17.0
   name: fleetsmembers.containerservice.azure.com
 spec:
   conversion:
@@ -2756,324 +2756,6 @@ spec:
   preserveUnknownFields: false
   scope: Namespaced
   versions:
-    - additionalPrinterColumns:
-        - jsonPath: .status.conditions[?(@.type=='Ready')].status
-          name: Ready
-          type: string
-        - jsonPath: .status.conditions[?(@.type=='Ready')].severity
-          name: Severity
-          type: string
-        - jsonPath: .status.conditions[?(@.type=='Ready')].reason
-          name: Reason
-          type: string
-        - jsonPath: .status.conditions[?(@.type=='Ready')].message
-          name: Message
-          type: string
-      name: v1api20230315preview
-      schema:
-        openAPIV3Schema:
-          properties:
-            apiVersion:
-              type: string
-            kind:
-              type: string
-            metadata:
-              type: object
-            spec:
-              properties:
-                azureName:
-                  maxLength: 50
-                  minLength: 1
-                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
-                  type: string
-                clusterResourceReference:
-                  properties:
-                    armId:
-                      pattern: (?i)(^(/subscriptions/([^/]+)(/resourcegroups/([^/]+))?)?/providers/([^/]+)/([^/]+/[^/]+)(/([^/]+/[^/]+))*$|^/subscriptions/([^/]+)(/resourcegroups/([^/]+))?$)
-                      type: string
-                    group:
-                      type: string
-                    kind:
-                      type: string
-                    name:
-                      type: string
-                  type: object
-                group:
-                  maxLength: 50
-                  minLength: 1
-                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
-                  type: string
-                operatorSpec:
-                  properties:
-                    configMapExpressions:
-                      items:
-                        properties:
-                          key:
-                            type: string
-                          name:
-                            type: string
-                          value:
-                            type: string
-                        required:
-                          - name
-                          - value
-                        type: object
-                      type: array
-                    secretExpressions:
-                      items:
-                        properties:
-                          key:
-                            type: string
-                          name:
-                            type: string
-                          value:
-                            type: string
-                        required:
-                          - name
-                          - value
-                        type: object
-                      type: array
-                  type: object
-                owner:
-                  properties:
-                    armId:
-                      pattern: (?i)(^(/subscriptions/([^/]+)(/resourcegroups/([^/]+))?)?/providers/([^/]+)/([^/]+/[^/]+)(/([^/]+/[^/]+))*$|^/subscriptions/([^/]+)(/resourcegroups/([^/]+))?$)
-                      type: string
-                    name:
-                      type: string
-                  type: object
-              required:
-                - clusterResourceReference
-                - owner
-              type: object
-            status:
-              properties:
-                clusterResourceId:
-                  type: string
-                conditions:
-                  items:
-                    properties:
-                      lastTransitionTime:
-                        format: date-time
-                        type: string
-                      message:
-                        type: string
-                      observedGeneration:
-                        format: int64
-                        type: integer
-                      reason:
-                        type: string
-                      severity:
-                        type: string
-                      status:
-                        type: string
-                      type:
-                        type: string
-                    required:
-                      - lastTransitionTime
-                      - reason
-                      - status
-                      - type
-                    type: object
-                  type: array
-                eTag:
-                  type: string
-                group:
-                  type: string
-                id:
-                  type: string
-                name:
-                  type: string
-                provisioningState:
-                  type: string
-                systemData:
-                  properties:
-                    createdAt:
-                      type: string
-                    createdBy:
-                      type: string
-                    createdByType:
-                      type: string
-                    lastModifiedAt:
-                      type: string
-                    lastModifiedBy:
-                      type: string
-                    lastModifiedByType:
-                      type: string
-                  type: object
-                type:
-                  type: string
-              type: object
-          type: object
-      served: true
-      storage: false
-      subresources:
-        status: {}
-    - additionalPrinterColumns:
-        - jsonPath: .status.conditions[?(@.type=='Ready')].status
-          name: Ready
-          type: string
-        - jsonPath: .status.conditions[?(@.type=='Ready')].severity
-          name: Severity
-          type: string
-        - jsonPath: .status.conditions[?(@.type=='Ready')].reason
-          name: Reason
-          type: string
-        - jsonPath: .status.conditions[?(@.type=='Ready')].message
-          name: Message
-          type: string
-      name: v1api20230315previewstorage
-      schema:
-        openAPIV3Schema:
-          properties:
-            apiVersion:
-              type: string
-            kind:
-              type: string
-            metadata:
-              type: object
-            spec:
-              properties:
-                $propertyBag:
-                  additionalProperties:
-                    type: string
-                  type: object
-                azureName:
-                  type: string
-                clusterResourceReference:
-                  properties:
-                    armId:
-                      pattern: (?i)(^(/subscriptions/([^/]+)(/resourcegroups/([^/]+))?)?/providers/([^/]+)/([^/]+/[^/]+)(/([^/]+/[^/]+))*$|^/subscriptions/([^/]+)(/resourcegroups/([^/]+))?$)
-                      type: string
-                    group:
-                      type: string
-                    kind:
-                      type: string
-                    name:
-                      type: string
-                  type: object
-                group:
-                  type: string
-                operatorSpec:
-                  properties:
-                    $propertyBag:
-                      additionalProperties:
-                        type: string
-                      type: object
-                    configMapExpressions:
-                      items:
-                        properties:
-                          key:
-                            type: string
-                          name:
-                            type: string
-                          value:
-                            type: string
-                        required:
-                          - name
-                          - value
-                        type: object
-                      type: array
-                    secretExpressions:
-                      items:
-                        properties:
-                          key:
-                            type: string
-                          name:
-                            type: string
-                          value:
-                            type: string
-                        required:
-                          - name
-                          - value
-                        type: object
-                      type: array
-                  type: object
-                originalVersion:
-                  type: string
-                owner:
-                  properties:
-                    armId:
-                      pattern: (?i)(^(/subscriptions/([^/]+)(/resourcegroups/([^/]+))?)?/providers/([^/]+)/([^/]+/[^/]+)(/([^/]+/[^/]+))*$|^/subscriptions/([^/]+)(/resourcegroups/([^/]+))?$)
-                      type: string
-                    name:
-                      type: string
-                  type: object
-              required:
-                - clusterResourceReference
-                - owner
-              type: object
-            status:
-              properties:
-                $propertyBag:
-                  additionalProperties:
-                    type: string
-                  type: object
-                clusterResourceId:
-                  type: string
-                conditions:
-                  items:
-                    properties:
-                      lastTransitionTime:
-                        format: date-time
-                        type: string
-                      message:
-                        type: string
-                      observedGeneration:
-                        format: int64
-                        type: integer
-                      reason:
-                        type: string
-                      severity:
-                        type: string
-                      status:
-                        type: string
-                      type:
-                        type: string
-                    required:
-                      - lastTransitionTime
-                      - reason
-                      - status
-                      - type
-                    type: object
-                  type: array
-                eTag:
-                  type: string
-                group:
-                  type: string
-                id:
-                  type: string
-                name:
-                  type: string
-                provisioningState:
-                  type: string
-                systemData:
-                  properties:
-                    $propertyBag:
-                      additionalProperties:
-                        type: string
-                      type: object
-                    createdAt:
-                      type: string
-                    createdBy:
-                      type: string
-                    createdByType:
-                      type: string
-                    lastModifiedAt:
-                      type: string
-                    lastModifiedBy:
-                      type: string
-                    lastModifiedByType:
-                      type: string
-                  type: object
-                type:
-                  type: string
-              type: object
-          type: object
-      served: true
-      storage: false
-      subresources:
-        status: {}
     - additionalPrinterColumns:
         - jsonPath: .status.conditions[?(@.type=='Ready')].status
           name: Ready
@@ -3512,10 +3194,10 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: azureserviceoperator-system/azureserviceoperator-serving-cert
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.19.0
   labels:
     app.kubernetes.io/name: azure-service-operator
-    app.kubernetes.io/version: v2.16.1
+    app.kubernetes.io/version: v2.17.0
   name: maintenanceconfigurations.containerservice.azure.com
 spec:
   conversion:
@@ -4921,10 +4603,10 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: azureserviceoperator-system/azureserviceoperator-serving-cert
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.19.0
   labels:
     app.kubernetes.io/name: azure-service-operator
-    app.kubernetes.io/version: v2.16.1
+    app.kubernetes.io/version: v2.17.0
   name: managedclusters.containerservice.azure.com
 spec:
   conversion:
@@ -31036,10 +30718,10 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: azureserviceoperator-system/azureserviceoperator-serving-cert
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.19.0
   labels:
     app.kubernetes.io/name: azure-service-operator
-    app.kubernetes.io/version: v2.16.1
+    app.kubernetes.io/version: v2.17.0
   name: managedclustersagentpools.containerservice.azure.com
 spec:
   conversion:
@@ -38797,10 +38479,10 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: azureserviceoperator-system/azureserviceoperator-serving-cert
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.19.0
   labels:
     app.kubernetes.io/name: azure-service-operator
-    app.kubernetes.io/version: v2.16.1
+    app.kubernetes.io/version: v2.17.0
   name: natgateways.network.azure.com
 spec:
   conversion:
@@ -39736,10 +39418,10 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: azureserviceoperator-system/azureserviceoperator-serving-cert
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.19.0
   labels:
     app.kubernetes.io/name: azure-service-operator
-    app.kubernetes.io/version: v2.16.1
+    app.kubernetes.io/version: v2.17.0
   name: privateendpoints.network.azure.com
 spec:
   conversion:
@@ -41443,10 +41125,10 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: azureserviceoperator-system/azureserviceoperator-serving-cert
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.19.0
   labels:
     app.kubernetes.io/name: azure-service-operator
-    app.kubernetes.io/version: v2.16.1
+    app.kubernetes.io/version: v2.17.0
   name: resourcegroups.resources.azure.com
 spec:
   conversion:
@@ -41740,10 +41422,10 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: azureserviceoperator-system/azureserviceoperator-serving-cert
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.19.0
   labels:
     app.kubernetes.io/name: azure-service-operator
-    app.kubernetes.io/version: v2.16.1
+    app.kubernetes.io/version: v2.17.0
   name: virtualnetworks.network.azure.com
 spec:
   conversion:
@@ -42920,10 +42602,10 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: azureserviceoperator-system/azureserviceoperator-serving-cert
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.19.0
   labels:
     app.kubernetes.io/name: azure-service-operator
-    app.kubernetes.io/version: v2.16.1
+    app.kubernetes.io/version: v2.17.0
   name: virtualnetworkssubnets.network.azure.com
 spec:
   conversion:

--- a/config/aso/kustomization.yaml
+++ b/config/aso/kustomization.yaml
@@ -3,7 +3,7 @@ kind: Component
 namespace: capz-system
 resources:
   # The ASO version here is managed by `make generate-aso-crds`
-  - https://github.com/Azure/azure-service-operator/releases/download/v2.16.1/azureserviceoperator_v2.16.1.yaml
+  - https://github.com/Azure/azure-service-operator/releases/download/v2.17.0/azureserviceoperator_v2.17.0.yaml
   - crds.yaml
   - settings.yaml
 patches:

--- a/controllers/azuremanagedcontrolplane_controller_test.go
+++ b/controllers/azuremanagedcontrolplane_controller_test.go
@@ -19,8 +19,8 @@ package controllers
 import (
 	"testing"
 
-	asocontainerservicev1preview "github.com/Azure/azure-service-operator/v2/api/containerservice/v1api20230315preview"
-	asocontainerservicev1 "github.com/Azure/azure-service-operator/v2/api/containerservice/v1api20231001"
+	asocontainerservicev1api20231001 "github.com/Azure/azure-service-operator/v2/api/containerservice/v1api20231001"
+	asocontainerservicev1 "github.com/Azure/azure-service-operator/v2/api/containerservice/v1api20250301"
 	asonetworkv1 "github.com/Azure/azure-service-operator/v2/api/network/v1api20201101"
 	asoresourcesv1 "github.com/Azure/azure-service-operator/v2/api/resources/v1api20200601"
 	. "github.com/onsi/gomega"
@@ -116,10 +116,10 @@ func TestAzureManagedControlPlaneReconcilePaused(t *testing.T) {
 		clusterv1.AddToScheme,
 		infrav1.AddToScheme,
 		asoresourcesv1.AddToScheme,
-		asocontainerservicev1.AddToScheme,
+		asocontainerservicev1api20231001.AddToScheme,
 		asonetworkv1.AddToScheme,
 		corev1.AddToScheme,
-		asocontainerservicev1preview.AddToScheme,
+		asocontainerservicev1.AddToScheme,
 	)
 	s := runtime.NewScheme()
 	g.Expect(sb.AddToScheme(s)).To(Succeed())
@@ -224,7 +224,7 @@ func TestAzureManagedControlPlaneReconcilePaused(t *testing.T) {
 	}
 	g.Expect(c.Create(ctx, rg)).To(Succeed())
 
-	mc := &asocontainerservicev1.ManagedCluster{
+	mc := &asocontainerservicev1api20231001.ManagedCluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
@@ -240,7 +240,7 @@ func TestAzureManagedControlPlaneReconcilePaused(t *testing.T) {
 	}
 	g.Expect(c.Create(ctx, vnet)).To(Succeed())
 
-	fleetsMember := &asocontainerservicev1preview.FleetsMember{
+	fleetsMember := &asocontainerservicev1.FleetsMember{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcehealth/armresourcehealth v1.3.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.2.0
 	github.com/Azure/azure-sdk-for-go/sdk/tracing/azotel v0.4.0
-	github.com/Azure/azure-service-operator/v2 v2.16.1
+	github.com/Azure/azure-service-operator/v2 v2.17.0
 	github.com/Azure/msi-dataplane v0.4.3
 	github.com/asaskevich/govalidator/v11 v11.0.2-0.20250122183457-e11347878e23
 	github.com/blang/semver v3.5.1+incompatible

--- a/go.sum
+++ b/go.sum
@@ -73,12 +73,16 @@ github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v6 v6.2
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v6 v6.2.0/go.mod h1:ulHyBFJOI0ONiRL4vcJTmS7rx18jQQlEPmAgo80cRdM=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/notificationhubs/armnotificationhubs v1.2.0 h1:ZzshIzB4SnLLHFFHbBMxG5Sn2QCo9LWl4K5Nqz0Eysk=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/notificationhubs/armnotificationhubs v1.2.0/go.mod h1:YuV5NCOq5toIonfwdVfw2j99Uuy25Df2Tb5O83ZIuV4=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/operationalinsights/armoperationalinsights v1.2.0 h1:4FlNvfcPu7tTvOgOzXxIbZLvwvmZq1OdhQUdIa9g2N4=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/operationalinsights/armoperationalinsights v1.2.0/go.mod h1:A4nzEXwVd5pAyneR6KOvUAo72svUc5rmCzRHhAbP6lA=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/privatedns/armprivatedns v1.3.0 h1:yzrctSl9GMIQ5lHu7jc8olOsGjWDCsBpJhWqfGa/YIM=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/privatedns/armprivatedns v1.3.0/go.mod h1:GE4m0rnnfwLGX0Y9A9A25Zx5N/90jneT5ABevqzhuFQ=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/redhatopenshift/armredhatopenshift v1.6.0 h1:66BMYGcSQ+uMaWXiB1Kaf6PDauXGMVSLxdA9SGlE6Sc=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/redhatopenshift/armredhatopenshift v1.6.0/go.mod h1:/t2+d3mPIi1Ul1eXtxc5y9qmxMD3oHfSlCibhYKIB/U=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/redis/armredis v1.0.0 h1:nmpTBgRg1HynngFYICRhceC7s5dmbKN9fJ/XQz/UQ2I=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/redis/armredis v1.0.0/go.mod h1:3yjiOtnkVociBTlF7UZrwAGfJrGaOCsvtVS4HzNajxQ=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/redisenterprise/armredisenterprise v1.2.0 h1:hTmVmyvriwO+ymGLEsH7HZokVwinC2MZl8F0LjvPdHU=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/redisenterprise/armredisenterprise v1.2.0/go.mod h1:uHEpZj4TWSZEp35rIByJ8RX7hQBm3bxfPxS4tiz+x+g=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcehealth/armresourcehealth v1.3.0 h1:hz+ZQ21PKZ6TBEiVMq8zqWUzA5DGj087lYC8OCm6wuY=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcehealth/armresourcehealth v1.3.0/go.mod h1:AN7AudLmrOvJlt7ormR1M5splG0TkZ4xyAqEIMIwTB0=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.2.0 h1:Dd+RhdJn0OTtVGaeDLZpcumkIVCtA/3/Fo42+eoYvVM=
@@ -99,8 +103,8 @@ github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/internal v1.2.0 h1:nCYfg
 github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/internal v1.2.0/go.mod h1:ucUjca2JtSZboY8IoUqyQyuuXvwbMBVwFOm0vdQPNhA=
 github.com/Azure/azure-sdk-for-go/sdk/tracing/azotel v0.4.0 h1:RTTsXUJWn0jumeX62Mb153wYXykqnrzYBYDeHp0kiuk=
 github.com/Azure/azure-sdk-for-go/sdk/tracing/azotel v0.4.0/go.mod h1:k4MMjrPHIEK+umaMGk1GNLgjEybJZ9mHSRDZ+sDFv3Y=
-github.com/Azure/azure-service-operator/v2 v2.16.1 h1:8ueCiy14nTJnLdV93g0g9LDx66SHGXTX5pZonpEw0is=
-github.com/Azure/azure-service-operator/v2 v2.16.1/go.mod h1:wsorpZjfMMYHdN3B5C6aY9hrae3aBcaVTn1LYwy22M0=
+github.com/Azure/azure-service-operator/v2 v2.17.0 h1:dfEG9npJmWNEtGenQ5a2LqDIuqQCeAKvxcrF34PxFeU=
+github.com/Azure/azure-service-operator/v2 v2.17.0/go.mod h1:IwWu+T+LgIn8awMfQ3pg7Q30VGnDVBWO3tiLiU+cn+w=
 github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c h1:udKWzYgxTojEKWjV8V+WSxDXJ4NFATAsZjh8iIbsQIg=
 github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/Azure/msi-dataplane v0.4.3 h1:dWPWzY4b54tLIR9T1Q014Xxd/1DxOsMIp6EjRFAJlQY=

--- a/main.go
+++ b/main.go
@@ -25,10 +25,10 @@ import (
 
 	// +kubebuilder:scaffold:imports
 	asocontainerservicev1api20230201 "github.com/Azure/azure-service-operator/v2/api/containerservice/v1api20230201"
-	asocontainerservicev1api20230315preview "github.com/Azure/azure-service-operator/v2/api/containerservice/v1api20230315preview"
 	asocontainerservicev1api20231001 "github.com/Azure/azure-service-operator/v2/api/containerservice/v1api20231001"
 	asocontainerservicev1api20240402preview "github.com/Azure/azure-service-operator/v2/api/containerservice/v1api20240402preview"
 	asocontainerservicev1api20240901 "github.com/Azure/azure-service-operator/v2/api/containerservice/v1api20240901"
+	asocontainerservicev1api20250301 "github.com/Azure/azure-service-operator/v2/api/containerservice/v1api20250301"
 	asokubernetesconfigurationv1 "github.com/Azure/azure-service-operator/v2/api/kubernetesconfiguration/v1api20230501"
 	asonetworkv1api20201101 "github.com/Azure/azure-service-operator/v2/api/network/v1api20201101"
 	asonetworkv1api20220701 "github.com/Azure/azure-service-operator/v2/api/network/v1api20220701"
@@ -86,7 +86,7 @@ func init() {
 	_ = asocontainerservicev1api20231001.AddToScheme(scheme)
 	_ = asonetworkv1api20220701.AddToScheme(scheme)
 	_ = asonetworkv1api20201101.AddToScheme(scheme)
-	_ = asocontainerservicev1api20230315preview.AddToScheme(scheme)
+	_ = asocontainerservicev1api20250301.AddToScheme(scheme)
 	_ = asocontainerservicev1api20240402preview.AddToScheme(scheme)
 	_ = asocontainerservicev1api20240901.AddToScheme(scheme)
 	_ = asokubernetesconfigurationv1.AddToScheme(scheme)


### PR DESCRIPTION
## What type of PR is this?

/kind cleanup

## What this PR does / why we need it:

Bumps Azure Service Operator (ASO) from v2.16.1 to v2.17.0.

v2.17.0 picks up [microsoft-authentication-library-for-go v1.6.0+](https://github.com/AzureAD/microsoft-authentication-library-for-go/issues/589), which fixes Azure China Cloud authentication for ASO-managed resources. CAPZ's controller manager already uses the patched MSAL library, but the vendored ASO version did not until now.

### Code changes

The only ASO API removed in v2.17.0 that CAPZ depends on is `containerservice/v1api20230315preview`. CAPZ uses this for `FleetsMember`; this PR migrates those imports to `containerservice/v1api20250301`, which is the new GA Fleet API.

- `go.mod` / `go.sum`: ASO v2.16.1 → v2.17.0
- `azure/services/fleetsmembers/*`, `azure/scope/managedcontrolplane.go`, `controllers/azuremanagedcontrolplane_controller_test.go`, `main.go`: import `v1api20250301` instead of `v1api20230315preview` for `FleetsMember`
- `config/aso/kustomization.yaml`, `config/aso/crds.yaml`: regenerated via `make generate-aso-crds`

### User upgrade impact

Per the [v2.17.0 release notes](https://github.com/Azure/azure-service-operator/releases/tag/v2.17.0), the `containerservice` `v20230315preview` Fleet CRD versions are removed. Users with existing `FleetsMember` resources stored at the `v1api20230315preview` API version need to migrate them to `v1api20250301` (running [`asoctl clean crds`](https://azure.github.io/azure-service-operator/tools/asoctl/#clean-crds)) before upgrading to a CAPZ release that includes this change.

### Upcoming breaking changes (heads up, not in this PR)

- ASO v2.18 will remove `containerservice` `ManagedCluster`/`AgentPool` API versions `v1api20230201` and `v1api20231001` — CAPZ currently uses `v1api20231001`.
- ASO v2.19 will remove `v1api20240402preview`.

## Which issue(s) this PR fixes:

Fixes #6275

## Special notes for your reviewer:

TODOs:

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] cherry-pick candidate

## Release note:

```release-note
Bump Azure Service Operator from v2.16.1 to v2.17.0
```
