### PR TITLE
fix: default control plane subnet to share the node route table

### DIFF
--- a/azure/scope/cluster.go
+++ b/azure/scope/cluster.go
@@ -388,8 +388,16 @@ func (s *ClusterScope) LBSpecs() []azure.ResourceSpecGetter {
 // RouteTableSpecs returns the subnet route tables.
 func (s *ClusterScope) RouteTableSpecs() []azure.ResourceSpecGetter {
 	var specs []azure.ResourceSpecGetter
+	// Multiple subnets may reference the same route table (e.g. the control
+	// plane and node subnets both share the node route table), so de-duplicate
+	// by name to avoid reconciling the same route table more than once.
+	seen := make(map[string]struct{})
 	for _, subnet := range s.AzureCluster.Spec.NetworkSpec.Subnets {
 		if subnet.RouteTable.Name != "" {
+			if _, ok := seen[subnet.RouteTable.Name]; ok {
+				continue
+			}
+			seen[subnet.RouteTable.Name] = struct{}{}
 			specs = append(specs, &routetables.RouteTableSpec{
 				Name:           subnet.RouteTable.Name,
 				Location:       s.Location(),

--- a/azure/scope/cluster_test.go
+++ b/azure/scope/cluster_test.go
@@ -1142,6 +1142,52 @@ func TestRouteTableSpecs(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "de-duplicates route tables shared by multiple subnets",
+			clusterScope: ClusterScope{
+				Cluster: &clusterv1.Cluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "my-cluster",
+					},
+				},
+				AzureCluster: &infrav1.AzureCluster{
+					Spec: infrav1.AzureClusterSpec{
+						AzureClusterClassSpec: infrav1.AzureClusterClassSpec{
+							Location: "centralIndia",
+						},
+						NetworkSpec: infrav1.NetworkSpec{
+							Vnet: infrav1.VnetSpec{
+								ResourceGroup: "my-rg",
+							},
+							Subnets: infrav1.Subnets{
+								{
+									SubnetClassSpec: infrav1.SubnetClassSpec{Role: infrav1.SubnetControlPlane},
+									RouteTable: infrav1.RouteTable{
+										Name: "shared-route-table",
+									},
+								},
+								{
+									SubnetClassSpec: infrav1.SubnetClassSpec{Role: infrav1.SubnetNode},
+									RouteTable: infrav1.RouteTable{
+										Name: "shared-route-table",
+									},
+								},
+							},
+						},
+					},
+				},
+				cache: &ClusterCache{},
+			},
+			want: []azure.ResourceSpecGetter{
+				&routetables.RouteTableSpec{
+					Name:           "shared-route-table",
+					ResourceGroup:  "my-rg",
+					Location:       "centralIndia",
+					ClusterName:    "my-cluster",
+					AdditionalTags: make(infrav1.Tags),
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/api/v1beta1/azurecluster_default.go
+++ b/internal/api/v1beta1/azurecluster_default.go
@@ -170,6 +170,39 @@ func setDefaultAzureClusterSubnets(c *infrav1.AzureCluster) {
 		}
 		c.Spec.NetworkSpec.Subnets = append(c.Spec.NetworkSpec.Subnets, nodeSubnet)
 	}
+
+	// Default the control plane subnet to share the same route table as the
+	// node subnet. The cloud-controller-manager route controller programs
+	// pod-CIDR routes into a single route table (the one on the node/cluster
+	// subnet, see getOneNodeSubnet and the cloud config routeTableName). When
+	// the control plane and node subnets differ and the CNI relies on Azure
+	// routing (e.g. dual-stack/IPv6 with encapsulation disabled), the control
+	// plane node must share that route table; otherwise the API server
+	// aggregator cannot reach aggregated-API/webhook pods scheduled on worker
+	// nodes. For overlay CNIs (e.g. single-stack VXLAN) the route table carries
+	// no pod routes, so sharing it is a no-op. We copy the node subnet's actual
+	// route table name (rather than the generated default) so this also works
+	// when a custom node route table name is configured.
+	if c.Spec.ControlPlaneEnabled {
+		if cpSubnet, err := c.Spec.NetworkSpec.GetSubnet(infrav1.SubnetControlPlane); err == nil && cpSubnet.RouteTable.Name == "" {
+			if rtName := nodeRouteTableName(c); rtName != "" {
+				cpSubnet.RouteTable.Name = rtName
+				c.Spec.NetworkSpec.UpdateSubnet(cpSubnet, infrav1.SubnetControlPlane)
+			}
+		}
+	}
+}
+
+// nodeRouteTableName returns the route table name of the subnet that the
+// cloud-controller-manager programs pod routes into. This mirrors the subnet
+// selection in getOneNodeSubnet (the first node- or cluster-role subnet).
+func nodeRouteTableName(c *infrav1.AzureCluster) string {
+	for _, subnet := range c.Spec.NetworkSpec.Subnets {
+		if subnet.Role == infrav1.SubnetNode || subnet.Role == infrav1.SubnetCluster {
+			return subnet.RouteTable.Name
+		}
+	}
+	return ""
 }
 
 // setDefaultSubnetSpecNodeSubnet sets default values for a node SubnetSpec.

--- a/internal/api/v1beta1/azurecluster_default_test.go
+++ b/internal/api/v1beta1/azurecluster_default_test.go
@@ -341,7 +341,7 @@ func TestSubnetDefaults(t *testing.T) {
 								},
 
 								SecurityGroup: infrav1.SecurityGroup{Name: "cluster-test-controlplane-nsg"},
-								RouteTable:    infrav1.RouteTable{},
+								RouteTable:    infrav1.RouteTable{Name: "cluster-test-node-routetable"},
 							},
 							{
 								SubnetClassSpec: infrav1.SubnetClassSpec{
@@ -408,7 +408,7 @@ func TestSubnetDefaults(t *testing.T) {
 									Name:       "my-controlplane-subnet",
 								},
 								SecurityGroup: infrav1.SecurityGroup{Name: "cluster-test-controlplane-nsg"},
-								RouteTable:    infrav1.RouteTable{},
+								RouteTable:    infrav1.RouteTable{Name: "cluster-test-node-routetable"},
 							},
 							{
 								SubnetClassSpec: infrav1.SubnetClassSpec{
@@ -474,7 +474,7 @@ func TestSubnetDefaults(t *testing.T) {
 								},
 
 								SecurityGroup: infrav1.SecurityGroup{Name: "cluster-test-controlplane-nsg"},
-								RouteTable:    infrav1.RouteTable{},
+								RouteTable:    infrav1.RouteTable{Name: "cluster-test-node-routetable"},
 							},
 							{
 								SubnetClassSpec: infrav1.SubnetClassSpec{
@@ -673,6 +673,76 @@ func TestSubnetDefaults(t *testing.T) {
 			},
 		},
 		{
+			name: "control plane subnet inherits the node subnet's custom route table",
+			cluster: &infrav1.AzureCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cluster-test",
+				},
+				Spec: infrav1.AzureClusterSpec{
+					ControlPlaneEnabled: true,
+					NetworkSpec: infrav1.NetworkSpec{
+						Subnets: infrav1.Subnets{
+							{
+								SubnetClassSpec: infrav1.SubnetClassSpec{
+									Role: infrav1.SubnetControlPlane,
+									Name: "cluster-test-controlplane-subnet",
+								},
+							},
+							{
+								SubnetClassSpec: infrav1.SubnetClassSpec{
+									Role: infrav1.SubnetNode,
+									Name: "cluster-test-node-subnet",
+								},
+								RouteTable: infrav1.RouteTable{
+									Name: "custom-node-route-table",
+								},
+							},
+						},
+					},
+				},
+			},
+			output: &infrav1.AzureCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cluster-test",
+				},
+				Spec: infrav1.AzureClusterSpec{
+					ControlPlaneEnabled: true,
+					NetworkSpec: infrav1.NetworkSpec{
+						Subnets: infrav1.Subnets{
+							{
+								SubnetClassSpec: infrav1.SubnetClassSpec{
+									Role:       infrav1.SubnetControlPlane,
+									CIDRBlocks: []string{DefaultControlPlaneSubnetCIDR},
+									Name:       "cluster-test-controlplane-subnet",
+								},
+								SecurityGroup: infrav1.SecurityGroup{Name: "cluster-test-controlplane-nsg"},
+								// Inherits the node subnet's custom route table name, not
+								// the generated default, so it shares the table CCM manages.
+								RouteTable: infrav1.RouteTable{Name: "custom-node-route-table"},
+							},
+							{
+								SubnetClassSpec: infrav1.SubnetClassSpec{
+									Role:       infrav1.SubnetNode,
+									CIDRBlocks: []string{DefaultNodeSubnetCIDR},
+									Name:       "cluster-test-node-subnet",
+								},
+								SecurityGroup: infrav1.SecurityGroup{Name: "cluster-test-node-nsg"},
+								RouteTable:    infrav1.RouteTable{Name: "custom-node-route-table"},
+								NatGateway: infrav1.NatGateway{
+									NatGatewayClassSpec: infrav1.NatGatewayClassSpec{
+										Name: "cluster-test-node-natgw-1",
+									},
+									NatGatewayIP: infrav1.PublicIPSpec{
+										Name: "pip-cluster-test-node-natgw-1",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "only node subnet specified",
 			cluster: &infrav1.AzureCluster{
 				ObjectMeta: metav1.ObjectMeta{
@@ -725,7 +795,7 @@ func TestSubnetDefaults(t *testing.T) {
 									Name:       "cluster-test-controlplane-subnet",
 								},
 								SecurityGroup: infrav1.SecurityGroup{Name: "cluster-test-controlplane-nsg"},
-								RouteTable:    infrav1.RouteTable{},
+								RouteTable:    infrav1.RouteTable{Name: "cluster-test-node-routetable"},
 							},
 						},
 					},
@@ -785,7 +855,7 @@ func TestSubnetDefaults(t *testing.T) {
 									Name:       "cluster-test-controlplane-subnet",
 								},
 								SecurityGroup: infrav1.SecurityGroup{Name: "cluster-test-controlplane-nsg"},
-								RouteTable:    infrav1.RouteTable{},
+								RouteTable:    infrav1.RouteTable{Name: "cluster-test-node-routetable"},
 							},
 							{
 								SubnetClassSpec: infrav1.SubnetClassSpec{
@@ -896,6 +966,7 @@ func TestSubnetDefaults(t *testing.T) {
 									},
 									Name: "my-custom-sg",
 								},
+								RouteTable: infrav1.RouteTable{Name: "cluster-test-node-routetable"},
 							},
 							{
 								SubnetClassSpec: infrav1.SubnetClassSpec{
@@ -1008,6 +1079,7 @@ func TestSubnetDefaults(t *testing.T) {
 									},
 									Name: "my-custom-sg",
 								},
+								RouteTable: infrav1.RouteTable{Name: "cluster-test-node-routetable"},
 							},
 							{
 								SubnetClassSpec: infrav1.SubnetClassSpec{
@@ -1075,7 +1147,7 @@ func TestSubnetDefaults(t *testing.T) {
 								},
 								ID:            "my-subnet-id",
 								SecurityGroup: infrav1.SecurityGroup{Name: "cluster-test-controlplane-nsg"},
-								RouteTable:    infrav1.RouteTable{},
+								RouteTable:    infrav1.RouteTable{Name: "cluster-test-node-routetable"},
 							},
 							{
 								SubnetClassSpec: infrav1.SubnetClassSpec{

--- a/internal/webhooks/azurecluster_validation.go
+++ b/internal/webhooks/azurecluster_validation.go
@@ -829,7 +829,11 @@ func validateAzureClusterSubnetUpdate(c *infrav1.AzureCluster, old *infrav1.Azur
 						c.Spec.NetworkSpec.Subnets[i].CIDRBlocks, "field is immutable"),
 				)
 			}
-			if subnet.RouteTable.Name != oldSubnet.RouteTable.Name {
+			// RouteTable.Name is immutable once set, but allow defaulting it from
+			// empty to a generated name so existing clusters (whose control plane
+			// subnet had no route table) can adopt the shared node route table on
+			// upgrade. This mirrors the NatGateway.Name handling below.
+			if (subnet.RouteTable.Name != oldSubnet.RouteTable.Name) && (oldSubnet.RouteTable.Name != "") {
 				allErrs = append(allErrs,
 					field.Invalid(field.NewPath("spec", "networkSpec", "subnets").Index(oldSubnetIndex[subnet.Name]).Child("RouteTable").Child("Name"),
 						c.Spec.NetworkSpec.Subnets[i].RouteTable.Name, "field is immutable"),

--- a/internal/webhooks/azurecluster_webhook_test.go
+++ b/internal/webhooks/azurecluster_webhook_test.go
@@ -428,6 +428,30 @@ func TestAzureCluster_ValidateUpdate(t *testing.T) {
 			}(),
 			wantErr: false,
 		},
+		{
+			name:       "route table name can be defaulted from empty before AzureCluster is updated",
+			oldCluster: apifixtures.CreateValidCluster(),
+			cluster: func() *infrav1.AzureCluster {
+				cluster := apifixtures.CreateValidCluster()
+				cluster.Spec.NetworkSpec.Subnets[0].RouteTable.Name = "cluster-test-node-routetable"
+				return cluster
+			}(),
+			wantErr: false,
+		},
+		{
+			name: "route table name is immutable once set to a non-empty value",
+			oldCluster: func() *infrav1.AzureCluster {
+				cluster := apifixtures.CreateValidCluster()
+				cluster.Spec.NetworkSpec.Subnets[0].RouteTable.Name = "cluster-test-node-routetable"
+				return cluster
+			}(),
+			cluster: func() *infrav1.AzureCluster {
+				cluster := apifixtures.CreateValidCluster()
+				cluster.Spec.NetworkSpec.Subnets[0].RouteTable.Name = "some-other-routetable"
+				return cluster
+			}(),
+			wantErr: true,
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
CAPZ clusters put the control plane and worker nodes in separate subnets by default. In dual-stack and IPv6 clusters, Calico runs with encapsulation: None, so cross-node pod traffic relies on Azure user-defined routes that the cloud-provider-azure route controller writes into the node route table (one podCIDR -> nodeIP route per node). (Single-stack clusters use VXLAN, which tunnels between node IPs and needs no route table for this, which is why they are unaffected.)

CAPZ defaults a route table onto the node subnet but not the control-plane subnet, so the control plane has no route to worker pod CIDRs. Any aggregated APIService or webhook whose pod runs on a worker is then unreachable from the kube-apiserver. In practice the Calico v3.projectcalico.org APIService goes Available=False, which breaks namespace API discovery and leaves every namespace stuck Terminating, even empty ones. This surfaced as 100% failures in the cloud-provider-azure e2e-ccm-dualstack-capz-1.30 presubmit.

CAPZ defaults the node subnet routetables here: https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/66895d3553c4893a7152a5b09bd140b918fdfe1d/internal/api/v1beta1/azurecluster_default.go#L187-L189

It does not do the same for the control plane subnet: https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/66895d3553c4893a7152a5b09bd140b918fdfe1d/internal/api/v1beta1/azurecluster_default.go#L205-L216

**Solution**:
Default the control-plane subnet to share the node route table so the control plane gets the same CCM-programmed pod routes as workers. This matches CAPZ's existing single-subnet (cluster role) behavior and is a no-op for overlay CNIs like single-stack VXLAN.

 - Default the control-plane subnet RouteTable.Name to the node route table.
 - Allow the route table name to default from empty on update so existing clusters adopt it on upgrade.
 - De-duplicate RouteTableSpecs() now that two subnets reference the same route table.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->


**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] cherry-pick candidate

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
fix: default control plane subnet to share the node route table
```
