### PR TITLE
fix: increase MachineDeployment Ready condition timeout from 10m to 20m

### DIFF
--- a/scripts/ci-entrypoint.sh
+++ b/scripts/ci-entrypoint.sh
@@ -281,7 +281,7 @@ if [[ ! "${CLUSTER_TEMPLATE}" =~ "aks" ]]; then
   install_addons
 fi
 
-"${KUBECTL}" --kubeconfig "${REPO_ROOT}/${KIND_CLUSTER_NAME}.kubeconfig" wait -A --for=condition=Ready --timeout=10m -l "cluster.x-k8s.io/cluster-name=${CLUSTER_NAME}" machinepools.v1beta1.cluster.x-k8s.io,machinedeployments.v1beta1.cluster.x-k8s.io
+"${KUBECTL}" --kubeconfig "${REPO_ROOT}/${KIND_CLUSTER_NAME}.kubeconfig" wait -A --for=condition=Ready --timeout=20m -l "cluster.x-k8s.io/cluster-name=${CLUSTER_NAME}" machinepools.v1beta1.cluster.x-k8s.io,machinedeployments.v1beta1.cluster.x-k8s.io
 
 echo "Cluster ${CLUSTER_NAME} created and fully operational"
 


### PR DESCRIPTION
## What type of PR is this?

/kind bug

## What this PR does / why we need it

Increases the final `kubectl wait --for=condition=Ready` timeout for MachineDeployments/MachinePools from 10 minutes to 20 minutes in `scripts/ci-entrypoint.sh`.

## Problem

Downstream e2e jobs (e.g., azurefile-csi-driver, azuredisk-csi-driver Windows HostProcess tests) are intermittently failing with:
```
error: timed out waiting for the condition on machinedeployments/capz-xxx-md-win
```

Despite both Windows nodes being `Ready` in the workload cluster and all pods running normally. The Linux MachineDeployment consistently passes while the Windows one times out.

## Root Cause

The Ready condition on a v1beta1 MachineDeployment is derived through this chain:

```
Node Ready (workload cluster)
  → ClusterCache health probe succeeds
    → Machine.NodeHealthy + Machine.NodeReady conditions set
      → Machine.Ready condition set
        → MachineSet.AvailableReplicas updated
          → MachineDeployment.Available condition set
            → MachineDeployment.Ready (v1beta1 mirror) set
```

For Windows nodes, several factors extend this propagation time:
1. Windows nodes take longer to boot and register with the API server
2. The CAPI ClusterCache requires multiple successful probes before node health status propagates
3. The entire condition chain (Machine → MachineSet → MachineDeployment) must reconcile sequentially

10 minutes is often insufficient for this full chain to complete with Windows nodes, causing flaky failures in CI.

## Changes

- `scripts/ci-entrypoint.sh`: `--timeout=10m` → `--timeout=20m` for the final MachineDeployment/MachinePool Ready wait

## Evidence

Recent failures showing this exact pattern (nodes Ready, pods Running, MachineDeployment timeout):
- [build-log 1](https://storage.googleapis.com/kubernetes-ci-logs/pr-logs/pull/kubernetes-sigs_azurefile-csi-driver/3212/pull-azurefile-csi-driver-e2e-capz-windows-2022-hostprocess/2067817575454085120/build-log.txt)
- [build-log 2](https://storage.googleapis.com/kubernetes-ci-logs/pr-logs/pull/kubernetes-sigs_azurefile-csi-driver/3212/pull-azurefile-csi-driver-e2e-capz-windows-2022-hostprocess/2067850162021076992/build-log.txt)

/release-note-none