### PR TITLE
Add Dependabot entries for supported release branches

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -43,7 +43,108 @@ updates:
     - dependency-name: "github.com/prometheus/*"
       update-types: [ "version-update:semver-major", "version-update:semver-minor"] # Consume only patch updates.
     - dependency-name: "go.etcd.io/*"
-    - dependency-name: "google.golang.org/grpc"
+    - dependency-name: "sigs.k8s.io/cloud-provider-azure"
+    # Ignore subpackage releases of opentelemetry-go; just watch go.opentelemetry.io/otel.
+    - dependency-name: "go.opentelemetry.io/contrib/*"
+    - dependency-name: "go.opentelemetry.io/otel/exporters/*"
+    - dependency-name: "go.opentelemetry.io/otel/metric"
+    - dependency-name: "go.opentelemetry.io/otel/sdk*"
+    - dependency-name: "go.opentelemetry.io/otel/trace"
+  labels:
+    - "ok-to-test"
+    - "kind/cleanup"
+    - "release-note-none"
+
+# Go - root directory, release-1.26 branch
+# Release branches only get Go updates for the root module, since that's what the
+# weekly security scan checks. Updates are grouped into a single PR to limit churn
+# on a stable branch. Keep this list in sync with the weekly security scan matrix.
+- directory: "/"
+  package-ecosystem: "gomod"
+  target-branch: "release-1.26"
+  open-pull-requests-limit: 5
+  schedule:
+    interval: "weekly"
+    time: "09:00"
+    # Use America/New_York Standard Time (UTC -05:00)
+    timezone: "America/New_York"
+  commit-message:
+    prefix: "dependabot"
+    include: scope
+  ignore:
+    # Ignore controller-runtime as its upgraded manually.
+    - dependency-name: "sigs.k8s.io/controller-runtime"
+    # Ignore k8s and its transitives modules as they are upgraded manually together with controller-runtime.
+    - dependency-name: "k8s.io/*"
+    - dependency-name: "github.com/prometheus/*"
+      update-types: [ "version-update:semver-major", "version-update:semver-minor"] # Consume only patch updates.
+    - dependency-name: "go.etcd.io/*"
+    - dependency-name: "sigs.k8s.io/cloud-provider-azure"
+    # Ignore subpackage releases of opentelemetry-go; just watch go.opentelemetry.io/otel.
+    - dependency-name: "go.opentelemetry.io/contrib/*"
+    - dependency-name: "go.opentelemetry.io/otel/exporters/*"
+    - dependency-name: "go.opentelemetry.io/otel/metric"
+    - dependency-name: "go.opentelemetry.io/otel/sdk*"
+    - dependency-name: "go.opentelemetry.io/otel/trace"
+  labels:
+    - "ok-to-test"
+    - "kind/cleanup"
+    - "release-note-none"
+
+# Go - root directory, release-1.25 branch
+- directory: "/"
+  package-ecosystem: "gomod"
+  target-branch: "release-1.25"
+  open-pull-requests-limit: 5
+  schedule:
+    interval: "weekly"
+    time: "09:00"
+    # Use America/New_York Standard Time (UTC -05:00)
+    timezone: "America/New_York"
+  commit-message:
+    prefix: "dependabot"
+    include: scope
+  ignore:
+    # Ignore controller-runtime as its upgraded manually.
+    - dependency-name: "sigs.k8s.io/controller-runtime"
+    # Ignore k8s and its transitives modules as they are upgraded manually together with controller-runtime.
+    - dependency-name: "k8s.io/*"
+    - dependency-name: "github.com/prometheus/*"
+      update-types: [ "version-update:semver-major", "version-update:semver-minor"] # Consume only patch updates.
+    - dependency-name: "go.etcd.io/*"
+    - dependency-name: "sigs.k8s.io/cloud-provider-azure"
+    # Ignore subpackage releases of opentelemetry-go; just watch go.opentelemetry.io/otel.
+    - dependency-name: "go.opentelemetry.io/contrib/*"
+    - dependency-name: "go.opentelemetry.io/otel/exporters/*"
+    - dependency-name: "go.opentelemetry.io/otel/metric"
+    - dependency-name: "go.opentelemetry.io/otel/sdk*"
+    - dependency-name: "go.opentelemetry.io/otel/trace"
+  labels:
+    - "ok-to-test"
+    - "kind/cleanup"
+    - "release-note-none"
+
+# Go - root directory, release-1.24 branch
+- directory: "/"
+  package-ecosystem: "gomod"
+  target-branch: "release-1.24"
+  open-pull-requests-limit: 5
+  schedule:
+    interval: "weekly"
+    time: "09:00"
+    # Use America/New_York Standard Time (UTC -05:00)
+    timezone: "America/New_York"
+  commit-message:
+    prefix: "dependabot"
+    include: scope
+  ignore:
+    # Ignore controller-runtime as its upgraded manually.
+    - dependency-name: "sigs.k8s.io/controller-runtime"
+    # Ignore k8s and its transitives modules as they are upgraded manually together with controller-runtime.
+    - dependency-name: "k8s.io/*"
+    - dependency-name: "github.com/prometheus/*"
+      update-types: [ "version-update:semver-major", "version-update:semver-minor"] # Consume only patch updates.
+    - dependency-name: "go.etcd.io/*"
     - dependency-name: "sigs.k8s.io/cloud-provider-azure"
     # Ignore subpackage releases of opentelemetry-go; just watch go.opentelemetry.io/otel.
     - dependency-name: "go.opentelemetry.io/contrib/*"
@@ -74,7 +175,6 @@ updates:
     # Ignore k8s and its transitives modules as they are upgraded manually together with controller-runtime.
     - dependency-name: "k8s.io/*"
     - dependency-name: "go.etcd.io/*"
-    - dependency-name: "google.golang.org/grpc"
     # Ignore subpackage releases of opentelemetry-go; just watch go.opentelemetry.io/otel.
     - dependency-name: "go.opentelemetry.io/contrib/*"
     - dependency-name: "go.opentelemetry.io/otel/exporters/*"

--- a/docs/book/src/developers/releasing.md
+++ b/docs/book/src/developers/releasing.md
@@ -155,14 +155,26 @@ Go to [the Netlify branches and deploy contexts in site settings](https://app.ne
 
 Note: this step requires access to the Netlify site. If you don't have access, please ask a maintainer to update the branch.
 
-### 9. Update security scanner branches (skip for patch releases)
+### 9. Update security scanner and Dependabot branches (skip for patch releases)
 
-Open a pull request to update the branches in the [weekly security scan workflow](../../.github/workflows/weekly-security-scan.yaml) to include the new release branch. For example, if the new release branch is `release-1.23`, update the `branch` matrix to:
+Open a pull request to update the branches in the [weekly security scan workflow](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/.github/workflows/weekly-security-scan.yaml) to include the new release branch. For example, if the new release branch is `release-1.23`, update the `branch` matrix to:
 
 ```yaml
       matrix:
         branch: [ main, release-1.23, release-1.22 ]
 ```
+
+In the same pull request, update [dependabot.yml](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/.github/dependabot.yml) to match. Dependabot only opens pull requests against the default branch unless an entry sets `target-branch`, so each supported release branch needs its own `gomod` entry. Add one for the new release branch and delete the entry for any branch that's no longer supported:
+
+```yaml
+# Go - root directory, release-1.23 branch
+- directory: "/"
+  package-ecosystem: "gomod"
+  target-branch: "release-1.23"
+  # ...copy the rest from an existing release branch entry
+```
+
+Keep the branches listed here in sync with the security scan matrix. If they drift, the weekly scan will keep reporting vulnerabilities on a branch that Dependabot never updates.
 
 ### 10. Announce the new release
 


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Dependabot only opens pull requests against the default branch unless an entry sets `target-branch`, so our release branches have never received dependency updates. That's why the weekly security scan passes on `main` but fails on `release-1.24`, `release-1.25`, and `release-1.26` — CVE fixes land on `main` and stay there.

This adds a `gomod` entry per supported release branch, plus a note in the release docs to keep that list in sync with the security scan matrix.

**Which issue(s) this PR fixes**:

None.

**Special notes for your reviewer**:

We used to have this, and dropped it in 7e00d1912 (July 2023) because "we don't need to update dependencies on release branches, and it's a bit of a pain to have to manually update the config file every time we create a new release branch." The weekly security scan didn't exist until August 2025 and it does cover release branches, so the first half no longer holds — the scan is red right now. I don't think the second half is much of a burden, and step 9 of the release docs now covers it.

Other choices worth a look:

- Root module only. `hack/tools` isn't in the scanned image and govulncheck only runs against the root module, so tooling bumps on a release branch would just be noise.
- Updates are grouped into one PR per branch per week, same idea as the existing `all-github-actions` group.
- Stop ignoring `google.golang.org/grpc` everywhere. It was ignored in the original config (#2752) as a k8s transitive "upgraded manually together with controller-runtime", but it reaches us via `pkg/ot` → `otlptracegrpc` these days, so that reasoning is stale. That ignore is why #6486 had to pin it by hand and why `release-1.24` is still on a vulnerable v1.80.0.

This doesn't fix the current failures — see #6508, #6509, and #6510 for those — it just keeps us from ending up here again.

**TODOs**:

- [x] squashed commits
- [x] includes documentation
- [ ] adds unit tests
- [ ] cherry-pick candidate

**Release note**:

```release-note
NONE
```
