### PR TITLE
Allow async cluster delete in ci-entrypoint to avoid prow timeout

### DIFF
--- a/scripts/ci-entrypoint.sh
+++ b/scripts/ci-entrypoint.sh
@@ -259,7 +259,16 @@ capz::ci-entrypoint::on_exit() {
     "${REPO_ROOT}/hack/log/redact.sh" || true
     # cleanup all resources we use
     if [[ ! "${SKIP_CLEANUP:-}" == "true" ]]; then
-        timeout 1800 "${KUBECTL}" --kubeconfig "${REPO_ROOT}/${KIND_CLUSTER_NAME}.kubeconfig" delete cluster "${CLUSTER_NAME}" -n default || echo "Unable to delete cluster ${CLUSTER_NAME}"
+        if [[ "${ASYNC_DELETE_CLUSTER:-}" == "true" ]]; then
+            # Fire-and-forget delete: kubectl returns once the API server
+            # accepts the request and CAPI/CAPZ controllers reconcile Azure
+            # resource removal asynchronously. Boskos reclaims the entire
+            # subscription afterwards so orphans are bounded. Useful for
+            # prow jobs whose total time approaches the entrypoint timeout.
+            "${KUBECTL}" --kubeconfig "${REPO_ROOT}/${KIND_CLUSTER_NAME}.kubeconfig" delete cluster "${CLUSTER_NAME}" -n default --wait=false --timeout=2m || echo "Unable to delete cluster ${CLUSTER_NAME}"
+        else
+            timeout 1800 "${KUBECTL}" --kubeconfig "${REPO_ROOT}/${KIND_CLUSTER_NAME}.kubeconfig" delete cluster "${CLUSTER_NAME}" -n default || echo "Unable to delete cluster ${CLUSTER_NAME}"
+        fi
         make --directory="${REPO_ROOT}" kind-reset || true
     fi
 }


### PR DESCRIPTION
## What this PR does / why we need it

The on-exit trap in `scripts/ci-entrypoint.sh` currently blocks for up to **30 minutes** waiting for `kubectl delete cluster` to fully reconcile Azure resource removal:

https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/scripts/ci-entrypoint.sh#L262

```bash
timeout 1800 "${KUBECTL}" --kubeconfig ... delete cluster "${CLUSTER_NAME}" -n default || echo "..."
```

For e2e jobs whose total wall-clock time already approaches the prow 3h timeout, this push the job past the limit even when **every Ginkgo spec passed**. Concrete example:

[`pull-azuredisk-csi-driver-e2e-capz-windows-2022-hostprocess` run `2071144279681536000`](https://storage.googleapis.com/kubernetes-ci-logs/pr-logs/pull/kubernetes-sigs_azuredisk-csi-driver/3677/pull-azuredisk-csi-driver-e2e-capz-windows-2022-hostprocess/2071144279681536000/build-log.txt)
- 22/71 specs ran, **0 failed**, AfterSuite PASSED
- E2E: ~110 min, capz log dump: ~12 min
- Hit prow 3h timeout at 11:11:07Z while still waiting on `kubectl delete cluster capz-oa6x06`
- Result: prow marks the job FAILURE despite a clean test run

## Change

Add an opt-in env var `ASYNC_DELETE_CLUSTER`. When set to `"true"` the on-exit trap issues a fire-and-forget delete:

```bash
kubectl delete cluster <name> -n default --wait=false --timeout=2m
```

`kubectl` returns as soon as the management cluster API server accepts the delete request, and the CAPI/CAPZ controllers reconcile Azure resource removal asynchronously. **Boskos still reclaims the entire subscription** when the prow job ends, bounding any orphaned resources.

## Compatibility

- **Default behaviour is unchanged** — the existing synchronous `timeout 1800 ... delete cluster` path runs when the env var is unset or not `"true"`.
- No new dependencies.
- `bash -n` clean.

## How prow jobs opt in

In `test-infra`'s job spec:

```yaml
env:
- name: ASYNC_DELETE_CLUSTER
  value: "true"
```

I will follow up with a `test-infra` PR enabling this on the azuredisk / azurefile / blob CSI driver Windows-hostprocess presubmits once this lands.

## Risk

- Orphaned Azure resources if the CAPI controller in the management kind cluster fails after the API server accepts the delete. Mitigation: boskos subscription reclaim already covers this, and the synchronous path remains the default.
- The 2-minute `--timeout` on the kubectl call only bounds how long we wait for the API server to ACK the delete request, not for actual resource removal.

/release-note-none

```release-note
NONE
```

/cc @CecileRobertMichon @nojnhuh