### PR TITLE
fix: pin google.golang.org/grpc to v1.82.1 (GHSA-hrxh-6v49-42gf)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -196,7 +196,7 @@ require (
 	gomodules.xyz/jsonpatch/v2 v2.5.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa // indirect
-	google.golang.org/grpc v1.81.1 // indirect
+	google.golang.org/grpc v1.82.1 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -566,8 +566,8 @@ google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa h1:
 google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa/go.mod h1:q4lMZS6kskjT5HvCPrnnypcDPVJqT/f4nfxmkE7gryY=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa h1:mZHHdPZl0dbGHCflZgAq/Q468DWVFcU2whhB2KAo8fk=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
-google.golang.org/grpc v1.81.1 h1:VnnIIZ88UzOOKLukQi+ImGz8O1Wdp8nAGGnvOfEIWQQ=
-google.golang.org/grpc v1.81.1/go.mod h1:xGH9GfzOyMTGIOXBJmXt+BX/V0kcdQbdcuwQ/zNw42I=
+google.golang.org/grpc v1.82.1 h1:NnAxzGRA0677vCa4BUkOAnO5+FfQqVl9iUXeD0IqcGE=
+google.golang.org/grpc v1.82.1/go.mod h1:yzTZ1TB1Z3SG+LIYaI+WiE8D5+PZ3ArnrSp8zF3+/ZA=
 google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=
 google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
## Summary

Pin `google.golang.org/grpc` from v1.81.1 to v1.82.1 to address [GHSA-hrxh-6v49-42gf](https://github.com/advisories/GHSA-hrxh-6v49-42gf) — gRPC-Go: xDS RBAC and HTTP/2 Vulnerabilities.

## Vulnerability details

| | |
|---|---|
| **Advisory** | GHSA-hrxh-6v49-42gf |
| **Package** | `google.golang.org/grpc` |
| **Installed** | v1.81.1 |
| **Fixed** | v1.82.1 |

Three issues bundled in this advisory:
- **xDS RBAC authorization bypass** (CVSS 8.2 / HIGH) — unsupported matcher types silently dropped, policies fail open
- **HTTP/2 Rapid Reset DoS bypass** (CVSS 7.5 / HIGH) — prior mitigation only counted wire writes, buffer queue not counted
- **xDS RBAC server panic** (CVSS 5.9 / MEDIUM) — `NOT` rule wrapping unhandled field causes runtime panic

## Why a direct pin

`grpc` is an **indirect** dependency pulled in via:
```
otlptracegrpc v1.44.0 → google.golang.org/grpc
```
`otlptracegrpc` has not yet released a version requiring v1.82.1+, so explicit MVS pinning is required to bridge the gap.

```release-note
Pin google.golang.org/grpc to v1.82.1 to address GHSA-hrxh-6v49-42gf (gRPC-Go xDS RBAC authorization bypass, HTTP/2 Rapid Reset DoS, and server panic — HIGH severity).
```