### PR TITLE
Mark AzureMachinePool NotReady when VMSS provisioning fails

### DIFF
--- a/azure/scope/machinepool.go
+++ b/azure/scope/machinepool.go
@@ -628,9 +628,14 @@ func (m *MachinePoolScope) setProvisioningStateAndConditions(v infrav1.Provision
 	case v == infrav1.Failed:
 		v1beta1conditions.MarkFalse(m.AzureMachinePool, infrav1.ScaleSetRunningCondition, infrav1.ScaleSetProvisionFailedReason, clusterv1beta1.ConditionSeverityInfo, "")
 		m.SetNotReady()
-	default:
+	case v == infrav1.Canceled || v == infrav1.Deleted:
 		v1beta1conditions.MarkFalse(m.AzureMachinePool, infrav1.ScaleSetRunningCondition, string(v), clusterv1beta1.ConditionSeverityInfo, "")
 		m.SetNotReady()
+	default:
+		// Migrating and any future or unrecognized in-progress states are left as-is:
+		// Azure still considers the operation running, and flipping Ready here would
+		// make CAPI return before spec.providerIDList is updated (see #5537).
+		v1beta1conditions.MarkFalse(m.AzureMachinePool, infrav1.ScaleSetRunningCondition, string(v), clusterv1beta1.ConditionSeverityInfo, "")
 	}
 }
 

--- a/azure/scope/machinepool.go
+++ b/azure/scope/machinepool.go
@@ -630,6 +630,7 @@ func (m *MachinePoolScope) setProvisioningStateAndConditions(v infrav1.Provision
 		m.SetNotReady()
 	default:
 		v1beta1conditions.MarkFalse(m.AzureMachinePool, infrav1.ScaleSetRunningCondition, string(v), clusterv1beta1.ConditionSeverityInfo, "")
+		m.SetNotReady()
 	}
 }
 

--- a/azure/scope/machinepool.go
+++ b/azure/scope/machinepool.go
@@ -632,9 +632,7 @@ func (m *MachinePoolScope) setProvisioningStateAndConditions(v infrav1.Provision
 		v1beta1conditions.MarkFalse(m.AzureMachinePool, infrav1.ScaleSetRunningCondition, string(v), clusterv1beta1.ConditionSeverityInfo, "")
 		m.SetNotReady()
 	default:
-		// Migrating and any future or unrecognized in-progress states are left as-is:
-		// Azure still considers the operation running, and flipping Ready here would
-		// make CAPI return before spec.providerIDList is updated (see #5537).
+		// Preserve readiness for unhandled provisioning states.
 		v1beta1conditions.MarkFalse(m.AzureMachinePool, infrav1.ScaleSetRunningCondition, string(v), clusterv1beta1.ConditionSeverityInfo, "")
 	}
 }

--- a/azure/scope/machinepool.go
+++ b/azure/scope/machinepool.go
@@ -627,6 +627,7 @@ func (m *MachinePoolScope) setProvisioningStateAndConditions(v infrav1.Provision
 		m.SetNotReady()
 	case v == infrav1.Failed:
 		v1beta1conditions.MarkFalse(m.AzureMachinePool, infrav1.ScaleSetRunningCondition, infrav1.ScaleSetProvisionFailedReason, clusterv1beta1.ConditionSeverityInfo, "")
+		m.SetNotReady()
 	default:
 		v1beta1conditions.MarkFalse(m.AzureMachinePool, infrav1.ScaleSetRunningCondition, string(v), clusterv1beta1.ConditionSeverityInfo, "")
 	}

--- a/azure/scope/machinepool_test.go
+++ b/azure/scope/machinepool_test.go
@@ -1909,13 +1909,41 @@ func TestMachinePoolScope_setProvisioningStateAndConditions(t *testing.T) {
 			ProvisioningState: infrav1.Failed,
 		},
 		{
-			Name: "if provisioning state is set to something not explicitly handled, MachinePool is NotReady and scale set running condition is set to the ProvisioningState",
+			Name: "if provisioning state is set to Canceled, MachinePool is NotReady and scale set running condition is set to the ProvisioningState",
 			Setup: func(mp *clusterv1.MachinePool, amp *infrav1exp.AzureMachinePool, cb *fake.ClientBuilder) {
 				// A previously-ready MachinePool (e.g. an aborted scale operation reporting Canceled) must be marked NotReady.
 				amp.Status.Ready = true
 			},
 			Verify: func(g *WithT, amp *infrav1exp.AzureMachinePool, c client.Client) {
 				g.Expect(amp.Status.Ready).To(BeFalse())
+				condition := v1beta1conditions.Get(amp, infrav1.ScaleSetRunningCondition)
+				g.Expect(condition.Status).To(Equal(corev1.ConditionFalse))
+				g.Expect(condition.Reason).To(Equal(string(infrav1.Canceled)))
+			},
+			ProvisioningState: infrav1.Canceled,
+		},
+		{
+			Name: "if provisioning state is set to Deleted, MachinePool is NotReady and scale set running condition is set to the ProvisioningState",
+			Setup: func(mp *clusterv1.MachinePool, amp *infrav1exp.AzureMachinePool, cb *fake.ClientBuilder) {
+				amp.Status.Ready = true
+			},
+			Verify: func(g *WithT, amp *infrav1exp.AzureMachinePool, c client.Client) {
+				g.Expect(amp.Status.Ready).To(BeFalse())
+				condition := v1beta1conditions.Get(amp, infrav1.ScaleSetRunningCondition)
+				g.Expect(condition.Status).To(Equal(corev1.ConditionFalse))
+				g.Expect(condition.Reason).To(Equal(string(infrav1.Deleted)))
+			},
+			ProvisioningState: infrav1.Deleted,
+		},
+		{
+			Name: "if provisioning state is set to Migrating, MachinePool Ready status is left unchanged and scale set running condition is set to the ProvisioningState",
+			Setup: func(mp *clusterv1.MachinePool, amp *infrav1exp.AzureMachinePool, cb *fake.ClientBuilder) {
+				// Migrating is not a terminal state; a previously-ready MachinePool must stay Ready so CAPI
+				// keeps updating spec.providerIDList instead of returning early (see #5537).
+				amp.Status.Ready = true
+			},
+			Verify: func(g *WithT, amp *infrav1exp.AzureMachinePool, c client.Client) {
+				g.Expect(amp.Status.Ready).To(BeTrue())
 				condition := v1beta1conditions.Get(amp, infrav1.ScaleSetRunningCondition)
 				g.Expect(condition.Status).To(Equal(corev1.ConditionFalse))
 				g.Expect(condition.Reason).To(Equal(string(infrav1.Migrating)))

--- a/azure/scope/machinepool_test.go
+++ b/azure/scope/machinepool_test.go
@@ -1895,9 +1895,13 @@ func TestMachinePoolScope_setProvisioningStateAndConditions(t *testing.T) {
 			ProvisioningState: infrav1.Deleting,
 		},
 		{
-			Name:  "if provisioning state is set to Failed, MachinePool ready state is not adjusted, and scale set running condition is set to Failed",
-			Setup: func(mp *clusterv1.MachinePool, amp *infrav1exp.AzureMachinePool, cb *fake.ClientBuilder) {},
+			Name: "if provisioning state is set to Failed, MachinePool is NotReady and scale set running condition is set to Failed",
+			Setup: func(mp *clusterv1.MachinePool, amp *infrav1exp.AzureMachinePool, cb *fake.ClientBuilder) {
+				// A previously-ready MachinePool (e.g. a stalled scale-up) must be marked NotReady when it fails.
+				amp.Status.Ready = true
+			},
 			Verify: func(g *WithT, amp *infrav1exp.AzureMachinePool, c client.Client) {
+				g.Expect(amp.Status.Ready).To(BeFalse())
 				condition := v1beta1conditions.Get(amp, infrav1.ScaleSetRunningCondition)
 				g.Expect(condition.Status).To(Equal(corev1.ConditionFalse))
 				g.Expect(condition.Reason).To(Equal(infrav1.ScaleSetProvisionFailedReason))

--- a/azure/scope/machinepool_test.go
+++ b/azure/scope/machinepool_test.go
@@ -1909,9 +1909,13 @@ func TestMachinePoolScope_setProvisioningStateAndConditions(t *testing.T) {
 			ProvisioningState: infrav1.Failed,
 		},
 		{
-			Name:  "if provisioning state is set to something not explicitly handled, MachinePool ready state is not adjusted, and scale set running condition is set to the ProvisioningState",
-			Setup: func(mp *clusterv1.MachinePool, amp *infrav1exp.AzureMachinePool, cb *fake.ClientBuilder) {},
+			Name: "if provisioning state is set to something not explicitly handled, MachinePool is NotReady and scale set running condition is set to the ProvisioningState",
+			Setup: func(mp *clusterv1.MachinePool, amp *infrav1exp.AzureMachinePool, cb *fake.ClientBuilder) {
+				// A previously-ready MachinePool (e.g. an aborted scale operation reporting Canceled) must be marked NotReady.
+				amp.Status.Ready = true
+			},
 			Verify: func(g *WithT, amp *infrav1exp.AzureMachinePool, c client.Client) {
+				g.Expect(amp.Status.Ready).To(BeFalse())
 				condition := v1beta1conditions.Get(amp, infrav1.ScaleSetRunningCondition)
 				g.Expect(condition.Status).To(Equal(corev1.ConditionFalse))
 				g.Expect(condition.Reason).To(Equal(string(infrav1.Migrating)))


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:

Motivation:
PR #5537 changed setProvisioningStateAndConditions so that the
`Failed` VMSS provisioning state no longer calls SetNotReady() on the
AzureMachinePool (this call was silently dropped; prior to #5537 the
`Failed` state fell through to the `default` case, which did call
SetNotReady()). As a result, once an AzureMachinePool has been marked
Ready (e.g. after a prior successful reconcile), it stays Ready even
after Azure reports the VMSS scale operation as Failed, for example
when a scale-up cannot be fulfilled due to capacity constraints in a
zone. This matches the repro in #5860: a partially-fulfilled scale-up
times out on the Azure side, but the AzureMachinePool keeps reporting
Ready, so nothing signals downstream that the attempt failed, and
cluster-autoscaler/CAPZ are expected to keep retrying against the same
constrained zone instead of backing off. User-visible behavior for the
`Succeeded`/`Updating` cases added by #5537 is unchanged; this only
restores the pre-#5537 behavior for the `Failed` case specifically.

Approach:
Add back the `m.SetNotReady()` call in the `infrav1.Failed` case of
MachinePoolScope.setProvisioningStateAndConditions in
azure/scope/machinepool.go, so a VMSS that Azure reports as Failed is
reflected as NotReady on the AzureMachinePool, regardless of what its
Ready status was before entering the Failed state.

Note this leaves the `default` case (covering less common states like
Migrating/Canceled) unchanged; it has the same latent issue but is out
of scope for this minimal fix targeting the specific Failed-state
repro in #5860.

Validation:
  go build ./...
  go test ./azure/scope/... -run TestMachinePoolScope -v

Both passed, including the updated
TestMachinePoolScope_setProvisioningStateAndConditions/Failed case,
which now sets Ready=true before invoking the function to reproduce
the reported "stuck ready" scenario, and asserts it flips to false.

**Which issue(s) this PR fixes**:
Fixes #5860

**Release note**:
```release-note
Fix AzureMachinePool remaining marked Ready after a VMSS scale operation fails (e.g. due to capacity constraints), so failed scale-ups are correctly reflected instead of appearing to have succeeded.
```

Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>