### PR TITLE
Bump Go toolchain to v1.25.10

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module sigs.k8s.io/cluster-api-provider-azure
 
 go 1.25.0
 
-toolchain go1.25.9
+toolchain go1.25.10
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.1

--- a/hack/ensure-go.sh
+++ b/hack/ensure-go.sh
@@ -31,7 +31,7 @@ EOF
   local go_version
   IFS=" " read -ra go_version <<< "$(go version)"
   local minimum_go_version
-  minimum_go_version=go1.25.9
+  minimum_go_version=go1.25.10
   if [[ "${minimum_go_version}" != $(echo -e "${minimum_go_version}\n${go_version[2]}" | sort -s -t. -k 1,1 -k 2,2n -k 3,3n | head -n1) && "${go_version[2]}" != "devel" ]]; then
     cat <<EOF
 Detected go version: ${go_version[*]}.

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -2,7 +2,7 @@ module sigs.k8s.io/cluster-api-provider-azure/hack/tools
 
 go 1.25.0
 
-toolchain go1.25.9
+toolchain go1.25.10
 
 require sigs.k8s.io/cluster-api/hack/tools v0.0.0-20260427114648-16d0a6538ef0
 


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Updates the Go compiler and tools to v1.25.10.

> go1.25.10 (released 2026-05-07) includes security fixes to the `go` command, the `pack` tool, and the `html/template`, `net`, `net/http`, `net/http/httputil`, `net/mail`, and `syscall` packages, as well as bug fixes to the `go` command, the compiler, the linker, the runtime, and the `crypto/fips140`, `go/types`, and `os` packages. See the [Go 1.25.10 milestone](https://github.com/golang/go/issues?q=milestone%3AGo1.25.10+label%3ACherryPickApproved) on our issue tracker for details.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:

This PR will fix several CVEs reported against the previous version of the toolchain.

See #6214 for prior art.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [x] cherry-pick candidate

**Release note**:

```release-note
NONE
```
