### PR TITLE
Add release 1.26 to the metadata file

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -93,3 +93,6 @@ releaseSeries:
   - major: 1
     minor: 25
     contract: v1beta1
+  - major: 1
+    minor: 26
+    contract: v1beta1


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:
Adds release 1.26 to the metadata file

**Special notes for your reviewer**:
Follows the [releasing docs](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#2-update-main-metadatayaml-skip-for-patch-releases) step to update `metadata.yaml` for the new minor release. Same change as #6400 (1.25).

**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] cherry-pick candidate

**Release note**:
```release-note
NONE
```
