### PR TITLE
🌱 harden git workflows

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -47,6 +47,8 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/cover.yaml
+++ b/.github/workflows/cover.yaml
@@ -18,6 +18,8 @@ jobs:
       with:
         egress-policy: audit
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
     - name: Get Go version
       id: vars
       run: echo "go_version=$(make go-version)" >> $GITHUB_OUTPUT

--- a/.github/workflows/lint-docs.yaml
+++ b/.github/workflows/lint-docs.yaml
@@ -21,6 +21,8 @@ jobs:
         egress-policy: audit
 
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
     - uses: tcort/github-action-markdown-link-check@e7c7a18363c842693fadde5d41a3bd3573a7a225 # v1.1.2
       with:
         use-quiet-mode: 'yes'

--- a/.github/workflows/pr-golangci-lint.yaml
+++ b/.github/workflows/pr-golangci-lint.yaml
@@ -19,7 +19,8 @@ jobs:
           - test
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # tag=v6.0.2
-
+        with:
+          persist-credentials: false
       - name: Get Go version
         id: vars
         run: echo "go_version=$(make go-version)" >> $GITHUB_OUTPUT

--- a/.github/workflows/weekly-security-scan.yaml
+++ b/.github/workflows/weekly-security-scan.yaml
@@ -22,6 +22,7 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # tag=v6.0.2
       with:
         ref: ${{ matrix.branch }}
+        persist-credentials: false
     - name: Get Go version
       id: vars
       run: echo "go_version=$(make go-version)" >> $GITHUB_OUTPUT


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

This PR hardens GitHub Actions workflows by aligning them with current GitHub Actions security best practices and similar hardening changes already applied across other Cluster API providers.

The changes include:

* Adding `persist-credentials: false` to `actions/checkout` steps where repository write access is not required.
* Ensuring workflows follow the principle of least privilege.

These changes reduce the risk of credential misuse from workflow execution while preserving existing CI/CD functionality.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>` format)*:

Fixes #

**Special notes for your reviewer**:

This PR mirrors workflow hardening changes previously adopted in Cluster API Provider AWS and applies the same security posture to CAPZ workflows.

No functional changes to Cluster API Provider Azure components are expected. The changes are limited to GitHub Actions workflow configuration and credential handling.

**TODOs**:

* [x] squashed commits
* [ ] includes documentation
* [ ] adds unit tests
* [ ] cherry-pick candidate

**Release note**:

```release-note
Harden GitHub Actions workflows by disabling persisted checkout credentials and reducing unnecessary workflow permissions.
```
