### PR TITLE
[release-1.24] Bump CAPI to v1.13.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ export GOTOOLCHAIN
 export GO111MODULE=on
 
 # Kubebuilder.
-export KUBEBUILDER_ENVTEST_KUBERNETES_VERSION ?= 1.35.0
+export KUBEBUILDER_ENVTEST_KUBERNETES_VERSION ?= 1.36.0
 export KUBEBUILDER_CONTROLPLANE_START_TIMEOUT ?= 60s
 export KUBEBUILDER_CONTROLPLANE_STOP_TIMEOUT ?= 60s
 
@@ -94,7 +94,7 @@ GOLANGCI_LINT_KAL_BIN := golangci-lint-kube-api-linter
 GOLANGCI_LINT_KAL := $(TOOLS_BIN_DIR)/$(GOLANGCI_LINT_KAL_BIN)
 
 GOVULNCHECK_BIN := govulncheck
-GOVULNCHECK_VER := v1.1.4
+GOVULNCHECK_VER := v1.3.0
 GOVULNCHECK := $(abspath $(TOOLS_BIN_DIR)/$(GOVULNCHECK_BIN)-$(GOVULNCHECK_VER))
 GOVULNCHECK_PKG := golang.org/x/vuln/cmd/govulncheck
 
@@ -323,12 +323,7 @@ verify-codespell: codespell ## Verify codespell.
 
 .PHONY: verify-govulncheck
 verify-govulncheck: $(GOVULNCHECK) ## Verify code for vulnerabilities
-	$(GOVULNCHECK) ./... && R1=$$? || R1=$$?; \
-	$(GOVULNCHECK) -C "$(TOOLS_DIR)" ./... && R2=$$? || R2=$$?; \
-	$(GOVULNCHECK) -C "$(TEST_DIR)" ./... && R3=$$? || R3=$$?; \
-	if [ "$$R1" -ne "0" ] || [ "$$R2" -ne "0" ] || [ "$$R3" -ne "0" ]; then \
-		exit 1; \
-	fi
+	$(GOVULNCHECK) -tags=e2e ./...
 
 .PHONY: verify-security
 verify-security: ## Verify code and images for vulnerabilities
@@ -365,7 +360,7 @@ create-management-cluster: $(KUSTOMIZE) $(ENVSUBST) $(KUBECTL) $(KIND) ## Create
 	./hack/create-custom-cloud-provider-config.sh
 
 	# Deploy CAPI
-	timeout --foreground 300 bash -c "until curl --retry $(CURL_RETRIES) -sSL https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.13.1/cluster-api-components.yaml | $(ENVSUBST) | $(KUBECTL) apply -f - --server-side=true; do sleep 5; done"
+	timeout --foreground 300 bash -c "until curl --retry $(CURL_RETRIES) -sSL https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.13.2/cluster-api-components.yaml | $(ENVSUBST) | $(KUBECTL) apply -f - --server-side=true; do sleep 5; done"
 
 	# Deploy CAAPH
 	timeout --foreground 300 bash -c "until curl --retry $(CURL_RETRIES) -sSL https://github.com/kubernetes-sigs/cluster-api-addon-provider-helm/releases/download/v0.6.2/addon-components.yaml | $(ENVSUBST) | $(KUBECTL) apply -f - --server-side=true; do sleep 5; done"

--- a/Tiltfile
+++ b/Tiltfile
@@ -22,7 +22,7 @@ settings = {
     "deploy_cert_manager": True,
     "preload_images_for_kind": True,
     "kind_cluster_name": "capz",
-    "capi_version": "v1.13.1",
+    "capi_version": "v1.13.2",
     "caaph_version": "v0.6.2",
     "cert_manager_version": "v1.20.2",
     "kubernetes_version": "v1.35.4",

--- a/docs/book/src/developers/getting-started-with-capi-operator.md
+++ b/docs/book/src/developers/getting-started-with-capi-operator.md
@@ -120,7 +120,7 @@ helm install cert-manager jetstack/cert-manager --namespace cert-manager --creat
 Create a `values.yaml` file for the CAPI Operator Helm chart like so:
 
 ```yaml
-core: "cluster-api:v1.13.1"
+core: "cluster-api:v1.13.2"
 infrastructure: "azure:v1.17.2"
 addon: "helm:v0.6.2"
 manager:

--- a/go.mod
+++ b/go.mod
@@ -56,8 +56,8 @@ require (
 	k8s.io/kubectl v0.34.2
 	k8s.io/utils v0.0.0-20251002143259-bc988d571ff4
 	sigs.k8s.io/cloud-provider-azure v1.34.3
-	sigs.k8s.io/cluster-api v1.13.1
-	sigs.k8s.io/cluster-api/test v1.13.1
+	sigs.k8s.io/cluster-api v1.13.2
+	sigs.k8s.io/cluster-api/test v1.13.2
 	sigs.k8s.io/controller-runtime v0.23.3
 	sigs.k8s.io/kind v0.31.0
 )

--- a/go.sum
+++ b/go.sum
@@ -149,8 +149,8 @@ github.com/containerd/errdefs/pkg v0.3.0 h1:9IKJ06FvyNlexW690DXuQNx2KA2cUJXx151X
 github.com/containerd/errdefs/pkg v0.3.0/go.mod h1:NJw6s9HwNuRhnjJhM7pylWwMyAkmCQvQ4GpJHEqRLVk=
 github.com/coredns/caddy v1.1.1 h1:2eYKZT7i6yxIfGP3qLJoJ7HAsDJqYB+X68g4NYjSrE0=
 github.com/coredns/caddy v1.1.1/go.mod h1:A6ntJQlAWuQfFlsd9hvigKbo2WS0VUs2l1e2F+BawD4=
-github.com/coredns/corefile-migration v1.0.31 h1:f7WGhY8M2Jn8P2dVO0p7wSQ1QKsMARl6WEyUjCb/V38=
-github.com/coredns/corefile-migration v1.0.31/go.mod h1:56DPqONc3njpVPsdilEnfijCwNGC3/kTJLl7i7SPavY=
+github.com/coredns/corefile-migration v1.0.32 h1:tlbtXBpt7UzmedEoMqnfqOTnGCvzYfJ/Rrfqf+/W+TY=
+github.com/coredns/corefile-migration v1.0.32/go.mod h1:56DPqONc3njpVPsdilEnfijCwNGC3/kTJLl7i7SPavY=
 github.com/coreos/go-semver v0.3.1 h1:yi21YpKnrx1gt5R+la8n5WgS0kCrsPp33dmEyHReZr4=
 github.com/coreos/go-semver v0.3.1/go.mod h1:irMmmIw/7yzSRPWryHsK7EYSg09caPQL03VsM8rvUec=
 github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf h1:iW4rZ826su+pqaw19uhpSCzhj44qo35pNgKFGqzDKkU=
@@ -608,10 +608,10 @@ sigs.k8s.io/cloud-provider-azure/pkg/azclient v0.9.2 h1:7vEaYwdsvOz1OBAtEm6vyc4K
 sigs.k8s.io/cloud-provider-azure/pkg/azclient v0.9.2/go.mod h1:BgPOvGEdPTyaIWREF7pywm6teBhO3fNVQ+CTPYyr/5w=
 sigs.k8s.io/cloud-provider-azure/pkg/azclient/configloader v0.8.4 h1:Sy+dyfxemdQaz/UfJYWzALlbLdEaZ7IoKn93JXTqWYs=
 sigs.k8s.io/cloud-provider-azure/pkg/azclient/configloader v0.8.4/go.mod h1:RgIi9n/PhULbvPjYZGsjP2zWJf1ZEd1qyA0CYUuSgcE=
-sigs.k8s.io/cluster-api v1.13.1 h1:5qksGznSU1fJOXIxsI4EayTqG1Q9S0qJNp3HdsVm1KU=
-sigs.k8s.io/cluster-api v1.13.1/go.mod h1:Hqq5yucu3OwPiAjNEh/O/zZX4dF63MD8Q6I0cwL/bUU=
-sigs.k8s.io/cluster-api/test v1.13.1 h1:NimY83SFiO24J3GhF2Fw+iUcKzRPUY2Ev0wRPbogl2k=
-sigs.k8s.io/cluster-api/test v1.13.1/go.mod h1:3FL7oJBT6ThT63TcbTigSNNXCXK/2CJ5b8ODbaVs3nk=
+sigs.k8s.io/cluster-api v1.13.2 h1:NVdbVLmh6IyfdtENQAi80AijJf/FjfQLODz/6caDjlc=
+sigs.k8s.io/cluster-api v1.13.2/go.mod h1:h7cyiUh+N7sIBkSerqU8cDkYMtRlXVO1c5RoJE1p5+g=
+sigs.k8s.io/cluster-api/test v1.13.2 h1:DIcgMPIMyQyHjZWtEx5YlzHPktuU/wRlCU+0gK32RJk=
+sigs.k8s.io/cluster-api/test v1.13.2/go.mod h1:3FL7oJBT6ThT63TcbTigSNNXCXK/2CJ5b8ODbaVs3nk=
 sigs.k8s.io/controller-runtime v0.23.3 h1:VjB/vhoPoA9l1kEKZHBMnQF33tdCLQKJtydy4iqwZ80=
 sigs.k8s.io/controller-runtime v0.23.3/go.mod h1:B6COOxKptp+YaUT5q4l6LqUJTRpizbgf9KSRNdQGns0=
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 h1:IpInykpT6ceI+QxKBbEflcR5EXP7sU1kvOlxwZh5txg=

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 toolchain go1.25.10
 
-require sigs.k8s.io/cluster-api/hack/tools v0.0.0-20260427114648-16d0a6538ef0
+require sigs.k8s.io/cluster-api/hack/tools v0.0.0-20260513122147-ebd807c66351
 
 require (
 	github.com/fxamacker/cbor/v2 v2.9.0 // indirect

--- a/hack/tools/go.sum
+++ b/hack/tools/go.sum
@@ -82,8 +82,8 @@ k8s.io/kube-openapi v0.0.0-20250910181357-589584f1c912 h1:Y3gxNAuB0OBLImH611+UDZ
 k8s.io/kube-openapi v0.0.0-20250910181357-589584f1c912/go.mod h1:kdmbQkyfwUagLfXIad1y2TdrjPFWp2Q89B3qkRwf/pQ=
 k8s.io/utils v0.0.0-20251002143259-bc988d571ff4 h1:SjGebBtkBqHFOli+05xYbK8YF1Dzkbzn+gDM4X9T4Ck=
 k8s.io/utils v0.0.0-20251002143259-bc988d571ff4/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
-sigs.k8s.io/cluster-api/hack/tools v0.0.0-20260427114648-16d0a6538ef0 h1:UWW+2n7ef4Cmnk+U5XwfY/fLT9Admg9wA3NZpMwQ/HY=
-sigs.k8s.io/cluster-api/hack/tools v0.0.0-20260427114648-16d0a6538ef0/go.mod h1:zIKgABMegdCknbQ3HnEuOS74syLC3C5nIrc1HFtrv38=
+sigs.k8s.io/cluster-api/hack/tools v0.0.0-20260513122147-ebd807c66351 h1:CUWGjEUMJKWUD8yxPktMSTuRv3DEr9AzRefkogo4ooA=
+sigs.k8s.io/cluster-api/hack/tools v0.0.0-20260513122147-ebd807c66351/go.mod h1:zIKgABMegdCknbQ3HnEuOS74syLC3C5nIrc1HFtrv38=
 sigs.k8s.io/controller-tools v0.20.1 h1:gkfMt9YodI0K85oT8rVi80NTXO/kDmabKR5Ajn5GYxs=
 sigs.k8s.io/controller-tools v0.20.1/go.mod h1:b4qPmjGU3iZwqn34alUU5tILhNa9+VXK+J3QV0fT/uU=
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 h1:IpInykpT6ceI+QxKBbEflcR5EXP7sU1kvOlxwZh5txg=

--- a/test/e2e/config/azure-dev.yaml
+++ b/test/e2e/config/azure-dev.yaml
@@ -3,17 +3,17 @@ managementClusterName: capz-e2e
 images:
   - name: ${MANAGER_IMAGE}
     loadBehavior: mustLoad
-  - name: registry.k8s.io/cluster-api/cluster-api-controller:v1.12.7
+  - name: registry.k8s.io/cluster-api/cluster-api-controller:v1.12.8
     loadBehavior: tryLoad
-  - name: registry.k8s.io/cluster-api/cluster-api-controller:v1.13.1
+  - name: registry.k8s.io/cluster-api/cluster-api-controller:v1.13.2
     loadBehavior: tryLoad
-  - name: registry.k8s.io/cluster-api/kubeadm-bootstrap-controller:v1.12.7
+  - name: registry.k8s.io/cluster-api/kubeadm-bootstrap-controller:v1.12.8
     loadBehavior: tryLoad
-  - name: registry.k8s.io/cluster-api/kubeadm-bootstrap-controller:v1.13.1
+  - name: registry.k8s.io/cluster-api/kubeadm-bootstrap-controller:v1.13.2
     loadBehavior: tryLoad
-  - name: registry.k8s.io/cluster-api/kubeadm-control-plane-controller:v1.12.7
+  - name: registry.k8s.io/cluster-api/kubeadm-control-plane-controller:v1.12.8
     loadBehavior: tryLoad
-  - name: registry.k8s.io/cluster-api/kubeadm-control-plane-controller:v1.13.1
+  - name: registry.k8s.io/cluster-api/kubeadm-control-plane-controller:v1.13.2
     loadBehavior: tryLoad
   - name: registry.k8s.io/cluster-api-helm/cluster-api-helm-controller:v0.6.2
     loadBehavior: tryLoad
@@ -22,8 +22,8 @@ providers:
   - name: cluster-api
     type: CoreProvider
     versions:
-    - name: v1.11.7 # latest patch of earliest minor in supported v1beta1 releases; this is used for v1beta1 old --> v1beta1 latest clusterctl upgrades test only.
-      value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.11.7/core-components.yaml"
+    - name: v1.11.11 # latest patch of earliest minor in supported v1beta1 releases; this is used for v1beta1 old --> v1beta1 latest clusterctl upgrades test only.
+      value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.11.11/core-components.yaml"
       type: "url"
       contract: v1beta1
       replacements:
@@ -31,8 +31,8 @@ providers:
           new: --metrics-addr=:8080
       files:
         - sourcePath: "../data/shared/v1beta1/metadata.yaml"
-    - name: v1.12.7
-      value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.12.7/core-components.yaml
+    - name: v1.12.8
+      value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.12.8/core-components.yaml
       type: url
       contract: v1beta2
       files:
@@ -42,8 +42,8 @@ providers:
         new: "imagePullPolicy: IfNotPresent"
       - old: "- --leader-elect"
         new: "- --leader-elect\n        - --remote-connection-grace-period=3m"
-    - name: v1.13.1
-      value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.13.1/core-components.yaml
+    - name: v1.13.2
+      value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.13.2/core-components.yaml
       type: url
       contract: v1beta2
       files:
@@ -57,8 +57,8 @@ providers:
   - name: kubeadm
     type: BootstrapProvider
     versions:
-    - name: v1.11.7 # latest patch of earliest minor in supported v1beta1 releases; this is used for v1beta1 old --> v1beta1 latest clusterctl upgrades test only.
-      value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.11.7/bootstrap-components.yaml"
+    - name: v1.11.11 # latest patch of earliest minor in supported v1beta1 releases; this is used for v1beta1 old --> v1beta1 latest clusterctl upgrades test only.
+      value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.11.11/bootstrap-components.yaml"
       type: "url"
       contract: v1beta1
       replacements:
@@ -66,8 +66,8 @@ providers:
           new: --metrics-addr=:8080
       files:
         - sourcePath: "../data/shared/v1beta1/metadata.yaml"
-    - name: v1.12.7
-      value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.12.7/bootstrap-components.yaml
+    - name: v1.12.8
+      value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.12.8/bootstrap-components.yaml
       type: url
       contract: v1beta2
       files:
@@ -75,8 +75,8 @@ providers:
       replacements:
       - old: "imagePullPolicy: Always"
         new: "imagePullPolicy: IfNotPresent"
-    - name: v1.13.1
-      value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.13.1/bootstrap-components.yaml
+    - name: v1.13.2
+      value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.13.2/bootstrap-components.yaml
       type: url
       contract: v1beta2
       files:
@@ -88,8 +88,8 @@ providers:
   - name: kubeadm
     type: ControlPlaneProvider
     versions:
-    - name: v1.11.7 # latest patch of earliest minor in supported v1beta1 releases; this is used for v1beta1 old --> v1beta1 latest clusterctl upgrades test only.
-      value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.11.7/control-plane-components.yaml"
+    - name: v1.11.11 # latest patch of earliest minor in supported v1beta1 releases; this is used for v1beta1 old --> v1beta1 latest clusterctl upgrades test only.
+      value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.11.11/control-plane-components.yaml"
       type: "url"
       contract: v1beta1
       replacements:
@@ -97,8 +97,8 @@ providers:
           new: --metrics-addr=:8080
       files:
         - sourcePath: "../data/shared/v1beta1/metadata.yaml"
-    - name: v1.12.7
-      value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.12.7/control-plane-components.yaml
+    - name: v1.12.8
+      value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.12.8/control-plane-components.yaml
       type: url
       contract: v1beta2
       files:
@@ -106,8 +106,8 @@ providers:
       replacements:
       - old: "imagePullPolicy: Always"
         new: "imagePullPolicy: IfNotPresent"
-    - name: v1.13.1
-      value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.13.1/control-plane-components.yaml
+    - name: v1.13.2
+      value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.13.2/control-plane-components.yaml
       type: url
       contract: v1beta2
       files:
@@ -295,8 +295,8 @@ variables:
   KUBETEST_CONFIGURATION: "./data/kubetest/conformance.yaml"
   WINDOWS_CONTAINERD_URL: "${WINDOWS_CONTAINERD_URL:-}"
   AZURE_CNI_V1_MANIFEST_PATH: "${PWD}/templates/addons/azure-cni-v1.yaml"
-  OLD_CAPI_UPGRADE_VERSION: "v1.11.7"
-  LATEST_CAPI_UPGRADE_VERSION: "v1.12.7"
+  OLD_CAPI_UPGRADE_VERSION: "v1.11.11"
+  LATEST_CAPI_UPGRADE_VERSION: "v1.12.8"
   OLD_PROVIDER_UPGRADE_VERSION: "v1.22.2"
   LATEST_PROVIDER_UPGRADE_VERSION: "v1.23.0"
   OLD_CAAPH_UPGRADE_VERSION: "v0.5.3"


### PR DESCRIPTION
Manual cherry-pick of #6309 to `release-1.24` after the cherrypick-robot's attempt failed.

Conflict resolution: in `test/e2e/config/azure-dev.yaml` took the CAPI patch bumps (`v1.11.7` → `v1.11.11`, `v1.12.7` → `v1.12.8`) but kept the existing `release-1.24` provider-upgrade pins (`OLD_PROVIDER_UPGRADE_VERSION: v1.22.2`, `LATEST_PROVIDER_UPGRADE_VERSION: v1.23.0`). The provider bumps on `main` (`v1.23.1` / `v1.24.0`) don't belong on this branch — it's already v1.24.x and its upgrade tests still target older releases.

```release-note
Bump CAPI to v1.13.2
```
