### PR TITLE
Use ASO v20251002preview API for managed clusters

### DIFF
--- a/azure/services/agentpools/agentpools_test.go
+++ b/azure/services/agentpools/agentpools_test.go
@@ -19,8 +19,8 @@ package agentpools
 import (
 	"testing"
 
-	asocontainerservicev1preview "github.com/Azure/azure-service-operator/v2/api/containerservice/v1api20240402preview"
 	asocontainerservicev1 "github.com/Azure/azure-service-operator/v2/api/containerservice/v1api20250801"
+	asocontainerservicev1preview "github.com/Azure/azure-service-operator/v2/api/containerservice/v20251002preview"
 	. "github.com/onsi/gomega"
 	"github.com/pkg/errors"
 	"go.uber.org/mock/gomock"

--- a/azure/services/agentpools/spec.go
+++ b/azure/services/agentpools/spec.go
@@ -19,9 +19,9 @@ package agentpools
 import (
 	"context"
 
-	asocontainerservicev1preview "github.com/Azure/azure-service-operator/v2/api/containerservice/v1api20240402preview"
 	asocontainerservicev1 "github.com/Azure/azure-service-operator/v2/api/containerservice/v1api20250801"
 	asocontainerservicev1hub "github.com/Azure/azure-service-operator/v2/api/containerservice/v1api20250801/storage"
+	asocontainerservicev1preview "github.com/Azure/azure-service-operator/v2/api/containerservice/v20251002preview"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/azure/services/agentpools/spec_test.go
+++ b/azure/services/agentpools/spec_test.go
@@ -19,8 +19,8 @@ package agentpools
 import (
 	"testing"
 
-	asocontainerservicev1preview "github.com/Azure/azure-service-operator/v2/api/containerservice/v1api20240402preview"
 	asocontainerservicev1 "github.com/Azure/azure-service-operator/v2/api/containerservice/v1api20250801"
+	asocontainerservicev1preview "github.com/Azure/azure-service-operator/v2/api/containerservice/v20251002preview"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	"github.com/google/go-cmp/cmp"
 	. "github.com/onsi/gomega"
@@ -188,10 +188,10 @@ func TestParameters(t *testing.T) {
 				NodeLabels:             map[string]string{"node": "labels"},
 				NodeTaints:             []string{"node taints"},
 				OrchestratorVersion:    ptr.To("1.26.6"),
-				OsDiskSizeGB:           ptr.To(asocontainerservicev1preview.ContainerServiceOSDisk(2)),
+				OsDiskSizeGB:           ptr.To(2),
 				OsDiskType:             ptr.To(asocontainerservicev1preview.OSDiskType("disk type")),
-				OsType:                 ptr.To(asocontainerservicev1preview.OSType("os type")),
-				ScaleSetPriority:       ptr.To(asocontainerservicev1preview.ScaleSetPriority("scaleset priority")),
+				OsType:                 ptr.To(asocontainerservicev1preview.ManagedClusterAgentPoolProfileProperties_OsType("os type")),
+				ScaleSetPriority:       ptr.To(asocontainerservicev1preview.ManagedClusterAgentPoolProfileProperties_ScaleSetPriority("scaleset priority")),
 				ScaleDownMode:          ptr.To(asocontainerservicev1preview.ScaleDownMode("scale down mode")),
 				Type:                   ptr.To(asocontainerservicev1preview.AgentPoolType_VirtualMachineScaleSets),
 				EnableNodePublicIP:     ptr.To(true),
@@ -270,7 +270,7 @@ func TestParameters(t *testing.T) {
 			Spec: asocontainerservicev1preview.ManagedClustersAgentPool_Spec{
 				AzureName: "set by the user",
 				PowerState: &asocontainerservicev1preview.PowerState{
-					Code: ptr.To(asocontainerservicev1preview.PowerState_Code("set by the user")),
+					Code: ptr.To(asocontainerservicev1preview.Code("set by the user")),
 				},
 				OrchestratorVersion: ptr.To("1.27.2"),
 			},
@@ -286,7 +286,7 @@ func TestParameters(t *testing.T) {
 		g.Expect(err).NotTo(HaveOccurred())
 		g.Expect(actualTyped.Spec.AzureName).To(Equal("managed by CAPZ"))
 		g.Expect(actualTyped.Spec.Count).To(Equal(ptr.To(1212)))
-		g.Expect(actualTyped.Spec.PowerState.Code).To(Equal(ptr.To(asocontainerservicev1preview.PowerState_Code("set by the user"))))
+		g.Expect(actualTyped.Spec.PowerState.Code).To(Equal(ptr.To(asocontainerservicev1preview.Code("set by the user"))))
 		g.Expect(actualTyped.Spec.OrchestratorVersion).NotTo(BeNil())
 		g.Expect(*actualTyped.Spec.OrchestratorVersion).To(Equal("1.27.2"))
 	})

--- a/azure/services/managedclusters/managedclusters_test.go
+++ b/azure/services/managedclusters/managedclusters_test.go
@@ -20,8 +20,8 @@ import (
 	"errors"
 	"testing"
 
-	asocontainerservicev1preview "github.com/Azure/azure-service-operator/v2/api/containerservice/v1api20240402preview"
 	asocontainerservicev1 "github.com/Azure/azure-service-operator/v2/api/containerservice/v1api20250801"
+	asocontainerservicev1preview "github.com/Azure/azure-service-operator/v2/api/containerservice/v20251002preview"
 	. "github.com/onsi/gomega"
 	"go.uber.org/mock/gomock"
 	corev1 "k8s.io/api/core/v1"
@@ -86,7 +86,7 @@ func TestPostCreateOrUpdateResourceHook(t *testing.T) {
 			Spec: asocontainerservicev1preview.ManagedCluster_Spec{
 				KubernetesVersion: ptr.To("1.19.0"),
 				AutoUpgradeProfile: &asocontainerservicev1preview.ManagedClusterAutoUpgradeProfile{
-					UpgradeChannel: ptr.To(asocontainerservicev1preview.ManagedClusterAutoUpgradeProfile_UpgradeChannel_Stable),
+					UpgradeChannel: ptr.To(asocontainerservicev1preview.UpgradeChannel_Stable),
 				},
 			},
 			Status: asocontainerservicev1preview.ManagedCluster_STATUS{

--- a/azure/services/managedclusters/spec.go
+++ b/azure/services/managedclusters/spec.go
@@ -23,9 +23,9 @@ import (
 	"net"
 	"sort"
 
-	asocontainerservicev1preview "github.com/Azure/azure-service-operator/v2/api/containerservice/v1api20240402preview"
 	asocontainerservicev1 "github.com/Azure/azure-service-operator/v2/api/containerservice/v1api20250801"
 	asocontainerservicev1hub "github.com/Azure/azure-service-operator/v2/api/containerservice/v1api20250801/storage"
+	asocontainerservicev1preview "github.com/Azure/azure-service-operator/v2/api/containerservice/v20251002preview"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/azure/services/managedclusters/spec_test.go
+++ b/azure/services/managedclusters/spec_test.go
@@ -20,8 +20,8 @@ import (
 	"encoding/base64"
 	"testing"
 
-	asocontainerservicev1preview "github.com/Azure/azure-service-operator/v2/api/containerservice/v1api20240402preview"
 	asocontainerservicev1 "github.com/Azure/azure-service-operator/v2/api/containerservice/v1api20250801"
+	asocontainerservicev1preview "github.com/Azure/azure-service-operator/v2/api/containerservice/v20251002preview"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	"github.com/google/go-cmp/cmp"
 	. "github.com/onsi/gomega"

--- a/controllers/azuremanagedmachinepool_reconciler.go
+++ b/controllers/azuremanagedmachinepool_reconciler.go
@@ -23,8 +23,8 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
-	asocontainerservicev1preview "github.com/Azure/azure-service-operator/v2/api/containerservice/v1api20240402preview"
 	asocontainerservicev1 "github.com/Azure/azure-service-operator/v2/api/containerservice/v1api20250801"
+	asocontainerservicev1preview "github.com/Azure/azure-service-operator/v2/api/containerservice/v20251002preview"
 	"github.com/pkg/errors"
 	azprovider "sigs.k8s.io/cloud-provider-azure/pkg/provider"
 

--- a/docs/book/src/managed/managedcluster.md
+++ b/docs/book/src/managed/managedcluster.md
@@ -384,7 +384,9 @@ spec:
 
 To enable preview features for managed clusters, you can use the `enablePreviewFeatures` field in the `AzureManagedControlPlane` resource spec. To use any of the new fields included in the preview API version, use the `asoManagedClusterPatches` field in the `AzureManagedControlPlane` resource spec and the `asoManagedClustersAgentPoolPatches` field in the `AzureManagedMachinePool` resource spec to patch in the new fields.
 
-Please refer to the [ASO Docs](https://azure.github.io/azure-service-operator/reference/containerservice/) for the ContainerService API reference for the latest preview fields and their usage.
+When `enablePreviewFeatures` is set, CAPZ manages the underlying ASO resources using the `containerservice.azure.com/v20251002preview` API version. Any preview fields you patch in must exist in that version. See the [ASO Docs](https://azure.github.io/azure-service-operator/reference/containerservice/) for the ContainerService API reference.
+
+> :warning: Some fields available in older preview API versions have changed or been removed. For example, the per-agent-pool `enableCustomCATrust` field no longer exists; configure custom CA trust through the cluster-level `securityProfile.customCATrustCertificates` field instead. If you previously patched preview fields, confirm they still exist in `v20251002preview` before upgrading.
 
 Example for enabling preview features for managed clusters:
 
@@ -405,7 +407,7 @@ metadata:
   ...
 spec:
   asoManagedClustersAgentPoolPatches:
-  - '{"spec": {"enableCustomCATrust": true}}'
+  - '{"spec": {"nodeInitializationTaints": ["capz.io/preview=true:NoSchedule"]}}'
 ```
 
 ### OIDC Issuer on AKS

--- a/docs/book/src/topics/FAQ.md
+++ b/docs/book/src/topics/FAQ.md
@@ -2,19 +2,19 @@
 
 ## Does CAPZ support Feature X?
 The best way to check if CAPZ supports a feature is by reviewing [the roadmap](https://capz.sigs.k8s.io/roadmap) and [the public milestones](https://github.com/kubernetes-sigs/cluster-api-provider-azure/milestones). The public milestones will
-also provide insight into what's coming in the next 1-2 months. All open items for the next milestone are displayed in the [Milestone-Open project board](https://github.com/orgs/kubernetes-sigs/projects/26/views/7), which is updated at the 
-start of each 2-month release cycle. Planning and discussions for these milestones typically happen during the [Cluster API Azure Office Hours](https://docs.google.com/document/d/1P2FrRjuCZjGy0Yh72lwWCwmXekSEkqliUVTmJy_ETIk/edit?tab=t.0) 
-(every Thursday at 9am PT) after each major release. 
+also provide insight into what's coming in the next 1-2 months. All open items for the next milestone are displayed in the [Milestone-Open project board](https://github.com/orgs/kubernetes-sigs/projects/26/views/7), which is updated at the
+start of each 2-month release cycle. Planning and discussions for these milestones typically happen during the [Cluster API Azure Office Hours](https://docs.google.com/document/d/1P2FrRjuCZjGy0Yh72lwWCwmXekSEkqliUVTmJy_ETIk/edit?tab=t.0)
+(every Thursday at 9am PT) after each major release.
 
 For managed (AKS) clusters, all features should be available when using the AzureASOManaged API specification, which provides 100% API surface coverage via ASO. If there is no issue for a new feature in the repository, it likely does not
-exist yet. 
+exist yet.
 
-You can also check the [GitHub repository](https://github.com/kubernetes-sigs/cluster-api-provider-azure) issues and milestones for more details on specific features. 
+You can also check the [GitHub repository](https://github.com/kubernetes-sigs/cluster-api-provider-azure) issues and milestones for more details on specific features.
 
 
 ## How can I enable Feature X if it's not?
 If CAPZ does not currently support Feature X, you have a couple of options:
-1. **Check for Experimental Features**: Sometimes features not fully supported are available as experimental. You can experiment with said features by enabling them using feature gates. Refer to the 
+1. **Check for Experimental Features**: Sometimes features not fully supported are available as experimental. You can experiment with said features by enabling them using feature gates. Refer to the
 [Experimental Features](https://cluster-api.sigs.k8s.io/tasks/experimental-features/experimental-features) section in the CAPI documentation for detailed instructions.
 2. **Contribute to CAPZ**: If you're eager to use Feature X, consider contributing to the CAPZ project. Our community welcomes contributions, and your input can help accelerate support for new features.
 
@@ -23,17 +23,17 @@ CAPZ prioritizes features based on community demand, relevance to Azure Kubernet
 - **Limited Demand:** There might be insufficient demand from the community to prioritize its development.
 - **Technical Constraints:** Integrating Feature X could present technical challenges that require more time and resources.
 - **Roadmap Alignment:** Feature X may not align with our current strategic roadmap or immediate goals.
-We continuously evaluate and update our roadmap based on user feedback and evolving requirements, so your input is valuable in shaping future support. 
+We continuously evaluate and update our roadmap based on user feedback and evolving requirements, so your input is valuable in shaping future support.
 
 ## How do I add Feature X to CAPZ?
 To add Feature X to CAPZ, consider following these steps:
 1. **Review the Roadmap:** Ensure that Feature X aligns with the CAPZ roadmap and that it's not already planned or in development.
 2. **Submit an Issue:** Open an issue on our [GitHub Repository](https://github.com/kubernetes-sigs/cluster-api-provider-azure/issues) to discuss Feature X with the maintainers and the community. Please provide detailed information about the
 feature and its benefits.
-3. **Contribute Code:** If you have the capabilities, you can implement Feature X yourself. Fork the repository, develop the feature following our contribution guidelines, and submit a pull request for review. 
-4. **Collaborate with the Community:** Engage with and receive updates from other contributors and maintainers through our [Slack channel](https://kubernetes.slack.com/messages/CEX9HENG7) or 
+3. **Contribute Code:** If you have the capabilities, you can implement Feature X yourself. Fork the repository, develop the feature following our contribution guidelines, and submit a pull request for review.
+4. **Collaborate with the Community:** Engage with and receive updates from other contributors and maintainers through our [Slack channel](https://kubernetes.slack.com/messages/CEX9HENG7) or
 [mailing lists](https://groups.google.com/forum/#!forum/kubernetes-sig-cluster-lifecycle) to gather support and feedback for Feature X.
-By actively participating, you can enhance CAPZ's functionalilty and ensure it meets the needs of the Kubernetes community on Azure. 
+By actively participating, you can enhance CAPZ's functionalilty and ensure it meets the needs of the Kubernetes community on Azure.
 
 ## CAPZ creates a newer API version of an ASO resource, but kubectl shows me an older API version. Did the API version change?
 No, because the API version is not an integral property of Kubernetes resources. The same resource can be
@@ -43,7 +43,7 @@ https://kubernetes.io/docs/concepts/overview/kubernetes-api/#api-groups-and-vers
 ASO's versioning scheme isn't compatible with Kubernetes's assumptions about API versions w.r.t. `kubectl`'s
 default version selection, so you'll usually end up seeing an older version than you might have used to create
 the resource if you do a plain `kubectl get managedcluster` vs. specifying the version explicitly like
-`kubectl get managedclusters.v1api20240402preview.containerservice.azure.com`.
+`kubectl get managedclusters.v20251002preview.containerservice.azure.com`.
 
 There is an open issue with ASO to smooth this out so the newest Azure API version is selected by default:
 https://github.com/Azure/azure-service-operator/issues/4147 for more context.

--- a/main.go
+++ b/main.go
@@ -24,10 +24,10 @@ import (
 	"time"
 
 	// +kubebuilder:scaffold:imports
-	asocontainerservicev1api20240402preview "github.com/Azure/azure-service-operator/v2/api/containerservice/v1api20240402preview"
 	asocontainerservicev1api20240901 "github.com/Azure/azure-service-operator/v2/api/containerservice/v1api20240901"
 	asocontainerservicev1api20250301 "github.com/Azure/azure-service-operator/v2/api/containerservice/v1api20250301"
 	asocontainerservicev1api20250801 "github.com/Azure/azure-service-operator/v2/api/containerservice/v1api20250801"
+	asocontainerservicev1api20251002preview "github.com/Azure/azure-service-operator/v2/api/containerservice/v20251002preview"
 	asokubernetesconfigurationv1 "github.com/Azure/azure-service-operator/v2/api/kubernetesconfiguration/v1api20230501"
 	asonetworkv1api20201101 "github.com/Azure/azure-service-operator/v2/api/network/v1api20201101"
 	asonetworkv1api20220701 "github.com/Azure/azure-service-operator/v2/api/network/v1api20220701"
@@ -86,7 +86,7 @@ func init() {
 	_ = asonetworkv1api20220701.AddToScheme(scheme)
 	_ = asonetworkv1api20201101.AddToScheme(scheme)
 	_ = asocontainerservicev1api20250301.AddToScheme(scheme)
-	_ = asocontainerservicev1api20240402preview.AddToScheme(scheme)
+	_ = asocontainerservicev1api20251002preview.AddToScheme(scheme)
 	_ = asocontainerservicev1api20240901.AddToScheme(scheme)
 	_ = asokubernetesconfigurationv1.AddToScheme(scheme)
 	// +kubebuilder:scaffold:scheme

--- a/pkg/mutators/azureasomanagedcontrolplane_test.go
+++ b/pkg/mutators/azureasomanagedcontrolplane_test.go
@@ -22,8 +22,8 @@ import (
 	"slices"
 	"testing"
 
-	asocontainerservicev1preview "github.com/Azure/azure-service-operator/v2/api/containerservice/v1api20240402preview"
 	asocontainerservicev1 "github.com/Azure/azure-service-operator/v2/api/containerservice/v1api20250801"
+	asocontainerservicev1preview "github.com/Azure/azure-service-operator/v2/api/containerservice/v20251002preview"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	"github.com/google/go-cmp/cmp"
 	. "github.com/onsi/gomega"
@@ -771,9 +771,9 @@ func TestSetAgentPoolProfilesFromAgentPools(t *testing.T) {
 			// Not all pools have to be the same version, or the same version as the cluster.
 			&asocontainerservicev1preview.ManagedClustersAgentPool{
 				Spec: asocontainerservicev1preview.ManagedClustersAgentPool_Spec{
-					AzureName:           "pool1",
-					MinCount:            ptr.To(2),
-					EnableCustomCATrust: ptr.To(true),
+					AzureName:                "pool1",
+					MinCount:                 ptr.To(2),
+					NodeInitializationTaints: []string{"preview-only-taint"},
 				},
 			},
 		}
@@ -785,7 +785,7 @@ func TestSetAgentPoolProfilesFromAgentPools(t *testing.T) {
 			{
 				Name:     ptr.To("pool1"),
 				MinCount: ptr.To(2),
-				// EnableCustomCATrust is a preview-only feature that can't be represented here, so it should be lost.
+				// NodeInitializationTaints is a preview-only feature that can't be represented here, so it should be lost.
 			},
 		}
 
@@ -807,9 +807,9 @@ func TestSetAgentPoolProfilesFromAgentPools(t *testing.T) {
 			},
 			&asocontainerservicev1preview.ManagedClustersAgentPool{
 				Spec: asocontainerservicev1preview.ManagedClustersAgentPool_Spec{
-					AzureName:           "pool1",
-					MinCount:            ptr.To(2),
-					EnableCustomCATrust: ptr.To(true),
+					AzureName:                "pool1",
+					MinCount:                 ptr.To(2),
+					NodeInitializationTaints: []string{"preview-only-taint"},
 				},
 			},
 		}
@@ -819,9 +819,9 @@ func TestSetAgentPoolProfilesFromAgentPools(t *testing.T) {
 				MaxCount: ptr.To(1),
 			},
 			{
-				Name:                ptr.To("pool1"),
-				MinCount:            ptr.To(2),
-				EnableCustomCATrust: ptr.To(true),
+				Name:                     ptr.To("pool1"),
+				MinCount:                 ptr.To(2),
+				NodeInitializationTaints: []string{"preview-only-taint"},
 			},
 		}
 

--- a/test/e2e/aks_patches.go
+++ b/test/e2e/aks_patches.go
@@ -25,8 +25,8 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v4"
-	asocontainerservicev1preview "github.com/Azure/azure-service-operator/v2/api/containerservice/v1api20240402preview"
 	asocontainerservicev1 "github.com/Azure/azure-service-operator/v2/api/containerservice/v1api20250801"
+	asocontainerservicev1preview "github.com/Azure/azure-service-operator/v2/api/containerservice/v20251002preview"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/test/e2e/azure_clusterproxy.go
+++ b/test/e2e/azure_clusterproxy.go
@@ -34,9 +34,9 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/monitor/armmonitor"
-	asocontainerservicev1preview "github.com/Azure/azure-service-operator/v2/api/containerservice/v1api20240402preview"
 	asocontainerservicev1mc "github.com/Azure/azure-service-operator/v2/api/containerservice/v1api20240901"
 	asocontainerservicev1 "github.com/Azure/azure-service-operator/v2/api/containerservice/v1api20250801"
+	asocontainerservicev1preview "github.com/Azure/azure-service-operator/v2/api/containerservice/v20251002preview"
 	asoresourcesv1 "github.com/Azure/azure-service-operator/v2/api/resources/v1api20200601"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

CAPZ's managed-cluster preview path currently uses the `containerservice.azure.com/v1api20240402preview` ASO API version. AKS [retires that API version on July 1, 2026](https://learn.microsoft.com/en-us/azure/aks/concepts-preview-api-life-cycle) (no grace period), so this PR moves the preview alias to `v20251002preview`.

This stays on ASO **v2.18.0**, which already serves both versions, so it does not require bumping the ASO module. That keeps us within the "one ASO minor per CAPZ minor" constraint imposed by ASO's self-managed upgrade flow. (#6421 does the same alias switch but as part of the v2.19.0 bump, which removes the old version entirely.)

Fixes #6194 

**Upgrading**:

This only affects managed (AKS) clusters created with `enablePreviewFeatures: true` on `AzureManagedControlPlane`.

- No action is required for the alias switch itself. ASO v2.18.0 serves both `v1api20240402preview` and `v20251002preview` and stores both at the same hub version (`v1api20250801storage`), so existing clusters convert automatically and keep reconciling. The CRD storage version is unchanged, so no stored-version migration is needed.
- **Action may be required if you patch preview fields.** Some fields changed or were removed in the newer API. Most notably, the per-agent-pool `enableCustomCATrust` field no longer exists; configure custom CA trust through the cluster-level `securityProfile.customCATrustCertificates` instead. If you supply `asoManagedClusterPatches` / `asoManagedClustersAgentPoolPatches`, confirm those fields still exist in `v20251002preview` before upgrading.
- If you reference `containerservice.azure.com/v1api20240402preview` directly in your own manifests, update those references to `v20251002preview` before July 1, 2026.

**Special notes for your reviewer**:

This is an alternative to #6421 for teams that can't take the ASO v2.19.0 bump yet. Docs (`managedcluster.md`, FAQ) are updated, including the preview patch example that used the removed `enableCustomCATrust` field.

**TODOs**:

- [x] squashed commits
- [x] includes documentation
- [x] adds unit tests
- [ ] cherry-pick candidate

**Release note**:
```release-note
Managed clusters using `enablePreviewFeatures` now use the `containerservice.azure.com/v20251002preview` ASO API version instead of the soon-to-be-retired `v1api20240402preview`. If you patch preview fields, note that the per-agent-pool `enableCustomCATrust` field is gone; use the cluster-level `securityProfile.customCATrustCertificates` instead.
```
