### PR TITLE
fix: propagate SERVICE_ACCOUNT_ISSUER to workload cluster template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,4 @@ azure_identity_id
 azure_wi_back_compat
 openid-configuration.json
 aks-mgmt.config
+.service-account-issuer.env

--- a/Makefile
+++ b/Makefile
@@ -415,7 +415,13 @@ create-management-cluster: $(KUSTOMIZE) $(ENVSUBST) $(KUBECTL) $(KIND) ## Create
 .PHONY: create-workload-cluster
 create-workload-cluster: $(ENVSUBST) $(KUBECTL) ## Create a workload cluster.
 	# Create workload Cluster.
-	@if [ -z "${AZURE_CLIENT_ID_USER_ASSIGNED_IDENTITY}" ]; then \
+	# Source SERVICE_ACCOUNT_ISSUER from kind-with-registry.sh if available,
+	# so the workload cluster template gets the correct OIDC issuer URL.
+	@if [ -f "$(ROOT_DIR)/.service-account-issuer.env" ]; then \
+		. "$(ROOT_DIR)/.service-account-issuer.env"; \
+		export SERVICE_ACCOUNT_ISSUER; \
+	fi; \
+	if [ -z "${AZURE_CLIENT_ID_USER_ASSIGNED_IDENTITY}" ]; then \
 		export AZURE_CLIENT_ID_USER_ASSIGNED_IDENTITY=$(shell cat $(AZURE_IDENTITY_ID_FILEPATH)); \
 	fi; \
 	if [ -f "$(TEMPLATES_DIR)/$(CLUSTER_TEMPLATE)" ]; then \

--- a/scripts/kind-with-registry.sh
+++ b/scripts/kind-with-registry.sh
@@ -202,6 +202,13 @@ EOF
       --audiences "api://AzureADTokenExchange" \
       --subject "system:serviceaccount:capz-system:azureserviceoperator-default" --output none --only-show-errors
   fi
+
+  # Persist SERVICE_ACCOUNT_ISSUER so that downstream make targets
+  # (e.g., create-workload-cluster) running in separate shell contexts
+  # can pick it up via the .service-account-issuer.env file.
+  if [ -n "${SERVICE_ACCOUNT_ISSUER}" ]; then
+    echo "SERVICE_ACCOUNT_ISSUER=${SERVICE_ACCOUNT_ISSUER}" > "${REPO_ROOT}/.service-account-issuer.env"
+  fi
 }
 
 function upload_to_blob() {


### PR DESCRIPTION
## What this PR does

`kind-with-registry.sh` creates an OIDC storage account and exports `SERVICE_ACCOUNT_ISSUER`, but this value is lost when `create-workload-cluster` runs `envsubst` in a separate Make recipe (each recipe line runs in its own shell).

The workload cluster template (#6288) has:
```yaml
service-account-issuer: ${SERVICE_ACCOUNT_ISSUER:-https://kubernetes.default.svc.cluster.local}
```

Without propagation, the fallback `https://kubernetes.default.svc.cluster.local` is used. AAD cannot reach this URL for OIDC discovery, breaking Workload Identity on CAPZ workload clusters.

## How it works

1. **`kind-with-registry.sh`**: After resolving `SERVICE_ACCOUNT_ISSUER` (either BYO or auto-created), persist it to `${REPO_ROOT}/.service-account-issuer.env`
2. **`Makefile` (`create-workload-cluster`)**: Source the `.env` file before running `envsubst` on the cluster template

## Why this is needed

Downstream CSI driver E2E tests (e.g., blob-csi-driver) that test Workload Identity on CAPZ workload clusters fail because AAD returns `AADSTS501661` — it cannot perform OIDC discovery against the cluster-internal `kubernetes.default.svc.cluster.local` URL.

Related: #6288


**Release note**:
```
none
```
