### PR TITLE
Detach ASO agent pools during AKS cluster deletion

### DIFF
--- a/controllers/azuremanagedmachinepool_controller.go
+++ b/controllers/azuremanagedmachinepool_controller.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"time"
 
-	asoannotations "github.com/Azure/azure-service-operator/v2/pkg/common/annotations"
 	"github.com/pkg/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/tools/record"
@@ -41,6 +40,7 @@ import (
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/scope"
+	"sigs.k8s.io/cluster-api-provider-azure/azure/services/agentpools"
 	"sigs.k8s.io/cluster-api-provider-azure/pkg/coalescing"
 	"sigs.k8s.io/cluster-api-provider-azure/util/reconciler"
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
@@ -330,10 +330,10 @@ func (ammpr *AzureManagedMachinePoolReconciler) reconcileDelete(ctx context.Cont
 		// will be garbage collected when the AzureManagedMachinePool is deleted. If
 		// ASO sees a managed deleting agent pool after the parent AKS cluster delete
 		// has started, Azure rejects the child delete as an update to a deleting
-		// cluster. Detach the ASO resource so ASO removes its own finalizer without
+		// cluster. Pause the ASO resource so ASO removes its own finalizer without
 		// issuing the child Azure delete.
-		if err := detachASOAgentPoolOnDelete(ctx, scope); err != nil {
-			return reconcile.Result{}, err
+		if err := agentpools.New(scope).Pause(ctx); err != nil && !apierrors.IsNotFound(err) {
+			return reconcile.Result{}, errors.Wrap(err, "failed to pause ASO agent pool before deletion")
 		}
 		// So, remove the finalizer.
 		controllerutil.RemoveFinalizer(scope.InfraMachinePool, infrav1.ClusterFinalizer)
@@ -365,33 +365,4 @@ func (ammpr *AzureManagedMachinePoolReconciler) reconcileDelete(ctx context.Cont
 	}
 
 	return reconcile.Result{}, nil
-}
-
-func detachASOAgentPoolOnDelete(ctx context.Context, scope *scope.ManagedMachinePoolScope) error {
-	resource := scope.AgentPoolSpec().ResourceRef()
-	resource.SetNamespace(scope.InfraMachinePool.Namespace)
-
-	if err := scope.Client.Get(ctx, client.ObjectKeyFromObject(resource), resource); err != nil {
-		if apierrors.IsNotFound(err) {
-			return nil
-		}
-		return errors.Wrapf(err, "failed to get ASO agent pool %s/%s", resource.GetNamespace(), resource.GetName())
-	}
-
-	annotations := resource.GetAnnotations()
-	if annotations[asoannotations.ReconcilePolicy] == string(asoannotations.ReconcilePolicyDetachOnDelete) {
-		return nil
-	}
-
-	patch := client.MergeFrom(resource.DeepCopyObject().(client.Object))
-	if annotations == nil {
-		annotations = map[string]string{}
-	}
-	annotations[asoannotations.ReconcilePolicy] = string(asoannotations.ReconcilePolicyDetachOnDelete)
-	resource.SetAnnotations(annotations)
-
-	if err := scope.Client.Patch(ctx, resource, patch); err != nil {
-		return errors.Wrapf(err, "failed to detach ASO agent pool %s/%s", resource.GetNamespace(), resource.GetName())
-	}
-	return nil
 }

--- a/controllers/azuremanagedmachinepool_controller.go
+++ b/controllers/azuremanagedmachinepool_controller.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"time"
 
+	asoannotations "github.com/Azure/azure-service-operator/v2/pkg/common/annotations"
 	"github.com/pkg/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/tools/record"
@@ -325,6 +326,15 @@ func (ammpr *AzureManagedMachinePoolReconciler) reconcileDelete(ctx context.Cont
 
 	if !scope.Cluster.DeletionTimestamp.IsZero() {
 		// Cluster was deleted, skip machine pool deletion and let AKS delete the whole cluster.
+		// The ASO agent pool resource is owned by the AzureManagedMachinePool and
+		// will be garbage collected when the AzureManagedMachinePool is deleted. If
+		// ASO sees a managed deleting agent pool after the parent AKS cluster delete
+		// has started, Azure rejects the child delete as an update to a deleting
+		// cluster. Detach the ASO resource so ASO removes its own finalizer without
+		// issuing the child Azure delete.
+		if err := detachASOAgentPoolOnDelete(ctx, scope); err != nil {
+			return reconcile.Result{}, err
+		}
 		// So, remove the finalizer.
 		controllerutil.RemoveFinalizer(scope.InfraMachinePool, infrav1.ClusterFinalizer)
 	} else {
@@ -355,4 +365,33 @@ func (ammpr *AzureManagedMachinePoolReconciler) reconcileDelete(ctx context.Cont
 	}
 
 	return reconcile.Result{}, nil
+}
+
+func detachASOAgentPoolOnDelete(ctx context.Context, scope *scope.ManagedMachinePoolScope) error {
+	resource := scope.AgentPoolSpec().ResourceRef()
+	resource.SetNamespace(scope.InfraMachinePool.Namespace)
+
+	if err := scope.Client.Get(ctx, client.ObjectKeyFromObject(resource), resource); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return errors.Wrapf(err, "failed to get ASO agent pool %s/%s", resource.GetNamespace(), resource.GetName())
+	}
+
+	annotations := resource.GetAnnotations()
+	if annotations[asoannotations.ReconcilePolicy] == string(asoannotations.ReconcilePolicyDetachOnDelete) {
+		return nil
+	}
+
+	patch := client.MergeFrom(resource.DeepCopyObject().(client.Object))
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
+	annotations[asoannotations.ReconcilePolicy] = string(asoannotations.ReconcilePolicyDetachOnDelete)
+	resource.SetAnnotations(annotations)
+
+	if err := scope.Client.Patch(ctx, resource, patch); err != nil {
+		return errors.Wrapf(err, "failed to detach ASO agent pool %s/%s", resource.GetNamespace(), resource.GetName())
+	}
+	return nil
 }

--- a/controllers/azuremanagedmachinepool_controller_test.go
+++ b/controllers/azuremanagedmachinepool_controller_test.go
@@ -133,6 +133,14 @@ func TestAzureManagedMachinePoolReconcile(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      azure.GetNormalizedKubernetesName(ammp.Name),
 						Namespace: ammp.Namespace,
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion: infrav1.GroupVersion.String(),
+								Kind:       infrav1.AzureManagedMachinePoolKind,
+								Name:       ammp.Name,
+								Controller: ptr.To(true),
+							},
+						},
 						Annotations: map[string]string{
 							asoannotations.ReconcilePolicy: string(asoannotations.ReconcilePolicyManage),
 						},
@@ -146,7 +154,26 @@ func TestAzureManagedMachinePoolReconcile(t *testing.T) {
 
 				agentPool := &asocontainerservicev1.ManagedClustersAgentPool{}
 				g.Expect(c.Get(t.Context(), types.NamespacedName{Name: "foo-ammp", Namespace: "foobar"}, agentPool)).To(Succeed())
-				g.Expect(agentPool.Annotations).To(HaveKeyWithValue(asoannotations.ReconcilePolicy, string(asoannotations.ReconcilePolicyDetachOnDelete)))
+				g.Expect(agentPool.Annotations).To(HaveKeyWithValue(asoannotations.ReconcilePolicy, string(asoannotations.ReconcilePolicySkip)))
+
+				ammp := &infrav1.AzureManagedMachinePool{}
+				g.Expect(c.Get(t.Context(), types.NamespacedName{Name: "foo-ammp", Namespace: "foobar"}, ammp)).To(Succeed())
+				g.Expect(ammp.Finalizers).NotTo(ContainElement(infrav1.ClusterFinalizer))
+			},
+		},
+		{
+			name: "Reconcile delete with deleting cluster and missing ASO agent pool",
+			Setup: func(cb *fake.ClientBuilder, _ pausingReconciler, _ *mock_agentpools.MockAgentPoolScopeMockRecorder, _ *MockNodeListerMockRecorder) {
+				cluster, azManagedCluster, azManagedControlPlane, ammp, mp := newReadyAzureManagedMachinePoolCluster()
+				cluster.DeletionTimestamp = &metav1.Time{Time: time.Now()}
+				cluster.Finalizers = []string{"test"}
+				ammp.DeletionTimestamp = &metav1.Time{Time: time.Now()}
+				ammp.Finalizers = []string{infrav1.ClusterFinalizer, "test"}
+
+				cb.WithObjects(cluster, azManagedCluster, azManagedControlPlane, ammp, mp)
+			},
+			Verify: func(g *WithT, c client.Client, result ctrl.Result, err error) {
+				g.Expect(err).NotTo(HaveOccurred())
 
 				ammp := &infrav1.AzureManagedMachinePool{}
 				g.Expect(c.Get(t.Context(), types.NamespacedName{Name: "foo-ammp", Namespace: "foobar"}, ammp)).To(Succeed())
@@ -236,73 +263,6 @@ func TestAzureManagedMachinePoolReconcile(t *testing.T) {
 			c.Verify(g, fakeClient, res, err)
 		})
 	}
-}
-
-func TestDetachASOAgentPoolOnDelete(t *testing.T) {
-	g := NewWithT(t)
-	_, _, controlPlane, ammp, mp := newReadyAzureManagedMachinePoolCluster()
-
-	sch := runtime.NewScheme()
-	for _, addTo := range []func(*runtime.Scheme) error{
-		scheme.AddToScheme,
-		clusterv1.AddToScheme,
-		infrav1.AddToScheme,
-		corev1.AddToScheme,
-		asocontainerservicev1.AddToScheme,
-	} {
-		g.Expect(addTo(sch)).To(Succeed())
-	}
-
-	agentPool := &asocontainerservicev1.ManagedClustersAgentPool{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      azure.GetNormalizedKubernetesName(ammp.Name),
-			Namespace: ammp.Namespace,
-			Annotations: map[string]string{
-				asoannotations.PerResourceSecret: "foo-aso-secret",
-				asoannotations.ReconcilePolicy:   string(asoannotations.ReconcilePolicyManage),
-			},
-		},
-	}
-	c := fake.NewClientBuilder().WithScheme(sch).WithObjects(agentPool).Build()
-	mcpScope := &scope.ManagedMachinePoolScope{
-		Client:           c,
-		ControlPlane:     controlPlane,
-		MachinePool:      mp,
-		InfraMachinePool: ammp,
-	}
-
-	g.Expect(detachASOAgentPoolOnDelete(t.Context(), mcpScope)).To(Succeed())
-
-	updated := &asocontainerservicev1.ManagedClustersAgentPool{}
-	g.Expect(c.Get(t.Context(), types.NamespacedName{Name: agentPool.Name, Namespace: agentPool.Namespace}, updated)).To(Succeed())
-	g.Expect(updated.Annotations).To(HaveKeyWithValue(asoannotations.PerResourceSecret, "foo-aso-secret"))
-	g.Expect(updated.Annotations).To(HaveKeyWithValue(asoannotations.ReconcilePolicy, string(asoannotations.ReconcilePolicyDetachOnDelete)))
-}
-
-func TestDetachASOAgentPoolOnDeleteSkipsMissingResource(t *testing.T) {
-	g := NewWithT(t)
-	_, _, controlPlane, ammp, mp := newReadyAzureManagedMachinePoolCluster()
-
-	sch := runtime.NewScheme()
-	for _, addTo := range []func(*runtime.Scheme) error{
-		scheme.AddToScheme,
-		clusterv1.AddToScheme,
-		infrav1.AddToScheme,
-		corev1.AddToScheme,
-		asocontainerservicev1.AddToScheme,
-	} {
-		g.Expect(addTo(sch)).To(Succeed())
-	}
-
-	c := fake.NewClientBuilder().WithScheme(sch).Build()
-	mcpScope := &scope.ManagedMachinePoolScope{
-		Client:           c,
-		ControlPlane:     controlPlane,
-		MachinePool:      mp,
-		InfraMachinePool: ammp,
-	}
-
-	g.Expect(detachASOAgentPoolOnDelete(t.Context(), mcpScope)).To(Succeed())
 }
 
 func newReadyAzureManagedMachinePoolCluster() (*clusterv1.Cluster, *infrav1.AzureManagedCluster, *infrav1.AzureManagedControlPlane, *infrav1.AzureManagedMachinePool, *clusterv1.MachinePool) {

--- a/controllers/azuremanagedmachinepool_controller_test.go
+++ b/controllers/azuremanagedmachinepool_controller_test.go
@@ -21,6 +21,8 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
+	asocontainerservicev1 "github.com/Azure/azure-service-operator/v2/api/containerservice/v1api20250801"
+	asoannotations "github.com/Azure/azure-service-operator/v2/pkg/common/annotations"
 	. "github.com/onsi/gomega"
 	"github.com/pkg/errors"
 	"go.uber.org/mock/gomock"
@@ -198,6 +200,73 @@ func TestAzureManagedMachinePoolReconcile(t *testing.T) {
 			c.Verify(g, res, err)
 		})
 	}
+}
+
+func TestDetachASOAgentPoolOnDelete(t *testing.T) {
+	g := NewWithT(t)
+	_, _, controlPlane, ammp, mp := newReadyAzureManagedMachinePoolCluster()
+
+	sch := runtime.NewScheme()
+	for _, addTo := range []func(*runtime.Scheme) error{
+		scheme.AddToScheme,
+		clusterv1.AddToScheme,
+		infrav1.AddToScheme,
+		corev1.AddToScheme,
+		asocontainerservicev1.AddToScheme,
+	} {
+		g.Expect(addTo(sch)).To(Succeed())
+	}
+
+	agentPool := &asocontainerservicev1.ManagedClustersAgentPool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      azure.GetNormalizedKubernetesName(ammp.Name),
+			Namespace: ammp.Namespace,
+			Annotations: map[string]string{
+				asoannotations.PerResourceSecret: "foo-aso-secret",
+				asoannotations.ReconcilePolicy:   string(asoannotations.ReconcilePolicyManage),
+			},
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(sch).WithObjects(agentPool).Build()
+	mcpScope := &scope.ManagedMachinePoolScope{
+		Client:           c,
+		ControlPlane:     controlPlane,
+		MachinePool:      mp,
+		InfraMachinePool: ammp,
+	}
+
+	g.Expect(detachASOAgentPoolOnDelete(t.Context(), mcpScope)).To(Succeed())
+
+	updated := &asocontainerservicev1.ManagedClustersAgentPool{}
+	g.Expect(c.Get(t.Context(), types.NamespacedName{Name: agentPool.Name, Namespace: agentPool.Namespace}, updated)).To(Succeed())
+	g.Expect(updated.Annotations).To(HaveKeyWithValue(asoannotations.PerResourceSecret, "foo-aso-secret"))
+	g.Expect(updated.Annotations).To(HaveKeyWithValue(asoannotations.ReconcilePolicy, string(asoannotations.ReconcilePolicyDetachOnDelete)))
+}
+
+func TestDetachASOAgentPoolOnDeleteSkipsMissingResource(t *testing.T) {
+	g := NewWithT(t)
+	_, _, controlPlane, ammp, mp := newReadyAzureManagedMachinePoolCluster()
+
+	sch := runtime.NewScheme()
+	for _, addTo := range []func(*runtime.Scheme) error{
+		scheme.AddToScheme,
+		clusterv1.AddToScheme,
+		infrav1.AddToScheme,
+		corev1.AddToScheme,
+		asocontainerservicev1.AddToScheme,
+	} {
+		g.Expect(addTo(sch)).To(Succeed())
+	}
+
+	c := fake.NewClientBuilder().WithScheme(sch).Build()
+	mcpScope := &scope.ManagedMachinePoolScope{
+		Client:           c,
+		ControlPlane:     controlPlane,
+		MachinePool:      mp,
+		InfraMachinePool: ammp,
+	}
+
+	g.Expect(detachASOAgentPoolOnDelete(t.Context(), mcpScope)).To(Succeed())
 }
 
 func newReadyAzureManagedMachinePoolCluster() (*clusterv1.Cluster, *infrav1.AzureManagedCluster, *infrav1.AzureManagedControlPlane, *infrav1.AzureManagedMachinePool, *clusterv1.MachinePool) {

--- a/controllers/azuremanagedmachinepool_controller_test.go
+++ b/controllers/azuremanagedmachinepool_controller_test.go
@@ -35,6 +35,7 @@ import (
 	clusterv1beta1 "sigs.k8s.io/cluster-api/api/core/v1beta1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
@@ -56,7 +57,7 @@ func TestAzureManagedMachinePoolReconcile(t *testing.T) {
 	cases := []struct {
 		name   string
 		Setup  func(cb *fake.ClientBuilder, reconciler pausingReconciler, agentpools *mock_agentpools.MockAgentPoolScopeMockRecorder, nodelister *MockNodeListerMockRecorder)
-		Verify func(g *WithT, result ctrl.Result, err error)
+		Verify func(g *WithT, c client.Client, result ctrl.Result, err error)
 	}{
 		{
 			name: "Reconcile succeed",
@@ -87,7 +88,7 @@ func TestAzureManagedMachinePoolReconcile(t *testing.T) {
 
 				cb.WithObjects(cluster, azManagedCluster, azManagedControlPlane, ammp, mp)
 			},
-			Verify: func(g *WithT, result ctrl.Result, err error) {
+			Verify: func(g *WithT, _ client.Client, result ctrl.Result, err error) {
 				g.Expect(err).NotTo(HaveOccurred())
 			},
 		},
@@ -101,7 +102,7 @@ func TestAzureManagedMachinePoolReconcile(t *testing.T) {
 
 				cb.WithObjects(cluster, azManagedCluster, azManagedControlPlane, ammp, mp)
 			},
-			Verify: func(g *WithT, result ctrl.Result, err error) {
+			Verify: func(g *WithT, _ client.Client, result ctrl.Result, err error) {
 				g.Expect(err).NotTo(HaveOccurred())
 			},
 		},
@@ -115,8 +116,41 @@ func TestAzureManagedMachinePoolReconcile(t *testing.T) {
 				}
 				cb.WithObjects(cluster, azManagedCluster, azManagedControlPlane, ammp, mp)
 			},
-			Verify: func(g *WithT, result ctrl.Result, err error) {
+			Verify: func(g *WithT, _ client.Client, result ctrl.Result, err error) {
 				g.Expect(err).NotTo(HaveOccurred())
+			},
+		},
+		{
+			name: "Reconcile delete with deleting cluster",
+			Setup: func(cb *fake.ClientBuilder, _ pausingReconciler, _ *mock_agentpools.MockAgentPoolScopeMockRecorder, _ *MockNodeListerMockRecorder) {
+				cluster, azManagedCluster, azManagedControlPlane, ammp, mp := newReadyAzureManagedMachinePoolCluster()
+				cluster.DeletionTimestamp = &metav1.Time{Time: time.Now()}
+				cluster.Finalizers = []string{"test"}
+				ammp.DeletionTimestamp = &metav1.Time{Time: time.Now()}
+				ammp.Finalizers = []string{infrav1.ClusterFinalizer, "test"}
+
+				agentPool := &asocontainerservicev1.ManagedClustersAgentPool{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      azure.GetNormalizedKubernetesName(ammp.Name),
+						Namespace: ammp.Namespace,
+						Annotations: map[string]string{
+							asoannotations.ReconcilePolicy: string(asoannotations.ReconcilePolicyManage),
+						},
+					},
+				}
+
+				cb.WithObjects(cluster, azManagedCluster, azManagedControlPlane, ammp, mp, agentPool)
+			},
+			Verify: func(g *WithT, c client.Client, result ctrl.Result, err error) {
+				g.Expect(err).NotTo(HaveOccurred())
+
+				agentPool := &asocontainerservicev1.ManagedClustersAgentPool{}
+				g.Expect(c.Get(t.Context(), types.NamespacedName{Name: "foo-ammp", Namespace: "foobar"}, agentPool)).To(Succeed())
+				g.Expect(agentPool.Annotations).To(HaveKeyWithValue(asoannotations.ReconcilePolicy, string(asoannotations.ReconcilePolicyDetachOnDelete)))
+
+				ammp := &infrav1.AzureManagedMachinePool{}
+				g.Expect(c.Get(t.Context(), types.NamespacedName{Name: "foo-ammp", Namespace: "foobar"}, ammp)).To(Succeed())
+				g.Expect(ammp.Finalizers).NotTo(ContainElement(infrav1.ClusterFinalizer))
 			},
 		},
 		{
@@ -130,7 +164,7 @@ func TestAzureManagedMachinePoolReconcile(t *testing.T) {
 				}
 				cb.WithObjects(cluster, azManagedCluster, azManagedControlPlane, ammp, mp)
 			},
-			Verify: func(g *WithT, result ctrl.Result, err error) {
+			Verify: func(g *WithT, _ client.Client, result ctrl.Result, err error) {
 				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(result.RequeueAfter).To(Equal(76 * time.Second))
 			},
@@ -167,6 +201,7 @@ func TestAzureManagedMachinePoolReconcile(t *testing.T) {
 						clusterv1.AddToScheme,
 						infrav1.AddToScheme,
 						corev1.AddToScheme,
+						asocontainerservicev1.AddToScheme,
 					} {
 						g.Expect(addTo(s)).To(Succeed())
 					}
@@ -183,7 +218,8 @@ func TestAzureManagedMachinePoolReconcile(t *testing.T) {
 			defer mockCtrl.Finish()
 
 			c.Setup(cb, reconciler, agentpools.EXPECT(), nodelister.EXPECT())
-			controller := NewAzureManagedMachinePoolReconciler(cb.Build(), nil, reconcilerutils.Timeouts{}, "foo", azure.NewCredentialCache())
+			fakeClient := cb.Build()
+			controller := NewAzureManagedMachinePoolReconciler(fakeClient, nil, reconcilerutils.Timeouts{}, "foo", azure.NewCredentialCache())
 			controller.createAzureManagedMachinePoolService = func(_ *scope.ManagedMachinePoolScope, _ time.Duration) (*azureManagedMachinePoolService, error) {
 				return &azureManagedMachinePoolService{
 					scope:         agentpools,
@@ -197,7 +233,7 @@ func TestAzureManagedMachinePoolReconcile(t *testing.T) {
 					Namespace: "foobar",
 				},
 			})
-			c.Verify(g, res, err)
+			c.Verify(g, fakeClient, res, err)
 		})
 	}
 }


### PR DESCRIPTION
### What
- Patch the generated ASO `ManagedClustersAgentPool` to `detach-on-delete` when an `AzureManagedMachinePool` is deleted because its owning CAPI `Cluster` is deleting.
- Preserve normal standalone agent-pool deletion behavior when the owning cluster is not deleting.
- Add focused fake-client coverage for setting the ASO reconcile policy and tolerating a missing ASO agent-pool resource.

### Why
CAPZ already skips direct AKS agent-pool deletion during owning Cluster teardown and lets AKS parent cluster deletion clean up child pools. The generated ASO child resource should follow the same lifecycle decision; otherwise ASO can attempt a child ARM delete while the parent AKS cluster is deleting, which Azure rejects.

### Tests
- `go test ./controllers -run 'TestDetachASOAgentPoolOnDelete' -count=1`
- `AZURE_SUBSCRIPTION_ID=00000000-0000-0000-0000-000000000000 go test ./controllers -run 'TestAzureManagedMachinePoolReconcile' -count=1`

**What type of PR is this?**

/kind bug

**Release note**:
```release-note
Detach ASO agent pool resources during AKS cluster deletion to prevent conflicting child resource deletion requests.
```
