### PR TITLE
Add encryptionAtHost function to managed disk

### DIFF
--- a/azure/services/virtualmachines/spec.go
+++ b/azure/services/virtualmachines/spec.go
@@ -346,6 +346,14 @@ func (s *VMSpec) generateSecurityProfile(storageProfile *armcompute.StorageProfi
 			VTpmEnabled:       s.SecurityProfile.UefiSettings.VTpmEnabled,
 		}
 
+		if s.SecurityProfile.EncryptionAtHost != nil {
+			if !s.SKU.HasCapability(resourceskus.EncryptionAtHost) && *s.SecurityProfile.EncryptionAtHost {
+				return nil, azure.WithTerminalError(errors.Errorf("encryption at host is not supported for VM type %s", s.Size))
+			}
+
+			securityProfile.EncryptionAtHost = s.SecurityProfile.EncryptionAtHost
+		}
+
 		return securityProfile, nil
 	}
 

--- a/azure/services/virtualmachines/spec_test.go
+++ b/azure/services/virtualmachines/spec_test.go
@@ -94,6 +94,32 @@ var (
 		},
 	}
 
+	validSKUWithConfidentialComputingTypeAndEncryptionAtHost = resourceskus.SKU{
+		Name: ptr.To("Standard_D2v3"),
+		Kind: ptr.To(string(resourceskus.VirtualMachines)),
+		Locations: []*string{
+			ptr.To("test-location"),
+		},
+		Capabilities: []*armcompute.ResourceSKUCapabilities{
+			{
+				Name:  ptr.To(resourceskus.VCPUs),
+				Value: ptr.To("2"),
+			},
+			{
+				Name:  ptr.To(resourceskus.MemoryGB),
+				Value: ptr.To("4"),
+			},
+			{
+				Name:  ptr.To(resourceskus.ConfidentialComputingType),
+				Value: ptr.To(string(resourceskus.CapabilitySupported)),
+			},
+			{
+				Name:  ptr.To(resourceskus.EncryptionAtHost),
+				Value: ptr.To(string(resourceskus.CapabilitySupported)),
+			},
+		},
+	}
+
 	validSKUWithConfidentialComputingType = resourceskus.SKU{
 		Name: ptr.To("Standard_D2v3"),
 		Kind: ptr.To(string(resourceskus.VirtualMachines)),
@@ -552,6 +578,46 @@ func TestParameters(t *testing.T) {
 			expect: func(g *WithT, result any) {
 				g.Expect(result).To(BeAssignableToTypeOf(armcompute.VirtualMachine{}))
 				g.Expect(result.(armcompute.VirtualMachine).Properties.StorageProfile.OSDisk.ManagedDisk.SecurityProfile.SecurityEncryptionType).To(Equal(ptr.To(armcompute.SecurityEncryptionTypesVMGuestStateOnly)))
+				g.Expect(*result.(armcompute.VirtualMachine).Properties.SecurityProfile.UefiSettings.VTpmEnabled).To(BeTrue())
+			},
+			expectedError: "",
+		},
+		{
+			name: "can create a confidential vm with VMGuestStateOnly and encryption at host",
+			spec: &VMSpec{
+				Name:              "my-vm",
+				Role:              infrav1.Node,
+				NICIDs:            []string{"my-nic"},
+				SSHKeyData:        "fakesshpublickey",
+				Size:              "Standard_D2v3",
+				AvailabilitySetID: "fake-availability-set-id",
+				Zone:              "",
+				Image:             &infrav1.Image{ID: ptr.To("fake-image-id")},
+				OSDisk: infrav1.OSDisk{
+					OSType:     "Linux",
+					DiskSizeGB: ptr.To[int32](128),
+					ManagedDisk: &infrav1.ManagedDiskParameters{
+						StorageAccountType: string(armcompute.StorageAccountTypesPremiumLRS),
+						SecurityProfile: &infrav1.VMDiskSecurityProfile{
+							SecurityEncryptionType: infrav1.SecurityEncryptionTypeVMGuestStateOnly,
+						},
+					},
+				},
+				SecurityProfile: &infrav1.SecurityProfile{
+					EncryptionAtHost: ptr.To(true),
+					SecurityType:     infrav1.SecurityTypesConfidentialVM,
+					UefiSettings: &infrav1.UefiSettings{
+						SecureBootEnabled: ptr.To(false),
+						VTpmEnabled:       ptr.To(true),
+					},
+				},
+				SKU: validSKUWithConfidentialComputingTypeAndEncryptionAtHost,
+			},
+			existing: nil,
+			expect: func(g *WithT, result any) {
+				g.Expect(result).To(BeAssignableToTypeOf(armcompute.VirtualMachine{}))
+				g.Expect(result.(armcompute.VirtualMachine).Properties.StorageProfile.OSDisk.ManagedDisk.SecurityProfile.SecurityEncryptionType).To(Equal(ptr.To(armcompute.SecurityEncryptionTypesVMGuestStateOnly)))
+				g.Expect(*result.(armcompute.VirtualMachine).Properties.SecurityProfile.EncryptionAtHost).To(BeTrue())
 				g.Expect(*result.(armcompute.VirtualMachine).Properties.SecurityProfile.UefiSettings.VTpmEnabled).To(BeTrue())
 			},
 			expectedError: "",


### PR DESCRIPTION
Honoring the encryptionAtHost field value when creating managed disk. Seems to prematurely return before setting the field.

 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:


**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->


**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests
- [ ] cherry-pick candidate

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Honoring the encryptionAtHost field value when creating managed disk. 
```
