### PR TITLE
ci: bump codecov-action v5.5.2 → v7.0.0

### DIFF
--- a/.github/workflows/cover.yaml
+++ b/.github/workflows/cover.yaml
@@ -26,7 +26,7 @@ jobs:
       with:
         go-version: ${{ steps.vars.outputs.go_version }}
     - run: "PATH=/usr/local/go/bin:$PATH make test-cover"
-    - uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
+    - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       with:


### PR DESCRIPTION
## Summary
- Bump `codecov/codecov-action` from v5.5.2 to v7.0.0
- The v5.5.2 wrapper has a broken GPG key import that causes intermittent "Could not verify signature" failures in the coverage CI job
- Aligns release-1.22 with main and release-1.23+ which already use v7.0.0

## Test plan
- [ ] CI `coverage` job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)