### PR TITLE
ci: build Go with e2e tag for full CodeQL coverage

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -59,20 +59,13 @@ jobs:
           # By default, queries listed here will override any specified in a config file.
           # Prefix the list here with "+" to use these queries and those in the config file.
 
-      # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-      # If this step fails, then you should remove it and run the build manually (see below)
       - name: Autobuild
+        if: matrix.language != 'go'
         uses: github/codeql-action/autobuild@87557b9c84dde89fdd9b10e88954ac2f4248e463 # v4.36.1
 
-      # ℹ️ Command-line programs to run using the OS shell.
-      # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
-
-      #   If the Autobuild fails above, remove it and uncomment the following three lines.
-      #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
-
-      # - run: |
-      #   echo "Run, Build Application using script"
-      #   ./location_of_script_within_repo/buildscript.sh
+      - name: Build Go
+        if: matrix.language == 'go'
+        run: go build -tags e2e ./...
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@87557b9c84dde89fdd9b10e88954ac2f4248e463 # v4.36.1


### PR DESCRIPTION
## Summary
- CodeQL autobuild runs `go build ./...` without custom build tags, causing 225 Go files with `//go:build e2e` constraints (mostly in `test/e2e/`) to be detected but not analyzed
- This results in the ["Go files were found but not processed"](https://github.com/github/codeql-action/issues/2515) warning on the code scanning status page (382 out of 607 Go files scanned)
- Replaces autobuild for Go with a custom `go build -tags e2e ./...` step so all Go files are included in the analysis

## Test plan
- [x] Verify CodeQL workflow completes successfully for all languages
- [x] Confirm the "Go files were found but not processed" warning disappears from the Security tab
- [ ] Check that CodeQL now reports scanning all 607 Go files

```release-note
NONE
```