### PR TITLE
Enable DRA workload resource claim tests

### DIFF
--- a/templates/test/ci/cluster-template-prow-ci-version-dra.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version-dra.yaml
@@ -56,8 +56,8 @@ spec:
     clusterConfiguration:
       apiServer:
         extraArgs:
-          feature-gates: ${K8S_FEATURE_GATES:-"DynamicResourceAllocation=true,DRADeviceTaints=true,DRADeviceTaintRules=true"}
-          runtime-config: resource.k8s.io/v1beta1=true,resource.k8s.io/v1beta2=true
+          feature-gates: ${K8S_FEATURE_GATES:-"DynamicResourceAllocation=true,DRADeviceTaints=true,DRADeviceTaintRules=true,GenericWorkload=true,DRAWorkloadResourceClaims=true"}
+          runtime-config: resource.k8s.io/v1beta1=true,resource.k8s.io/v1beta2=true,scheduling.k8s.io/v1beta1=true
           service-account-issuer: ${SERVICE_ACCOUNT_ISSUER:-https://kubernetes.default.svc.cluster.local}
         timeoutForControlPlane: 20m
       controllerManager:
@@ -65,7 +65,7 @@ spec:
           allocate-node-cidrs: "false"
           cloud-provider: external
           cluster-name: ${CLUSTER_NAME}
-          feature-gates: DynamicResourceAllocation=true,DRADeviceTaints=true,DRADeviceTaintRules=true
+          feature-gates: DynamicResourceAllocation=true,DRADeviceTaints=true,DRADeviceTaintRules=true,GenericWorkload=true,DRAWorkloadResourceClaims=true
           v: "4"
       etcd:
         local:
@@ -75,7 +75,7 @@ spec:
       kubernetesVersion: ci/${CI_VERSION}
       scheduler:
         extraArgs:
-          feature-gates: DynamicResourceAllocation=true,DRADeviceTaints=true,DRADeviceTaintRules=true
+          feature-gates: DynamicResourceAllocation=true,DRADeviceTaints=true,DRADeviceTaintRules=true,GenericWorkload=true,DRAWorkloadResourceClaims=true
     diskSetup:
       filesystems:
       - device: /dev/disk/azure/scsi1/lun0
@@ -208,7 +208,7 @@ spec:
       nodeRegistration:
         kubeletExtraArgs:
           cloud-provider: external
-          feature-gates: DynamicResourceAllocation=true,DRADeviceTaints=true,DRADeviceTaintRules=true
+          feature-gates: DynamicResourceAllocation=true,DRADeviceTaints=true,DRADeviceTaintRules=true,GenericWorkload=true,DRAWorkloadResourceClaims=true
           image-credential-provider-bin-dir: /var/lib/kubelet/credential-provider
           image-credential-provider-config: /var/lib/kubelet/credential-provider-config.yaml
         name: '{{ ds.meta_data["local_hostname"] }}'
@@ -216,7 +216,7 @@ spec:
       nodeRegistration:
         kubeletExtraArgs:
           cloud-provider: external
-          feature-gates: DynamicResourceAllocation=true,DRADeviceTaints=true,DRADeviceTaintRules=true
+          feature-gates: DynamicResourceAllocation=true,DRADeviceTaints=true,DRADeviceTaintRules=true,GenericWorkload=true,DRAWorkloadResourceClaims=true
           image-credential-provider-bin-dir: /var/lib/kubelet/credential-provider
           image-credential-provider-config: /var/lib/kubelet/credential-provider-config.yaml
         name: '{{ ds.meta_data["local_hostname"] }}'
@@ -469,7 +469,7 @@ spec:
     nodeRegistration:
       kubeletExtraArgs:
         cloud-provider: external
-        feature-gates: ${NODE_FEATURE_GATES:-"DynamicResourceAllocation=true,DRADeviceTaints=true,DRADeviceTaintRules=true"}
+        feature-gates: ${NODE_FEATURE_GATES:-"DynamicResourceAllocation=true,DRADeviceTaints=true,DRADeviceTaintRules=true,GenericWorkload=true,DRAWorkloadResourceClaims=true"}
         image-credential-provider-bin-dir: /var/lib/kubelet/credential-provider
         image-credential-provider-config: /var/lib/kubelet/credential-provider-config.yaml
       name: '{{ ds.meta_data["local_hostname"] }}'

--- a/templates/test/ci/prow-ci-version-dra/kustomization.yaml
+++ b/templates/test/ci/prow-ci-version-dra/kustomization.yaml
@@ -17,6 +17,33 @@ patches:
 - path: ../patches/dra-kubeadmconfig.yaml
   target:
     kind: KubeadmConfig
+- patch: |-
+    - op: replace
+      path: /spec/kubeadmConfigSpec/clusterConfiguration/apiServer/extraArgs/feature-gates
+      value: ${K8S_FEATURE_GATES:-"DynamicResourceAllocation=true,DRADeviceTaints=true,DRADeviceTaintRules=true,GenericWorkload=true,DRAWorkloadResourceClaims=true"}
+    - op: replace
+      path: /spec/kubeadmConfigSpec/clusterConfiguration/apiServer/extraArgs/runtime-config
+      value: resource.k8s.io/v1beta1=true,resource.k8s.io/v1beta2=true,scheduling.k8s.io/v1beta1=true
+    - op: replace
+      path: /spec/kubeadmConfigSpec/clusterConfiguration/controllerManager/extraArgs/feature-gates
+      value: DynamicResourceAllocation=true,DRADeviceTaints=true,DRADeviceTaintRules=true,GenericWorkload=true,DRAWorkloadResourceClaims=true
+    - op: replace
+      path: /spec/kubeadmConfigSpec/clusterConfiguration/scheduler/extraArgs/feature-gates
+      value: DynamicResourceAllocation=true,DRADeviceTaints=true,DRADeviceTaintRules=true,GenericWorkload=true,DRAWorkloadResourceClaims=true
+    - op: replace
+      path: /spec/kubeadmConfigSpec/initConfiguration/nodeRegistration/kubeletExtraArgs/feature-gates
+      value: DynamicResourceAllocation=true,DRADeviceTaints=true,DRADeviceTaintRules=true,GenericWorkload=true,DRAWorkloadResourceClaims=true
+    - op: replace
+      path: /spec/kubeadmConfigSpec/joinConfiguration/nodeRegistration/kubeletExtraArgs/feature-gates
+      value: DynamicResourceAllocation=true,DRADeviceTaints=true,DRADeviceTaintRules=true,GenericWorkload=true,DRAWorkloadResourceClaims=true
+  target:
+    kind: KubeadmControlPlane
+- patch: |-
+    - op: replace
+      path: /spec/joinConfiguration/nodeRegistration/kubeletExtraArgs/feature-gates
+      value: ${NODE_FEATURE_GATES:-"DynamicResourceAllocation=true,DRADeviceTaints=true,DRADeviceTaintRules=true,GenericWorkload=true,DRAWorkloadResourceClaims=true"}
+  target:
+    kind: KubeadmConfig
 
 sortOptions:
   order: fifo


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind failing-test

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:
Kubernetes 1.37 added DRA tests for PodGroup ResourceClaims, but CAPZ's DRA flavor did not enable the required feature gates or scheduling API. This caused five tests to fail because the Workload resource was unavailable. This PR enables the required configuration so the tests can run as intended.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->


**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] cherry-pick candidate

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
