### PR TITLE
Give ASO CRD migration a writeable filesystem for Tilt

### DIFF
--- a/hack/observability/kustomization.yaml
+++ b/hack/observability/kustomization.yaml
@@ -6,3 +6,17 @@ resources:
 
 patches:
 - path: opentelemetry/controller-manager-patch.yaml
+# Tilt hot-reload requires a writeable filesystem
+- patch: |
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: azureserviceoperator-controller-manager
+      namespace: capz-system
+    spec:
+      template:
+        spec:
+          initContainers:
+            - name: migrate-aso-crd-stored-versions
+              securityContext:
+                readOnlyRootFilesystem: false


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

The way we've wired up hot-reloading for Tilt, containers need a writeable filesystem. Since the `migrate-aso-crd-stored-versions` init container added to ASO has `securityContext.readOnlyRootFilesystem: true`, the Pod fails to start in Tilt with:
`/tilt/start.sh: line 34: can't create process.txt: Read-only file system`. Adding a Tilt-only patch to set `readOnlyRootFilesystem: false` lets the container run successfully.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->


**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] cherry-pick candidate

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
