### PR TITLE
Bump old CAPI upgrade version to v1.12.9

### DIFF
--- a/test/e2e/config/azure-dev.yaml
+++ b/test/e2e/config/azure-dev.yaml
@@ -3,15 +3,15 @@ managementClusterName: capz-e2e
 images:
   - name: ${MANAGER_IMAGE}
     loadBehavior: mustLoad
-  - name: registry.k8s.io/cluster-api/cluster-api-controller:v1.12.8
+  - name: registry.k8s.io/cluster-api/cluster-api-controller:v1.12.9
     loadBehavior: tryLoad
   - name: registry.k8s.io/cluster-api/cluster-api-controller:v1.13.3
     loadBehavior: tryLoad
-  - name: registry.k8s.io/cluster-api/kubeadm-bootstrap-controller:v1.12.8
+  - name: registry.k8s.io/cluster-api/kubeadm-bootstrap-controller:v1.12.9
     loadBehavior: tryLoad
   - name: registry.k8s.io/cluster-api/kubeadm-bootstrap-controller:v1.13.3
     loadBehavior: tryLoad
-  - name: registry.k8s.io/cluster-api/kubeadm-control-plane-controller:v1.12.8
+  - name: registry.k8s.io/cluster-api/kubeadm-control-plane-controller:v1.12.9
     loadBehavior: tryLoad
   - name: registry.k8s.io/cluster-api/kubeadm-control-plane-controller:v1.13.3
     loadBehavior: tryLoad
@@ -31,8 +31,8 @@ providers:
           new: --metrics-addr=:8080
       files:
         - sourcePath: "../data/shared/v1beta1/metadata.yaml"
-    - name: v1.12.8
-      value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.12.8/core-components.yaml
+    - name: v1.12.9
+      value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.12.9/core-components.yaml
       type: url
       contract: v1beta2
       files:
@@ -66,8 +66,8 @@ providers:
           new: --metrics-addr=:8080
       files:
         - sourcePath: "../data/shared/v1beta1/metadata.yaml"
-    - name: v1.12.8
-      value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.12.8/bootstrap-components.yaml
+    - name: v1.12.9
+      value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.12.9/bootstrap-components.yaml
       type: url
       contract: v1beta2
       files:
@@ -97,8 +97,8 @@ providers:
           new: --metrics-addr=:8080
       files:
         - sourcePath: "../data/shared/v1beta1/metadata.yaml"
-    - name: v1.12.8
-      value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.12.8/control-plane-components.yaml
+    - name: v1.12.9
+      value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.12.9/control-plane-components.yaml
       type: url
       contract: v1beta2
       files:
@@ -297,7 +297,7 @@ variables:
   WINDOWS_CONTAINERD_URL: "${WINDOWS_CONTAINERD_URL:-}"
   AZURE_CNI_V1_MANIFEST_PATH: "${PWD}/templates/addons/azure-cni-v1.yaml"
   OLD_CAPI_UPGRADE_VERSION: "v1.11.11"
-  LATEST_CAPI_UPGRADE_VERSION: "v1.12.8"
+  LATEST_CAPI_UPGRADE_VERSION: "v1.12.9"
   OLD_PROVIDER_UPGRADE_VERSION: "v1.23.1"
   LATEST_PROVIDER_UPGRADE_VERSION: "v1.24.0"
   OLD_CAAPH_UPGRADE_VERSION: "v0.5.3"


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

PR #6395 bumped the current CAPI test version to v1.13.3 but left the older upgrade version at v1.12.8, even though v1.12.9 was also released. This bumps the `LATEST_CAPI_UPGRADE_VERSION` and the related v1.12 e2e image/provider references from v1.12.8 to v1.12.9.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

Only the older upgrade version changes; the current CAPI dependency stays at v1.13.3.

**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] cherry-pick candidate

**Release note**:

```release-note
NONE
```
