### PR TITLE
Fix MachinePool scale-down with unready instances

### DIFF
--- a/azure/scope/strategies/machinepool_deployments/machinepool_deployment_strategy.go
+++ b/azure/scope/strategies/machinepool_deployments/machinepool_deployment_strategy.go
@@ -137,9 +137,35 @@ func (rollingUpdateStrategy rollingUpdateStrategy) SelectMachinesToDelete(ctx co
 		failedMachines             = order(getFailedMachines(machinesByProviderID))
 		deletingMachines           = order(getDeletingMachines(machinesByProviderID))
 		readyMachines              = order(getReadyMachines(machinesByProviderID))
+		unreadyMachines            = order(getUnreadyMachines(machinesByProviderID))
 		machinesWithoutLatestModel = order(getMachinesWithoutLatestModel(machinesByProviderID))
-		overProvisionCount         = len(readyMachines) - int(desiredReplicaCount)
-		disruptionBudget           = func() int {
+		protectedUnreadyCount      = func() int {
+			if skipModelReconciliation {
+				return 0
+			}
+
+			readyOldModelCount := 0
+			for _, machine := range readyMachines {
+				if !machine.Status.LatestModelApplied {
+					readyOldModelCount++
+				}
+			}
+
+			unreadyLatestModelCount := 0
+			for _, machine := range unreadyMachines {
+				if machine.Status.LatestModelApplied {
+					unreadyLatestModelCount++
+				}
+			}
+
+			return min(readyOldModelCount, unreadyLatestModelCount)
+		}()
+		overProvisionCount = func() int {
+			// During a rollout, don't count an unready latest-model replacement as excess capacity while the
+			// ready old-model machine it replaces is still present.
+			return len(readyMachines) + len(unreadyMachines) - protectedUnreadyCount - int(desiredReplicaCount)
+		}()
+		disruptionBudget = func() int {
 			if maxUnavailable > int(desiredReplicaCount) {
 				return int(desiredReplicaCount)
 			}
@@ -155,6 +181,8 @@ func (rollingUpdateStrategy rollingUpdateStrategy) SelectMachinesToDelete(ctx co
 
 	log.Info("selecting machines to delete",
 		"readyMachines", len(readyMachines),
+		"unreadyMachines", len(unreadyMachines),
+		"protectedUnreadyMachines", protectedUnreadyCount,
 		"desiredReplicaCount", desiredReplicaCount,
 		"maxUnavailable", maxUnavailable,
 		"disruptionBudget", disruptionBudget,
@@ -176,16 +204,54 @@ func (rollingUpdateStrategy rollingUpdateStrategy) SelectMachinesToDelete(ctx co
 		return deleteAnnotatedMachines, nil
 	}
 
-	// if we have not yet reached our desired count, don't try to delete anything
-	if len(readyMachines) < int(desiredReplicaCount) {
-		log.Info("not enough ready machines", "desiredReplicaCount", desiredReplicaCount, "readyMachinesCount", len(readyMachines), "machinesByProviderID", len(machinesByProviderID))
-		return []infrav1exp.AzureMachinePoolMachine{}, nil
-	}
-
 	// we have too many machines, let's choose the oldest to remove
 	if overProvisionCount > 0 {
 		var toDelete []infrav1exp.AzureMachinePoolMachine
-		log.Info("over-provisioned", "desiredReplicaCount", desiredReplicaCount, "overProvisionCount", overProvisionCount, "machinesWithoutLatestModel", getProviderIDs(machinesWithoutLatestModel), "skipModelReconciliation", skipModelReconciliation)
+		log.Info("over-provisioned", "desiredReplicaCount", desiredReplicaCount, "overProvisionCount", overProvisionCount, "unreadyMachines", getProviderIDs(unreadyMachines), "machinesWithoutLatestModel", getProviderIDs(machinesWithoutLatestModel), "skipModelReconciliation", skipModelReconciliation)
+
+		// Prefer deleting unready machines when explicitly scaling down. Counting only ready machines here can
+		// leave the pool permanently over-provisioned if an extra VM joins the cluster but never becomes ready.
+		if skipModelReconciliation {
+			for _, v := range unreadyMachines {
+				if len(toDelete) >= overProvisionCount {
+					return toDelete, nil
+				}
+
+				toDelete = append(toDelete, v)
+			}
+		} else {
+			for _, v := range unreadyMachines {
+				if len(toDelete) >= overProvisionCount {
+					return toDelete, nil
+				}
+				if v.Status.LatestModelApplied {
+					continue
+				}
+
+				toDelete = append(toDelete, v)
+			}
+			unreadyLatestModelDeleteCount := 0
+			for _, v := range unreadyMachines {
+				if v.Status.LatestModelApplied {
+					unreadyLatestModelDeleteCount++
+				}
+			}
+			unreadyLatestModelDeleteCount -= protectedUnreadyCount
+			for _, v := range unreadyMachines {
+				if len(toDelete) >= overProvisionCount {
+					return toDelete, nil
+				}
+				if unreadyLatestModelDeleteCount <= 0 {
+					break
+				}
+				if !v.Status.LatestModelApplied {
+					continue
+				}
+
+				toDelete = append(toDelete, v)
+				unreadyLatestModelDeleteCount--
+			}
+		}
 
 		// When SkipMachinePoolModelReconciliation is enabled, skip prioritizing machines without latest model.
 		// Just delete the oldest ready machines to meet the desired replica count.
@@ -194,6 +260,9 @@ func (rollingUpdateStrategy rollingUpdateStrategy) SelectMachinesToDelete(ctx co
 			for _, v := range machinesWithoutLatestModel {
 				if len(toDelete) >= overProvisionCount {
 					return toDelete, nil
+				}
+				if !v.Status.Ready {
+					continue
 				}
 
 				toDelete = append(toDelete, v)
@@ -206,11 +275,20 @@ func (rollingUpdateStrategy rollingUpdateStrategy) SelectMachinesToDelete(ctx co
 			if len(toDelete) >= overProvisionCount {
 				return toDelete, nil
 			}
+			if !skipModelReconciliation && !v.Status.LatestModelApplied {
+				continue
+			}
 
 			toDelete = append(toDelete, v)
 		}
 
 		return toDelete, nil
+	}
+
+	// if we have not yet reached our desired count, don't try to replace anything
+	if len(readyMachines) < int(desiredReplicaCount) {
+		log.Info("not enough ready machines", "desiredReplicaCount", desiredReplicaCount, "readyMachinesCount", len(readyMachines), "machinesByProviderID", len(machinesByProviderID))
+		return []infrav1exp.AzureMachinePoolMachine{}, nil
 	}
 
 	if skipModelReconciliation {
@@ -300,6 +378,22 @@ func getReadyMachines(machinesByProviderID map[string]infrav1exp.AzureMachinePoo
 	}
 
 	return readyMachines
+}
+
+func getUnreadyMachines(machinesByProviderID map[string]infrav1exp.AzureMachinePoolMachine) []infrav1exp.AzureMachinePoolMachine {
+	var unreadyMachines []infrav1exp.AzureMachinePoolMachine
+	for _, v := range machinesByProviderID {
+		if v.Status.Ready || v.Status.ProvisioningState == nil || !v.DeletionTimestamp.IsZero() {
+			continue
+		}
+		if *v.Status.ProvisioningState == infrav1.Failed || *v.Status.ProvisioningState == infrav1.Deleting {
+			continue
+		}
+
+		unreadyMachines = append(unreadyMachines, v)
+	}
+
+	return unreadyMachines
 }
 
 func getMachinesWithoutLatestModel(machinesByProviderID map[string]infrav1exp.AzureMachinePoolMachine) []infrav1exp.AzureMachinePoolMachine {

--- a/azure/scope/strategies/machinepool_deployments/machinepool_deployment_strategy_test.go
+++ b/azure/scope/strategies/machinepool_deployments/machinepool_deployment_strategy_test.go
@@ -216,6 +216,124 @@ func TestMachinePoolRollingUpdateStrategy_SelectMachinesToDelete(t *testing.T) {
 			}),
 		},
 		{
+			name:            "if over-provisioned by an unready machine, select the unready machine",
+			strategy:        makeRollingUpdateStrategy(infrav1exp.MachineRollingUpdateDeployment{}),
+			desiredReplicas: 2,
+			input: map[string]infrav1exp.AzureMachinePoolMachine{
+				"foo": makeAMPM(ampmOptions{Ready: true, LatestModel: true, ProvisioningState: succeeded}),
+				"bin": makeAMPM(ampmOptions{Ready: true, LatestModel: true, ProvisioningState: succeeded}),
+				"baz": makeAMPM(ampmOptions{Ready: false, LatestModel: true, ProvisioningState: succeeded}),
+			},
+			want: Equal([]infrav1exp.AzureMachinePoolMachine{
+				makeAMPM(ampmOptions{Ready: false, LatestModel: true, ProvisioningState: succeeded}),
+			}),
+		},
+		{
+			name:            "if an unready machine is needed to reach the desired count, do not select it",
+			strategy:        makeRollingUpdateStrategy(infrav1exp.MachineRollingUpdateDeployment{}),
+			desiredReplicas: 3,
+			input: map[string]infrav1exp.AzureMachinePoolMachine{
+				"foo": makeAMPM(ampmOptions{Ready: true, LatestModel: true, ProvisioningState: succeeded}),
+				"bin": makeAMPM(ampmOptions{Ready: true, LatestModel: true, ProvisioningState: succeeded}),
+				"baz": makeAMPM(ampmOptions{Ready: false, LatestModel: true, ProvisioningState: succeeded}),
+			},
+			want: BeEmpty(),
+		},
+		{
+			name:            "if active machines exceed desired replicas, scale down even when ready machines are below desired replicas",
+			strategy:        makeRollingUpdateStrategy(infrav1exp.MachineRollingUpdateDeployment{}),
+			desiredReplicas: 3,
+			input: map[string]infrav1exp.AzureMachinePoolMachine{
+				"foo": makeAMPM(ampmOptions{Ready: true, LatestModel: true, ProvisioningState: succeeded}),
+				"bin": makeAMPM(ampmOptions{Ready: true, LatestModel: true, ProvisioningState: succeeded}),
+				"baz": makeAMPM(ampmOptions{Ready: false, LatestModel: true, ProvisioningState: succeeded}),
+				"qux": makeAMPM(ampmOptions{Ready: false, LatestModel: true, ProvisioningState: succeeded}),
+			},
+			want: HaveLen(1),
+		},
+		{
+			name: "if an unready latest-model surge replacement exists, wait for it to become ready before deleting an old-model machine",
+			strategy: makeRollingUpdateStrategy(infrav1exp.MachineRollingUpdateDeployment{
+				MaxSurge: &one,
+			}),
+			desiredReplicas: 2,
+			input: map[string]infrav1exp.AzureMachinePoolMachine{
+				"foo": makeAMPM(ampmOptions{Ready: true, LatestModel: false, ProvisioningState: succeeded}),
+				"bin": makeAMPM(ampmOptions{Ready: true, LatestModel: false, ProvisioningState: succeeded}),
+				"baz": makeAMPM(ampmOptions{Ready: false, LatestModel: true, ProvisioningState: succeeded}),
+			},
+			want: BeEmpty(),
+		},
+		{
+			name: "if model reconciliation is skipped, delete an excess unready latest-model machine",
+			strategy: makeRollingUpdateStrategy(infrav1exp.MachineRollingUpdateDeployment{
+				MaxSurge: &one,
+			}),
+			desiredReplicas: 2,
+			skipModel:       true,
+			input: map[string]infrav1exp.AzureMachinePoolMachine{
+				"foo": makeAMPM(ampmOptions{Ready: true, LatestModel: false, ProvisioningState: succeeded}),
+				"bin": makeAMPM(ampmOptions{Ready: true, LatestModel: false, ProvisioningState: succeeded}),
+				"baz": makeAMPM(ampmOptions{Ready: false, LatestModel: true, ProvisioningState: succeeded}),
+			},
+			want: Equal([]infrav1exp.AzureMachinePoolMachine{
+				makeAMPM(ampmOptions{Ready: false, LatestModel: true, ProvisioningState: succeeded}),
+			}),
+		},
+		{
+			name:            "if over-provisioned by an unready old-model machine, select the unready old-model machine",
+			strategy:        makeRollingUpdateStrategy(infrav1exp.MachineRollingUpdateDeployment{}),
+			desiredReplicas: 2,
+			input: map[string]infrav1exp.AzureMachinePoolMachine{
+				"foo": makeAMPM(ampmOptions{Ready: true, LatestModel: true, ProvisioningState: succeeded}),
+				"bin": makeAMPM(ampmOptions{Ready: true, LatestModel: true, ProvisioningState: succeeded}),
+				"baz": makeAMPM(ampmOptions{Ready: false, LatestModel: false, ProvisioningState: succeeded}),
+			},
+			want: Equal([]infrav1exp.AzureMachinePoolMachine{
+				makeAMPM(ampmOptions{Ready: false, LatestModel: false, ProvisioningState: succeeded}),
+			}),
+		},
+		{
+			name:            "if a new machine has empty status during a rollout, do not select it",
+			strategy:        makeRollingUpdateStrategy(infrav1exp.MachineRollingUpdateDeployment{}),
+			desiredReplicas: 2,
+			input: map[string]infrav1exp.AzureMachinePoolMachine{
+				"foo": makeAMPM(ampmOptions{Ready: true, LatestModel: false, ProvisioningState: succeeded}),
+				"bin": makeAMPM(ampmOptions{Ready: true, LatestModel: false, ProvisioningState: succeeded}),
+				"baz": makeAMPMWithEmptyStatus(),
+			},
+			want: BeEmpty(),
+		},
+		{
+			name:            "if protected unready replacements exist with separate ready excess, select a ready old-model machine",
+			strategy:        makeRollingUpdateStrategy(infrav1exp.MachineRollingUpdateDeployment{}),
+			desiredReplicas: 2,
+			input: map[string]infrav1exp.AzureMachinePoolMachine{
+				"foo": makeAMPM(ampmOptions{Ready: true, LatestModel: false, ProvisioningState: succeeded}),
+				"bin": makeAMPM(ampmOptions{Ready: true, LatestModel: false, ProvisioningState: succeeded}),
+				"baz": makeAMPM(ampmOptions{Ready: true, LatestModel: true, ProvisioningState: succeeded}),
+				"qux": makeAMPM(ampmOptions{Ready: false, LatestModel: true, ProvisioningState: succeeded}),
+			},
+			want: Equal([]infrav1exp.AzureMachinePoolMachine{
+				makeAMPM(ampmOptions{Ready: true, LatestModel: false, ProvisioningState: succeeded}),
+			}),
+		},
+		{
+			name:            "if model reconciliation is skipped, order mixed-model unready machines by delete policy",
+			strategy:        makeRollingUpdateStrategy(infrav1exp.MachineRollingUpdateDeployment{DeletePolicy: infrav1exp.OldestDeletePolicyType}),
+			desiredReplicas: 3,
+			skipModel:       true,
+			input: map[string]infrav1exp.AzureMachinePoolMachine{
+				"foo": makeAMPM(ampmOptions{Ready: true, LatestModel: true, ProvisioningState: succeeded}),
+				"bin": makeAMPM(ampmOptions{Ready: true, LatestModel: true, ProvisioningState: succeeded}),
+				"baz": makeAMPM(ampmOptions{Ready: false, LatestModel: false, ProvisioningState: succeeded, CreationTime: metav1.NewTime(baseTime.Add(2 * time.Hour))}),
+				"qux": makeAMPM(ampmOptions{Ready: false, LatestModel: true, ProvisioningState: succeeded, CreationTime: metav1.NewTime(baseTime.Add(1 * time.Hour))}),
+			},
+			want: Equal([]infrav1exp.AzureMachinePoolMachine{
+				makeAMPM(ampmOptions{Ready: false, LatestModel: true, ProvisioningState: succeeded, CreationTime: metav1.NewTime(baseTime.Add(1 * time.Hour))}),
+			}),
+		},
+		{
 			name:            "if over-provisioned, select a machine with an out-of-date model when using Random Delete Policy",
 			strategy:        makeRollingUpdateStrategy(infrav1exp.MachineRollingUpdateDeployment{DeletePolicy: infrav1exp.RandomDeletePolicyType}),
 			desiredReplicas: 2,
@@ -475,4 +593,8 @@ func makeAMPM(opts ampmOptions) infrav1exp.AzureMachinePoolMachine {
 	}
 
 	return ampm
+}
+
+func makeAMPMWithEmptyStatus() infrav1exp.AzureMachinePoolMachine {
+	return infrav1exp.AzureMachinePoolMachine{}
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

MachinePool scale-down currently counts only ready instances, so an extra VM can stick around forever if it never becomes ready. This makes explicit scale-down count all active instances and prefer removing unready ones first.

**Which issue(s) this PR fixes**:

None.

**Special notes for your reviewer**:

Includes regression coverage for the reported scale-up/scale-down failure.

**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests
- [ ] cherry-pick candidate

**Release note**:

```release-note
Fix MachinePool scale-down when excess VMSS instances are not ready.
```