### PR TITLE
Register Windows nodes with uninitialized cloud taint

### DIFF
--- a/templates/cluster-template-machinepool-windows.yaml
+++ b/templates/cluster-template-machinepool-windows.yaml
@@ -275,6 +275,7 @@ spec:
       criSocket: npipe:////./pipe/containerd-containerd
       kubeletExtraArgs:
         cloud-provider: external
+        register-with-taints: node.cloudprovider.kubernetes.io/uninitialized=true:NoSchedule
       name: '{{ ds.meta_data["local_hostname"] }}'
   postKubeadmCommands:
   - nssm set kubelet start SERVICE_AUTO_START

--- a/templates/cluster-template-windows-apiserver-ilb.yaml
+++ b/templates/cluster-template-windows-apiserver-ilb.yaml
@@ -299,6 +299,7 @@ spec:
           criSocket: npipe:////./pipe/containerd-containerd
           kubeletExtraArgs:
             cloud-provider: external
+            register-with-taints: node.cloudprovider.kubernetes.io/uninitialized=true:NoSchedule
             v: "2"
             windows-priorityclass: ABOVE_NORMAL_PRIORITY_CLASS
           name: '{{ ds.meta_data["local_hostname"] }}'

--- a/templates/cluster-template-windows.yaml
+++ b/templates/cluster-template-windows.yaml
@@ -283,6 +283,7 @@ spec:
           criSocket: npipe:////./pipe/containerd-containerd
           kubeletExtraArgs:
             cloud-provider: external
+            register-with-taints: node.cloudprovider.kubernetes.io/uninitialized=true:NoSchedule
             v: "2"
             windows-priorityclass: ABOVE_NORMAL_PRIORITY_CLASS
           name: '{{ ds.meta_data["local_hostname"] }}'

--- a/templates/flavors/machinepool-windows/machine-pool-deployment-windows.yaml
+++ b/templates/flavors/machinepool-windows/machine-pool-deployment-windows.yaml
@@ -59,6 +59,7 @@ spec:
       criSocket: npipe:////./pipe/containerd-containerd
       kubeletExtraArgs:
         cloud-provider: external
+        register-with-taints: "node.cloudprovider.kubernetes.io/uninitialized=true:NoSchedule"
   files:
   - contentFrom:
       secret:

--- a/templates/flavors/windows-apiserver-ilb/machine-deployment-windows.yaml
+++ b/templates/flavors/windows-apiserver-ilb/machine-deployment-windows.yaml
@@ -67,6 +67,7 @@ spec:
           criSocket: npipe:////./pipe/containerd-containerd
           kubeletExtraArgs:
             cloud-provider: external
+            register-with-taints: "node.cloudprovider.kubernetes.io/uninitialized=true:NoSchedule"
             v: "2"
             windows-priorityclass: "ABOVE_NORMAL_PRIORITY_CLASS"
       files:

--- a/templates/flavors/windows/machine-deployment-windows.yaml
+++ b/templates/flavors/windows/machine-deployment-windows.yaml
@@ -67,6 +67,7 @@ spec:
           criSocket: npipe:////./pipe/containerd-containerd
           kubeletExtraArgs:
             cloud-provider: external
+            register-with-taints: "node.cloudprovider.kubernetes.io/uninitialized=true:NoSchedule"
             v: "2"
             windows-priorityclass: "ABOVE_NORMAL_PRIORITY_CLASS"
       files:

--- a/templates/test/ci/cluster-template-prow-ci-version-windows.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version-windows.yaml
@@ -601,6 +601,7 @@ spec:
             feature-gates: ${NODE_FEATURE_GATES:-""}
             image-credential-provider-bin-dir: /var/lib/kubelet/credential-provider
             image-credential-provider-config: /var/lib/kubelet/credential-provider-config.yaml
+            register-with-taints: node.cloudprovider.kubernetes.io/uninitialized=true:NoSchedule
             v: "2"
             windows-priorityclass: ABOVE_NORMAL_PRIORITY_CLASS
           name: '{{ ds.meta_data["local_hostname"] }}'

--- a/templates/test/ci/cluster-template-prow-clusterclass-ci-default.yaml
+++ b/templates/test/ci/cluster-template-prow-clusterclass-ci-default.yaml
@@ -539,6 +539,7 @@ spec:
           criSocket: npipe:////./pipe/containerd-containerd
           kubeletExtraArgs:
             cloud-provider: external
+            register-with-taints: node.cloudprovider.kubernetes.io/uninitialized=true:NoSchedule
             v: "2"
             windows-priorityclass: ABOVE_NORMAL_PRIORITY_CLASS
           name: '{{ ds.meta_data["local_hostname"] }}'

--- a/templates/test/ci/cluster-template-prow-machine-pool-ci-version-windows.yaml
+++ b/templates/test/ci/cluster-template-prow-machine-pool-ci-version-windows.yaml
@@ -566,6 +566,7 @@ spec:
         cloud-provider: external
         image-credential-provider-bin-dir: /var/lib/kubelet/credential-provider
         image-credential-provider-config: /var/lib/kubelet/credential-provider-config.yaml
+        register-with-taints: node.cloudprovider.kubernetes.io/uninitialized=true:NoSchedule
       name: '{{ ds.meta_data["local_hostname"] }}'
   postKubeadmCommands:
   - nssm set kubelet start SERVICE_AUTO_START

--- a/templates/test/ci/cluster-template-prow-machine-pool-windows.yaml
+++ b/templates/test/ci/cluster-template-prow-machine-pool-windows.yaml
@@ -295,6 +295,7 @@ spec:
       criSocket: npipe:////./pipe/containerd-containerd
       kubeletExtraArgs:
         cloud-provider: external
+        register-with-taints: node.cloudprovider.kubernetes.io/uninitialized=true:NoSchedule
       name: '{{ ds.meta_data["local_hostname"] }}'
   postKubeadmCommands:
   - nssm set kubelet start SERVICE_AUTO_START

--- a/templates/test/ci/cluster-template-prow-windows.yaml
+++ b/templates/test/ci/cluster-template-prow-windows.yaml
@@ -334,6 +334,7 @@ spec:
           kubeletExtraArgs:
             cloud-provider: external
             feature-gates: ${NODE_FEATURE_GATES:-""}
+            register-with-taints: node.cloudprovider.kubernetes.io/uninitialized=true:NoSchedule
             v: "2"
             windows-priorityclass: ABOVE_NORMAL_PRIORITY_CLASS
           name: '{{ ds.meta_data["local_hostname"] }}'

--- a/templates/test/ci/prow-clusterclass-ci-default/windows.yaml
+++ b/templates/test/ci/prow-clusterclass-ci-default/windows.yaml
@@ -28,6 +28,7 @@ spec:
           criSocket: npipe:////./pipe/containerd-containerd
           kubeletExtraArgs:
             cloud-provider: external
+            register-with-taints: "node.cloudprovider.kubernetes.io/uninitialized=true:NoSchedule"
             v: "2"
             windows-priorityclass: "ABOVE_NORMAL_PRIORITY_CLASS"
       files:

--- a/templates/test/dev/cluster-template-custom-builds-machine-pool-windows.yaml
+++ b/templates/test/dev/cluster-template-custom-builds-machine-pool-windows.yaml
@@ -516,6 +516,7 @@ spec:
         cloud-provider: external
         image-credential-provider-bin-dir: /var/lib/kubelet/credential-provider
         image-credential-provider-config: /var/lib/kubelet/credential-provider-config.yaml
+        register-with-taints: node.cloudprovider.kubernetes.io/uninitialized=true:NoSchedule
       name: '{{ ds.meta_data["local_hostname"] }}'
   postKubeadmCommands:
   - nssm set kubelet start SERVICE_AUTO_START

--- a/templates/test/dev/cluster-template-custom-builds-windows.yaml
+++ b/templates/test/dev/cluster-template-custom-builds-windows.yaml
@@ -604,6 +604,7 @@ spec:
             feature-gates: ${NODE_FEATURE_GATES:-""}
             image-credential-provider-bin-dir: /var/lib/kubelet/credential-provider
             image-credential-provider-config: /var/lib/kubelet/credential-provider-config.yaml
+            register-with-taints: node.cloudprovider.kubernetes.io/uninitialized=true:NoSchedule
             v: "2"
             windows-priorityclass: ABOVE_NORMAL_PRIORITY_CLASS
           name: '{{ ds.meta_data["local_hostname"] }}'


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Adds `register-with-taints: node.cloudprovider.kubernetes.io/uninitialized=true:NoSchedule` to the Windows worker `kubeletExtraArgs` in every CAPZ cluster template (and flavor source) that has `cloud-provider: external` for Windows.

**Why**

The `cloud-provider-azure-ccm-windows-capz` prow job has been failing because Windows nodes register without the `node.cloudprovider.kubernetes.io/uninitialized` taint. Without that taint, the `cloud-node-manager` daemonset on the workload cluster logs `Node has no cloud taint, skipping initialization`, the `providerID` never gets set on the Node, and `MachineDeployment` readiness never converges.

Linux nodes in the same run get the taint applied (the Linux CNM log shows `Initializing node with cloud provider -> Successfully initialized node with cloud provider`), so something about how `cloud-provider: external` gets translated through `kubeadm join` → `KubeletConfiguration` strategic-merge patch → Windows kubelet 1.37-alpha is no longer producing the taint on Windows. The root cause is somewhere in the kubeadm/kubelet/Windows stack, and there's an upstream issue to file with the per-node `kubeadm-flags.env` and `config.yaml`.

In the meantime, explicitly registering the taint via `kubeletExtraArgs.register-with-taints` makes the behavior independent of any cloud-provider flag translation. The cloud-node-manager will clear the taint after initializing the node, and the rest of the flow proceeds as before. Linux is unaffected (it already gets the same taint via its own path; this just makes it explicit on Windows).

**Which issue(s) this PR fixes**:
Refs the failing job: https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/cloud-provider-azure-ccm-windows-capz/2053505513055850496

See also kubernetes-sigs/image-builder#2009

**Special notes for your reviewer**:

- Edited only the four Windows flavor sources (`templates/flavors/windows/`, `templates/flavors/windows-apiserver-ilb/`, `templates/flavors/machinepool-windows/`, `templates/test/ci/prow-clusterclass-ci-default/`) and ran `make generate-flavors`; the rest of the diff is regenerated output.
- No Linux templates are touched.
- Workaround, not a root-cause fix. Tracking the upstream behavior change separately.

**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [x] cherry-pick candidate

**Release note**:

```release-note
Register Windows nodes with uninitialized cloud taint
```
