### PR TITLE
Retry Kubernetes CI artifact downloads

### DIFF
--- a/templates/test/ci/cluster-template-prow-ci-version-dra.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version-dra.yaml
@@ -378,6 +378,27 @@ spec:
       echo "$${LINE_SEPARATOR}"
       CI_VERSION=${CI_VERSION}
 
+      download() {
+        local url="$${1}"
+        local output="$${2}"
+        local attempts=10
+
+        for ((attempt = 1; attempt <= attempts; attempt++)); do
+          if wget --inet4-only "$${url}" -O "$${output}"; then
+            return 0
+          fi
+
+          rm -f "$${output}"
+          if ((attempt == attempts)); then
+            echo "* failed to download $${url} after $${attempts} attempts" >&2
+            return 1
+          fi
+
+          echo "* download failed; retrying in 5 seconds ($${attempt}/$${attempts})"
+          sleep 5
+        done
+      }
+
       # Note: We assume if kubectl has the right version, everything else has as well
       if [[ $(kubectl version --client=true -o json | jq '.clientVersion.gitVersion' -r) = "$${CI_VERSION}" ]]; then
         echo "Detected Kubernetes $${CI_VERSION} via kubectl version, nothing to do"
@@ -400,7 +421,7 @@ spec:
           # Browser: https://console.cloud.google.com/storage/browser/k8s-release-dev?project=k8s-release-dev
           # e.g.: https://storage.googleapis.com/k8s-release-dev/ci/v1.21.0-beta.1.378+cf3374e43491c5/bin/linux/amd64/kubectl
           echo "* downloading binary: $${CI_URL}/$${CI_PACKAGE}"
-          wget --inet4-only "$${CI_URL}/$${CI_PACKAGE}" -O "$${CI_DIR}/$${CI_PACKAGE}"
+          download "$${CI_URL}/$${CI_PACKAGE}" "$${CI_DIR}/$${CI_PACKAGE}"
           chmod +x "$${CI_DIR}/$${CI_PACKAGE}"
           mv "$${CI_DIR}/$${CI_PACKAGE}" "/usr/bin/$${CI_PACKAGE}"
         done
@@ -413,7 +434,7 @@ spec:
         fi
         for CI_CONTAINER in "$${CONTAINERS_TO_TEST[@]}"; do
           echo "* downloading package: $${CI_URL}/$${CI_CONTAINER}.$${CONTAINER_EXT}"
-          wget --inet4-only "$${CI_URL}/$${CI_CONTAINER}.$${CONTAINER_EXT}" -O "$${CI_DIR}/$${CI_CONTAINER}.$${CONTAINER_EXT}"
+          download "$${CI_URL}/$${CI_CONTAINER}.$${CONTAINER_EXT}" "$${CI_DIR}/$${CI_CONTAINER}.$${CONTAINER_EXT}"
           $${SUDO} ctr -n k8s.io images import "$${CI_DIR}/$${CI_CONTAINER}.$${CONTAINER_EXT}" || echo "* ignoring expected 'ctr images import' result"
           $${SUDO} ctr -n k8s.io images tag "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}-amd64:$${CI_VERSION//+/_}" "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}:$${CI_VERSION//+/_}"
           $${SUDO} ctr -n k8s.io images tag "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}-amd64:$${CI_VERSION//+/_}" "gcr.io/k8s-staging-ci-images/$${CI_CONTAINER}:$${CI_VERSION//+/_}"

--- a/templates/test/ci/cluster-template-prow-ci-version-md-and-mp.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version-md-and-mp.yaml
@@ -971,6 +971,27 @@ spec:
       echo "$${LINE_SEPARATOR}"
       CI_VERSION=${CI_VERSION}
 
+      download() {
+        local url="$${1}"
+        local output="$${2}"
+        local attempts=10
+
+        for ((attempt = 1; attempt <= attempts; attempt++)); do
+          if wget --inet4-only "$${url}" -O "$${output}"; then
+            return 0
+          fi
+
+          rm -f "$${output}"
+          if ((attempt == attempts)); then
+            echo "* failed to download $${url} after $${attempts} attempts" >&2
+            return 1
+          fi
+
+          echo "* download failed; retrying in 5 seconds ($${attempt}/$${attempts})"
+          sleep 5
+        done
+      }
+
       # Note: We assume if kubectl has the right version, everything else has as well
       if [[ $(kubectl version --client=true -o json | jq '.clientVersion.gitVersion' -r) = "$${CI_VERSION}" ]]; then
         echo "Detected Kubernetes $${CI_VERSION} via kubectl version, nothing to do"
@@ -993,7 +1014,7 @@ spec:
           # Browser: https://console.cloud.google.com/storage/browser/k8s-release-dev?project=k8s-release-dev
           # e.g.: https://storage.googleapis.com/k8s-release-dev/ci/v1.21.0-beta.1.378+cf3374e43491c5/bin/linux/amd64/kubectl
           echo "* downloading binary: $${CI_URL}/$${CI_PACKAGE}"
-          wget --inet4-only "$${CI_URL}/$${CI_PACKAGE}" -O "$${CI_DIR}/$${CI_PACKAGE}"
+          download "$${CI_URL}/$${CI_PACKAGE}" "$${CI_DIR}/$${CI_PACKAGE}"
           chmod +x "$${CI_DIR}/$${CI_PACKAGE}"
           mv "$${CI_DIR}/$${CI_PACKAGE}" "/usr/bin/$${CI_PACKAGE}"
         done
@@ -1006,7 +1027,7 @@ spec:
         fi
         for CI_CONTAINER in "$${CONTAINERS_TO_TEST[@]}"; do
           echo "* downloading package: $${CI_URL}/$${CI_CONTAINER}.$${CONTAINER_EXT}"
-          wget --inet4-only "$${CI_URL}/$${CI_CONTAINER}.$${CONTAINER_EXT}" -O "$${CI_DIR}/$${CI_CONTAINER}.$${CONTAINER_EXT}"
+          download "$${CI_URL}/$${CI_CONTAINER}.$${CONTAINER_EXT}" "$${CI_DIR}/$${CI_CONTAINER}.$${CONTAINER_EXT}"
           $${SUDO} ctr -n k8s.io images import "$${CI_DIR}/$${CI_CONTAINER}.$${CONTAINER_EXT}" || echo "* ignoring expected 'ctr images import' result"
           $${SUDO} ctr -n k8s.io images tag "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}-amd64:$${CI_VERSION//+/_}" "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}:$${CI_VERSION//+/_}"
           $${SUDO} ctr -n k8s.io images tag "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}-amd64:$${CI_VERSION//+/_}" "gcr.io/k8s-staging-ci-images/$${CI_CONTAINER}:$${CI_VERSION//+/_}"

--- a/templates/test/ci/cluster-template-prow-machine-pool-ci-version-multi-zone.yaml
+++ b/templates/test/ci/cluster-template-prow-machine-pool-ci-version-multi-zone.yaml
@@ -364,6 +364,27 @@ spec:
       echo "$${LINE_SEPARATOR}"
       CI_VERSION=${CI_VERSION}
 
+      download() {
+        local url="$${1}"
+        local output="$${2}"
+        local attempts=10
+
+        for ((attempt = 1; attempt <= attempts; attempt++)); do
+          if wget --inet4-only "$${url}" -O "$${output}"; then
+            return 0
+          fi
+
+          rm -f "$${output}"
+          if ((attempt == attempts)); then
+            echo "* failed to download $${url} after $${attempts} attempts" >&2
+            return 1
+          fi
+
+          echo "* download failed; retrying in 5 seconds ($${attempt}/$${attempts})"
+          sleep 5
+        done
+      }
+
       # Note: We assume if kubectl has the right version, everything else has as well
       if [[ $(kubectl version --client=true -o json | jq '.clientVersion.gitVersion' -r) = "$${CI_VERSION}" ]]; then
         echo "Detected Kubernetes $${CI_VERSION} via kubectl version, nothing to do"
@@ -386,7 +407,7 @@ spec:
           # Browser: https://console.cloud.google.com/storage/browser/k8s-release-dev?project=k8s-release-dev
           # e.g.: https://storage.googleapis.com/k8s-release-dev/ci/v1.21.0-beta.1.378+cf3374e43491c5/bin/linux/amd64/kubectl
           echo "* downloading binary: $${CI_URL}/$${CI_PACKAGE}"
-          wget --inet4-only "$${CI_URL}/$${CI_PACKAGE}" -O "$${CI_DIR}/$${CI_PACKAGE}"
+          download "$${CI_URL}/$${CI_PACKAGE}" "$${CI_DIR}/$${CI_PACKAGE}"
           chmod +x "$${CI_DIR}/$${CI_PACKAGE}"
           mv "$${CI_DIR}/$${CI_PACKAGE}" "/usr/bin/$${CI_PACKAGE}"
         done
@@ -399,7 +420,7 @@ spec:
         fi
         for CI_CONTAINER in "$${CONTAINERS_TO_TEST[@]}"; do
           echo "* downloading package: $${CI_URL}/$${CI_CONTAINER}.$${CONTAINER_EXT}"
-          wget --inet4-only "$${CI_URL}/$${CI_CONTAINER}.$${CONTAINER_EXT}" -O "$${CI_DIR}/$${CI_CONTAINER}.$${CONTAINER_EXT}"
+          download "$${CI_URL}/$${CI_CONTAINER}.$${CONTAINER_EXT}" "$${CI_DIR}/$${CI_CONTAINER}.$${CONTAINER_EXT}"
           $${SUDO} ctr -n k8s.io images import "$${CI_DIR}/$${CI_CONTAINER}.$${CONTAINER_EXT}" || echo "* ignoring expected 'ctr images import' result"
           $${SUDO} ctr -n k8s.io images tag "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}-amd64:$${CI_VERSION//+/_}" "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}:$${CI_VERSION//+/_}"
           $${SUDO} ctr -n k8s.io images tag "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}-amd64:$${CI_VERSION//+/_}" "gcr.io/k8s-staging-ci-images/$${CI_CONTAINER}:$${CI_VERSION//+/_}"

--- a/templates/test/ci/cluster-template-prow-machine-pool-ci-version.yaml
+++ b/templates/test/ci/cluster-template-prow-machine-pool-ci-version.yaml
@@ -360,6 +360,27 @@ spec:
       echo "$${LINE_SEPARATOR}"
       CI_VERSION=${CI_VERSION}
 
+      download() {
+        local url="$${1}"
+        local output="$${2}"
+        local attempts=10
+
+        for ((attempt = 1; attempt <= attempts; attempt++)); do
+          if wget --inet4-only "$${url}" -O "$${output}"; then
+            return 0
+          fi
+
+          rm -f "$${output}"
+          if ((attempt == attempts)); then
+            echo "* failed to download $${url} after $${attempts} attempts" >&2
+            return 1
+          fi
+
+          echo "* download failed; retrying in 5 seconds ($${attempt}/$${attempts})"
+          sleep 5
+        done
+      }
+
       # Note: We assume if kubectl has the right version, everything else has as well
       if [[ $(kubectl version --client=true -o json | jq '.clientVersion.gitVersion' -r) = "$${CI_VERSION}" ]]; then
         echo "Detected Kubernetes $${CI_VERSION} via kubectl version, nothing to do"
@@ -382,7 +403,7 @@ spec:
           # Browser: https://console.cloud.google.com/storage/browser/k8s-release-dev?project=k8s-release-dev
           # e.g.: https://storage.googleapis.com/k8s-release-dev/ci/v1.21.0-beta.1.378+cf3374e43491c5/bin/linux/amd64/kubectl
           echo "* downloading binary: $${CI_URL}/$${CI_PACKAGE}"
-          wget --inet4-only "$${CI_URL}/$${CI_PACKAGE}" -O "$${CI_DIR}/$${CI_PACKAGE}"
+          download "$${CI_URL}/$${CI_PACKAGE}" "$${CI_DIR}/$${CI_PACKAGE}"
           chmod +x "$${CI_DIR}/$${CI_PACKAGE}"
           mv "$${CI_DIR}/$${CI_PACKAGE}" "/usr/bin/$${CI_PACKAGE}"
         done
@@ -395,7 +416,7 @@ spec:
         fi
         for CI_CONTAINER in "$${CONTAINERS_TO_TEST[@]}"; do
           echo "* downloading package: $${CI_URL}/$${CI_CONTAINER}.$${CONTAINER_EXT}"
-          wget --inet4-only "$${CI_URL}/$${CI_CONTAINER}.$${CONTAINER_EXT}" -O "$${CI_DIR}/$${CI_CONTAINER}.$${CONTAINER_EXT}"
+          download "$${CI_URL}/$${CI_CONTAINER}.$${CONTAINER_EXT}" "$${CI_DIR}/$${CI_CONTAINER}.$${CONTAINER_EXT}"
           $${SUDO} ctr -n k8s.io images import "$${CI_DIR}/$${CI_CONTAINER}.$${CONTAINER_EXT}" || echo "* ignoring expected 'ctr images import' result"
           $${SUDO} ctr -n k8s.io images tag "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}-amd64:$${CI_VERSION//+/_}" "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}:$${CI_VERSION//+/_}"
           $${SUDO} ctr -n k8s.io images tag "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}-amd64:$${CI_VERSION//+/_}" "gcr.io/k8s-staging-ci-images/$${CI_CONTAINER}:$${CI_VERSION//+/_}"

--- a/templates/test/ci/prow-machine-pool-ci-version/patches/kubeadm-bootstrap-k8s-ci-binaries.yaml
+++ b/templates/test/ci/prow-machine-pool-ci-version/patches/kubeadm-bootstrap-k8s-ci-binaries.yaml
@@ -20,6 +20,27 @@
       echo "$${LINE_SEPARATOR}"
       CI_VERSION=${CI_VERSION}
 
+      download() {
+        local url="$${1}"
+        local output="$${2}"
+        local attempts=10
+
+        for ((attempt = 1; attempt <= attempts; attempt++)); do
+          if wget --inet4-only "$${url}" -O "$${output}"; then
+            return 0
+          fi
+
+          rm -f "$${output}"
+          if ((attempt == attempts)); then
+            echo "* failed to download $${url} after $${attempts} attempts" >&2
+            return 1
+          fi
+
+          echo "* download failed; retrying in 5 seconds ($${attempt}/$${attempts})"
+          sleep 5
+        done
+      }
+
       # Note: We assume if kubectl has the right version, everything else has as well
       if [[ $(kubectl version --client=true -o json | jq '.clientVersion.gitVersion' -r) = "$${CI_VERSION}" ]]; then
         echo "Detected Kubernetes $${CI_VERSION} via kubectl version, nothing to do"
@@ -42,7 +63,7 @@
           # Browser: https://console.cloud.google.com/storage/browser/k8s-release-dev?project=k8s-release-dev
           # e.g.: https://storage.googleapis.com/k8s-release-dev/ci/v1.21.0-beta.1.378+cf3374e43491c5/bin/linux/amd64/kubectl
           echo "* downloading binary: $${CI_URL}/$${CI_PACKAGE}"
-          wget --inet4-only "$${CI_URL}/$${CI_PACKAGE}" -O "$${CI_DIR}/$${CI_PACKAGE}"
+          download "$${CI_URL}/$${CI_PACKAGE}" "$${CI_DIR}/$${CI_PACKAGE}"
           chmod +x "$${CI_DIR}/$${CI_PACKAGE}"
           mv "$${CI_DIR}/$${CI_PACKAGE}" "/usr/bin/$${CI_PACKAGE}"
         done
@@ -55,7 +76,7 @@
         fi
         for CI_CONTAINER in "$${CONTAINERS_TO_TEST[@]}"; do
           echo "* downloading package: $${CI_URL}/$${CI_CONTAINER}.$${CONTAINER_EXT}"
-          wget --inet4-only "$${CI_URL}/$${CI_CONTAINER}.$${CONTAINER_EXT}" -O "$${CI_DIR}/$${CI_CONTAINER}.$${CONTAINER_EXT}"
+          download "$${CI_URL}/$${CI_CONTAINER}.$${CONTAINER_EXT}" "$${CI_DIR}/$${CI_CONTAINER}.$${CONTAINER_EXT}"
           $${SUDO} ctr -n k8s.io images import "$${CI_DIR}/$${CI_CONTAINER}.$${CONTAINER_EXT}" || echo "* ignoring expected 'ctr images import' result"
           $${SUDO} ctr -n k8s.io images tag "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}-amd64:$${CI_VERSION//+/_}" "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}:$${CI_VERSION//+/_}"
           $${SUDO} ctr -n k8s.io images tag "$${IMAGE_REGISTRY_PREFIX}/$${CI_CONTAINER}-amd64:$${CI_VERSION//+/_}" "gcr.io/k8s-staging-ci-images/$${CI_CONTAINER}:$${CI_VERSION//+/_}"


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Transient network failures can leave CI nodes without the Kubernetes binaries or images they need. Retry each download up to ten times, cleaning up partial files between attempts.

**Which issue(s) this PR fixes**:

Fixes #6478

**Special notes for your reviewer**:

None.

**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] cherry-pick candidate

**Release note**:

```release-note
NONE
```