### PR TITLE
Bump Go toolchain to v1.25.12

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module sigs.k8s.io/cluster-api-provider-azure
 
 go 1.25.7
 
-toolchain go1.25.11
+toolchain go1.25.12
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.22.0

--- a/hack/ensure-go.sh
+++ b/hack/ensure-go.sh
@@ -31,7 +31,7 @@ EOF
   local go_version
   IFS=" " read -ra go_version <<< "$(go version)"
   local minimum_go_version
-  minimum_go_version=go1.25.11
+  minimum_go_version=go1.25.12
   if [[ "${minimum_go_version}" != $(echo -e "${minimum_go_version}\n${go_version[2]}" | sort -s -t. -k 1,1 -k 2,2n -k 3,3n | head -n1) && "${go_version[2]}" != "devel" ]]; then
     cat <<EOF
 Detected go version: ${go_version[*]}.

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -2,7 +2,7 @@ module sigs.k8s.io/cluster-api-provider-azure/hack/tools
 
 go 1.25.0
 
-toolchain go1.25.11
+toolchain go1.25.12
 
 require sigs.k8s.io/cluster-api/hack/tools v0.0.0-20260617161443-cf0f6c00fbf7
 


### PR DESCRIPTION
/kind cleanup

Updates the Go compiler and tools to v1.25.12.

> go1.25.12 (released 2026-07-07) includes security fixes to the `crypto/tls` and `os` packages, as well as bug fixes to the compiler, the `go` command, and the `net` and `os` packages. See the [Go 1.25.12 milestone](https://github.com/golang/go/issues?q=milestone%3AGo1.25.12+label%3ACherryPickApproved) on our issue tracker for details.

This PR will fix several CVEs reported against the previous version of the toolchain.

See #6357 for prior art.

```release-note
NONE
```
