### PR TITLE
Prefix release branch Dependabot pull requests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -69,7 +69,7 @@ updates:
     # Use America/New_York Standard Time (UTC -05:00)
     timezone: "America/New_York"
   commit-message:
-    prefix: "dependabot"
+    prefix: "[release-1.26] dependabot"
     include: scope
   ignore:
     # Ignore controller-runtime as its upgraded manually.
@@ -102,7 +102,7 @@ updates:
     # Use America/New_York Standard Time (UTC -05:00)
     timezone: "America/New_York"
   commit-message:
-    prefix: "dependabot"
+    prefix: "[release-1.25] dependabot"
     include: scope
   ignore:
     # Ignore controller-runtime as its upgraded manually.
@@ -135,7 +135,7 @@ updates:
     # Use America/New_York Standard Time (UTC -05:00)
     timezone: "America/New_York"
   commit-message:
-    prefix: "dependabot"
+    prefix: "[release-1.24] dependabot"
     include: scope
   ignore:
     # Ignore controller-runtime as its upgraded manually.


### PR DESCRIPTION
/kind cleanup

**What this PR does / why we need it**:

Configures Dependabot pull request title prefixes for updates targeting supported release branches. For example, updates targeting `release-1.26` will use `[release-1.26] dependabot(deps): ...`, while updates targeting `main` remain unchanged.

**Which issue(s) this PR fixes**:

None.

**Special notes for your reviewer**:

This follows the repository convention for pull requests targeting release branches.

**TODOs**:

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] cherry-pick candidate

**Release note**:

```release-note
NONE
```