### PR TITLE
[release-1.22] test/e2e/helpers.go: add some debugging code for CAAPH issues

### DIFF
--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -118,16 +118,56 @@ func WaitForDeploymentsAvailable(ctx context.Context, input WaitForDeploymentsAv
 func GetWaitForDeploymentsAvailableInput(ctx context.Context, clusterProxy framework.ClusterProxy, name, namespace string, specName string) WaitForDeploymentsAvailableInput {
 	Expect(clusterProxy).NotTo(BeNil())
 	cl := clusterProxy.GetClient()
+	clientset := clusterProxy.GetClientSet()
 	var d = &appsv1.Deployment{}
 	Eventually(func() error {
 		return cl.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, d)
-	}, e2eConfig.GetIntervals(specName, "wait-deployment")...).Should(Succeed())
-	clientset := clusterProxy.GetClientSet()
+	}, e2eConfig.GetIntervals(specName, "wait-deployment")...).Should(Succeed(), func() string {
+		return describeDeploymentsInNamespace(ctx, clientset, namespace, name)
+	})
 	return WaitForDeploymentsAvailableInput{
 		Deployment: d,
 		Clientset:  clientset,
 		Getter:     cl,
 	}
+}
+
+// describeDeploymentsInNamespace returns a string summarizing the deployments and pods that do exist
+// in the given namespace, to help debug why an expected deployment never showed up (e.g. when its
+// Helm chart install via CAAPH failed).
+func describeDeploymentsInNamespace(ctx context.Context, clientset *kubernetes.Clientset, namespace, name string) string {
+	b := strings.Builder{}
+	b.WriteString(fmt.Sprintf("Deployment %s/%s never appeared", namespace, name))
+	if clientset == nil {
+		b.WriteString("\nclientset is nil, so skipping output of namespace state")
+		return b.String()
+	}
+	deployments, err := clientset.AppsV1().Deployments(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		b.WriteString(fmt.Sprintf("\nfailed to list deployments in namespace %s: %s\n", namespace, err.Error()))
+	} else {
+		b.WriteString(fmt.Sprintf("\nDeployments currently in namespace %s: %d\n", namespace, len(deployments.Items)))
+		for i := range deployments.Items {
+			dep := &deployments.Items[i]
+			b.WriteString(fmt.Sprintf("  %s: replicas=%d ready=%d available=%d\n", dep.Name, dep.Status.Replicas, dep.Status.ReadyReplicas, dep.Status.AvailableReplicas))
+		}
+	}
+	pods, err := clientset.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		b.WriteString(fmt.Sprintf("failed to list pods in namespace %s: %s\n", namespace, err.Error()))
+	} else {
+		b.WriteString(fmt.Sprintf("Pods currently in namespace %s: %d\n", namespace, len(pods.Items)))
+		for i := range pods.Items {
+			pod := &pods.Items[i]
+			b.WriteString(fmt.Sprintf("  %s: phase=%s\n", pod.Name, pod.Status.Phase))
+			for _, cs := range pod.Status.ContainerStatuses {
+				if w := cs.State.Waiting; w != nil {
+					b.WriteString(fmt.Sprintf("    container %s waiting: reason=%q message=%q\n", cs.Name, w.Reason, w.Message))
+				}
+			}
+		}
+	}
+	return b.String()
 }
 
 // DescribeFailedDeployment returns detailed output to help debug a deployment failure in e2e.
@@ -138,6 +178,105 @@ func DescribeFailedDeployment(ctx context.Context, input WaitForDeploymentsAvail
 		namespace, name))
 	b.WriteString(fmt.Sprintf("\nDeployment:\n%s\n", prettyPrint(input.Deployment)))
 	b.WriteString(describeEvents(ctx, input.Clientset, namespace, name))
+	b.WriteString(describeDeploymentPods(ctx, input.Clientset, input.Deployment))
+	b.WriteString(describeEnvFromConfigMaps(ctx, input.Clientset, input.Deployment))
+	return b.String()
+}
+
+// describeEnvFromConfigMaps returns a string summarizing the keys of any ConfigMaps referenced via
+// envFrom by the deployment's containers. This surfaces misconfigured env sources such as the
+// tigera-operator "kubernetes-services-endpoint" ConfigMap being populated with "<no value>" when
+// the Helm chart is rendered before the cluster controlPlaneEndpoint is set.
+//
+// To avoid leaking private configuration or mistakenly stored credentials into test failure output,
+// only each key's state is reported ("empty", "<no value>" or "set") and never the actual value.
+// Secret envFrom sources are not inspected at all.
+func describeEnvFromConfigMaps(ctx context.Context, clientset *kubernetes.Clientset, deployment *appsv1.Deployment) string {
+	b := strings.Builder{}
+	if clientset == nil {
+		return b.String()
+	}
+	namespace := deployment.GetNamespace()
+	seen := map[string]bool{}
+	containers := append([]corev1.Container{}, deployment.Spec.Template.Spec.InitContainers...)
+	containers = append(containers, deployment.Spec.Template.Spec.Containers...)
+	for _, c := range containers {
+		for _, ef := range c.EnvFrom {
+			if ef.ConfigMapRef == nil || seen[ef.ConfigMapRef.Name] {
+				continue
+			}
+			seen[ef.ConfigMapRef.Name] = true
+			name := ef.ConfigMapRef.Name
+			cm, err := clientset.CoreV1().ConfigMaps(namespace).Get(ctx, name, metav1.GetOptions{})
+			if err != nil {
+				b.WriteString(fmt.Sprintf("\nenvFrom ConfigMap %s/%s: failed to get: %s\n", namespace, name, err.Error()))
+				continue
+			}
+			b.WriteString(fmt.Sprintf("\nenvFrom ConfigMap %s/%s keys:\n", namespace, name))
+			for k, v := range cm.Data {
+				b.WriteString(fmt.Sprintf("  %s: %s\n", k, envValueState(v)))
+			}
+		}
+	}
+	return b.String()
+}
+
+// envValueState reports the state of an env value without exposing the value itself, so that private
+// configuration or credentials are not copied into test failure output. It distinguishes the
+// "<no value>" placeholder (baked in by a Helm render before its templated source was populated) and
+// empty values from any other set value.
+func envValueState(v string) string {
+	switch v {
+	case "":
+		return "empty"
+	case "<no value>":
+		return "<no value>"
+	default:
+		return "set"
+	}
+}
+
+// describeDeploymentPods returns a string summarizing the pods owned by the given deployment,
+// including their phase, container statuses (e.g. ImagePullBackOff, CrashLoopBackOff) and related
+// events. This helps debug why a deployment never becomes available.
+func describeDeploymentPods(ctx context.Context, clientset *kubernetes.Clientset, deployment *appsv1.Deployment) string {
+	b := strings.Builder{}
+	if clientset == nil {
+		b.WriteString("clientset is nil, so skipping output of deployment pods")
+		return b.String()
+	}
+	namespace := deployment.GetNamespace()
+	selector, err := metav1.LabelSelectorAsSelector(deployment.Spec.Selector)
+	if err != nil {
+		b.WriteString(fmt.Sprintf("\nfailed to build pod selector for deployment %s/%s: %s\n", namespace, deployment.GetName(), err.Error()))
+		return b.String()
+	}
+	pods, err := clientset.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{LabelSelector: selector.String()})
+	if err != nil {
+		b.WriteString(fmt.Sprintf("\nfailed to list pods for deployment %s/%s: %s\n", namespace, deployment.GetName(), err.Error()))
+		return b.String()
+	}
+	b.WriteString(fmt.Sprintf("\nPods for deployment %s/%s (matching %q):\n", namespace, deployment.GetName(), selector.String()))
+	if len(pods.Items) == 0 {
+		b.WriteString("no pods found\n")
+	}
+	for i := range pods.Items {
+		pod := &pods.Items[i]
+		b.WriteString(fmt.Sprintf("\nPod %s/%s: phase=%s node=%q\n", pod.Namespace, pod.Name, pod.Status.Phase, pod.Spec.NodeName))
+		for _, cond := range pod.Status.Conditions {
+			b.WriteString(fmt.Sprintf("  condition %s=%s reason=%q message=%q\n", cond.Type, cond.Status, cond.Reason, cond.Message))
+		}
+		for _, cs := range pod.Status.ContainerStatuses {
+			b.WriteString(fmt.Sprintf("  container %s: ready=%t restartCount=%d\n", cs.Name, cs.Ready, cs.RestartCount))
+			if w := cs.State.Waiting; w != nil {
+				b.WriteString(fmt.Sprintf("    waiting: reason=%q message=%q\n", w.Reason, w.Message))
+			}
+			if t := cs.State.Terminated; t != nil {
+				b.WriteString(fmt.Sprintf("    terminated: reason=%q exitCode=%d message=%q\n", t.Reason, t.ExitCode, t.Message))
+			}
+		}
+		b.WriteString(describeEvents(ctx, clientset, pod.Namespace, pod.Name))
+	}
 	return b.String()
 }
 


### PR DESCRIPTION
**What type of PR is this?**

/kind failing-test

**What this PR does / why we need it**:

Cherry pick of #6494

While running CAPZ tests at scale, I often hit tigera-operator deployment timeout, which error looks like this:
```console

  [FAILED] Timed out after 900.001s.
  Deployment tigera-operator/tigera-operator failed
  Deployment:
  {
    "metadata": {
      "name": "tigera-operator",
      "namespace": "tigera-operator",
      "uid": "43dc8dca-93d6-4ff7-a763-03fb307af454",
      "resourceVersion": "1497",
      "generation": 1,
      "creationTimestamp": "2026-07-17T12:48:29Z",
      "labels": {
        "app.kubernetes.io/managed-by": "Helm",
        "k8s-app": "tigera-operator"
      },
      "annotations": {
        "deployment.kubernetes.io/revision": "1",
        "meta.helm.sh/release-name": "projectcalico",
        "meta.helm.sh/release-namespace": "tigera-operator"
      },
      "managedFields": [
        {
          "manager": "manager",
          "operation": "Update",
          "apiVersion": "apps/v1",
          "time": "2026-07-17T12:48:29Z",
          "fieldsType": "FieldsV1",
          "fieldsV1": {
            "f:metadata": {
              "f:annotations": {
                ".": {},
                "f:meta.helm.sh/release-name": {},
                "f:meta.helm.sh/release-namespace": {}
              },
              "f:labels": {
                ".": {},
                "f:app.kubernetes.io/managed-by": {},
                "f:k8s-app": {}
              }
            },
            "f:spec": {
              "f:progressDeadlineSeconds": {},
              "f:replicas": {},
              "f:revisionHistoryLimit": {},
              "f:selector": {},
              "f:strategy": {
                "f:rollingUpdate": {
                  ".": {},
                  "f:maxSurge": {},
                  "f:maxUnavailable": {}
                },
                "f:type": {}
              },
              "f:template": {
                "f:metadata": {
                  "f:labels": {
                    ".": {},
                    "f:k8s-app": {},
                    "f:name": {}
                  }
                },
                "f:spec": {
                  "f:containers": {
                    "k:{\"name\":\"tigera-operator\"}": {
                      ".": {},
                      "f:command": {},
                      "f:env": {
                        ".": {},
                        "k:{\"name\":\"OPERATOR_NAME\"}": {
                          ".": {},
                          "f:name": {},
                          "f:value": {}
                        },
                        "k:{\"name\":\"POD_NAME\"}": {
                          ".": {},
                          "f:name": {},
                          "f:valueFrom": {
                            ".": {},
                            "f:fieldRef": {}
                          }
                        },
                        "k:{\"name\":\"TIGERA_OPERATOR_INIT_IMAGE_VERSION\"}": {
                          ".": {},
                          "f:name": {},
                          "f:value": {}
                        },
                        "k:{\"name\":\"WATCH_NAMESPACE\"}": {
                          ".": {},
                          "f:name": {}
                        }
                      },
                      "f:envFrom": {},
                      "f:image": {},
                      "f:imagePullPolicy": {},
                      "f:name": {},
                      "f:resources": {},
                      "f:terminationMessagePath": {},
                      "f:terminationMessagePolicy": {},
                      "f:volumeMounts": {
                        ".": {},
                        "k:{\"mountPath\":\"/var/lib/calico\"}": {
                          ".": {},
                          "f:mountPath": {},
                          "f:name": {},
                          "f:readOnly": {}
                        }
                      }
                    }
                  },
                  "f:dnsConfig": {
                    ".": {},
                    "f:nameservers": {},
                    "f:options": {}
                  },
                  "f:dnsPolicy": {},
                  "f:hostNetwork": {},
                  "f:nodeSelector": {},
                  "f:restartPolicy": {},
                  "f:schedulerName": {},
                  "f:securityContext": {},
                  "f:serviceAccount": {},
                  "f:serviceAccountName": {},
                  "f:terminationGracePeriodSeconds": {},
                  "f:tolerations": {},
                  "f:volumes": {
                    ".": {},
                    "k:{\"name\":\"var-lib-calico\"}": {
                      ".": {},
                      "f:hostPath": {
                        ".": {},
                        "f:path": {},
                        "f:type": {}
                      },
                      "f:name": {}
                    }
                  }
                }
              }
            }
          }
        },
        {
          "manager": "kube-controller-manager",
          "operation": "Update",
          "apiVersion": "apps/v1",
          "time": "2026-07-17T12:54:58Z",
          "fieldsType": "FieldsV1",
          "fieldsV1": {
            "f:metadata": {
              "f:annotations": {
                "f:deployment.kubernetes.io/revision": {}
              }
            },
            "f:status": {
              "f:conditions": {
                ".": {},
                "k:{\"type\":\"Available\"}": {
                  ".": {},
                  "f:lastTransitionTime": {},
                  "f:lastUpdateTime": {},
                  "f:message": {},
                  "f:reason": {},
                  "f:status": {},
                  "f:type": {}
                },
                "k:{\"type\":\"Progressing\"}": {
                  ".": {},
                  "f:lastTransitionTime": {},
                  "f:lastUpdateTime": {},
                  "f:message": {},
                  "f:reason": {},
                  "f:status": {},
                  "f:type": {}
                }
              },
              "f:observedGeneration": {},
              "f:replicas": {},
              "f:unavailableReplicas": {},
              "f:updatedReplicas": {}
            }
          },
          "subresource": "status"
        }
      ]
    },
    "spec": {
      "replicas": 1,
      "selector": {
        "matchLabels": {
          "name": "tigera-operator"
        }
      },
      "template": {
        "metadata": {
          "creationTimestamp": null,
          "labels": {
            "k8s-app": "tigera-operator",
            "name": "tigera-operator"
          }
        },
        "spec": {
          "volumes": [
            {
              "name": "var-lib-calico",
              "hostPath": {
                "path": "/var/lib/calico",
                "type": ""
              }
            }
          ],
          "containers": [
            {
              "name": "tigera-operator",
              "image": "capzcicommunity.azurecr.io/tigera/operator:v1.36.9",
              "command": [
                "operator"
              ],
              "envFrom": [
                {
                  "configMapRef": {
                    "name": "kubernetes-services-endpoint",
                    "optional": true
                  }
                }
              ],
              "env": [
                {
                  "name": "WATCH_NAMESPACE"
                },
                {
                  "name": "POD_NAME",
                  "valueFrom": {
                    "fieldRef": {
                      "apiVersion": "v1",
                      "fieldPath": "metadata.name"
                    }
                  }
                },
                {
                  "name": "OPERATOR_NAME",
                  "value": "tigera-operator"
                },
                {
                  "name": "TIGERA_OPERATOR_INIT_IMAGE_VERSION",
                  "value": "v1.36.9"
                }
              ],
              "resources": {},
              "volumeMounts": [
                {
                  "name": "var-lib-calico",
                  "readOnly": true,
                  "mountPath": "/var/lib/calico"
                }
              ],
              "terminationMessagePath": "/dev/termination-log",
              "terminationMessagePolicy": "File",
              "imagePullPolicy": "IfNotPresent"
            }
          ],
          "restartPolicy": "Always",
          "terminationGracePeriodSeconds": 60,
          "dnsPolicy": "ClusterFirstWithHostNet",
          "nodeSelector": {
            "kubernetes.io/os": "linux"
          },
          "serviceAccountName": "tigera-operator",
          "serviceAccount": "tigera-operator",
          "hostNetwork": true,
          "securityContext": {},
          "schedulerName": "default-scheduler",
          "tolerations": [
            {
              "operator": "Exists",
              "effect": "NoExecute"
            },
            {
              "key": "node-role.kubernetes.io/control-plane",
              "operator": "Exists",
              "effect": "NoSchedule"
            },
            {
              "key": "node.kubernetes.io/not-ready",
              "operator": "Exists",
              "effect": "NoSchedule"
            }
          ],
          "dnsConfig": {
            "nameservers": [
              "127.0.0.53"
            ],
            "options": [
              {
                "name": "edns0"
              },
              {
                "name": "trust-ad"
              }
            ]
          }
        }
      },
      "strategy": {
        "type": "RollingUpdate",
        "rollingUpdate": {
          "maxUnavailable": "25%",
          "maxSurge": "25%"
        }
      },
      "revisionHistoryLimit": 10,
      "progressDeadlineSeconds": 600
    },
    "status": {
      "observedGeneration": 1,
      "replicas": 1,
      "updatedReplicas": 1,
      "unavailableReplicas": 1,
      "conditions": [
        {
          "type": "Progressing",
          "status": "True",
          "lastUpdateTime": "2026-07-17T12:48:59Z",
          "lastTransitionTime": "2026-07-17T12:48:29Z",
          "reason": "NewReplicaSetAvailable",
          "message": "ReplicaSet \"tigera-operator-596b8f4874\" has successfully progressed."
        },
        {
          "type": "Available",
          "status": "False",
          "lastUpdateTime": "2026-07-17T12:54:58Z",
          "lastTransitionTime": "2026-07-17T12:54:58Z",
          "reason": "MinimumReplicasUnavailable",
          "message": "Deployment does not have minimum availability."
        }
      ]
    }
  }
  LAST SEEN                      TYPE    REASON             OBJECT                      MESSAGE
  2026-07-17 12:48:29 +0000 UTC  Normal  ScalingReplicaSet  deployment/tigera-operator  Scaled up replica set tigera-operator-596b8f4874 from 0 to 1

  Expected
      <bool>: false
  to be true
```

Copilot suggests this is CAAPH and template issue, where tigera config gets deployed with wrong values looking like this:
```
          KUBERNETES_SERVICE_HOST="<no value>"
          KUBERNETES_SERVICE_PORT="<no value>"
```

Since I was not able to confirm this, having this additional debug could would be useful to be able to capture this issue in the wild and then provide appropriate fix.

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

Dump code has been AI generated for this specific issue. I can make it more generic if desired.

Since this code runs on a failure path, it has been manually tested via this helper:

```go
$ cat test/e2e/diagnose_manual_test.go
//go:build e2e
// +build e2e

/*
Copyright 2026 The Kubernetes Authors.

Licensed under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
*/

package e2e

import (
	"context"
	"os"
	"testing"

	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
	"k8s.io/client-go/kubernetes"
	"k8s.io/client-go/tools/clientcmd"
)

// TestDiagnoseDeployment is a manual helper to exercise the deployment-failure
// diagnostics (DescribeFailedDeployment and describeDeploymentsInNamespace)
// against a real cluster, without running the full Ginkgo e2e suite.
//
// Apply hack/diagnose/failing-deployment.yaml to a cluster first, then run:
//
//	KUBECONFIG=/path/to/kubeconfig \
//	DIAGNOSE_NAMESPACE=diagnose-test \
//	DIAGNOSE_DEPLOYMENT=tigera-operator \
//	go test -tags e2e -run TestDiagnoseDeployment -v ./test/e2e/
//
// To exercise the "deployment never appeared" path instead, point
// DIAGNOSE_DEPLOYMENT at a name that does not exist in the namespace.
//
// The test is skipped unless DIAGNOSE_NAMESPACE and DIAGNOSE_DEPLOYMENT are set,
// so it never runs as part of normal CI.
func TestDiagnoseDeployment(t *testing.T) {
	namespace := os.Getenv("DIAGNOSE_NAMESPACE")
	name := os.Getenv("DIAGNOSE_DEPLOYMENT")
	if namespace == "" || name == "" {
		t.Skip("set DIAGNOSE_NAMESPACE and DIAGNOSE_DEPLOYMENT (and KUBECONFIG) to run this diagnostic")
	}

	// Loads the kubeconfig using the default loading rules, which honor the
	// KUBECONFIG environment variable and the --kubeconfig flag.
	restConfig, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
		clientcmd.NewDefaultClientConfigLoadingRules(), &clientcmd.ConfigOverrides{}).ClientConfig()
	if err != nil {
		t.Fatalf("failed to load kubeconfig: %v", err)
	}

	clientset, err := kubernetes.NewForConfig(restConfig)
	if err != nil {
		t.Fatalf("failed to build clientset: %v", err)
	}

	ctx := context.Background()

	deployment, err := clientset.AppsV1().Deployments(namespace).Get(ctx, name, metav1.GetOptions{})
	if err != nil {
		// The deployment does not exist: exercise the "never appeared" diagnostic
		// used by GetWaitForDeploymentsAvailableInput.
		t.Logf("deployment %s/%s not found (%v); running describeDeploymentsInNamespace diagnostic:", namespace, name, err)
		t.Logf("\n%s", describeDeploymentsInNamespace(ctx, clientset, namespace, name))
		return
	}

	// The deployment exists: exercise the full failure diagnostic used by
	// WaitForDeploymentsAvailable.
	input := WaitForDeploymentsAvailableInput{
		Deployment: deployment,
		Clientset:  clientset,
	}
	t.Logf("\n%s", DescribeFailedDeployment(ctx, input))
}
```

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] cherry-pick candidate

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
