### PR TITLE
fix: validate API server LB private IP is unchanged on update

### DIFF
--- a/internal/webhooks/azurecluster_validation.go
+++ b/internal/webhooks/azurecluster_validation.go
@@ -393,12 +393,31 @@ func validateSecurityRule(rule infrav1.SecurityRule, fldPath *field.Path) (allEr
 }
 
 func validateAPIServerLBPrivateIPUnchanged(lb, old *infrav1.LoadBalancerSpec, fldPath *field.Path) *field.Error {
-	if lb == nil || old == nil || len(old.FrontendIPs) == 0 || len(lb.FrontendIPs) == 0 {
+	if lb == nil || old == nil {
 		return nil
 	}
-	if old.FrontendIPs[0].PrivateIPAddress != lb.FrontendIPs[0].PrivateIPAddress {
+	var oldPrivateIP string
+	for i := range old.FrontendIPs {
+		if old.FrontendIPs[i].PrivateIPAddress != "" {
+			oldPrivateIP = old.FrontendIPs[i].PrivateIPAddress
+			break
+		}
+	}
+	var newPrivateIP string
+	var newIdx int
+	for i := range lb.FrontendIPs {
+		if lb.FrontendIPs[i].PrivateIPAddress != "" {
+			newPrivateIP = lb.FrontendIPs[i].PrivateIPAddress
+			newIdx = i
+			break
+		}
+	}
+	if oldPrivateIP == "" || newPrivateIP == "" {
+		return nil
+	}
+	if oldPrivateIP != newPrivateIP {
 		return field.Forbidden(
-			fldPath.Child("frontendIPConfigs").Index(0).Child("privateIP"),
+			fldPath.Child("frontendIPConfigs").Index(newIdx).Child("privateIP"),
 			"API Server load balancer private IP should not be modified after AzureCluster creation.")
 	}
 	return nil

--- a/internal/webhooks/azurecluster_validation.go
+++ b/internal/webhooks/azurecluster_validation.go
@@ -392,6 +392,18 @@ func validateSecurityRule(rule infrav1.SecurityRule, fldPath *field.Path) (allEr
 	return allErrs
 }
 
+func validateAPIServerLBPrivateIPUnchanged(lb, old *infrav1.LoadBalancerSpec, fldPath *field.Path) *field.Error {
+	if lb == nil || old == nil || len(old.FrontendIPs) == 0 || len(lb.FrontendIPs) == 0 {
+		return nil
+	}
+	if old.FrontendIPs[0].PrivateIPAddress != lb.FrontendIPs[0].PrivateIPAddress {
+		return field.Forbidden(
+			fldPath.Child("frontendIPConfigs").Index(0).Child("privateIP"),
+			"API Server load balancer private IP should not be modified after AzureCluster creation.")
+	}
+	return nil
+}
+
 func validateAPIServerLB(lb *infrav1.LoadBalancerSpec, old *infrav1.LoadBalancerSpec, cidrs []string, fldPath *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
 
@@ -434,12 +446,13 @@ func validateAPIServerLB(lb *infrav1.LoadBalancerSpec, old *infrav1.LoadBalancer
 			if err := validateInternalLBIPAddress(privateIP, cidrs, fldPath.Child("frontendIPConfigs").Index(0).Child("privateIP")); err != nil {
 				allErrs = append(allErrs, err)
 			}
-		} else {
-			// API Server LB should not have a Private IP if APIServerILB feature is disabled.
-			if privateIPCount > 0 {
-				allErrs = append(allErrs, field.Forbidden(fldPath.Child("frontendIPConfigs").Index(0).Child("privateIP"),
-					"Public Load Balancers cannot have a Private IP"))
+			if err := validateAPIServerLBPrivateIPUnchanged(lb, old, fldPath); err != nil {
+				allErrs = append(allErrs, err)
 			}
+		} else if privateIPCount > 0 {
+			// API Server LB should not have a Private IP if APIServerILB feature is disabled.
+			allErrs = append(allErrs, field.Forbidden(fldPath.Child("frontendIPConfigs").Index(0).Child("privateIP"),
+				"Public Load Balancers cannot have a Private IP"))
 		}
 	}
 
@@ -458,8 +471,8 @@ func validateAPIServerLB(lb *infrav1.LoadBalancerSpec, old *infrav1.LoadBalancer
 				allErrs = append(allErrs, err)
 			}
 
-			if old != nil && len(old.FrontendIPs) != 0 && old.FrontendIPs[0].PrivateIPAddress != lb.FrontendIPs[0].PrivateIPAddress {
-				allErrs = append(allErrs, field.Forbidden(fldPath.Child("name"), "API Server load balancer private IP should not be modified after AzureCluster creation."))
+			if err := validateAPIServerLBPrivateIPUnchanged(lb, old, fldPath); err != nil {
+				allErrs = append(allErrs, err)
 			}
 		}
 	}

--- a/internal/webhooks/azurecluster_validation_test.go
+++ b/internal/webhooks/azurecluster_validation_test.go
@@ -1293,15 +1293,15 @@ func TestValidateAPIServerLB(t *testing.T) {
 				FrontendIPs: []infrav1.FrontendIP{
 					{
 						Name: "ip-1",
-						FrontendIPClass: infrav1.FrontendIPClass{
-							PrivateIPAddress: "10.0.0.10",
+						PublicIP: &infrav1.PublicIPSpec{
+							Name:    "my-valid-ip",
+							DNSName: "my-valid-ip",
 						},
 					},
 					{
 						Name: "ip-2",
-						PublicIP: &infrav1.PublicIPSpec{
-							Name:    "my-valid-ip",
-							DNSName: "my-valid-ip",
+						FrontendIPClass: infrav1.FrontendIPClass{
+							PrivateIPAddress: "10.0.0.10",
 						},
 					},
 				},
@@ -1315,15 +1315,15 @@ func TestValidateAPIServerLB(t *testing.T) {
 				FrontendIPs: []infrav1.FrontendIP{
 					{
 						Name: "ip-1",
-						FrontendIPClass: infrav1.FrontendIPClass{
-							PrivateIPAddress: "10.0.0.11",
+						PublicIP: &infrav1.PublicIPSpec{
+							Name:    "my-valid-ip",
+							DNSName: "my-valid-ip",
 						},
 					},
 					{
 						Name: "ip-2",
-						PublicIP: &infrav1.PublicIPSpec{
-							Name:    "my-valid-ip",
-							DNSName: "my-valid-ip",
+						FrontendIPClass: infrav1.FrontendIPClass{
+							PrivateIPAddress: "10.0.0.11",
 						},
 					},
 				},
@@ -1337,7 +1337,7 @@ func TestValidateAPIServerLB(t *testing.T) {
 			wantErr: true,
 			expectedErr: field.Error{
 				Type:   "FieldValueForbidden",
-				Field:  "apiServerLB.frontendIPConfigs[0].privateIP",
+				Field:  "apiServerLB.frontendIPConfigs[1].privateIP",
 				Detail: "API Server load balancer private IP should not be modified after AzureCluster creation.",
 			},
 		},
@@ -1388,15 +1388,15 @@ func TestValidateAPIServerLB(t *testing.T) {
 				FrontendIPs: []infrav1.FrontendIP{
 					{
 						Name: "ip-1",
-						FrontendIPClass: infrav1.FrontendIPClass{
-							PrivateIPAddress: "10.0.0.10",
+						PublicIP: &infrav1.PublicIPSpec{
+							Name:    "my-valid-ip",
+							DNSName: "my-valid-ip",
 						},
 					},
 					{
 						Name: "ip-2",
-						PublicIP: &infrav1.PublicIPSpec{
-							Name:    "my-valid-ip",
-							DNSName: "my-valid-ip",
+						FrontendIPClass: infrav1.FrontendIPClass{
+							PrivateIPAddress: "10.0.0.10",
 						},
 					},
 				},
@@ -1410,15 +1410,15 @@ func TestValidateAPIServerLB(t *testing.T) {
 				FrontendIPs: []infrav1.FrontendIP{
 					{
 						Name: "ip-1",
-						FrontendIPClass: infrav1.FrontendIPClass{
-							PrivateIPAddress: "10.0.0.10",
+						PublicIP: &infrav1.PublicIPSpec{
+							Name:    "my-valid-ip",
+							DNSName: "my-valid-ip",
 						},
 					},
 					{
 						Name: "ip-2",
-						PublicIP: &infrav1.PublicIPSpec{
-							Name:    "my-valid-ip",
-							DNSName: "my-valid-ip",
+						FrontendIPClass: infrav1.FrontendIPClass{
+							PrivateIPAddress: "10.0.0.10",
 						},
 					},
 				},

--- a/internal/webhooks/azurecluster_validation_test.go
+++ b/internal/webhooks/azurecluster_validation_test.go
@@ -1286,6 +1286,187 @@ func TestValidateAPIServerLB(t *testing.T) {
 				Detail:   "Internal LB IP address needs to be in control plane subnet range ([10.0.0.0/24 10.1.0.0/24])",
 			},
 		},
+		{
+			name:        "public LB with APIServerILB enabled changing private IP after creation is forbidden",
+			featureGate: feature.APIServerILB,
+			old: &infrav1.LoadBalancerSpec{
+				FrontendIPs: []infrav1.FrontendIP{
+					{
+						Name: "ip-1",
+						FrontendIPClass: infrav1.FrontendIPClass{
+							PrivateIPAddress: "10.0.0.10",
+						},
+					},
+					{
+						Name: "ip-2",
+						PublicIP: &infrav1.PublicIPSpec{
+							Name:    "my-valid-ip",
+							DNSName: "my-valid-ip",
+						},
+					},
+				},
+				LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{
+					Type: infrav1.Public,
+					SKU:  infrav1.SKUStandard,
+				},
+				Name: "my-public-lb",
+			},
+			lb: &infrav1.LoadBalancerSpec{
+				FrontendIPs: []infrav1.FrontendIP{
+					{
+						Name: "ip-1",
+						FrontendIPClass: infrav1.FrontendIPClass{
+							PrivateIPAddress: "10.0.0.11",
+						},
+					},
+					{
+						Name: "ip-2",
+						PublicIP: &infrav1.PublicIPSpec{
+							Name:    "my-valid-ip",
+							DNSName: "my-valid-ip",
+						},
+					},
+				},
+				LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{
+					Type: infrav1.Public,
+					SKU:  infrav1.SKUStandard,
+				},
+				Name: "my-public-lb",
+			},
+			cpCIDRS: []string{"10.0.0.0/24"},
+			wantErr: true,
+			expectedErr: field.Error{
+				Type:   "FieldValueForbidden",
+				Field:  "apiServerLB.frontendIPConfigs[0].privateIP",
+				Detail: "API Server load balancer private IP should not be modified after AzureCluster creation.",
+			},
+		},
+		{
+			name: "internal LB: changing private IP after creation is forbidden",
+			old: &infrav1.LoadBalancerSpec{
+				FrontendIPs: []infrav1.FrontendIP{
+					{
+						Name: "ip-1",
+						FrontendIPClass: infrav1.FrontendIPClass{
+							PrivateIPAddress: "10.1.0.3",
+						},
+					},
+				},
+				LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{
+					Type: infrav1.Internal,
+					SKU:  infrav1.SKUStandard,
+				},
+				Name: "my-private-lb",
+			},
+			lb: &infrav1.LoadBalancerSpec{
+				FrontendIPs: []infrav1.FrontendIP{
+					{
+						Name: "ip-1",
+						FrontendIPClass: infrav1.FrontendIPClass{
+							PrivateIPAddress: "10.1.0.4",
+						},
+					},
+				},
+				LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{
+					Type: infrav1.Internal,
+					SKU:  infrav1.SKUStandard,
+				},
+				Name: "my-private-lb",
+			},
+			cpCIDRS: []string{"10.1.0.0/24"},
+			wantErr: true,
+			expectedErr: field.Error{
+				Type:   "FieldValueForbidden",
+				Field:  "apiServerLB.frontendIPConfigs[0].privateIP",
+				Detail: "API Server load balancer private IP should not be modified after AzureCluster creation.",
+			},
+		},
+		{
+			name:        "public LB with APIServerILB enabled and unchanged private IP",
+			featureGate: feature.APIServerILB,
+			old: &infrav1.LoadBalancerSpec{
+				FrontendIPs: []infrav1.FrontendIP{
+					{
+						Name: "ip-1",
+						FrontendIPClass: infrav1.FrontendIPClass{
+							PrivateIPAddress: "10.0.0.10",
+						},
+					},
+					{
+						Name: "ip-2",
+						PublicIP: &infrav1.PublicIPSpec{
+							Name:    "my-valid-ip",
+							DNSName: "my-valid-ip",
+						},
+					},
+				},
+				LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{
+					Type: infrav1.Public,
+					SKU:  infrav1.SKUStandard,
+				},
+				Name: "my-public-lb",
+			},
+			lb: &infrav1.LoadBalancerSpec{
+				FrontendIPs: []infrav1.FrontendIP{
+					{
+						Name: "ip-1",
+						FrontendIPClass: infrav1.FrontendIPClass{
+							PrivateIPAddress: "10.0.0.10",
+						},
+					},
+					{
+						Name: "ip-2",
+						PublicIP: &infrav1.PublicIPSpec{
+							Name:    "my-valid-ip",
+							DNSName: "my-valid-ip",
+						},
+					},
+				},
+				LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{
+					Type: infrav1.Public,
+					SKU:  infrav1.SKUStandard,
+				},
+				Name: "my-public-lb",
+			},
+			cpCIDRS: []string{"10.0.0.0/24"},
+			wantErr: false,
+		},
+		{
+			name:        "internal LB with APIServerILB enabled and unchanged private IP",
+			featureGate: feature.APIServerILB,
+			old: &infrav1.LoadBalancerSpec{
+				FrontendIPs: []infrav1.FrontendIP{
+					{
+						Name: "ip-1",
+						FrontendIPClass: infrav1.FrontendIPClass{
+							PrivateIPAddress: "10.1.0.3",
+						},
+					},
+				},
+				LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{
+					Type: infrav1.Internal,
+					SKU:  infrav1.SKUStandard,
+				},
+				Name: "my-private-lb",
+			},
+			lb: &infrav1.LoadBalancerSpec{
+				FrontendIPs: []infrav1.FrontendIP{
+					{
+						Name: "ip-1",
+						FrontendIPClass: infrav1.FrontendIPClass{
+							PrivateIPAddress: "10.1.0.3",
+						},
+					},
+				},
+				LoadBalancerClassSpec: infrav1.LoadBalancerClassSpec{
+					Type: infrav1.Internal,
+					SKU:  infrav1.SKUStandard,
+				},
+				Name: "my-private-lb",
+			},
+			cpCIDRS: []string{"10.1.0.0/24"},
+			wantErr: false,
+		},
 	}
 
 	for _, test := range testcases {


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
- Fixes a bug where the API server load balancer private IP can be changed after AzureCluster creation when APIServerILB is enabled and the LB type is Public
- Previously, the validation only ran for Internal type LBs, leaving the Public + APIServerILB path unguarded
- Adds a function validateAPIServerLBPrivateIPUnchanged and uses it for both Internal and Public + APIServerILB paths, deduplicating the validation logic
- Fixes the error field path for the Internal LB immutability check from apiServerLB.name to apiServerLB.frontendIPConfigs[0].privateIP

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #5314 

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->


**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests
- [ ] cherry-pick candidate

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
fix: validate API server LB private IP is unchanged on update for Public and APIServerILB configuration
```
