### PR TITLE
Don't specify rules in aggregated cluster role

### DIFF
--- a/config/rbac/aggregation_role.yaml
+++ b/config/rbac/aggregation_role.yaml
@@ -7,4 +7,3 @@ aggregationRule:
   clusterRoleSelectors:
   - matchLabels:
       cluster.x-k8s.io/aggregate-to-capz-manager: "true"
-rules: []


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Fixes an issue where the CAPZ manifests will be continuously reconciled if they
are monitored by an operator which expects its own managed fields to be
unaltered.

By specifying an explicitly empty ruleset we:
* own the rules field
* assert that it is explicitly empty, given that it is atomic

The aggregation controller populates the field itself when it writes the rules
to it, which results in a conflict the next time we reconcile the manifest.

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->


**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] cherry-pick candidate

**Release note**:
```release-note
Fixes an issue where capz-manager-role reconciles continuously if managed by an installer which uses server-side apply.
```
