### PR TITLE
Bump Ray and KubeRay e2e test versions to latest releases

### DIFF
--- a/test/e2e/azure_kuberay.go
+++ b/test/e2e/azure_kuberay.go
@@ -41,8 +41,8 @@ const (
 	kubeRayOperatorHelmChartName   = "kuberay-operator"
 	kubeRayOperatorHelmReleaseName = "kuberay-operator"
 	kubeRayOperatorNamespace       = "default"
-	kubeRayVersion                 = "1.6.1"
-	rayVersion                     = "2.55.1"
+	kubeRayVersion                 = "1.6.2"
+	rayVersion                     = "2.56.0"
 	rayImage                       = "rayproject/ray:" + rayVersion
 	objectStoreMemory              = "200000000" // ~200MB, prevents Ray from consuming all of /dev/shm
 )


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Bumps Ray (2.55.1 → 2.56.0) and KubeRay (1.6.1 → 1.6.2) to their latest releases in the e2e tests.

**Release note**:
```release-note
NONE
```