### PR TITLE
[release-1.23] ci: build Go with e2e tag for full CodeQL coverage

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -59,20 +59,13 @@ jobs:
           # By default, queries listed here will override any specified in a config file.
           # Prefix the list here with "+" to use these queries and those in the config file.
 
-      # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-      # If this step fails, then you should remove it and run the build manually (see below)
       - name: Autobuild
+        if: matrix.language != 'go'
         uses: github/codeql-action/autobuild@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
 
-      # ℹ️ Command-line programs to run using the OS shell.
-      # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
-
-      #   If the Autobuild fails above, remove it and uncomment the following three lines.
-      #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
-
-      # - run: |
-      #   echo "Run, Build Application using script"
-      #   ./location_of_script_within_repo/buildscript.sh
+      - name: Build Go
+        if: matrix.language == 'go'
+        run: go build -tags e2e ./...
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2


### PR DESCRIPTION
This is a manual cherry-pick of #6345 into release-1.23.

The original PR did not apply cleanly: the `codeql-action` step is pinned to a different version on the release branch (`v4.36.2`) than on main (`v4.36.1`), so the context lines around the modified `Autobuild` step conflicted. Resolved by keeping the release branch's existing `codeql-action` pin and applying only the intended change (skip Autobuild for Go and add a `go build -tags e2e ./...` step so the e2e-tagged files
are scanned).

```release-note
NONE
```
