### PR TITLE
deps: bump golang.org/x/net from 0.53.0 to 0.55.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -195,7 +195,7 @@ require (
 	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
-	golang.org/x/net v0.54.0 // indirect
+	golang.org/x/net v0.55.0 // indirect
 	golang.org/x/oauth2 v0.35.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.45.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -522,8 +522,8 @@ golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
-golang.org/x/net v0.54.0 h1:2zJIZAxAHV/OHCDTCOHAYehQzLfSXuf/5SoL/Dv6w/w=
-golang.org/x/net v0.54.0/go.mod h1:Sj4oj8jK6XmHpBZU/zWHw3BV3abl4Kvi+Ut7cQcY+cQ=
+golang.org/x/net v0.55.0 h1:bcvxaJn3e1U6InsFWt1JUq1aSjnRxLzT2rtD2KfkDF8=
+golang.org/x/net v0.55.0/go.mod h1:L5U2KuzuOe1lY7Z+aWVIKK6qEeJXnXV9yzGA+WCHJww=
 golang.org/x/oauth2 v0.35.0 h1:Mv2mzuHuZuY2+bkyWXIHMfhNdJAdwW3FuWeCPYN5GVQ=
 golang.org/x/oauth2 v0.35.0/go.mod h1:lzm5WQJQwKZ3nwavOZ3IS5Aulzxi68dUSgRHujetwEA=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=


### PR DESCRIPTION
## Summary
- Bumps `golang.org/x/net` from v0.53.0 to v0.55.0
- Fixes 7 vulnerabilities:
  - **GO-2026-5025** (CVE-2026-42506): XSS — Parse-then-Render produces unexpected HTML tree
  - **GO-2026-5027** (CVE-2026-42502): XSS — Parse-then-Render variant
  - **GO-2026-5028** (CVE-2026-25680): CPU exhaustion via crafted HTML (DoS)
  - **GO-2026-5029** (CVE-2026-25681): XSS — Parse-then-Render variant
  - **GO-2026-5030** (CVE-2026-27136): XSS — Parse-then-Render variant
  - **GO-2026-5026** (CVE-2026-39821): Punycode privilege escalation in `x/net/idna`
  - **GO-2026-4918** (CVE-2026-33814): HTTP/2 infinite loop writing CONTINUATION frames
- Also transitively upgrades `golang.org/x/sys`, `golang.org/x/mod`, `golang.org/x/text`, `golang.org/x/term`, `golang.org/x/tools`

## Test plan
- [x] `go build ./...` passes
- [x] `go mod tidy` produces no diff

```release-note
NONE
```