### PR TITLE
CI: count MachinePool replicas when waiting for workload cluster nodes

### DIFF
--- a/scripts/ci-entrypoint.sh
+++ b/scripts/ci-entrypoint.sh
@@ -175,9 +175,17 @@ create_cluster() {
 wait_for_nodes() {
   echo "Waiting for ${CONTROL_PLANE_MACHINE_COUNT} control plane machine(s), ${WORKER_MACHINE_COUNT} worker machine(s), ${WINDOWS_WORKER_MACHINE_COUNT:-0} windows machine(s), and ${MONITORING_MACHINE_COUNT} monitoring machine(s) to become Ready"
 
-    # Ensure that all nodes are registered with the API server before checking for readiness
-    local total_nodes="$((CONTROL_PLANE_MACHINE_COUNT + WORKER_MACHINE_COUNT + WINDOWS_WORKER_MACHINE_COUNT + MONITORING_MACHINE_COUNT))"
-    while [[ $("${KUBECTL}" get nodes -ojson | jq '.items | length') -ne "${total_nodes}" ]]; do
+    # EXPECTED_NODE_COUNT is set by install_addons from the actual CAPI replicas.
+    # Fall back to the machine count env vars if unset or it could not be computed.
+    local total_nodes="${EXPECTED_NODE_COUNT:-0}"
+    if [[ "${total_nodes}" -le 0 ]]; then
+        total_nodes="$((CONTROL_PLANE_MACHINE_COUNT + WORKER_MACHINE_COUNT + WINDOWS_WORKER_MACHINE_COUNT + MONITORING_MACHINE_COUNT))"
+    fi
+
+    # Wait for at least total_nodes to register. -lt (not an exact match) avoids
+    # hanging when a template defines both a MachineDeployment and a MachinePool.
+    echo "Waiting for at least ${total_nodes} node(s) to become Ready"
+    while [[ $("${KUBECTL}" get nodes -ojson | jq '.items | length') -lt "${total_nodes}" ]]; do
         sleep 10
     done
 
@@ -211,6 +219,18 @@ install_addons() {
     # In order to determine the successful outcome of CNI and cloud-provider-azure,
     # we need to wait a little bit for nodes and pods terminal state,
     # so we block successful return upon the cluster being fully operational.
+
+    # Derive the expected node count from the actual CAPI replicas (KCP +
+    # MachineDeployments + MachinePools). The CONTROL_PLANE/WORKER_MACHINE_COUNT
+    # formula undercounts templates with both a MachineDeployment and a MachinePool,
+    # since each consumes WORKER_MACHINE_COUNT (e.g. dual-stack and ipv6).
+    EXPECTED_NODE_COUNT=$("${KUBECTL}" --kubeconfig "${REPO_ROOT}/${KIND_CLUSTER_NAME}.kubeconfig" \
+        get kubeadmcontrolplanes.v1beta1.controlplane.cluster.x-k8s.io,machinedeployments.v1beta1.cluster.x-k8s.io,machinepools.v1beta1.cluster.x-k8s.io \
+        -A -l "cluster.x-k8s.io/cluster-name=${CLUSTER_NAME}" \
+        -o jsonpath='{range .items[*]}{.spec.replicas}{"\n"}{end}' 2>/dev/null \
+        | awk '{sum += $1} END {print sum + 0}') || EXPECTED_NODE_COUNT=0
+    export EXPECTED_NODE_COUNT
+
     export -f wait_for_nodes
     timeout --foreground 1800 bash -c wait_for_nodes
     export -f wait_for_pods


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
`wait_for_nodes` computed the expected node count as `CONTROL_PLANE_MACHINE_COUNT + WORKER_MACHINE_COUNT`, which assumes a single worker group. The dual-stack, ipv6, and ci-version-md-and-mp templates define both a MachineDeployment and a MachinePool, and each consumes `${WORKER_MACHINE_COUNT}`, so the real worker count is double what the formula assumes. The actual node count never matched the expected count, so the exact-match (-ne) wait looped until the 30-minute timeout and the job failed before any tests ran. This derives the expected count from the actual desired replicas of the cluster's KubeadmControlPlane, MachineDeployments, and MachinePools, and waits for at least that many nodes so the check is correct regardless of template shape.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->


**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] cherry-pick candidate

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
