### PR TITLE
fix: propagate SERVICE_ACCOUNT_ISSUER to workload cluster template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,4 @@ azure_identity_id
 azure_wi_back_compat
 openid-configuration.json
 aks-mgmt.config
+.service-account-issuer.env

--- a/Makefile
+++ b/Makefile
@@ -407,7 +407,13 @@ create-management-cluster: $(KUSTOMIZE) $(ENVSUBST) $(KUBECTL) $(KIND) ## Create
 .PHONY: create-workload-cluster
 create-workload-cluster: $(ENVSUBST) $(KUBECTL) ## Create a workload cluster.
 	# Create workload Cluster.
-	@if [ -z "${AZURE_CLIENT_ID_USER_ASSIGNED_IDENTITY}" ]; then \
+	# Source SERVICE_ACCOUNT_ISSUER from kind-with-registry.sh if available,
+	# so the workload cluster template gets the correct OIDC issuer URL.
+	@if [ -f "$(ROOT_DIR)/.service-account-issuer.env" ]; then \
+		. "$(ROOT_DIR)/.service-account-issuer.env"; \
+		export SERVICE_ACCOUNT_ISSUER; \
+	fi; \
+	if [ -z "${AZURE_CLIENT_ID_USER_ASSIGNED_IDENTITY}" ]; then \
 		export AZURE_CLIENT_ID_USER_ASSIGNED_IDENTITY=$(shell cat $(AZURE_IDENTITY_ID_FILEPATH)); \
 	fi; \
 	if [ -f "$(TEMPLATES_DIR)/$(CLUSTER_TEMPLATE)" ]; then \

--- a/scripts/kind-with-registry.sh
+++ b/scripts/kind-with-registry.sh
@@ -202,6 +202,13 @@ EOF
       --audiences "api://AzureADTokenExchange" \
       --subject "system:serviceaccount:capz-system:azureserviceoperator-default" --output none --only-show-errors
   fi
+
+  # Persist SERVICE_ACCOUNT_ISSUER so that downstream make targets
+  # (e.g., create-workload-cluster) running in separate shell contexts
+  # can pick it up via the .service-account-issuer.env file.
+  if [ -n "${SERVICE_ACCOUNT_ISSUER}" ]; then
+    echo "SERVICE_ACCOUNT_ISSUER=${SERVICE_ACCOUNT_ISSUER}" > "${REPO_ROOT}/.service-account-issuer.env"
+  fi
 }
 
 function upload_to_blob() {


### PR DESCRIPTION
## What this PR does

`kind-with-registry.sh` creates an OIDC storage account and exports `SERVICE_ACCOUNT_ISSUER`, but this value is lost when `create-workload-cluster` runs `envsubst` in a separate Make recipe (each recipe line runs in its own shell).

The workload cluster template (#6288) has:
```yaml
service-account-issuer: ${SERVICE_ACCOUNT_ISSUER:-https://kubernetes.default.svc.cluster.local}
```

Without propagation, the fallback `https://kubernetes.default.svc.cluster.local` is used — which is not publicly accessible, causing AAD Workload Identity token validation to fail with `AADSTS501661`.

### Changes

1. **`scripts/kind-with-registry.sh`**: Persist `SERVICE_ACCOUNT_ISSUER` to `${REPO_ROOT}/.service-account-issuer.env` after OIDC setup
2. **`Makefile`**: Source `.service-account-issuer.env` in `create-workload-cluster` target before running `envsubst`
3. **`.gitignore`**: Add `.service-account-issuer.env` (contains environment-specific values)

### Related
- Cherry-pick of #6302 (release-1.23) to main
- Fixes Workload Identity E2E test failures in downstream CSI driver repos (e.g., blob-csi-driver #2445)

**Release note**:
```
none
```