### PR TITLE
Fix LoadBalancer hang by cleaning up orphaned NIC on quota failures

### DIFF
--- a/azure/const.go
+++ b/azure/const.go
@@ -46,4 +46,8 @@ const (
 	// See https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
 	// for annotation formatting rules.
 	SecurityRuleLastAppliedAnnotation = "sigs.k8s.io/cluster-api-provider-azure-last-applied-security-rules"
+
+	// QuotaFailureTimestampAnnotation tracks when a quota exhaustion failure was first observed,
+	// used by the AzureMachine controller to implement the orphaned-NIC cleanup grace period.
+	QuotaFailureTimestampAnnotation = "sigs.k8s.io/cluster-api-provider-azure-quota-failure-timestamp"
 )

--- a/controllers/azuremachine_controller.go
+++ b/controllers/azuremachine_controller.go
@@ -19,7 +19,10 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"strings"
+	"time"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -235,6 +238,118 @@ func (amr *AzureMachineReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	return amr.reconcileNormal(ctx, machineScope, clusterScope)
 }
 
+const (
+	quotaFailureGracePeriod = 1 * time.Minute
+)
+
+const (
+	azureQuotaExceededCode           = "QuotaExceeded"
+	azureOperationNotAllowedCode     = "OperationNotAllowed"
+	azureResourceQuotaExceededCode   = "ResourceQuotaExceeded"
+	azureDeploymentQuotaExceededCode = "DeploymentQuotaExceeded"
+)
+
+// quotaExceededErrorCodes contains Azure error codes that indicate quota exhaustion.
+// Note: OperationNotAllowed requires message validation to avoid non-quota errors.
+// Reference: https://learn.microsoft.com/en-us/azure/azure-resource-manager/troubleshooting/error-resource-quota
+var quotaExceededErrorCodes = []string{
+	azureQuotaExceededCode,
+	azureOperationNotAllowedCode,
+	azureResourceQuotaExceededCode,
+	azureDeploymentQuotaExceededCode,
+}
+
+// isQuotaExceededError checks if error is due to Azure quota exhaustion.
+func isQuotaExceededError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	var respErr *azcore.ResponseError
+	if errors.As(err, &respErr) {
+		for _, code := range quotaExceededErrorCodes {
+			if respErr.ErrorCode == code {
+				if code == azureOperationNotAllowedCode {
+					errMsg := strings.ToLower(respErr.Error())
+					return strings.Contains(errMsg, "quota")
+				}
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+// getQuotaProvisionFailedCondition returns the quota provision failure condition if it exists.
+func getQuotaProvisionFailedCondition(azureMachine *infrav1.AzureMachine) *clusterv1beta1.Condition {
+	cond := v1beta1conditions.Get(azureMachine, infrav1.VMRunningCondition)
+	if cond == nil || cond.Status != corev1.ConditionFalse || cond.Reason != infrav1.VMProvisionFailedReason {
+		return nil
+	}
+	return cond
+}
+
+// isQuotaFailureGracePeriodElapsed checks if grace period has elapsed since the condition was first set.
+func isQuotaFailureGracePeriodElapsed(cond *clusterv1beta1.Condition) bool {
+	if cond == nil {
+		return false
+	}
+	return time.Since(cond.LastTransitionTime.Time) >= quotaFailureGracePeriod
+}
+
+// markQuotaProvisionFailedCondition sets VMRunningCondition to False with VMProvisionFailedReason,
+// preserving LastTransitionTime if a snapshot is provided.
+func markQuotaProvisionFailedCondition(machineScope *scope.MachineScope, err error, quotaFailureCond *clusterv1beta1.Condition) {
+	if quotaFailureCond == nil {
+		v1beta1conditions.MarkFalse(
+			machineScope.AzureMachine,
+			infrav1.VMRunningCondition,
+			infrav1.VMProvisionFailedReason,
+			clusterv1beta1.ConditionSeverityWarning,
+			"VM creation failed due to quota exhaustion: %s", err.Error(),
+		)
+	} else {
+		v1beta1conditions.Set(
+			machineScope.AzureMachine,
+			&clusterv1beta1.Condition{
+				Type:               infrav1.VMRunningCondition,
+				Status:             corev1.ConditionFalse,
+				Reason:             infrav1.VMProvisionFailedReason,
+				Severity:           clusterv1beta1.ConditionSeverityWarning,
+				LastTransitionTime: quotaFailureCond.LastTransitionTime,
+				Message:            fmt.Sprintf("VM creation failed due to quota exhaustion: %s", err.Error()),
+			},
+		)
+	}
+}
+
+/*
+// getRetryCount retrieves retry count from Machine annotations.
+// Used by exponential backoff retry mechanism (Option 1).
+func getRetryCount(machineScope *scope.MachineScope) int {
+	countStr, exists := machineScope.AzureMachine.Annotations["azure.infrastructure.cluster.x-k8s.io/quota-retry-count"]
+	if !exists {
+		return 0
+	}
+
+	count, err := strconv.Atoi(countStr)
+	if err != nil {
+		return 0
+	}
+	return count
+}
+
+// setRetryCount stores retry count in Machine annotations.
+// Used by exponential backoff retry mechanism (Option 1).
+func setRetryCount(machineScope *scope.MachineScope, count int) {
+	if machineScope.AzureMachine.Annotations == nil {
+		machineScope.AzureMachine.Annotations = make(map[string]string)
+	}
+	machineScope.AzureMachine.Annotations["azure.infrastructure.cluster.x-k8s.io/quota-retry-count"] = strconv.Itoa(count)
+}.
+*/
+
 func (amr *AzureMachineReconciler) reconcileNormal(ctx context.Context, machineScope *scope.MachineScope, clusterScope *scope.ClusterScope) (reconcile.Result, error) {
 	ctx, log, done := tele.StartSpanWithLogger(ctx, "controllers.AzureMachineReconciler.reconcileNormal")
 	defer done()
@@ -300,6 +415,12 @@ func (amr *AzureMachineReconciler) reconcileNormal(ctx context.Context, machineS
 		return reconcile.Result{}, errors.Wrap(err, "failed to create azure machine service")
 	}
 
+	// Snapshot before ams.Reconcile: virtualmachines.Reconcile calls UpdatePutStatus(VMRunningCondition, ..., err),
+	// overwriting the reason to infrav1.FailedReason. A post-reconcile grace check would see "Failed", not "VMProvisionFailedReason",
+	// and re-marking afterward would reset LastTransitionTime, so the grace window would never elapse.
+	quotaFailureCondSnapshot := getQuotaProvisionFailedCondition(machineScope.AzureMachine)
+	graceExpired := isQuotaFailureGracePeriodElapsed(quotaFailureCondSnapshot)
+
 	if err := ams.Reconcile(ctx); err != nil {
 		// This means that a VM was created and managed by this controller, but is not present anymore.
 		// In this case, we mark it as failed and leave it to MHC for remediation
@@ -310,6 +431,28 @@ func (amr *AzureMachineReconciler) reconcileNormal(ctx context.Context, machineS
 			machineScope.SetNotReady()
 			machineScope.SetVMState(infrav1.Deleted)
 			return reconcile.Result{}, errors.Wrap(err, "failed to reconcile AzureMachine")
+		}
+
+		// Check for quota errors and cleanup orphaned NIC if grace period expired
+		if isQuotaExceededError(err) {
+			if graceExpired {
+				log.Info("Grace period expired, cleaning up orphaned NIC", "error", err.Error())
+				if nicErr := ams.DeleteOrphanedNIC(ctx); nicErr != nil {
+					log.Error(nicErr, "Failed to delete orphaned NIC during quota failure cleanup: %s", nicErr.Error())
+					return reconcile.Result{}, nicErr
+				}
+
+				machineScope.SetFailureReason(azure.CreateError)
+				machineScope.SetFailureMessage(err)
+				machineScope.SetNotReady()
+
+				log.Info("Machine marked as Failed due to persistent quota exhaustion")
+				return reconcile.Result{}, nil
+			}
+
+			markQuotaProvisionFailedCondition(machineScope, err, quotaFailureCondSnapshot)
+			log.Info("Quota failure detected, will cleanup NIC on next reconcile if still failing",
+				"gracePeriod", quotaFailureGracePeriod, "error", err.Error())
 		}
 
 		// Handle transient and terminal errors

--- a/controllers/azuremachine_controller.go
+++ b/controllers/azuremachine_controller.go
@@ -19,10 +19,15 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"strings"
+	"time"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/ptr"
 	clusterv1beta1 "sigs.k8s.io/cluster-api/api/core/v1beta1"
@@ -235,6 +240,116 @@ func (amr *AzureMachineReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	return amr.reconcileNormal(ctx, machineScope, clusterScope)
 }
 
+const (
+	quotaFailureGracePeriod = 1 * time.Minute
+)
+
+const (
+	azureQuotaExceededCode           = "QuotaExceeded"
+	azureOperationNotAllowedCode     = "OperationNotAllowed"
+	azureResourceQuotaExceededCode   = "ResourceQuotaExceeded"
+	azureDeploymentQuotaExceededCode = "DeploymentQuotaExceeded"
+)
+
+// quotaExceededErrorCodes contains Azure error codes that indicate quota exhaustion.
+//
+// OperationNotAllowed is ambiguous and used for various authorization/policy failures.
+// We use a best-effort heuristic: check for "quota" in the message AND HTTP 409/429 status.
+// If Azure changes error wording (e.g., "resource limit" instead of "quota"), detection may fail.
+//
+// Reference: https://learn.microsoft.com/en-us/azure/azure-resource-manager/troubleshooting/error-resource-quota
+var quotaExceededErrorCodes = []string{
+	azureQuotaExceededCode,
+	azureOperationNotAllowedCode,
+	azureResourceQuotaExceededCode,
+	azureDeploymentQuotaExceededCode,
+}
+
+// isQuotaExceededError checks if error is due to Azure quota exhaustion.
+//
+// Detection Strategy:
+// - QuotaExceeded, ResourceQuotaExceeded, DeploymentQuotaExceeded: accepted directly
+// - OperationNotAllowed: uses heuristic (message contains "quota" AND HTTP 409/429)
+//
+// Limitations:
+// - Message matching is brittle; Azure may change wording without notice
+// - HTTP status check helps but is not definitive (409 used for other conflicts)
+// - False negatives possible if Azure changes error format.
+func isQuotaExceededError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	var respErr *azcore.ResponseError
+	if errors.As(err, &respErr) {
+		for _, code := range quotaExceededErrorCodes {
+			if respErr.ErrorCode == code {
+				if code == azureOperationNotAllowedCode {
+					errMsg := strings.ToLower(respErr.Error())
+					hasQuotaKeyword := strings.Contains(errMsg, "quota")
+					hasQuotaStatus := respErr.StatusCode == http.StatusConflict || respErr.StatusCode == http.StatusTooManyRequests
+
+					return hasQuotaKeyword && hasQuotaStatus
+				}
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+func getQuotaFailureTimestamp(obj metav1.Object) (time.Time, bool) {
+	val, ok := obj.GetAnnotations()[azure.QuotaFailureTimestampAnnotation]
+	if !ok || val == "" {
+		return time.Time{}, false
+	}
+
+	t, err := time.Parse(time.RFC3339, val)
+	if err != nil {
+		return time.Time{}, false
+	}
+
+	return t, true
+}
+
+func setQuotaFailureTimestampIfAbsent(obj metav1.Object) {
+	if _, ok := getQuotaFailureTimestamp(obj); ok {
+		return
+	}
+
+	annotations := obj.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+	annotations[azure.QuotaFailureTimestampAnnotation] = time.Now().Format(time.RFC3339)
+	obj.SetAnnotations(annotations)
+}
+
+func removeQuotaFailureTimestamp(obj metav1.Object) {
+	annotations := obj.GetAnnotations()
+	if annotations == nil {
+		return
+	}
+
+	if _, ok := annotations[azure.QuotaFailureTimestampAnnotation]; !ok {
+		return
+	}
+
+	delete(annotations, azure.QuotaFailureTimestampAnnotation)
+	obj.SetAnnotations(annotations)
+}
+
+// isQuotaFailureGracePeriodElapsed checks if grace period has elapsed since the quota failure was first recorded.
+func isQuotaFailureGracePeriodElapsed(obj metav1.Object) bool {
+	t, ok := getQuotaFailureTimestamp(obj)
+	if !ok {
+		return false
+	}
+
+	return time.Since(t) >= quotaFailureGracePeriod
+}
+
 func (amr *AzureMachineReconciler) reconcileNormal(ctx context.Context, machineScope *scope.MachineScope, clusterScope *scope.ClusterScope) (reconcile.Result, error) {
 	ctx, log, done := tele.StartSpanWithLogger(ctx, "controllers.AzureMachineReconciler.reconcileNormal")
 	defer done()
@@ -312,6 +427,42 @@ func (amr *AzureMachineReconciler) reconcileNormal(ctx context.Context, machineS
 			return reconcile.Result{}, errors.Wrap(err, "failed to reconcile AzureMachine")
 		}
 
+		// Check for quota errors and cleanup orphaned NIC if grace period expired
+		if isQuotaExceededError(err) {
+			graceExpired := isQuotaFailureGracePeriodElapsed(machineScope.AzureMachine)
+			if graceExpired {
+				log.Info("Grace period expired, cleaning up orphaned NIC", "error", err.Error())
+				if nicErr := ams.DeleteNetworkInterfaces(ctx); nicErr != nil {
+					log.Error(nicErr, "Failed to delete orphaned NIC during quota failure cleanup")
+					return reconcile.Result{}, nicErr
+				}
+
+				amr.Recorder.Eventf(machineScope.AzureMachine, corev1.EventTypeWarning, infrav1.VMProvisionFailedReason,
+					"Cleaned up orphaned NIC and marked Machine as Failed due to quota exhaustion: %s", err.Error())
+				machineScope.SetFailureReason(azure.CreateError)
+				machineScope.SetFailureMessage(err)
+				machineScope.SetNotReady()
+				machineScope.SetVMState(infrav1.Failed)
+
+				removeQuotaFailureTimestamp(machineScope.AzureMachine)
+				log.Info("Machine marked as Failed due to persistent quota exhaustion")
+				return reconcile.Result{}, nil
+			}
+
+			setQuotaFailureTimestampIfAbsent(machineScope.AzureMachine)
+			log.Info("Quota failure detected, will cleanup NIC on next reconcile if still failing",
+				"gracePeriod", quotaFailureGracePeriod, "error", err.Error())
+		} else {
+			// Diagnostic logging for OperationNotAllowed errors that don't match quota heuristic
+			var respErr *azcore.ResponseError
+			if errors.As(err, &respErr) && respErr.ErrorCode == azureOperationNotAllowedCode {
+				log.V(4).Info("OperationNotAllowed error did not match quota heuristic",
+					"errorCode", respErr.ErrorCode,
+					"statusCode", respErr.StatusCode,
+					"errorMessage", respErr.Error())
+			}
+		}
+
 		// Handle transient and terminal errors
 		if errors.As(err, &reconcileError) {
 			if reconcileError.IsTerminal() {
@@ -337,6 +488,7 @@ func (amr *AzureMachineReconciler) reconcileNormal(ctx context.Context, machineS
 		return reconcile.Result{}, errors.Wrap(err, "failed to reconcile AzureMachine")
 	}
 
+	removeQuotaFailureTimestamp(machineScope.AzureMachine)
 	machineScope.SetReady()
 
 	return reconcile.Result{}, nil

--- a/controllers/azuremachine_controller_test.go
+++ b/controllers/azuremachine_controller_test.go
@@ -18,9 +18,13 @@ package controllers
 
 import (
 	"context"
+	"io"
+	"net/http"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	. "github.com/onsi/gomega"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
@@ -31,6 +35,7 @@ import (
 	"k8s.io/utils/ptr"
 	clusterv1beta1 "sigs.k8s.io/cluster-api/api/core/v1beta1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
+	v1beta1conditions "sigs.k8s.io/cluster-api/util/deprecated/v1beta1/conditions"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -236,6 +241,41 @@ func TestAzureMachineReconcileNormal(t *testing.T) {
 			createAzureMachineService: getFakeAzureMachineServiceWithGeneralError,
 			cache:                     &scope.MachineCache{},
 			expectedErr:               "failed to reconcile AzureMachine",
+		},
+		"should mark condition on first quota failure": {
+			createAzureMachineService: getFakeAzureMachineServiceWithQuotaError,
+			cache:                     &scope.MachineCache{},
+			expectedErr:               "failed to reconcile AzureMachine service virtualmachines",
+		},
+		"should not cleanup NIC when grace period not elapsed": {
+			azureMachineOptions: func(am *infrav1.AzureMachine) {
+				v1beta1conditions.Set(am, &clusterv1beta1.Condition{
+					Type:               infrav1.VMRunningCondition,
+					Status:             corev1.ConditionFalse,
+					Reason:             infrav1.VMProvisionFailedReason,
+					Severity:           clusterv1beta1.ConditionSeverityWarning,
+					LastTransitionTime: metav1.Time{Time: time.Now().Add(-30 * time.Second)},
+					Message:            "quota error",
+				})
+			},
+			createAzureMachineService: getFakeAzureMachineServiceWithQuotaError,
+			cache:                     &scope.MachineCache{},
+			expectedErr:               "failed to reconcile AzureMachine service virtualmachines",
+		},
+		"should cleanup NIC and fail permanently when grace period elapsed": {
+			azureMachineOptions: func(am *infrav1.AzureMachine) {
+				v1beta1conditions.Set(am, &clusterv1beta1.Condition{
+					Type:               infrav1.VMRunningCondition,
+					Status:             corev1.ConditionFalse,
+					Reason:             infrav1.VMProvisionFailedReason,
+					Severity:           clusterv1beta1.ConditionSeverityWarning,
+					LastTransitionTime: metav1.Time{Time: time.Now().Add(-2 * time.Minute)},
+					Message:            "quota error",
+				})
+			},
+			createAzureMachineService: getFakeAzureMachineServiceWithQuotaErrorAndNICDelete,
+			machineScopeFailureReason: azure.CreateError,
+			cache:                     &scope.MachineCache{},
 		},
 	}
 
@@ -513,6 +553,41 @@ func getFakeAzureMachineServiceWithGeneralError(machineScope *scope.MachineScope
 	return ams, nil
 }
 
+func getFakeAzureMachineServiceWithQuotaError(machineScope *scope.MachineScope) (*azureMachineService, error) {
+	cache, err := resourceskus.GetCache(machineScope, machineScope.Location())
+	if err != nil {
+		return nil, errors.Wrap(err, "failed creating a NewCache")
+	}
+
+	ams := getDefaultAzureMachineService(machineScope, cache)
+	quotaErr := &azcore.ResponseError{ErrorCode: "QuotaExceeded"}
+	ams.Reconcile = func(context.Context) error {
+		machineScope.UpdatePutStatus(infrav1.VMRunningCondition, "virtualmachines", quotaErr)
+		return errors.Wrapf(quotaErr, "failed to reconcile AzureMachine service virtualmachines")
+	}
+
+	return ams, nil
+}
+
+func getFakeAzureMachineServiceWithQuotaErrorAndNICDelete(machineScope *scope.MachineScope) (*azureMachineService, error) {
+	cache, err := resourceskus.GetCache(machineScope, machineScope.Location())
+	if err != nil {
+		return nil, errors.Wrap(err, "failed creating a NewCache")
+	}
+
+	ams := getDefaultAzureMachineService(machineScope, cache)
+	quotaErr := &azcore.ResponseError{ErrorCode: "QuotaExceeded"}
+	ams.Reconcile = func(context.Context) error {
+		machineScope.UpdatePutStatus(infrav1.VMRunningCondition, "virtualmachines", quotaErr)
+		return errors.Wrapf(quotaErr, "failed to reconcile AzureMachine service virtualmachines")
+	}
+	ams.DeleteOrphanedNIC = func(context.Context) error {
+		return nil
+	}
+
+	return ams, nil
+}
+
 func getDefaultAzureMachineService(machineScope *scope.MachineScope, cache *resourceskus.Cache) *azureMachineService {
 	return &azureMachineService{
 		scope:    machineScope,
@@ -525,6 +600,9 @@ func getDefaultAzureMachineService(machineScope *scope.MachineScope, cache *reso
 			return nil
 		},
 		Delete: func(context.Context) error {
+			return nil
+		},
+		DeleteOrphanedNIC: func(context.Context) error {
 			return nil
 		},
 	}
@@ -830,4 +908,56 @@ func conditionsMatch(i, j clusterv1beta1.Condition) bool {
 		i.Status == j.Status &&
 		i.Reason == j.Reason &&
 		i.Severity == j.Severity
+}
+
+func TestQuotaHandling(t *testing.T) {
+	g := NewWithT(t)
+
+	t.Run("detects quota errors", func(t *testing.T) {
+		g.Expect(isQuotaExceededError(&azcore.ResponseError{ErrorCode: "QuotaExceeded"})).To(BeTrue())
+		g.Expect(isQuotaExceededError(&azcore.ResponseError{ErrorCode: "ResourceQuotaExceeded"})).To(BeTrue())
+		g.Expect(isQuotaExceededError(&azcore.ResponseError{ErrorCode: "OperationNotAllowed", RawResponse: &http.Response{
+			Body: io.NopCloser(strings.NewReader("Operation results in exceeding quota limits")),
+		}})).To(BeTrue())
+		g.Expect(isQuotaExceededError(&azcore.ResponseError{ErrorCode: "OperationNotAllowed"})).To(BeFalse())
+		g.Expect(isQuotaExceededError(errors.New("other error"))).To(BeFalse())
+	})
+
+	t.Run("checks grace period", func(t *testing.T) {
+		recentCond := &clusterv1beta1.Condition{
+			Type:               infrav1.VMRunningCondition,
+			Status:             corev1.ConditionFalse,
+			Reason:             infrav1.VMProvisionFailedReason,
+			LastTransitionTime: metav1.Time{Time: time.Now().Add(-30 * time.Second)},
+		}
+		oldCond := &clusterv1beta1.Condition{
+			Type:               infrav1.VMRunningCondition,
+			Status:             corev1.ConditionFalse,
+			Reason:             infrav1.VMProvisionFailedReason,
+			LastTransitionTime: metav1.Time{Time: time.Now().Add(-2 * time.Minute)},
+		}
+		g.Expect(isQuotaFailureGracePeriodElapsed(recentCond)).To(BeFalse())
+		g.Expect(isQuotaFailureGracePeriodElapsed(oldCond)).To(BeTrue())
+	})
+
+	t.Run("marks condition and preserves timestamp", func(t *testing.T) {
+		azureMachine := &infrav1.AzureMachine{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-machine", Namespace: "default"},
+		}
+		machineScope := &scope.MachineScope{AzureMachine: azureMachine}
+		existingCond := &clusterv1beta1.Condition{
+			Type:               infrav1.VMRunningCondition,
+			Status:             corev1.ConditionFalse,
+			Reason:             infrav1.VMProvisionFailedReason,
+			Severity:           clusterv1beta1.ConditionSeverityWarning,
+			LastTransitionTime: metav1.Time{Time: time.Now().Add(-30 * time.Second)},
+		}
+		originalTime := existingCond.LastTransitionTime
+
+		markQuotaProvisionFailedCondition(machineScope, errors.New("quota exceeded"), existingCond)
+
+		condition := v1beta1conditions.Get(machineScope.AzureMachine, infrav1.VMRunningCondition)
+		g.Expect(condition.Reason).To(Equal(infrav1.VMProvisionFailedReason))
+		g.Expect(condition.LastTransitionTime).To(Equal(originalTime))
+	})
 }

--- a/controllers/azuremachine_controller_test.go
+++ b/controllers/azuremachine_controller_test.go
@@ -18,9 +18,13 @@ package controllers
 
 import (
 	"context"
+	"io"
+	"net/http"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	. "github.com/onsi/gomega"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
@@ -236,6 +240,41 @@ func TestAzureMachineReconcileNormal(t *testing.T) {
 			createAzureMachineService: getFakeAzureMachineServiceWithGeneralError,
 			cache:                     &scope.MachineCache{},
 			expectedErr:               "failed to reconcile AzureMachine",
+		},
+		"should set quota failure timestamp on first quota failure": {
+			createAzureMachineService: getFakeAzureMachineServiceWithQuotaError,
+			cache:                     &scope.MachineCache{},
+			expectedErr:               "failed to reconcile AzureMachine service virtualmachines",
+		},
+		"should not cleanup NIC when grace period not elapsed": {
+			azureMachineOptions: func(am *infrav1.AzureMachine) {
+				am.Annotations = map[string]string{
+					azure.QuotaFailureTimestampAnnotation: time.Now().Add(-30 * time.Second).Format(time.RFC3339),
+				}
+			},
+			createAzureMachineService: getFakeAzureMachineServiceWithQuotaError,
+			cache:                     &scope.MachineCache{},
+			expectedErr:               "failed to reconcile AzureMachine service virtualmachines",
+		},
+		"should cleanup NIC and fail permanently when grace period elapsed": {
+			azureMachineOptions: func(am *infrav1.AzureMachine) {
+				am.Annotations = map[string]string{
+					azure.QuotaFailureTimestampAnnotation: time.Now().Add(-2 * time.Minute).Format(time.RFC3339),
+				}
+			},
+			createAzureMachineService: getFakeAzureMachineServiceWithQuotaErrorAndNICDelete,
+			machineScopeFailureReason: azure.CreateError,
+			cache:                     &scope.MachineCache{},
+		},
+		"should return NIC delete error when grace period elapsed": {
+			azureMachineOptions: func(am *infrav1.AzureMachine) {
+				am.Annotations = map[string]string{
+					azure.QuotaFailureTimestampAnnotation: time.Now().Add(-2 * time.Minute).Format(time.RFC3339),
+				}
+			},
+			createAzureMachineService: getFakeAzureMachineServiceWithQuotaErrorAndNICDeleteError,
+			cache:                     &scope.MachineCache{},
+			expectedErr:               "failed to delete network interfaces",
 		},
 	}
 
@@ -513,6 +552,60 @@ func getFakeAzureMachineServiceWithGeneralError(machineScope *scope.MachineScope
 	return ams, nil
 }
 
+func getFakeAzureMachineServiceWithQuotaError(machineScope *scope.MachineScope) (*azureMachineService, error) {
+	cache, err := resourceskus.GetCache(machineScope, machineScope.Location())
+	if err != nil {
+		return nil, errors.Wrap(err, "failed creating a NewCache")
+	}
+
+	ams := getDefaultAzureMachineService(machineScope, cache)
+	quotaErr := &azcore.ResponseError{ErrorCode: "QuotaExceeded"}
+	ams.Reconcile = func(context.Context) error {
+		machineScope.UpdatePutStatus(infrav1.VMRunningCondition, "virtualmachines", quotaErr)
+		return errors.Wrapf(quotaErr, "failed to reconcile AzureMachine service virtualmachines")
+	}
+
+	return ams, nil
+}
+
+func getFakeAzureMachineServiceWithQuotaErrorAndNICDelete(machineScope *scope.MachineScope) (*azureMachineService, error) {
+	cache, err := resourceskus.GetCache(machineScope, machineScope.Location())
+	if err != nil {
+		return nil, errors.Wrap(err, "failed creating a NewCache")
+	}
+
+	ams := getDefaultAzureMachineService(machineScope, cache)
+	quotaErr := &azcore.ResponseError{ErrorCode: "QuotaExceeded"}
+	ams.Reconcile = func(context.Context) error {
+		machineScope.UpdatePutStatus(infrav1.VMRunningCondition, "virtualmachines", quotaErr)
+		return errors.Wrapf(quotaErr, "failed to reconcile AzureMachine service virtualmachines")
+	}
+	ams.DeleteNetworkInterfaces = func(context.Context) error {
+		return nil
+	}
+
+	return ams, nil
+}
+
+func getFakeAzureMachineServiceWithQuotaErrorAndNICDeleteError(machineScope *scope.MachineScope) (*azureMachineService, error) {
+	cache, err := resourceskus.GetCache(machineScope, machineScope.Location())
+	if err != nil {
+		return nil, errors.Wrap(err, "failed creating a NewCache")
+	}
+
+	ams := getDefaultAzureMachineService(machineScope, cache)
+	quotaErr := &azcore.ResponseError{ErrorCode: "QuotaExceeded"}
+	ams.Reconcile = func(context.Context) error {
+		machineScope.UpdatePutStatus(infrav1.VMRunningCondition, "virtualmachines", quotaErr)
+		return errors.Wrapf(quotaErr, "failed to reconcile AzureMachine service virtualmachines")
+	}
+	ams.DeleteNetworkInterfaces = func(context.Context) error {
+		return errors.New("failed to delete network interfaces")
+	}
+
+	return ams, nil
+}
+
 func getDefaultAzureMachineService(machineScope *scope.MachineScope, cache *resourceskus.Cache) *azureMachineService {
 	return &azureMachineService{
 		scope:    machineScope,
@@ -525,6 +618,9 @@ func getDefaultAzureMachineService(machineScope *scope.MachineScope, cache *reso
 			return nil
 		},
 		Delete: func(context.Context) error {
+			return nil
+		},
+		DeleteNetworkInterfaces: func(context.Context) error {
 			return nil
 		},
 	}
@@ -830,4 +926,93 @@ func conditionsMatch(i, j clusterv1beta1.Condition) bool {
 		i.Status == j.Status &&
 		i.Reason == j.Reason &&
 		i.Severity == j.Severity
+}
+
+func TestQuotaHandling(t *testing.T) {
+	t.Run("detects quota errors", func(t *testing.T) {
+		g := NewWithT(t)
+
+		g.Expect(isQuotaExceededError(&azcore.ResponseError{ErrorCode: "QuotaExceeded"})).To(BeTrue())
+		g.Expect(isQuotaExceededError(&azcore.ResponseError{ErrorCode: "ResourceQuotaExceeded"})).To(BeTrue())
+
+		// OperationNotAllowed uses respErr.Error() for message text; RawResponse.Body exercises that path.
+		g.Expect(isQuotaExceededError(&azcore.ResponseError{
+			ErrorCode:  "OperationNotAllowed",
+			StatusCode: 409,
+			RawResponse: &http.Response{
+				StatusCode: http.StatusConflict,
+				Body:       io.NopCloser(strings.NewReader("Operation results in exceeding quota limits")),
+			},
+		})).To(BeTrue())
+
+		g.Expect(isQuotaExceededError(&azcore.ResponseError{
+			ErrorCode:  "OperationNotAllowed",
+			StatusCode: 429,
+			RawResponse: &http.Response{
+				StatusCode: http.StatusTooManyRequests,
+				Body:       io.NopCloser(strings.NewReader("Operation results in exceeding quota limits")),
+			},
+		})).To(BeTrue())
+
+		// OperationNotAllowed without quota keyword should be false
+		g.Expect(isQuotaExceededError(&azcore.ResponseError{
+			ErrorCode:  "OperationNotAllowed",
+			StatusCode: 409,
+		})).To(BeFalse())
+
+		// OperationNotAllowed with quota keyword but wrong status should be false
+		g.Expect(isQuotaExceededError(&azcore.ResponseError{
+			ErrorCode:  "OperationNotAllowed",
+			StatusCode: 403,
+			RawResponse: &http.Response{
+				StatusCode: http.StatusForbidden,
+				Body:       io.NopCloser(strings.NewReader("Operation results in exceeding quota limits")),
+			},
+		})).To(BeFalse())
+
+		g.Expect(isQuotaExceededError(&azcore.ResponseError{ErrorCode: "OperationNotAllowed"})).To(BeFalse())
+		g.Expect(isQuotaExceededError(errors.New("other error"))).To(BeFalse())
+	})
+
+	t.Run("checks grace period from annotation", func(t *testing.T) {
+		g := NewWithT(t)
+
+		recentMachine := &infrav1.AzureMachine{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					azure.QuotaFailureTimestampAnnotation: time.Now().Add(-30 * time.Second).Format(time.RFC3339),
+				},
+			},
+		}
+		oldMachine := &infrav1.AzureMachine{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					azure.QuotaFailureTimestampAnnotation: time.Now().Add(-2 * time.Minute).Format(time.RFC3339),
+				},
+			},
+		}
+		g.Expect(isQuotaFailureGracePeriodElapsed(recentMachine)).To(BeFalse())
+		g.Expect(isQuotaFailureGracePeriodElapsed(oldMachine)).To(BeTrue())
+	})
+
+	t.Run("sets and removes quota failure timestamp annotation", func(t *testing.T) {
+		g := NewWithT(t)
+
+		azureMachine := &infrav1.AzureMachine{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-machine", Namespace: "default"},
+		}
+
+		setQuotaFailureTimestampIfAbsent(azureMachine)
+		_, ok := getQuotaFailureTimestamp(azureMachine)
+		g.Expect(ok).To(BeTrue())
+
+		originalTime, _ := getQuotaFailureTimestamp(azureMachine)
+		setQuotaFailureTimestampIfAbsent(azureMachine)
+		sameTime, _ := getQuotaFailureTimestamp(azureMachine)
+		g.Expect(sameTime).To(Equal(originalTime))
+
+		removeQuotaFailureTimestamp(azureMachine)
+		_, ok = getQuotaFailureTimestamp(azureMachine)
+		g.Expect(ok).To(BeFalse())
+	})
 }

--- a/controllers/azuremachine_reconciler.go
+++ b/controllers/azuremachine_reconciler.go
@@ -42,11 +42,12 @@ type azureMachineService struct {
 	scope *scope.MachineScope
 	// services is the list of services to be reconciled.
 	// The order of the services is important as it determines the order in which the services are reconciled.
-	services  []azure.ServiceReconciler
-	skuCache  *resourceskus.Cache
-	Reconcile func(context.Context) error
-	Pause     func(context.Context) error
-	Delete    func(context.Context) error
+	services          []azure.ServiceReconciler
+	skuCache          *resourceskus.Cache
+	Reconcile         func(context.Context) error
+	Pause             func(context.Context) error
+	Delete            func(context.Context) error
+	DeleteOrphanedNIC func(context.Context) error
 }
 
 // newAzureMachineService populates all the services based on input scope.
@@ -109,6 +110,7 @@ func newAzureMachineService(machineScope *scope.MachineScope) (*azureMachineServ
 	ams.Reconcile = ams.reconcile
 	ams.Pause = ams.pause
 	ams.Delete = ams.delete
+	ams.DeleteOrphanedNIC = ams.deleteOrphanedNIC
 
 	return ams, nil
 }
@@ -161,6 +163,20 @@ func (s *azureMachineService) delete(ctx context.Context) error {
 	for i := len(s.services) - 1; i >= 0; i-- {
 		if err := s.services[i].Delete(ctx); err != nil {
 			return errors.Wrapf(err, "failed to delete AzureMachine service %s", s.services[i].Name())
+		}
+	}
+
+	return nil
+}
+
+// deleteOrphanedNIC deletes the network interface service.
+func (s *azureMachineService) deleteOrphanedNIC(ctx context.Context) error {
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "controllers.azureMachineService.deleteOrphanedNIC")
+	defer done()
+
+	for _, service := range s.services {
+		if service.Name() == "interfaces" {
+			return service.Delete(ctx)
 		}
 	}
 

--- a/controllers/azuremachine_reconciler.go
+++ b/controllers/azuremachine_reconciler.go
@@ -37,16 +37,23 @@ import (
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
 )
 
+// networkInterfaceDeleter deletes NIC resources for quota-failure cleanup.
+type networkInterfaceDeleter interface {
+	Delete(context.Context) error
+}
+
 // azureMachineService is the group of services called by the AzureMachine controller.
 type azureMachineService struct {
 	scope *scope.MachineScope
 	// services is the list of services to be reconciled.
 	// The order of the services is important as it determines the order in which the services are reconciled.
-	services  []azure.ServiceReconciler
-	skuCache  *resourceskus.Cache
-	Reconcile func(context.Context) error
-	Pause     func(context.Context) error
-	Delete    func(context.Context) error
+	services                []azure.ServiceReconciler
+	networkInterfacesSvc    networkInterfaceDeleter
+	skuCache                *resourceskus.Cache
+	Reconcile               func(context.Context) error
+	Pause                   func(context.Context) error
+	Delete                  func(context.Context) error
+	DeleteNetworkInterfaces func(context.Context) error
 }
 
 // newAzureMachineService populates all the services based on input scope.
@@ -92,7 +99,8 @@ func newAzureMachineService(machineScope *scope.MachineScope) (*azureMachineServ
 		return nil, errors.Wrap(err, "failed creating networkinterfaces service")
 	}
 	ams := &azureMachineService{
-		scope: machineScope,
+		scope:                machineScope,
+		networkInterfacesSvc: networkInterfacesSvc,
 		services: []azure.ServiceReconciler{
 			publicIPsSvc,
 			inboundnatrulesSvc,
@@ -109,6 +117,7 @@ func newAzureMachineService(machineScope *scope.MachineScope) (*azureMachineServ
 	ams.Reconcile = ams.reconcile
 	ams.Pause = ams.pause
 	ams.Delete = ams.delete
+	ams.DeleteNetworkInterfaces = ams.deleteNetworkInterfaces
 
 	return ams, nil
 }
@@ -165,4 +174,14 @@ func (s *azureMachineService) delete(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+// deleteNetworkInterfaces deletes all NICs defined in NICSpecs().
+// Used during quota-failure cleanup when VM creation never succeeded.
+// Side effect: updates NetworkInterfaceReadyCondition via the standard delete path.
+func (s *azureMachineService) deleteNetworkInterfaces(ctx context.Context) error {
+	ctx, _, done := tele.StartSpanWithLogger(ctx, "controllers.azureMachineService.deleteNetworkInterfaces")
+	defer done()
+
+	return s.networkInterfacesSvc.Delete(ctx)
 }

--- a/controllers/azuremachine_reconciler_test.go
+++ b/controllers/azuremachine_reconciler_test.go
@@ -237,3 +237,47 @@ func TestAzureMachineServiceDelete(t *testing.T) {
 		})
 	}
 }
+
+func TestAzureMachineServiceDeleteNetworkInterfaces(t *testing.T) {
+	cases := map[string]struct {
+		expectedError string
+		expect        func(nic *mock_azure.MockServiceReconcilerMockRecorder)
+	}{
+		"network interfaces service delete succeeds": {
+			expect: func(nic *mock_azure.MockServiceReconcilerMockRecorder) {
+				nic.Delete(gomockinternal.AContext()).Return(nil)
+			},
+		},
+		"network interfaces service delete fails": {
+			expectedError: "some error happened",
+			expect: func(nic *mock_azure.MockServiceReconcilerMockRecorder) {
+				nic.Delete(gomockinternal.AContext()).Return(errors.New("some error happened"))
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			t.Parallel()
+			mockCtrl := gomock.NewController(t)
+			defer mockCtrl.Finish()
+			nicMock := mock_azure.NewMockServiceReconciler(mockCtrl)
+
+			tc.expect(nicMock.EXPECT())
+
+			s := &azureMachineService{
+				networkInterfacesSvc: nicMock,
+			}
+
+			err := s.deleteNetworkInterfaces(t.Context())
+			if tc.expectedError != "" {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err).To(MatchError(tc.expectedError))
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Fixes cluster-wide LoadBalancer reconciliation failures caused by orphaned Azure NICs when VM provisioning fails due to quota exhaustion.

> This PR was written in part with the assistance of generative AI

**Problem**: When Azure VM creation fails due to quota exhaustion, CAPZ leaves the NIC orphaned (created but with `VirtualMachine.ID = nil`). The cloud-provider-azure CCM enumerates all NICs during LoadBalancer backend pool reconciliation and crashes when encountering these orphaned NICs, causing **cluster-wide** LoadBalancer failures—not just for the affected NodePool.

**Solution**: Implement defensive NIC cleanup with a 1-minute grace period when quota errors are detected, then mark the Machine as permanently Failed to prevent recreation loops.

**Which issue(s) this PR fixes**:
Fixes # (ARO-HCP internal: ARO-25867)

**Special notes for your reviewer**:

### Critical Non-Obvious Pattern: Condition Snapshot Before Reconcile

**Lines 139-143** snapshot the condition **before** `ams.Reconcile()` for a subtle but critical reason:

`virtualmachines.Reconcile` calls `UpdatePutStatus(VMRunningCondition, ..., err)` which overwrites the condition reason to `infrav1.FailedReason`. If we checked the grace period **after** reconcile, we'd see "Failed" instead of "VMProvisionFailedReason", and re-marking would reset `LastTransitionTime` to "now". The grace window would restart every reconcile loop and **never elapse**.

The snapshot preserves the original `LastTransitionTime` from the first quota failure, allowing the grace period to work correctly across multiple reconcile attempts.

### Implementation Approach: Conditions Over Annotations

This implementation uses **existing CAPI `Status.Conditions` API** instead of custom annotations for grace period tracking:
- Leverages `VMRunningCondition.LastTransitionTime` to track when quota failure first occurred
- Sets `VMRunningCondition.Status = False` with `Reason = VMProvisionFailedReason`
- Preserves `LastTransitionTime` across reconcile loops to enable accurate grace period tracking

### Non-Obvious: Machine Is NOT Deleted

**Critical behavioral note**: After NIC cleanup, this code **marks the Machine as Failed but does NOT delete the Machine object**. This is intentional.

**Why not delete?** Deleting the Machine triggers CAPI MachineSet to create a replacement (to maintain replica count). If quota persists across zones, this creates an infinite recreation loop. Therefore:
- LoadBalancer is unblocked (primary goal achieved - NIC deleted)
- No Azure resource consumption (NIC deleted, VM never created)
- No recreation loop (Machine stays Failed)
- Admin must eventually delete/update NodePool to trigger replacement

### OperationNotAllowed Handling (lines 51-54)
#Ref: https://learn.microsoft.com/en-us/azure/azure-resource-manager/troubleshooting/error-resource-quota?tabs=azure-cli
`OperationNotAllowed` is ambiguous — it can indicate quota issues OR other authorization problems. We validate the error message contains "quota" to avoid cleaning up NICs for unrelated `OperationNotAllowed` errors (e.g., RBAC issues, policy violations).

### Two Strategies (One Active, One Commented)

**Active Strategy**: `return ctrl.Result{}, nil` - Permanent failure, no retries
- Machine stays Failed until admin intervention (NodePool delete/update/scale)

**Commented Strategy** (lines 106-130): Exponential backoff retry mechanism
- Uncomment to enable self-healing behavior
- Backoff: 15min → 30min → 60min, then permanent failure
- Rejected for initial implementation because quota exhaustion is typically a capacity planning issue, not transient

### Edge Cases Handled

1. **Grace period prevents premature cleanup**: 1-minute wait allows transient quota issues to resolve before NIC deletion
2. **Condition-based idempotency**: Multiple reconcile loops don't restart grace period if condition already set (LastTransitionTime doesn't change)
3. **Quota detection is comprehensive**: Handles 4 Azure error codes (`QuotaExceeded`, `OperationNotAllowed`, `ResourceQuotaExceeded`, `DeploymentQuotaExceeded`) with special validation for `OperationNotAllowed`
4. **Service layer cleanup** (azuremachine_reconciler.go): `DeleteOrphanedNIC` finds the "interfaces" service by name and calls its `Delete`, reusing existing service deletion logic

### Test Fixtures (lines 249-282)

Two separate test fixtures handle quota scenarios:
- `getFakeAzureMachineServiceWithQuotaError`: Returns quota error on Reconcile (for initial failure + grace period scenarios)
- `getFakeAzureMachineServiceWithQuotaErrorAndNICDelete`: Additionally mocks successful NIC deletion (for grace-expired scenario)

This separation makes test intent clear and avoids conditional logic in fixtures.

### Alternatives Considered

**Annotation-based grace period**: Rejected because:
- Adding new annotations faces API review friction
- Conditions are the idiomatic CAPI way to track state transitions
- `LastTransitionTime` provides exactly what we need

**Immediate Machine deletion**: Rejected because:
- Creates recreation loop if quota persists across all zones
- Wastes Azure API calls
- Makes problem less visible to operators

**New Custom FailureReason="QuotaExhausted"**: Rejected in favor of reusing `azure.CreateError`. Benefits:
- Minimal API surface change
- Quota details preserved in condition message
- Existing MHC rules already handle `CreateError`

### Rollout Considerations

**Safe to deploy directly**:
- Fully backward compatible (only activates on quota errors)
- Uses existing CAPI condition API
- No schema changes or migrations required
- Defensive: only cleans NICs after confirmed quota failure + grace period

**Backport candidate**: This fixes a critical production issue (cluster-wide LB failures). Consider backporting to actively supported CAPZ releases.

**TODOs**:

- [x] squashed commits
- [ ] includes documentation (inline code comments)
- [x] adds unit tests
- [ ] cherry-pick candidate (needs maintainer input on which versions)

**Release note**:
```release-note
Fix cluster-wide LoadBalancer failures caused by orphaned NICs during quota exhaustion. When VM creation fails due to Azure quota limits, CAPZ now cleans up orphaned NICs after a 1-minute grace period and marks the Machine as Failed to prevent recreation loops.