### PR TITLE
[release-1.24] Bump CAPI to v1.13.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -360,7 +360,7 @@ create-management-cluster: $(KUSTOMIZE) $(ENVSUBST) $(KUBECTL) $(KIND) ## Create
 	./hack/create-custom-cloud-provider-config.sh
 
 	# Deploy CAPI
-	timeout --foreground 300 bash -c "until curl --retry $(CURL_RETRIES) -sSL https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.13.2/cluster-api-components.yaml | $(ENVSUBST) | $(KUBECTL) apply -f - --server-side=true; do sleep 5; done"
+	timeout --foreground 300 bash -c "until curl --retry $(CURL_RETRIES) -sSL https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.13.3/cluster-api-components.yaml | $(ENVSUBST) | $(KUBECTL) apply -f - --server-side=true; do sleep 5; done"
 
 	# Deploy CAAPH
 	timeout --foreground 300 bash -c "until curl --retry $(CURL_RETRIES) -sSL https://github.com/kubernetes-sigs/cluster-api-addon-provider-helm/releases/download/v0.6.2/addon-components.yaml | $(ENVSUBST) | $(KUBECTL) apply -f - --server-side=true; do sleep 5; done"

--- a/Tiltfile
+++ b/Tiltfile
@@ -22,7 +22,7 @@ settings = {
     "deploy_cert_manager": True,
     "preload_images_for_kind": True,
     "kind_cluster_name": "capz",
-    "capi_version": "v1.13.2",
+    "capi_version": "v1.13.3",
     "caaph_version": "v0.6.2",
     "cert_manager_version": "v1.20.2",
     "kubernetes_version": "v1.35.4",

--- a/docs/book/src/developers/getting-started-with-capi-operator.md
+++ b/docs/book/src/developers/getting-started-with-capi-operator.md
@@ -120,7 +120,7 @@ helm install cert-manager jetstack/cert-manager --namespace cert-manager --creat
 Create a `values.yaml` file for the CAPI Operator Helm chart like so:
 
 ```yaml
-core: "cluster-api:v1.13.2"
+core: "cluster-api:v1.13.3"
 infrastructure: "azure:v1.17.2"
 addon: "helm:v0.6.2"
 manager:

--- a/go.mod
+++ b/go.mod
@@ -56,8 +56,8 @@ require (
 	k8s.io/kubectl v0.34.2
 	k8s.io/utils v0.0.0-20251002143259-bc988d571ff4
 	sigs.k8s.io/cloud-provider-azure v1.34.3
-	sigs.k8s.io/cluster-api v1.13.2
-	sigs.k8s.io/cluster-api/test v1.13.2
+	sigs.k8s.io/cluster-api v1.13.3
+	sigs.k8s.io/cluster-api/test v1.13.3
 	sigs.k8s.io/controller-runtime v0.23.3
 	sigs.k8s.io/kind v0.32.0
 )

--- a/go.sum
+++ b/go.sum
@@ -610,10 +610,10 @@ sigs.k8s.io/cloud-provider-azure/pkg/azclient v0.9.2 h1:7vEaYwdsvOz1OBAtEm6vyc4K
 sigs.k8s.io/cloud-provider-azure/pkg/azclient v0.9.2/go.mod h1:BgPOvGEdPTyaIWREF7pywm6teBhO3fNVQ+CTPYyr/5w=
 sigs.k8s.io/cloud-provider-azure/pkg/azclient/configloader v0.8.4 h1:Sy+dyfxemdQaz/UfJYWzALlbLdEaZ7IoKn93JXTqWYs=
 sigs.k8s.io/cloud-provider-azure/pkg/azclient/configloader v0.8.4/go.mod h1:RgIi9n/PhULbvPjYZGsjP2zWJf1ZEd1qyA0CYUuSgcE=
-sigs.k8s.io/cluster-api v1.13.2 h1:NVdbVLmh6IyfdtENQAi80AijJf/FjfQLODz/6caDjlc=
-sigs.k8s.io/cluster-api v1.13.2/go.mod h1:h7cyiUh+N7sIBkSerqU8cDkYMtRlXVO1c5RoJE1p5+g=
-sigs.k8s.io/cluster-api/test v1.13.2 h1:DIcgMPIMyQyHjZWtEx5YlzHPktuU/wRlCU+0gK32RJk=
-sigs.k8s.io/cluster-api/test v1.13.2/go.mod h1:3FL7oJBT6ThT63TcbTigSNNXCXK/2CJ5b8ODbaVs3nk=
+sigs.k8s.io/cluster-api v1.13.3 h1:BlNVnjg644NnlWnxIWHbkltleFLVQwm8FmjWCSB9wGY=
+sigs.k8s.io/cluster-api v1.13.3/go.mod h1:7xB2mYn7oOxSlUw7wk6TukNCjR2phn+MI0gRju3TKSk=
+sigs.k8s.io/cluster-api/test v1.13.3 h1:af/dWuehRRPSy/oUiH4Dzq0bBZzvCZYvbBOL7jtTXnM=
+sigs.k8s.io/cluster-api/test v1.13.3/go.mod h1:ZR56m/ZorTnTEewLysDN5djnZX/oTAvYUTugQJzFxSg=
 sigs.k8s.io/controller-runtime v0.23.3 h1:VjB/vhoPoA9l1kEKZHBMnQF33tdCLQKJtydy4iqwZ80=
 sigs.k8s.io/controller-runtime v0.23.3/go.mod h1:B6COOxKptp+YaUT5q4l6LqUJTRpizbgf9KSRNdQGns0=
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 h1:IpInykpT6ceI+QxKBbEflcR5EXP7sU1kvOlxwZh5txg=

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 toolchain go1.25.11
 
-require sigs.k8s.io/cluster-api/hack/tools v0.0.0-20260513122147-ebd807c66351
+require sigs.k8s.io/cluster-api/hack/tools v0.0.0-20260617161443-cf0f6c00fbf7
 
 require (
 	github.com/fxamacker/cbor/v2 v2.9.0 // indirect

--- a/hack/tools/go.sum
+++ b/hack/tools/go.sum
@@ -82,8 +82,8 @@ k8s.io/kube-openapi v0.0.0-20250910181357-589584f1c912 h1:Y3gxNAuB0OBLImH611+UDZ
 k8s.io/kube-openapi v0.0.0-20250910181357-589584f1c912/go.mod h1:kdmbQkyfwUagLfXIad1y2TdrjPFWp2Q89B3qkRwf/pQ=
 k8s.io/utils v0.0.0-20251002143259-bc988d571ff4 h1:SjGebBtkBqHFOli+05xYbK8YF1Dzkbzn+gDM4X9T4Ck=
 k8s.io/utils v0.0.0-20251002143259-bc988d571ff4/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
-sigs.k8s.io/cluster-api/hack/tools v0.0.0-20260513122147-ebd807c66351 h1:CUWGjEUMJKWUD8yxPktMSTuRv3DEr9AzRefkogo4ooA=
-sigs.k8s.io/cluster-api/hack/tools v0.0.0-20260513122147-ebd807c66351/go.mod h1:zIKgABMegdCknbQ3HnEuOS74syLC3C5nIrc1HFtrv38=
+sigs.k8s.io/cluster-api/hack/tools v0.0.0-20260617161443-cf0f6c00fbf7 h1:tYJ5EQWZTU+EXtwr6UBzV0o7pkdi8SrKx3khpzNK/Wc=
+sigs.k8s.io/cluster-api/hack/tools v0.0.0-20260617161443-cf0f6c00fbf7/go.mod h1:nvsUKiJC/+Ii2t+1JClvDzO0fmOnYcDi47OJ3rkMHpQ=
 sigs.k8s.io/controller-tools v0.20.1 h1:gkfMt9YodI0K85oT8rVi80NTXO/kDmabKR5Ajn5GYxs=
 sigs.k8s.io/controller-tools v0.20.1/go.mod h1:b4qPmjGU3iZwqn34alUU5tILhNa9+VXK+J3QV0fT/uU=
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 h1:IpInykpT6ceI+QxKBbEflcR5EXP7sU1kvOlxwZh5txg=

--- a/test/e2e/capi_test.go
+++ b/test/e2e/capi_test.go
@@ -210,10 +210,11 @@ var _ = Describe("Running the Cluster API E2E tests", func() {
 			Context("upgrade from an old version of v1beta1 to current, and scale workload clusters created in the old version", func() {
 				capi_e2e.ClusterctlUpgradeSpec(ctx, func() capi_e2e.ClusterctlUpgradeSpecInput {
 					return capi_e2e.ClusterctlUpgradeSpecInput{
-						E2EConfig:                 e2eConfig,
-						ClusterctlConfigPath:      clusterctlConfigPath,
-						WorkloadFlavor:            "machine-and-machine-pool",
-						BootstrapClusterProxy:     bootstrapClusterProxy,
+						E2EConfig:             e2eConfig,
+						ClusterctlConfigPath:  clusterctlConfigPath,
+						WorkloadFlavor:        "machine-and-machine-pool",
+						BootstrapClusterProxy: bootstrapClusterProxy,
+						ManagementClusterControlPlaneMachineCount: ptr.To[int64](3),
 						ArtifactFolder:            artifactFolder,
 						SkipCleanup:               skipCleanup,
 						PreInit:                   getPreInitFunc(ctx),
@@ -235,10 +236,11 @@ var _ = Describe("Running the Cluster API E2E tests", func() {
 			Context("upgrade from the latest version of v1beta1 to current, and scale workload clusters created in the old version", func() {
 				capi_e2e.ClusterctlUpgradeSpec(ctx, func() capi_e2e.ClusterctlUpgradeSpecInput {
 					return capi_e2e.ClusterctlUpgradeSpecInput{
-						E2EConfig:                 e2eConfig,
-						ClusterctlConfigPath:      clusterctlConfigPath,
-						WorkloadFlavor:            "machine-and-machine-pool",
-						BootstrapClusterProxy:     bootstrapClusterProxy,
+						E2EConfig:             e2eConfig,
+						ClusterctlConfigPath:  clusterctlConfigPath,
+						WorkloadFlavor:        "machine-and-machine-pool",
+						BootstrapClusterProxy: bootstrapClusterProxy,
+						ManagementClusterControlPlaneMachineCount: ptr.To[int64](3),
 						ArtifactFolder:            artifactFolder,
 						SkipCleanup:               skipCleanup,
 						PreInit:                   getPreInitFunc(ctx),
@@ -260,16 +262,17 @@ var _ = Describe("Running the Cluster API E2E tests", func() {
 			Context("upgrade from an old version of v1beta1 to current, and scale AKS workload clusters created in the old version", func() {
 				capi_e2e.ClusterctlUpgradeSpec(ctx, func() capi_e2e.ClusterctlUpgradeSpecInput {
 					return capi_e2e.ClusterctlUpgradeSpecInput{
-						E2EConfig:                 e2eConfig,
-						ClusterctlConfigPath:      clusterctlConfigPath,
-						WorkloadFlavor:            "aks",
-						WorkloadKubernetesVersion: aksKubernetesVersion,
-						ControlPlaneMachineCount:  ptr.To[int64](0),
-						BootstrapClusterProxy:     bootstrapClusterProxy,
-						ArtifactFolder:            artifactFolder,
-						SkipCleanup:               skipCleanup,
-						PreInit:                   getPreInitFunc(ctx),
-						InitWithProvidersContract: "v1beta1",
+						E2EConfig:                                 e2eConfig,
+						ClusterctlConfigPath:                      clusterctlConfigPath,
+						WorkloadFlavor:                            "aks",
+						WorkloadKubernetesVersion:                 aksKubernetesVersion,
+						ControlPlaneMachineCount:                  ptr.To[int64](0),
+						BootstrapClusterProxy:                     bootstrapClusterProxy,
+						ManagementClusterControlPlaneMachineCount: ptr.To[int64](3),
+						ArtifactFolder:                            artifactFolder,
+						SkipCleanup:                               skipCleanup,
+						PreInit:                                   getPreInitFunc(ctx),
+						InitWithProvidersContract:                 "v1beta1",
 						ControlPlaneWaiters: clusterctl.ControlPlaneWaiters{
 							WaitForControlPlaneInitialized: EnsureControlPlaneInitialized,
 						},
@@ -298,16 +301,17 @@ var _ = Describe("Running the Cluster API E2E tests", func() {
 			Context("upgrade from the latest version of v1beta1 to current, and scale AKS workload clusters created in the old version", func() {
 				capi_e2e.ClusterctlUpgradeSpec(ctx, func() capi_e2e.ClusterctlUpgradeSpecInput {
 					return capi_e2e.ClusterctlUpgradeSpecInput{
-						E2EConfig:                 e2eConfig,
-						ClusterctlConfigPath:      clusterctlConfigPath,
-						WorkloadFlavor:            "aks",
-						WorkloadKubernetesVersion: aksKubernetesVersion,
-						ControlPlaneMachineCount:  ptr.To[int64](0),
-						BootstrapClusterProxy:     bootstrapClusterProxy,
-						ArtifactFolder:            artifactFolder,
-						SkipCleanup:               skipCleanup,
-						PreInit:                   getPreInitFunc(ctx),
-						InitWithProvidersContract: "v1beta1",
+						E2EConfig:                                 e2eConfig,
+						ClusterctlConfigPath:                      clusterctlConfigPath,
+						WorkloadFlavor:                            "aks",
+						WorkloadKubernetesVersion:                 aksKubernetesVersion,
+						ControlPlaneMachineCount:                  ptr.To[int64](0),
+						BootstrapClusterProxy:                     bootstrapClusterProxy,
+						ManagementClusterControlPlaneMachineCount: ptr.To[int64](3),
+						ArtifactFolder:                            artifactFolder,
+						SkipCleanup:                               skipCleanup,
+						PreInit:                                   getPreInitFunc(ctx),
+						InitWithProvidersContract:                 "v1beta1",
 						ControlPlaneWaiters: clusterctl.ControlPlaneWaiters{
 							WaitForControlPlaneInitialized: EnsureControlPlaneInitialized,
 						},

--- a/test/e2e/config/azure-dev.yaml
+++ b/test/e2e/config/azure-dev.yaml
@@ -3,17 +3,17 @@ managementClusterName: capz-e2e
 images:
   - name: ${MANAGER_IMAGE}
     loadBehavior: mustLoad
-  - name: registry.k8s.io/cluster-api/cluster-api-controller:v1.12.8
+  - name: registry.k8s.io/cluster-api/cluster-api-controller:v1.12.9
     loadBehavior: tryLoad
-  - name: registry.k8s.io/cluster-api/cluster-api-controller:v1.13.2
+  - name: registry.k8s.io/cluster-api/cluster-api-controller:v1.13.3
     loadBehavior: tryLoad
-  - name: registry.k8s.io/cluster-api/kubeadm-bootstrap-controller:v1.12.8
+  - name: registry.k8s.io/cluster-api/kubeadm-bootstrap-controller:v1.12.9
     loadBehavior: tryLoad
-  - name: registry.k8s.io/cluster-api/kubeadm-bootstrap-controller:v1.13.2
+  - name: registry.k8s.io/cluster-api/kubeadm-bootstrap-controller:v1.13.3
     loadBehavior: tryLoad
-  - name: registry.k8s.io/cluster-api/kubeadm-control-plane-controller:v1.12.8
+  - name: registry.k8s.io/cluster-api/kubeadm-control-plane-controller:v1.12.9
     loadBehavior: tryLoad
-  - name: registry.k8s.io/cluster-api/kubeadm-control-plane-controller:v1.13.2
+  - name: registry.k8s.io/cluster-api/kubeadm-control-plane-controller:v1.13.3
     loadBehavior: tryLoad
   - name: registry.k8s.io/cluster-api-helm/cluster-api-helm-controller:v0.6.2
     loadBehavior: tryLoad
@@ -31,8 +31,8 @@ providers:
           new: --metrics-addr=:8080
       files:
         - sourcePath: "../data/shared/v1beta1/metadata.yaml"
-    - name: v1.12.8
-      value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.12.8/core-components.yaml
+    - name: v1.12.9
+      value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.12.9/core-components.yaml
       type: url
       contract: v1beta2
       files:
@@ -42,8 +42,8 @@ providers:
         new: "imagePullPolicy: IfNotPresent"
       - old: "- --leader-elect"
         new: "- --leader-elect\n        - --remote-connection-grace-period=3m"
-    - name: v1.13.2
-      value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.13.2/core-components.yaml
+    - name: v1.13.3
+      value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.13.3/core-components.yaml
       type: url
       contract: v1beta2
       files:
@@ -66,8 +66,8 @@ providers:
           new: --metrics-addr=:8080
       files:
         - sourcePath: "../data/shared/v1beta1/metadata.yaml"
-    - name: v1.12.8
-      value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.12.8/bootstrap-components.yaml
+    - name: v1.12.9
+      value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.12.9/bootstrap-components.yaml
       type: url
       contract: v1beta2
       files:
@@ -75,8 +75,8 @@ providers:
       replacements:
       - old: "imagePullPolicy: Always"
         new: "imagePullPolicy: IfNotPresent"
-    - name: v1.13.2
-      value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.13.2/bootstrap-components.yaml
+    - name: v1.13.3
+      value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.13.3/bootstrap-components.yaml
       type: url
       contract: v1beta2
       files:
@@ -97,8 +97,8 @@ providers:
           new: --metrics-addr=:8080
       files:
         - sourcePath: "../data/shared/v1beta1/metadata.yaml"
-    - name: v1.12.8
-      value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.12.8/control-plane-components.yaml
+    - name: v1.12.9
+      value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.12.9/control-plane-components.yaml
       type: url
       contract: v1beta2
       files:
@@ -106,8 +106,8 @@ providers:
       replacements:
       - old: "imagePullPolicy: Always"
         new: "imagePullPolicy: IfNotPresent"
-    - name: v1.13.2
-      value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.13.2/control-plane-components.yaml
+    - name: v1.13.3
+      value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.13.3/control-plane-components.yaml
       type: url
       contract: v1beta2
       files:
@@ -296,7 +296,7 @@ variables:
   WINDOWS_CONTAINERD_URL: "${WINDOWS_CONTAINERD_URL:-}"
   AZURE_CNI_V1_MANIFEST_PATH: "${PWD}/templates/addons/azure-cni-v1.yaml"
   OLD_CAPI_UPGRADE_VERSION: "v1.11.11"
-  LATEST_CAPI_UPGRADE_VERSION: "v1.12.8"
+  LATEST_CAPI_UPGRADE_VERSION: "v1.12.9"
   OLD_PROVIDER_UPGRADE_VERSION: "v1.22.2"
   LATEST_PROVIDER_UPGRADE_VERSION: "v1.23.0"
   OLD_CAAPH_UPGRADE_VERSION: "v0.5.3"


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

This is a manual cherry-pick of #6395 and #6403 to `release-1.24`, squashed into a single commit. The automated `/cherry-pick` could not apply cleanly because the `require` block and e2e config on `release-1.24` differ from `main`.

It bumps CAPI to v1.13.3 and the old CAPI upgrade version to v1.12.9.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

Conflicts were resolved by keeping `release-1.24`'s existing `sigs.k8s.io/kind` and provider upgrade versions, applying only the CAPI version bumps from the two PRs.

**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [x] cherry-pick candidate

**Release note**:

```release-note
NONE
```
