### PR TITLE
retry kubeadm upload-config in AKS BYO node test

### DIFF
--- a/test/e2e/aks_byo_node.go
+++ b/test/e2e/aks_byo_node.go
@@ -116,7 +116,13 @@ func AKSBYONodeSpec(ctx context.Context, inputGetter func() AKSBYONodeSpecInput)
 					},
 				},
 			},
-			PreKubeadmCommands: []string{"kubeadm init phase upload-config all"},
+			PreKubeadmCommands: []string{
+				// Retry upload-config because the AKS apiserver intermittently returns connection-refused
+				// or rate-limit-exceeded during the BYO cloud-init window. A single failure here leaves
+				// kubeadm-config absent, which then causes the subsequent kubeadm join to fail with
+				// "configmaps \"kubeadm-config\" not found" and the node never registers.
+				`bash -c 'for i in 1 2 3 4 5 6; do kubeadm init phase upload-config all && exit 0; echo "kubeadm upload-config failed (attempt $i/6), retrying in 10s..."; sleep 10; done; echo "kubeadm upload-config failed after 6 attempts"; exit 1'`,
+			},
 		},
 	}
 	err = mgmtClient.Create(ctx, kubeadmConfig)


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind failing-test

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
This PR aims to fix a flake where kubectl upload config sometimes fails because the AKS apiserver intermittently returns connection-refused

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->


**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] cherry-pick candidate

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
