### PR TITLE
fix: clean up Azure resources between create-dev-cluster.sh retries

### DIFF
--- a/hack/create-dev-cluster.sh
+++ b/hack/create-dev-cluster.sh
@@ -21,6 +21,10 @@ REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 # shellcheck source=hack/util.sh
 source "${REPO_ROOT}/hack/util.sh"
 
+KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-capz}"
+KIND="${KIND:-${REPO_ROOT}/hack/tools/bin/kind}"
+KUBECTL="${KUBECTL:-${REPO_ROOT}/hack/tools/bin/kubectl}"
+
 # Verify the required Environment Variables are present.
 capz::util::ensure_azure_envs
 
@@ -66,7 +70,35 @@ capz::util::generate_ssh_key
 echo "================ DOCKER BUILD ==============="
 PULL_POLICY=IfNotPresent make modules docker-build
 
+# cleanup_previous_attempt deletes any workload cluster and Azure RG left behind
+# by a previous create_cluster iteration, so retries start with a clean slate.
+cleanup_previous_attempt() {
+    local kind_kubeconfig="${REPO_ROOT}/${KIND_CLUSTER_NAME}.kubeconfig"
+
+    if [[ -x "${KIND}" ]] && [[ -r "${kind_kubeconfig}" ]] && \
+       "${KIND}" get clusters 2>/dev/null | grep -qxF "${KIND_CLUSTER_NAME}"; then
+        echo "================ DELETE WORKLOAD CLUSTER (graceful) ==============="
+        if timeout 1200 "${KUBECTL}" --kubeconfig "${kind_kubeconfig}" \
+            delete cluster "${CLUSTER_NAME}" -n default --wait=true --ignore-not-found=true; then
+            return 0
+        fi
+        echo "Graceful cluster delete failed or timed out; falling back to az group delete"
+    fi
+
+    # Synchronous so attempt N+1 doesn't race a still-deleting RG.
+    if command -v az >/dev/null 2>&1 \
+        && [[ -n "${AZURE_RESOURCE_GROUP:-}" ]] \
+        && [[ "${AZURE_RESOURCE_GROUP}" == "${CLUSTER_NAME}" ]] \
+        && [[ "$(az group exists --name "${AZURE_RESOURCE_GROUP}" 2>/dev/null)" == "true" ]]; then
+        echo "================ AZURE RG CLEANUP (fallback) ==============="
+        timeout 1800 az group delete --name "${AZURE_RESOURCE_GROUP}" --yes \
+            || echo "WARNING: az group delete failed; subsequent attempt may see leftover Azure resources"
+    fi
+}
+
 create_cluster() {
+    cleanup_previous_attempt
+
     echo "================ MAKE CLEAN ==============="
     make clean
 


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
The retry loop's create_cluster() ran make kind-reset before anything deleted the workload cluster, which leaves resources behind. This PR adds a cleanup_previous_attempt() function called at the start of each create_cluster() iteration.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->


**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] cherry-pick candidate

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
