### PR TITLE
test/e2e: make collectPodLogs log dump best-effort

### DIFF
--- a/test/e2e/azure_clusterproxy.go
+++ b/test/e2e/azure_clusterproxy.go
@@ -109,7 +109,14 @@ func (acp *AzureClusterProxy) collectPodLogs(ctx context.Context, namespace stri
 	workload := acp.GetWorkloadCluster(ctx, namespace, name)
 	pods := &corev1.PodList{}
 
-	Expect(workload.GetClient().List(ctx, pods)).To(Succeed())
+	// Failing to collect pod logs should not cause the test to fail. The workload cluster
+	// API server may be unreachable during teardown (for example due to a transient Azure
+	// load balancer / DNS issue), and we should not turn an otherwise-successful spec into
+	// a failure during [AfterEach] log collection.
+	if err := workload.GetClient().List(ctx, pods); err != nil {
+		Logf("Failed to list pods for workload cluster %s/%s: %v", namespace, name, err)
+		return
+	}
 
 	var err error
 	var podDescribe string


### PR DESCRIPTION
**What type of PR is this?**

/kind flake

**What this PR does / why we need it**:

Mirrors the fix from #6265 (commit 4a8e9f11d) for the sibling `collectPodLogs` helper. `collectPodLogs` runs from `[AfterEach]` to dump pod descriptions and container logs for the workload cluster, and currently uses `Expect(...).To(Succeed())` when listing pods. That turns any transient unreachability of the workload cluster API server into a hard spec failure during teardown.

After #6265, `collectNodes` returns gracefully on i/o timeout, but `collectPodLogs` is the very next call in the `AfterEach` log-collection path and hits the same transient `*.cloudapp.azure.com:6443: i/o timeout` against the same load balancer. The result is that otherwise-successful runs of the `apiversion-upgrade-v1beta1` job fail in `[AfterEach]` at `test/e2e/azure_clusterproxy.go:112`.

Recent example: 5 of 6 consecutive failures on the cherry-pick PR #6314 show `STEP: PASSED!` followed by `[FAILED] in [AfterEach] - .../azure_clusterproxy.go:112`, with the same i/o timeout signature against the management cluster LB in canadacentral.

Match the pattern already used a few lines below for streaming container logs (and now used in `collectNodes`): log the error and continue instead of failing the spec.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

This should be cherry-picked to release-1.24 so it can unblock #6314.

/cherry-pick release-1.24

**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [x] cherry-pick candidate

**Release note**:
```release-note
test/e2e: make collectPodLogs log dump best-effort
```
