### PR TITLE
Add release notes for v1.25.1

### DIFF
--- a/CHANGELOG/v1.25.1.md
+++ b/CHANGELOG/v1.25.1.md
@@ -1,0 +1,96 @@
+## Upgrading
+
+Please note that upgrading CAPZ should be done one minor release at a time. Skipping ahead by more than one minor (for example, from v1.23.x to v1.25.1) is not tested and may cause problems.
+
+See [Upgrading](https://capz.sigs.k8s.io/topics/aso#upgrading) for more details.
+
+## Changes by Kind
+
+### Feature
+
+- Add support for zone-redundant load balancers. Users can now configure availability zones on load balancers (APIServerLB, NodeOutboundLB, ControlPlaneOutboundLB) to enable zone-redundant configurations for high availability across multiple availability zones. ([#5944](https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/5944), [@bryan-cox](https://github.com/bryan-cox))
+- Feat: SkipMachinePoolModelReconciliation ([#6325](https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/6325), [@jackfrancis](https://github.com/jackfrancis))
+
+
+### Bug or Regression
+
+- Fix: default control plane subnet to share the node route table ([#6358](https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/6358), [@willie-yao](https://github.com/willie-yao))
+- Fixes an issue where capz-manager-role reconciles continuously if managed by an installer which uses server-side apply. ([#6346](https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/6346), [@mdbooth](https://github.com/mdbooth))
+- Register Windows nodes with uninitialized cloud taint ([#6293](https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/6293), [@mboersma](https://github.com/mboersma))
+- Strip OpenAPI description fields from vendored ASO CRDs ([#6281](https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/6281), [@mboersma](https://github.com/mboersma))
+
+### Other (Cleanup or Flake)
+
+- Let ASO v2.17.0 install and manage its own CRDs ([#6304](https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/6304), [@mboersma](https://github.com/mboersma))
+- Bump CAPI to v1.13.3 ([#6395](https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/6395), [@mboersma](https://github.com/mboersma))
+- Disable VM Bootstrap Extension by default ([#6316](https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/6316), [@willie-yao](https://github.com/willie-yao))
+- Harden GitHub Actions workflows by disabling persisted checkout credentials and reducing unnecessary workflow permissions. ([#6331](https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/6331), [@PrashantR30](https://github.com/PrashantR30))
+- Make the apiversion-upgrade management cluster HA ([#6329](https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/6329), [@mboersma](https://github.com/mboersma))
+- Remove stale CRDs and add missing ASO managed kinds to PROJECT ([#6285](https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/6285), [@mboersma](https://github.com/mboersma))
+- Switch default Windows image to windows-2022 ([#6282](https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/6282), [@mboersma](https://github.com/mboersma))
+- Test/e2e: make collectPodLogs log dump best-effort ([#6315](https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/6315), [@mboersma](https://github.com/mboersma))
+- Extract shared ReconcileAll/DeleteAll helpers in the azure package to eliminate duplicated reconcile/delete loop boilerplate across eight services. ([#6324](https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/6324), [@bryan-cox](https://github.com/bryan-cox))
+
+## Dependencies
+
+### Added
+- github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/operationalinsights/armoperationalinsights: [v1.2.0](https://github.com/Azure/azure-sdk-for-go/tree/sdk/resourcemanager/operationalinsights/armoperationalinsights/v1.2.0)
+- github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/redisenterprise/armredisenterprise: [v1.2.0](https://github.com/Azure/azure-sdk-for-go/tree/sdk/resourcemanager/redisenterprise/armredisenterprise/v1.2.0)
+- github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armdeployments: [v1.0.0](https://github.com/Azure/azure-sdk-for-go/tree/sdk/resourcemanager/resources/armdeployments/v1.0.0)
+- github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources/v3: [v3.0.1](https://github.com/Azure/azure-sdk-for-go/tree/sdk/resourcemanager/resources/armresources/v3/v3.0.1)
+- github.com/go-openapi/testify/v2: [v2.0.2](https://github.com/go-openapi/testify/tree/v2.0.2)
+- go.opentelemetry.io/otel/metric/x: v0.66.0
+
+### Changed
+- github.com/Azure/azure-sdk-for-go/sdk/azcore: [v1.21.1 → v1.22.0](https://github.com/Azure/azure-sdk-for-go/compare/sdk/azcore/v1.21.1...sdk/azcore/v1.22.0)
+- github.com/Azure/azure-sdk-for-go/sdk/azidentity/cache: [v0.3.2 → v0.4.0](https://github.com/Azure/azure-sdk-for-go/compare/sdk/azidentity/cache/v0.3.2...sdk/azidentity/cache/v0.4.0)
+- github.com/Azure/azure-sdk-for-go/sdk/azidentity: [v1.13.1 → v1.14.0](https://github.com/Azure/azure-sdk-for-go/compare/sdk/azidentity/v1.13.1...sdk/azidentity/v1.14.0)
+- github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal/v3: [v3.1.0 → v3.2.0](https://github.com/Azure/azure-sdk-for-go/compare/sdk/resourcemanager/internal/v3/v3.1.0...sdk/resourcemanager/internal/v3/v3.2.0)
+- github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/monitor/armmonitor: [v0.11.0 → v0.12.0](https://github.com/Azure/azure-sdk-for-go/compare/sdk/resourcemanager/monitor/armmonitor/v0.11.0...sdk/resourcemanager/monitor/armmonitor/v0.12.0)
+- github.com/Azure/azure-service-operator/v2: [v2.16.0 → v2.17.0](https://github.com/Azure/azure-service-operator/compare/v2.16.0...v2.17.0)
+- github.com/AzureAD/microsoft-authentication-library-for-go: [v1.6.0 → v1.7.2](https://github.com/AzureAD/microsoft-authentication-library-for-go/compare/v1.6.0...v1.7.2)
+- github.com/cncf/xds/go: [ee656c7 → dba9d58](https://github.com/cncf/xds/compare/ee656c7...dba9d58)
+- github.com/coredns/corefile-migration: [v1.0.31 → v1.0.32](https://github.com/coredns/corefile-migration/compare/v1.0.31...v1.0.32)
+- github.com/envoyproxy/go-control-plane/envoy: [v1.36.0 → v1.37.0](https://github.com/envoyproxy/go-control-plane/compare/envoy/v1.36.0...envoy/v1.37.0)
+- github.com/envoyproxy/protoc-gen-validate: [v1.3.0 → v1.3.3](https://github.com/envoyproxy/protoc-gen-validate/compare/v1.3.0...v1.3.3)
+- github.com/go-jose/go-jose/v4: [v4.1.3 → v4.1.4](https://github.com/go-jose/go-jose/compare/v4.1.3...v4.1.4)
+- github.com/go-openapi/jsonpointer: [v0.22.1 → v0.22.3](https://github.com/go-openapi/jsonpointer/compare/v0.22.1...v0.22.3)
+- github.com/golang-jwt/jwt/v5: [v5.3.0 → v5.3.1](https://github.com/golang-jwt/jwt/compare/v5.3.0...v5.3.1)
+- github.com/grpc-ecosystem/grpc-gateway/v2: [v2.28.0 → v2.29.0](https://github.com/grpc-ecosystem/grpc-gateway/compare/v2.28.0...v2.29.0)
+- github.com/microsoft/go-mssqldb: [v1.9.3 → v1.9.4](https://github.com/microsoft/go-mssqldb/compare/v1.9.3...v1.9.4)
+- github.com/microsoftgraph/msgraph-sdk-go: [v1.87.0 → v1.90.0](https://github.com/microsoftgraph/msgraph-sdk-go/compare/v1.87.0...v1.90.0)
+- github.com/onsi/ginkgo/v2: [v2.28.3 → v2.31.0](https://github.com/onsi/ginkgo/compare/v2.28.3...v2.31.0)
+- github.com/onsi/gomega: [v1.40.0 → v1.42.0](https://github.com/onsi/gomega/compare/v1.40.0...v1.42.0)
+- go.opentelemetry.io/contrib/detectors/gcp: v1.39.0 → v1.42.0
+- go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc: v0.65.0 → v0.69.0
+- go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp: v0.65.0 → v0.69.0
+- go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc: v1.43.0 → v1.44.0
+- go.opentelemetry.io/otel/exporters/otlp/otlptrace: v1.43.0 → v1.44.0
+- go.opentelemetry.io/otel/exporters/prometheus: v0.65.0 → v0.66.0
+- go.opentelemetry.io/otel/metric: v1.43.0 → v1.44.0
+- go.opentelemetry.io/otel/sdk/metric: v1.43.0 → v1.44.0
+- go.opentelemetry.io/otel/sdk: v1.43.0 → v1.44.0
+- go.opentelemetry.io/otel/trace: v1.43.0 → v1.44.0
+- go.opentelemetry.io/otel: v1.43.0 → v1.44.0
+- golang.org/x/crypto: v0.50.0 → v0.53.0
+- golang.org/x/mod: v0.35.0 → v0.37.0
+- golang.org/x/net: v0.53.0 → v0.55.0
+- golang.org/x/sync: v0.20.0 → v0.21.0
+- golang.org/x/sys: v0.43.0 → v0.46.0
+- golang.org/x/telemetry: be6f6cb → 42602be
+- golang.org/x/term: v0.42.0 → v0.44.0
+- golang.org/x/text: v0.36.0 → v0.38.0
+- golang.org/x/tools: v0.44.0 → v0.45.0
+- google.golang.org/genproto/googleapis/api: 9d38bb4 → 3dc84a4
+- google.golang.org/genproto/googleapis/rpc: 9d38bb4 → 3dc84a4
+- google.golang.org/grpc: v1.80.0 → v1.81.1
+- sigs.k8s.io/cluster-api/test: v1.13.1 → v1.13.3
+- sigs.k8s.io/cluster-api: v1.13.1 → v1.13.3
+- sigs.k8s.io/kind: v0.31.0 → v0.32.0
+
+### Removed
+_Nothing has changed._
+
+## Details
+<!-- markdown-link-check-disable-next-line -->
+https://github.com/kubernetes-sigs/cluster-api-provider-azure/compare/v1.24.0...v1.25.1


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

Adds notes for the impending CAPZ v1.25.1 release.

Release v1.25.0 failed: see #6406. So we need a patch release to get past that. I included the v1.25.0 release notes because this will be the first user-visible v1.25.x release.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->


**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [x] includes documentation
- [ ] adds unit tests
- [ ] cherry-pick candidate

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
