### PR TITLE
templates/addons/cluster-api-helm: avoid empty kubernetesServiceEndpoint

### DIFF
--- a/templates/addons/cluster-api-helm/calico.yaml
+++ b/templates/addons/cluster-api-helm/calico.yaml
@@ -67,9 +67,17 @@ spec:
       options:
         - name: edns0
         - name: trust-ad
+    # Only set kubernetesServiceEndpoint once both parts of the control plane
+    # endpoint are populated. If rendered before infrastructure is ready, the
+    # host/port resolve to empty or "<no value>" and get baked into the
+    # kubernetes-services-endpoint ConfigMap, crash-looping the tigera-operator
+    # with "KUBERNETES_SERVICE_HOST ... must be defined". Omitting the block lets
+    # the operator use in-cluster config.
+    {{- if and .Cluster.spec.controlPlaneEndpoint.host .Cluster.spec.controlPlaneEndpoint.port }}
     kubernetesServiceEndpoint:
       host: "{{ .Cluster.spec.controlPlaneEndpoint.host }}"
       port: "{{ .Cluster.spec.controlPlaneEndpoint.port }}"
+    {{- end }}
     # By default, tigera tolerates all NoSchedule taints. This breaks upgrades
     # when it continuously gets scheduled onto an out-of-date Node that is being
     # deleted. Tolerate only the NoSchedule taints that are expected.

--- a/templates/test/ci/cluster-template-prow-apiserver-ilb-custom-images.yaml
+++ b/templates/test/ci/cluster-template-prow-apiserver-ilb-custom-images.yaml
@@ -429,9 +429,17 @@ spec:
       options:
         - name: edns0
         - name: trust-ad
+    # Only set kubernetesServiceEndpoint once both parts of the control plane
+    # endpoint are populated. If rendered before infrastructure is ready, the
+    # host/port resolve to empty or "<no value>" and get baked into the
+    # kubernetes-services-endpoint ConfigMap, crash-looping the tigera-operator
+    # with "KUBERNETES_SERVICE_HOST ... must be defined". Omitting the block lets
+    # the operator use in-cluster config.
+    {{- if and .Cluster.spec.controlPlaneEndpoint.host .Cluster.spec.controlPlaneEndpoint.port }}
     kubernetesServiceEndpoint:
       host: "{{ .Cluster.spec.controlPlaneEndpoint.host }}"
       port: "{{ .Cluster.spec.controlPlaneEndpoint.port }}"
+    {{- end }}
     # By default, tigera tolerates all NoSchedule taints. This breaks upgrades
     # when it continuously gets scheduled onto an out-of-date Node that is being
     # deleted. Tolerate only the NoSchedule taints that are expected.

--- a/templates/test/ci/cluster-template-prow-apiserver-ilb.yaml
+++ b/templates/test/ci/cluster-template-prow-apiserver-ilb.yaml
@@ -320,9 +320,17 @@ spec:
       options:
         - name: edns0
         - name: trust-ad
+    # Only set kubernetesServiceEndpoint once both parts of the control plane
+    # endpoint are populated. If rendered before infrastructure is ready, the
+    # host/port resolve to empty or "<no value>" and get baked into the
+    # kubernetes-services-endpoint ConfigMap, crash-looping the tigera-operator
+    # with "KUBERNETES_SERVICE_HOST ... must be defined". Omitting the block lets
+    # the operator use in-cluster config.
+    {{- if and .Cluster.spec.controlPlaneEndpoint.host .Cluster.spec.controlPlaneEndpoint.port }}
     kubernetesServiceEndpoint:
       host: "{{ .Cluster.spec.controlPlaneEndpoint.host }}"
       port: "{{ .Cluster.spec.controlPlaneEndpoint.port }}"
+    {{- end }}
     # By default, tigera tolerates all NoSchedule taints. This breaks upgrades
     # when it continuously gets scheduled onto an out-of-date Node that is being
     # deleted. Tolerate only the NoSchedule taints that are expected.

--- a/templates/test/ci/cluster-template-prow-azl3.yaml
+++ b/templates/test/ci/cluster-template-prow-azl3.yaml
@@ -394,9 +394,17 @@ spec:
       options:
         - name: edns0
         - name: trust-ad
+    # Only set kubernetesServiceEndpoint once both parts of the control plane
+    # endpoint are populated. If rendered before infrastructure is ready, the
+    # host/port resolve to empty or "<no value>" and get baked into the
+    # kubernetes-services-endpoint ConfigMap, crash-looping the tigera-operator
+    # with "KUBERNETES_SERVICE_HOST ... must be defined". Omitting the block lets
+    # the operator use in-cluster config.
+    {{- if and .Cluster.spec.controlPlaneEndpoint.host .Cluster.spec.controlPlaneEndpoint.port }}
     kubernetesServiceEndpoint:
       host: "{{ .Cluster.spec.controlPlaneEndpoint.host }}"
       port: "{{ .Cluster.spec.controlPlaneEndpoint.port }}"
+    {{- end }}
     # By default, tigera tolerates all NoSchedule taints. This breaks upgrades
     # when it continuously gets scheduled onto an out-of-date Node that is being
     # deleted. Tolerate only the NoSchedule taints that are expected.

--- a/templates/test/ci/cluster-template-prow-ci-version-azl3.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version-azl3.yaml
@@ -643,9 +643,17 @@ spec:
       options:
         - name: edns0
         - name: trust-ad
+    # Only set kubernetesServiceEndpoint once both parts of the control plane
+    # endpoint are populated. If rendered before infrastructure is ready, the
+    # host/port resolve to empty or "<no value>" and get baked into the
+    # kubernetes-services-endpoint ConfigMap, crash-looping the tigera-operator
+    # with "KUBERNETES_SERVICE_HOST ... must be defined". Omitting the block lets
+    # the operator use in-cluster config.
+    {{- if and .Cluster.spec.controlPlaneEndpoint.host .Cluster.spec.controlPlaneEndpoint.port }}
     kubernetesServiceEndpoint:
       host: "{{ .Cluster.spec.controlPlaneEndpoint.host }}"
       port: "{{ .Cluster.spec.controlPlaneEndpoint.port }}"
+    {{- end }}
     # By default, tigera tolerates all NoSchedule taints. This breaks upgrades
     # when it continuously gets scheduled onto an out-of-date Node that is being
     # deleted. Tolerate only the NoSchedule taints that are expected.

--- a/templates/test/ci/cluster-template-prow-ci-version-dra.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version-dra.yaml
@@ -595,9 +595,17 @@ spec:
       options:
         - name: edns0
         - name: trust-ad
+    # Only set kubernetesServiceEndpoint once both parts of the control plane
+    # endpoint are populated. If rendered before infrastructure is ready, the
+    # host/port resolve to empty or "<no value>" and get baked into the
+    # kubernetes-services-endpoint ConfigMap, crash-looping the tigera-operator
+    # with "KUBERNETES_SERVICE_HOST ... must be defined". Omitting the block lets
+    # the operator use in-cluster config.
+    {{- if and .Cluster.spec.controlPlaneEndpoint.host .Cluster.spec.controlPlaneEndpoint.port }}
     kubernetesServiceEndpoint:
       host: "{{ .Cluster.spec.controlPlaneEndpoint.host }}"
       port: "{{ .Cluster.spec.controlPlaneEndpoint.port }}"
+    {{- end }}
     # By default, tigera tolerates all NoSchedule taints. This breaks upgrades
     # when it continuously gets scheduled onto an out-of-date Node that is being
     # deleted. Tolerate only the NoSchedule taints that are expected.

--- a/templates/test/ci/cluster-template-prow-ci-version-md-and-mp.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version-md-and-mp.yaml
@@ -552,9 +552,17 @@ spec:
       options:
         - name: edns0
         - name: trust-ad
+    # Only set kubernetesServiceEndpoint once both parts of the control plane
+    # endpoint are populated. If rendered before infrastructure is ready, the
+    # host/port resolve to empty or "<no value>" and get baked into the
+    # kubernetes-services-endpoint ConfigMap, crash-looping the tigera-operator
+    # with "KUBERNETES_SERVICE_HOST ... must be defined". Omitting the block lets
+    # the operator use in-cluster config.
+    {{- if and .Cluster.spec.controlPlaneEndpoint.host .Cluster.spec.controlPlaneEndpoint.port }}
     kubernetesServiceEndpoint:
       host: "{{ .Cluster.spec.controlPlaneEndpoint.host }}"
       port: "{{ .Cluster.spec.controlPlaneEndpoint.port }}"
+    {{- end }}
     # By default, tigera tolerates all NoSchedule taints. This breaks upgrades
     # when it continuously gets scheduled onto an out-of-date Node that is being
     # deleted. Tolerate only the NoSchedule taints that are expected.

--- a/templates/test/ci/cluster-template-prow-ci-version-windows.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version-windows.yaml
@@ -779,9 +779,17 @@ spec:
       options:
         - name: edns0
         - name: trust-ad
+    # Only set kubernetesServiceEndpoint once both parts of the control plane
+    # endpoint are populated. If rendered before infrastructure is ready, the
+    # host/port resolve to empty or "<no value>" and get baked into the
+    # kubernetes-services-endpoint ConfigMap, crash-looping the tigera-operator
+    # with "KUBERNETES_SERVICE_HOST ... must be defined". Omitting the block lets
+    # the operator use in-cluster config.
+    {{- if and .Cluster.spec.controlPlaneEndpoint.host .Cluster.spec.controlPlaneEndpoint.port }}
     kubernetesServiceEndpoint:
       host: "{{ .Cluster.spec.controlPlaneEndpoint.host }}"
       port: "{{ .Cluster.spec.controlPlaneEndpoint.port }}"
+    {{- end }}
     # By default, tigera tolerates all NoSchedule taints. This breaks upgrades
     # when it continuously gets scheduled onto an out-of-date Node that is being
     # deleted. Tolerate only the NoSchedule taints that are expected.

--- a/templates/test/ci/cluster-template-prow-ci-version.yaml
+++ b/templates/test/ci/cluster-template-prow-ci-version.yaml
@@ -546,9 +546,17 @@ spec:
       options:
         - name: edns0
         - name: trust-ad
+    # Only set kubernetesServiceEndpoint once both parts of the control plane
+    # endpoint are populated. If rendered before infrastructure is ready, the
+    # host/port resolve to empty or "<no value>" and get baked into the
+    # kubernetes-services-endpoint ConfigMap, crash-looping the tigera-operator
+    # with "KUBERNETES_SERVICE_HOST ... must be defined". Omitting the block lets
+    # the operator use in-cluster config.
+    {{- if and .Cluster.spec.controlPlaneEndpoint.host .Cluster.spec.controlPlaneEndpoint.port }}
     kubernetesServiceEndpoint:
       host: "{{ .Cluster.spec.controlPlaneEndpoint.host }}"
       port: "{{ .Cluster.spec.controlPlaneEndpoint.port }}"
+    {{- end }}
     # By default, tigera tolerates all NoSchedule taints. This breaks upgrades
     # when it continuously gets scheduled onto an out-of-date Node that is being
     # deleted. Tolerate only the NoSchedule taints that are expected.

--- a/templates/test/ci/cluster-template-prow-clusterclass-ci-rke2.yaml
+++ b/templates/test/ci/cluster-template-prow-clusterclass-ci-rke2.yaml
@@ -471,9 +471,17 @@ spec:
       options:
         - name: edns0
         - name: trust-ad
+    # Only set kubernetesServiceEndpoint once both parts of the control plane
+    # endpoint are populated. If rendered before infrastructure is ready, the
+    # host/port resolve to empty or "<no value>" and get baked into the
+    # kubernetes-services-endpoint ConfigMap, crash-looping the tigera-operator
+    # with "KUBERNETES_SERVICE_HOST ... must be defined". Omitting the block lets
+    # the operator use in-cluster config.
+    {{- if and .Cluster.spec.controlPlaneEndpoint.host .Cluster.spec.controlPlaneEndpoint.port }}
     kubernetesServiceEndpoint:
       host: "{{ .Cluster.spec.controlPlaneEndpoint.host }}"
       port: "{{ .Cluster.spec.controlPlaneEndpoint.port }}"
+    {{- end }}
     # By default, tigera tolerates all NoSchedule taints. This breaks upgrades
     # when it continuously gets scheduled onto an out-of-date Node that is being
     # deleted. Tolerate only the NoSchedule taints that are expected.

--- a/templates/test/ci/cluster-template-prow-custom-vnet.yaml
+++ b/templates/test/ci/cluster-template-prow-custom-vnet.yaml
@@ -310,9 +310,17 @@ spec:
       options:
         - name: edns0
         - name: trust-ad
+    # Only set kubernetesServiceEndpoint once both parts of the control plane
+    # endpoint are populated. If rendered before infrastructure is ready, the
+    # host/port resolve to empty or "<no value>" and get baked into the
+    # kubernetes-services-endpoint ConfigMap, crash-looping the tigera-operator
+    # with "KUBERNETES_SERVICE_HOST ... must be defined". Omitting the block lets
+    # the operator use in-cluster config.
+    {{- if and .Cluster.spec.controlPlaneEndpoint.host .Cluster.spec.controlPlaneEndpoint.port }}
     kubernetesServiceEndpoint:
       host: "{{ .Cluster.spec.controlPlaneEndpoint.host }}"
       port: "{{ .Cluster.spec.controlPlaneEndpoint.port }}"
+    {{- end }}
     # By default, tigera tolerates all NoSchedule taints. This breaks upgrades
     # when it continuously gets scheduled onto an out-of-date Node that is being
     # deleted. Tolerate only the NoSchedule taints that are expected.

--- a/templates/test/ci/cluster-template-prow-dalec-custom-builds.yaml
+++ b/templates/test/ci/cluster-template-prow-dalec-custom-builds.yaml
@@ -678,9 +678,17 @@ spec:
       options:
         - name: edns0
         - name: trust-ad
+    # Only set kubernetesServiceEndpoint once both parts of the control plane
+    # endpoint are populated. If rendered before infrastructure is ready, the
+    # host/port resolve to empty or "<no value>" and get baked into the
+    # kubernetes-services-endpoint ConfigMap, crash-looping the tigera-operator
+    # with "KUBERNETES_SERVICE_HOST ... must be defined". Omitting the block lets
+    # the operator use in-cluster config.
+    {{- if and .Cluster.spec.controlPlaneEndpoint.host .Cluster.spec.controlPlaneEndpoint.port }}
     kubernetesServiceEndpoint:
       host: "{{ .Cluster.spec.controlPlaneEndpoint.host }}"
       port: "{{ .Cluster.spec.controlPlaneEndpoint.port }}"
+    {{- end }}
     # By default, tigera tolerates all NoSchedule taints. This breaks upgrades
     # when it continuously gets scheduled onto an out-of-date Node that is being
     # deleted. Tolerate only the NoSchedule taints that are expected.

--- a/templates/test/ci/cluster-template-prow-edgezone.yaml
+++ b/templates/test/ci/cluster-template-prow-edgezone.yaml
@@ -293,9 +293,17 @@ spec:
       options:
         - name: edns0
         - name: trust-ad
+    # Only set kubernetesServiceEndpoint once both parts of the control plane
+    # endpoint are populated. If rendered before infrastructure is ready, the
+    # host/port resolve to empty or "<no value>" and get baked into the
+    # kubernetes-services-endpoint ConfigMap, crash-looping the tigera-operator
+    # with "KUBERNETES_SERVICE_HOST ... must be defined". Omitting the block lets
+    # the operator use in-cluster config.
+    {{- if and .Cluster.spec.controlPlaneEndpoint.host .Cluster.spec.controlPlaneEndpoint.port }}
     kubernetesServiceEndpoint:
       host: "{{ .Cluster.spec.controlPlaneEndpoint.host }}"
       port: "{{ .Cluster.spec.controlPlaneEndpoint.port }}"
+    {{- end }}
     # By default, tigera tolerates all NoSchedule taints. This breaks upgrades
     # when it continuously gets scheduled onto an out-of-date Node that is being
     # deleted. Tolerate only the NoSchedule taints that are expected.

--- a/templates/test/ci/cluster-template-prow-flatcar-sysext.yaml
+++ b/templates/test/ci/cluster-template-prow-flatcar-sysext.yaml
@@ -87,9 +87,17 @@ spec:
       options:
         - name: edns0
         - name: trust-ad
+    # Only set kubernetesServiceEndpoint once both parts of the control plane
+    # endpoint are populated. If rendered before infrastructure is ready, the
+    # host/port resolve to empty or "<no value>" and get baked into the
+    # kubernetes-services-endpoint ConfigMap, crash-looping the tigera-operator
+    # with "KUBERNETES_SERVICE_HOST ... must be defined". Omitting the block lets
+    # the operator use in-cluster config.
+    {{- if and .Cluster.spec.controlPlaneEndpoint.host .Cluster.spec.controlPlaneEndpoint.port }}
     kubernetesServiceEndpoint:
       host: "{{ .Cluster.spec.controlPlaneEndpoint.host }}"
       port: "{{ .Cluster.spec.controlPlaneEndpoint.port }}"
+    {{- end }}
     # By default, tigera tolerates all NoSchedule taints. This breaks upgrades
     # when it continuously gets scheduled onto an out-of-date Node that is being
     # deleted. Tolerate only the NoSchedule taints that are expected.

--- a/templates/test/ci/cluster-template-prow-machine-pool-ci-version-multi-zone.yaml
+++ b/templates/test/ci/cluster-template-prow-machine-pool-ci-version-multi-zone.yaml
@@ -570,9 +570,17 @@ spec:
       options:
         - name: edns0
         - name: trust-ad
+    # Only set kubernetesServiceEndpoint once both parts of the control plane
+    # endpoint are populated. If rendered before infrastructure is ready, the
+    # host/port resolve to empty or "<no value>" and get baked into the
+    # kubernetes-services-endpoint ConfigMap, crash-looping the tigera-operator
+    # with "KUBERNETES_SERVICE_HOST ... must be defined". Omitting the block lets
+    # the operator use in-cluster config.
+    {{- if and .Cluster.spec.controlPlaneEndpoint.host .Cluster.spec.controlPlaneEndpoint.port }}
     kubernetesServiceEndpoint:
       host: "{{ .Cluster.spec.controlPlaneEndpoint.host }}"
       port: "{{ .Cluster.spec.controlPlaneEndpoint.port }}"
+    {{- end }}
     # By default, tigera tolerates all NoSchedule taints. This breaks upgrades
     # when it continuously gets scheduled onto an out-of-date Node that is being
     # deleted. Tolerate only the NoSchedule taints that are expected.

--- a/templates/test/ci/cluster-template-prow-machine-pool-ci-version-windows.yaml
+++ b/templates/test/ci/cluster-template-prow-machine-pool-ci-version-windows.yaml
@@ -727,9 +727,17 @@ spec:
       options:
         - name: edns0
         - name: trust-ad
+    # Only set kubernetesServiceEndpoint once both parts of the control plane
+    # endpoint are populated. If rendered before infrastructure is ready, the
+    # host/port resolve to empty or "<no value>" and get baked into the
+    # kubernetes-services-endpoint ConfigMap, crash-looping the tigera-operator
+    # with "KUBERNETES_SERVICE_HOST ... must be defined". Omitting the block lets
+    # the operator use in-cluster config.
+    {{- if and .Cluster.spec.controlPlaneEndpoint.host .Cluster.spec.controlPlaneEndpoint.port }}
     kubernetesServiceEndpoint:
       host: "{{ .Cluster.spec.controlPlaneEndpoint.host }}"
       port: "{{ .Cluster.spec.controlPlaneEndpoint.port }}"
+    {{- end }}
     # By default, tigera tolerates all NoSchedule taints. This breaks upgrades
     # when it continuously gets scheduled onto an out-of-date Node that is being
     # deleted. Tolerate only the NoSchedule taints that are expected.

--- a/templates/test/ci/cluster-template-prow-machine-pool-ci-version.yaml
+++ b/templates/test/ci/cluster-template-prow-machine-pool-ci-version.yaml
@@ -566,9 +566,17 @@ spec:
       options:
         - name: edns0
         - name: trust-ad
+    # Only set kubernetesServiceEndpoint once both parts of the control plane
+    # endpoint are populated. If rendered before infrastructure is ready, the
+    # host/port resolve to empty or "<no value>" and get baked into the
+    # kubernetes-services-endpoint ConfigMap, crash-looping the tigera-operator
+    # with "KUBERNETES_SERVICE_HOST ... must be defined". Omitting the block lets
+    # the operator use in-cluster config.
+    {{- if and .Cluster.spec.controlPlaneEndpoint.host .Cluster.spec.controlPlaneEndpoint.port }}
     kubernetesServiceEndpoint:
       host: "{{ .Cluster.spec.controlPlaneEndpoint.host }}"
       port: "{{ .Cluster.spec.controlPlaneEndpoint.port }}"
+    {{- end }}
     # By default, tigera tolerates all NoSchedule taints. This breaks upgrades
     # when it continuously gets scheduled onto an out-of-date Node that is being
     # deleted. Tolerate only the NoSchedule taints that are expected.

--- a/templates/test/ci/cluster-template-prow-machine-pool-flex.yaml
+++ b/templates/test/ci/cluster-template-prow-machine-pool-flex.yaml
@@ -332,9 +332,17 @@ spec:
       options:
         - name: edns0
         - name: trust-ad
+    # Only set kubernetesServiceEndpoint once both parts of the control plane
+    # endpoint are populated. If rendered before infrastructure is ready, the
+    # host/port resolve to empty or "<no value>" and get baked into the
+    # kubernetes-services-endpoint ConfigMap, crash-looping the tigera-operator
+    # with "KUBERNETES_SERVICE_HOST ... must be defined". Omitting the block lets
+    # the operator use in-cluster config.
+    {{- if and .Cluster.spec.controlPlaneEndpoint.host .Cluster.spec.controlPlaneEndpoint.port }}
     kubernetesServiceEndpoint:
       host: "{{ .Cluster.spec.controlPlaneEndpoint.host }}"
       port: "{{ .Cluster.spec.controlPlaneEndpoint.port }}"
+    {{- end }}
     # By default, tigera tolerates all NoSchedule taints. This breaks upgrades
     # when it continuously gets scheduled onto an out-of-date Node that is being
     # deleted. Tolerate only the NoSchedule taints that are expected.

--- a/templates/test/ci/cluster-template-prow-machine-pool-windows.yaml
+++ b/templates/test/ci/cluster-template-prow-machine-pool-windows.yaml
@@ -454,9 +454,17 @@ spec:
       options:
         - name: edns0
         - name: trust-ad
+    # Only set kubernetesServiceEndpoint once both parts of the control plane
+    # endpoint are populated. If rendered before infrastructure is ready, the
+    # host/port resolve to empty or "<no value>" and get baked into the
+    # kubernetes-services-endpoint ConfigMap, crash-looping the tigera-operator
+    # with "KUBERNETES_SERVICE_HOST ... must be defined". Omitting the block lets
+    # the operator use in-cluster config.
+    {{- if and .Cluster.spec.controlPlaneEndpoint.host .Cluster.spec.controlPlaneEndpoint.port }}
     kubernetesServiceEndpoint:
       host: "{{ .Cluster.spec.controlPlaneEndpoint.host }}"
       port: "{{ .Cluster.spec.controlPlaneEndpoint.port }}"
+    {{- end }}
     # By default, tigera tolerates all NoSchedule taints. This breaks upgrades
     # when it continuously gets scheduled onto an out-of-date Node that is being
     # deleted. Tolerate only the NoSchedule taints that are expected.

--- a/templates/test/ci/cluster-template-prow-machine-pool.yaml
+++ b/templates/test/ci/cluster-template-prow-machine-pool.yaml
@@ -332,9 +332,17 @@ spec:
       options:
         - name: edns0
         - name: trust-ad
+    # Only set kubernetesServiceEndpoint once both parts of the control plane
+    # endpoint are populated. If rendered before infrastructure is ready, the
+    # host/port resolve to empty or "<no value>" and get baked into the
+    # kubernetes-services-endpoint ConfigMap, crash-looping the tigera-operator
+    # with "KUBERNETES_SERVICE_HOST ... must be defined". Omitting the block lets
+    # the operator use in-cluster config.
+    {{- if and .Cluster.spec.controlPlaneEndpoint.host .Cluster.spec.controlPlaneEndpoint.port }}
     kubernetesServiceEndpoint:
       host: "{{ .Cluster.spec.controlPlaneEndpoint.host }}"
       port: "{{ .Cluster.spec.controlPlaneEndpoint.port }}"
+    {{- end }}
     # By default, tigera tolerates all NoSchedule taints. This breaks upgrades
     # when it continuously gets scheduled onto an out-of-date Node that is being
     # deleted. Tolerate only the NoSchedule taints that are expected.

--- a/templates/test/ci/cluster-template-prow-nvidia-gpu.yaml
+++ b/templates/test/ci/cluster-template-prow-nvidia-gpu.yaml
@@ -284,9 +284,17 @@ spec:
       options:
         - name: edns0
         - name: trust-ad
+    # Only set kubernetesServiceEndpoint once both parts of the control plane
+    # endpoint are populated. If rendered before infrastructure is ready, the
+    # host/port resolve to empty or "<no value>" and get baked into the
+    # kubernetes-services-endpoint ConfigMap, crash-looping the tigera-operator
+    # with "KUBERNETES_SERVICE_HOST ... must be defined". Omitting the block lets
+    # the operator use in-cluster config.
+    {{- if and .Cluster.spec.controlPlaneEndpoint.host .Cluster.spec.controlPlaneEndpoint.port }}
     kubernetesServiceEndpoint:
       host: "{{ .Cluster.spec.controlPlaneEndpoint.host }}"
       port: "{{ .Cluster.spec.controlPlaneEndpoint.port }}"
+    {{- end }}
     # By default, tigera tolerates all NoSchedule taints. This breaks upgrades
     # when it continuously gets scheduled onto an out-of-date Node that is being
     # deleted. Tolerate only the NoSchedule taints that are expected.

--- a/templates/test/ci/cluster-template-prow-private.yaml
+++ b/templates/test/ci/cluster-template-prow-private.yaml
@@ -358,9 +358,17 @@ spec:
       options:
         - name: edns0
         - name: trust-ad
+    # Only set kubernetesServiceEndpoint once both parts of the control plane
+    # endpoint are populated. If rendered before infrastructure is ready, the
+    # host/port resolve to empty or "<no value>" and get baked into the
+    # kubernetes-services-endpoint ConfigMap, crash-looping the tigera-operator
+    # with "KUBERNETES_SERVICE_HOST ... must be defined". Omitting the block lets
+    # the operator use in-cluster config.
+    {{- if and .Cluster.spec.controlPlaneEndpoint.host .Cluster.spec.controlPlaneEndpoint.port }}
     kubernetesServiceEndpoint:
       host: "{{ .Cluster.spec.controlPlaneEndpoint.host }}"
       port: "{{ .Cluster.spec.controlPlaneEndpoint.port }}"
+    {{- end }}
     # By default, tigera tolerates all NoSchedule taints. This breaks upgrades
     # when it continuously gets scheduled onto an out-of-date Node that is being
     # deleted. Tolerate only the NoSchedule taints that are expected.

--- a/templates/test/ci/cluster-template-prow-spot.yaml
+++ b/templates/test/ci/cluster-template-prow-spot.yaml
@@ -306,9 +306,17 @@ spec:
       options:
         - name: edns0
         - name: trust-ad
+    # Only set kubernetesServiceEndpoint once both parts of the control plane
+    # endpoint are populated. If rendered before infrastructure is ready, the
+    # host/port resolve to empty or "<no value>" and get baked into the
+    # kubernetes-services-endpoint ConfigMap, crash-looping the tigera-operator
+    # with "KUBERNETES_SERVICE_HOST ... must be defined". Omitting the block lets
+    # the operator use in-cluster config.
+    {{- if and .Cluster.spec.controlPlaneEndpoint.host .Cluster.spec.controlPlaneEndpoint.port }}
     kubernetesServiceEndpoint:
       host: "{{ .Cluster.spec.controlPlaneEndpoint.host }}"
       port: "{{ .Cluster.spec.controlPlaneEndpoint.port }}"
+    {{- end }}
     # By default, tigera tolerates all NoSchedule taints. This breaks upgrades
     # when it continuously gets scheduled onto an out-of-date Node that is being
     # deleted. Tolerate only the NoSchedule taints that are expected.

--- a/templates/test/ci/cluster-template-prow-topology.yaml
+++ b/templates/test/ci/cluster-template-prow-topology.yaml
@@ -116,9 +116,17 @@ spec:
       options:
         - name: edns0
         - name: trust-ad
+    # Only set kubernetesServiceEndpoint once both parts of the control plane
+    # endpoint are populated. If rendered before infrastructure is ready, the
+    # host/port resolve to empty or "<no value>" and get baked into the
+    # kubernetes-services-endpoint ConfigMap, crash-looping the tigera-operator
+    # with "KUBERNETES_SERVICE_HOST ... must be defined". Omitting the block lets
+    # the operator use in-cluster config.
+    {{- if and .Cluster.spec.controlPlaneEndpoint.host .Cluster.spec.controlPlaneEndpoint.port }}
     kubernetesServiceEndpoint:
       host: "{{ .Cluster.spec.controlPlaneEndpoint.host }}"
       port: "{{ .Cluster.spec.controlPlaneEndpoint.port }}"
+    {{- end }}
     # By default, tigera tolerates all NoSchedule taints. This breaks upgrades
     # when it continuously gets scheduled onto an out-of-date Node that is being
     # deleted. Tolerate only the NoSchedule taints that are expected.

--- a/templates/test/ci/cluster-template-prow-windows.yaml
+++ b/templates/test/ci/cluster-template-prow-windows.yaml
@@ -510,9 +510,17 @@ spec:
       options:
         - name: edns0
         - name: trust-ad
+    # Only set kubernetesServiceEndpoint once both parts of the control plane
+    # endpoint are populated. If rendered before infrastructure is ready, the
+    # host/port resolve to empty or "<no value>" and get baked into the
+    # kubernetes-services-endpoint ConfigMap, crash-looping the tigera-operator
+    # with "KUBERNETES_SERVICE_HOST ... must be defined". Omitting the block lets
+    # the operator use in-cluster config.
+    {{- if and .Cluster.spec.controlPlaneEndpoint.host .Cluster.spec.controlPlaneEndpoint.port }}
     kubernetesServiceEndpoint:
       host: "{{ .Cluster.spec.controlPlaneEndpoint.host }}"
       port: "{{ .Cluster.spec.controlPlaneEndpoint.port }}"
+    {{- end }}
     # By default, tigera tolerates all NoSchedule taints. This breaks upgrades
     # when it continuously gets scheduled onto an out-of-date Node that is being
     # deleted. Tolerate only the NoSchedule taints that are expected.

--- a/templates/test/ci/cluster-template-prow.yaml
+++ b/templates/test/ci/cluster-template-prow.yaml
@@ -335,9 +335,17 @@ spec:
       options:
         - name: edns0
         - name: trust-ad
+    # Only set kubernetesServiceEndpoint once both parts of the control plane
+    # endpoint are populated. If rendered before infrastructure is ready, the
+    # host/port resolve to empty or "<no value>" and get baked into the
+    # kubernetes-services-endpoint ConfigMap, crash-looping the tigera-operator
+    # with "KUBERNETES_SERVICE_HOST ... must be defined". Omitting the block lets
+    # the operator use in-cluster config.
+    {{- if and .Cluster.spec.controlPlaneEndpoint.host .Cluster.spec.controlPlaneEndpoint.port }}
     kubernetesServiceEndpoint:
       host: "{{ .Cluster.spec.controlPlaneEndpoint.host }}"
       port: "{{ .Cluster.spec.controlPlaneEndpoint.port }}"
+    {{- end }}
     # By default, tigera tolerates all NoSchedule taints. This breaks upgrades
     # when it continuously gets scheduled onto an out-of-date Node that is being
     # deleted. Tolerate only the NoSchedule taints that are expected.

--- a/templates/test/dev/cluster-template-custom-builds-dra.yaml
+++ b/templates/test/dev/cluster-template-custom-builds-dra.yaml
@@ -526,9 +526,17 @@ spec:
       options:
         - name: edns0
         - name: trust-ad
+    # Only set kubernetesServiceEndpoint once both parts of the control plane
+    # endpoint are populated. If rendered before infrastructure is ready, the
+    # host/port resolve to empty or "<no value>" and get baked into the
+    # kubernetes-services-endpoint ConfigMap, crash-looping the tigera-operator
+    # with "KUBERNETES_SERVICE_HOST ... must be defined". Omitting the block lets
+    # the operator use in-cluster config.
+    {{- if and .Cluster.spec.controlPlaneEndpoint.host .Cluster.spec.controlPlaneEndpoint.port }}
     kubernetesServiceEndpoint:
       host: "{{ .Cluster.spec.controlPlaneEndpoint.host }}"
       port: "{{ .Cluster.spec.controlPlaneEndpoint.port }}"
+    {{- end }}
     # By default, tigera tolerates all NoSchedule taints. This breaks upgrades
     # when it continuously gets scheduled onto an out-of-date Node that is being
     # deleted. Tolerate only the NoSchedule taints that are expected.

--- a/templates/test/dev/cluster-template-custom-builds-load-dra.yaml
+++ b/templates/test/dev/cluster-template-custom-builds-load-dra.yaml
@@ -578,9 +578,17 @@ spec:
       options:
         - name: edns0
         - name: trust-ad
+    # Only set kubernetesServiceEndpoint once both parts of the control plane
+    # endpoint are populated. If rendered before infrastructure is ready, the
+    # host/port resolve to empty or "<no value>" and get baked into the
+    # kubernetes-services-endpoint ConfigMap, crash-looping the tigera-operator
+    # with "KUBERNETES_SERVICE_HOST ... must be defined". Omitting the block lets
+    # the operator use in-cluster config.
+    {{- if and .Cluster.spec.controlPlaneEndpoint.host .Cluster.spec.controlPlaneEndpoint.port }}
     kubernetesServiceEndpoint:
       host: "{{ .Cluster.spec.controlPlaneEndpoint.host }}"
       port: "{{ .Cluster.spec.controlPlaneEndpoint.port }}"
+    {{- end }}
     # By default, tigera tolerates all NoSchedule taints. This breaks upgrades
     # when it continuously gets scheduled onto an out-of-date Node that is being
     # deleted. Tolerate only the NoSchedule taints that are expected.

--- a/templates/test/dev/cluster-template-custom-builds-load.yaml
+++ b/templates/test/dev/cluster-template-custom-builds-load.yaml
@@ -553,9 +553,17 @@ spec:
       options:
         - name: edns0
         - name: trust-ad
+    # Only set kubernetesServiceEndpoint once both parts of the control plane
+    # endpoint are populated. If rendered before infrastructure is ready, the
+    # host/port resolve to empty or "<no value>" and get baked into the
+    # kubernetes-services-endpoint ConfigMap, crash-looping the tigera-operator
+    # with "KUBERNETES_SERVICE_HOST ... must be defined". Omitting the block lets
+    # the operator use in-cluster config.
+    {{- if and .Cluster.spec.controlPlaneEndpoint.host .Cluster.spec.controlPlaneEndpoint.port }}
     kubernetesServiceEndpoint:
       host: "{{ .Cluster.spec.controlPlaneEndpoint.host }}"
       port: "{{ .Cluster.spec.controlPlaneEndpoint.port }}"
+    {{- end }}
     # By default, tigera tolerates all NoSchedule taints. This breaks upgrades
     # when it continuously gets scheduled onto an out-of-date Node that is being
     # deleted. Tolerate only the NoSchedule taints that are expected.

--- a/templates/test/dev/cluster-template-custom-builds-machine-pool-load-dra.yaml
+++ b/templates/test/dev/cluster-template-custom-builds-machine-pool-load-dra.yaml
@@ -536,9 +536,17 @@ spec:
       options:
         - name: edns0
         - name: trust-ad
+    # Only set kubernetesServiceEndpoint once both parts of the control plane
+    # endpoint are populated. If rendered before infrastructure is ready, the
+    # host/port resolve to empty or "<no value>" and get baked into the
+    # kubernetes-services-endpoint ConfigMap, crash-looping the tigera-operator
+    # with "KUBERNETES_SERVICE_HOST ... must be defined". Omitting the block lets
+    # the operator use in-cluster config.
+    {{- if and .Cluster.spec.controlPlaneEndpoint.host .Cluster.spec.controlPlaneEndpoint.port }}
     kubernetesServiceEndpoint:
       host: "{{ .Cluster.spec.controlPlaneEndpoint.host }}"
       port: "{{ .Cluster.spec.controlPlaneEndpoint.port }}"
+    {{- end }}
     # By default, tigera tolerates all NoSchedule taints. This breaks upgrades
     # when it continuously gets scheduled onto an out-of-date Node that is being
     # deleted. Tolerate only the NoSchedule taints that are expected.

--- a/templates/test/dev/cluster-template-custom-builds-machine-pool-load.yaml
+++ b/templates/test/dev/cluster-template-custom-builds-machine-pool-load.yaml
@@ -507,9 +507,17 @@ spec:
       options:
         - name: edns0
         - name: trust-ad
+    # Only set kubernetesServiceEndpoint once both parts of the control plane
+    # endpoint are populated. If rendered before infrastructure is ready, the
+    # host/port resolve to empty or "<no value>" and get baked into the
+    # kubernetes-services-endpoint ConfigMap, crash-looping the tigera-operator
+    # with "KUBERNETES_SERVICE_HOST ... must be defined". Omitting the block lets
+    # the operator use in-cluster config.
+    {{- if and .Cluster.spec.controlPlaneEndpoint.host .Cluster.spec.controlPlaneEndpoint.port }}
     kubernetesServiceEndpoint:
       host: "{{ .Cluster.spec.controlPlaneEndpoint.host }}"
       port: "{{ .Cluster.spec.controlPlaneEndpoint.port }}"
+    {{- end }}
     # By default, tigera tolerates all NoSchedule taints. This breaks upgrades
     # when it continuously gets scheduled onto an out-of-date Node that is being
     # deleted. Tolerate only the NoSchedule taints that are expected.

--- a/templates/test/dev/cluster-template-custom-builds-machine-pool-windows.yaml
+++ b/templates/test/dev/cluster-template-custom-builds-machine-pool-windows.yaml
@@ -677,9 +677,17 @@ spec:
       options:
         - name: edns0
         - name: trust-ad
+    # Only set kubernetesServiceEndpoint once both parts of the control plane
+    # endpoint are populated. If rendered before infrastructure is ready, the
+    # host/port resolve to empty or "<no value>" and get baked into the
+    # kubernetes-services-endpoint ConfigMap, crash-looping the tigera-operator
+    # with "KUBERNETES_SERVICE_HOST ... must be defined". Omitting the block lets
+    # the operator use in-cluster config.
+    {{- if and .Cluster.spec.controlPlaneEndpoint.host .Cluster.spec.controlPlaneEndpoint.port }}
     kubernetesServiceEndpoint:
       host: "{{ .Cluster.spec.controlPlaneEndpoint.host }}"
       port: "{{ .Cluster.spec.controlPlaneEndpoint.port }}"
+    {{- end }}
     # By default, tigera tolerates all NoSchedule taints. This breaks upgrades
     # when it continuously gets scheduled onto an out-of-date Node that is being
     # deleted. Tolerate only the NoSchedule taints that are expected.

--- a/templates/test/dev/cluster-template-custom-builds-machine-pool.yaml
+++ b/templates/test/dev/cluster-template-custom-builds-machine-pool.yaml
@@ -497,9 +497,17 @@ spec:
       options:
         - name: edns0
         - name: trust-ad
+    # Only set kubernetesServiceEndpoint once both parts of the control plane
+    # endpoint are populated. If rendered before infrastructure is ready, the
+    # host/port resolve to empty or "<no value>" and get baked into the
+    # kubernetes-services-endpoint ConfigMap, crash-looping the tigera-operator
+    # with "KUBERNETES_SERVICE_HOST ... must be defined". Omitting the block lets
+    # the operator use in-cluster config.
+    {{- if and .Cluster.spec.controlPlaneEndpoint.host .Cluster.spec.controlPlaneEndpoint.port }}
     kubernetesServiceEndpoint:
       host: "{{ .Cluster.spec.controlPlaneEndpoint.host }}"
       port: "{{ .Cluster.spec.controlPlaneEndpoint.port }}"
+    {{- end }}
     # By default, tigera tolerates all NoSchedule taints. This breaks upgrades
     # when it continuously gets scheduled onto an out-of-date Node that is being
     # deleted. Tolerate only the NoSchedule taints that are expected.

--- a/templates/test/dev/cluster-template-custom-builds-windows.yaml
+++ b/templates/test/dev/cluster-template-custom-builds-windows.yaml
@@ -783,9 +783,17 @@ spec:
       options:
         - name: edns0
         - name: trust-ad
+    # Only set kubernetesServiceEndpoint once both parts of the control plane
+    # endpoint are populated. If rendered before infrastructure is ready, the
+    # host/port resolve to empty or "<no value>" and get baked into the
+    # kubernetes-services-endpoint ConfigMap, crash-looping the tigera-operator
+    # with "KUBERNETES_SERVICE_HOST ... must be defined". Omitting the block lets
+    # the operator use in-cluster config.
+    {{- if and .Cluster.spec.controlPlaneEndpoint.host .Cluster.spec.controlPlaneEndpoint.port }}
     kubernetesServiceEndpoint:
       host: "{{ .Cluster.spec.controlPlaneEndpoint.host }}"
       port: "{{ .Cluster.spec.controlPlaneEndpoint.port }}"
+    {{- end }}
     # By default, tigera tolerates all NoSchedule taints. This breaks upgrades
     # when it continuously gets scheduled onto an out-of-date Node that is being
     # deleted. Tolerate only the NoSchedule taints that are expected.

--- a/templates/test/dev/cluster-template-custom-builds.yaml
+++ b/templates/test/dev/cluster-template-custom-builds.yaml
@@ -549,9 +549,17 @@ spec:
       options:
         - name: edns0
         - name: trust-ad
+    # Only set kubernetesServiceEndpoint once both parts of the control plane
+    # endpoint are populated. If rendered before infrastructure is ready, the
+    # host/port resolve to empty or "<no value>" and get baked into the
+    # kubernetes-services-endpoint ConfigMap, crash-looping the tigera-operator
+    # with "KUBERNETES_SERVICE_HOST ... must be defined". Omitting the block lets
+    # the operator use in-cluster config.
+    {{- if and .Cluster.spec.controlPlaneEndpoint.host .Cluster.spec.controlPlaneEndpoint.port }}
     kubernetesServiceEndpoint:
       host: "{{ .Cluster.spec.controlPlaneEndpoint.host }}"
       port: "{{ .Cluster.spec.controlPlaneEndpoint.port }}"
+    {{- end }}
     # By default, tigera tolerates all NoSchedule taints. This breaks upgrades
     # when it continuously gets scheduled onto an out-of-date Node that is being
     # deleted. Tolerate only the NoSchedule taints that are expected.

--- a/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-kcp-remediation.yaml
+++ b/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-kcp-remediation.yaml
@@ -85,9 +85,17 @@ spec:
       options:
         - name: edns0
         - name: trust-ad
+    # Only set kubernetesServiceEndpoint once both parts of the control plane
+    # endpoint are populated. If rendered before infrastructure is ready, the
+    # host/port resolve to empty or "<no value>" and get baked into the
+    # kubernetes-services-endpoint ConfigMap, crash-looping the tigera-operator
+    # with "KUBERNETES_SERVICE_HOST ... must be defined". Omitting the block lets
+    # the operator use in-cluster config.
+    {{- if and .Cluster.spec.controlPlaneEndpoint.host .Cluster.spec.controlPlaneEndpoint.port }}
     kubernetesServiceEndpoint:
       host: "{{ .Cluster.spec.controlPlaneEndpoint.host }}"
       port: "{{ .Cluster.spec.controlPlaneEndpoint.port }}"
+    {{- end }}
     # By default, tigera tolerates all NoSchedule taints. This breaks upgrades
     # when it continuously gets scheduled onto an out-of-date Node that is being
     # deleted. Tolerate only the NoSchedule taints that are expected.

--- a/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-kcp-scale-in.yaml
+++ b/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-kcp-scale-in.yaml
@@ -85,9 +85,17 @@ spec:
       options:
         - name: edns0
         - name: trust-ad
+    # Only set kubernetesServiceEndpoint once both parts of the control plane
+    # endpoint are populated. If rendered before infrastructure is ready, the
+    # host/port resolve to empty or "<no value>" and get baked into the
+    # kubernetes-services-endpoint ConfigMap, crash-looping the tigera-operator
+    # with "KUBERNETES_SERVICE_HOST ... must be defined". Omitting the block lets
+    # the operator use in-cluster config.
+    {{- if and .Cluster.spec.controlPlaneEndpoint.host .Cluster.spec.controlPlaneEndpoint.port }}
     kubernetesServiceEndpoint:
       host: "{{ .Cluster.spec.controlPlaneEndpoint.host }}"
       port: "{{ .Cluster.spec.controlPlaneEndpoint.port }}"
+    {{- end }}
     # By default, tigera tolerates all NoSchedule taints. This breaks upgrades
     # when it continuously gets scheduled onto an out-of-date Node that is being
     # deleted. Tolerate only the NoSchedule taints that are expected.

--- a/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-machine-and-machine-pool.yaml
+++ b/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-machine-and-machine-pool.yaml
@@ -85,9 +85,17 @@ spec:
       options:
         - name: edns0
         - name: trust-ad
+    # Only set kubernetesServiceEndpoint once both parts of the control plane
+    # endpoint are populated. If rendered before infrastructure is ready, the
+    # host/port resolve to empty or "<no value>" and get baked into the
+    # kubernetes-services-endpoint ConfigMap, crash-looping the tigera-operator
+    # with "KUBERNETES_SERVICE_HOST ... must be defined". Omitting the block lets
+    # the operator use in-cluster config.
+    {{- if and .Cluster.spec.controlPlaneEndpoint.host .Cluster.spec.controlPlaneEndpoint.port }}
     kubernetesServiceEndpoint:
       host: "{{ .Cluster.spec.controlPlaneEndpoint.host }}"
       port: "{{ .Cluster.spec.controlPlaneEndpoint.port }}"
+    {{- end }}
     # By default, tigera tolerates all NoSchedule taints. This breaks upgrades
     # when it continuously gets scheduled onto an out-of-date Node that is being
     # deleted. Tolerate only the NoSchedule taints that are expected.

--- a/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-machine-pool.yaml
+++ b/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-machine-pool.yaml
@@ -85,9 +85,17 @@ spec:
       options:
         - name: edns0
         - name: trust-ad
+    # Only set kubernetesServiceEndpoint once both parts of the control plane
+    # endpoint are populated. If rendered before infrastructure is ready, the
+    # host/port resolve to empty or "<no value>" and get baked into the
+    # kubernetes-services-endpoint ConfigMap, crash-looping the tigera-operator
+    # with "KUBERNETES_SERVICE_HOST ... must be defined". Omitting the block lets
+    # the operator use in-cluster config.
+    {{- if and .Cluster.spec.controlPlaneEndpoint.host .Cluster.spec.controlPlaneEndpoint.port }}
     kubernetesServiceEndpoint:
       host: "{{ .Cluster.spec.controlPlaneEndpoint.host }}"
       port: "{{ .Cluster.spec.controlPlaneEndpoint.port }}"
+    {{- end }}
     # By default, tigera tolerates all NoSchedule taints. This breaks upgrades
     # when it continuously gets scheduled onto an out-of-date Node that is being
     # deleted. Tolerate only the NoSchedule taints that are expected.

--- a/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-md-remediation.yaml
+++ b/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-md-remediation.yaml
@@ -85,9 +85,17 @@ spec:
       options:
         - name: edns0
         - name: trust-ad
+    # Only set kubernetesServiceEndpoint once both parts of the control plane
+    # endpoint are populated. If rendered before infrastructure is ready, the
+    # host/port resolve to empty or "<no value>" and get baked into the
+    # kubernetes-services-endpoint ConfigMap, crash-looping the tigera-operator
+    # with "KUBERNETES_SERVICE_HOST ... must be defined". Omitting the block lets
+    # the operator use in-cluster config.
+    {{- if and .Cluster.spec.controlPlaneEndpoint.host .Cluster.spec.controlPlaneEndpoint.port }}
     kubernetesServiceEndpoint:
       host: "{{ .Cluster.spec.controlPlaneEndpoint.host }}"
       port: "{{ .Cluster.spec.controlPlaneEndpoint.port }}"
+    {{- end }}
     # By default, tigera tolerates all NoSchedule taints. This breaks upgrades
     # when it continuously gets scheduled onto an out-of-date Node that is being
     # deleted. Tolerate only the NoSchedule taints that are expected.

--- a/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-node-drain.yaml
+++ b/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-node-drain.yaml
@@ -85,9 +85,17 @@ spec:
       options:
         - name: edns0
         - name: trust-ad
+    # Only set kubernetesServiceEndpoint once both parts of the control plane
+    # endpoint are populated. If rendered before infrastructure is ready, the
+    # host/port resolve to empty or "<no value>" and get baked into the
+    # kubernetes-services-endpoint ConfigMap, crash-looping the tigera-operator
+    # with "KUBERNETES_SERVICE_HOST ... must be defined". Omitting the block lets
+    # the operator use in-cluster config.
+    {{- if and .Cluster.spec.controlPlaneEndpoint.host .Cluster.spec.controlPlaneEndpoint.port }}
     kubernetesServiceEndpoint:
       host: "{{ .Cluster.spec.controlPlaneEndpoint.host }}"
       port: "{{ .Cluster.spec.controlPlaneEndpoint.port }}"
+    {{- end }}
     # By default, tigera tolerates all NoSchedule taints. This breaks upgrades
     # when it continuously gets scheduled onto an out-of-date Node that is being
     # deleted. Tolerate only the NoSchedule taints that are expected.

--- a/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-upgrades.yaml
+++ b/test/e2e/data/infrastructure-azure/v1beta1/cluster-template-upgrades.yaml
@@ -85,9 +85,17 @@ spec:
       options:
         - name: edns0
         - name: trust-ad
+    # Only set kubernetesServiceEndpoint once both parts of the control plane
+    # endpoint are populated. If rendered before infrastructure is ready, the
+    # host/port resolve to empty or "<no value>" and get baked into the
+    # kubernetes-services-endpoint ConfigMap, crash-looping the tigera-operator
+    # with "KUBERNETES_SERVICE_HOST ... must be defined". Omitting the block lets
+    # the operator use in-cluster config.
+    {{- if and .Cluster.spec.controlPlaneEndpoint.host .Cluster.spec.controlPlaneEndpoint.port }}
     kubernetesServiceEndpoint:
       host: "{{ .Cluster.spec.controlPlaneEndpoint.host }}"
       port: "{{ .Cluster.spec.controlPlaneEndpoint.port }}"
+    {{- end }}
     # By default, tigera tolerates all NoSchedule taints. This breaks upgrades
     # when it continuously gets scheduled onto an out-of-date Node that is being
     # deleted. Tolerate only the NoSchedule taints that are expected.

--- a/test/e2e/data/infrastructure-azure/v1beta1/cluster-template.yaml
+++ b/test/e2e/data/infrastructure-azure/v1beta1/cluster-template.yaml
@@ -85,9 +85,17 @@ spec:
       options:
         - name: edns0
         - name: trust-ad
+    # Only set kubernetesServiceEndpoint once both parts of the control plane
+    # endpoint are populated. If rendered before infrastructure is ready, the
+    # host/port resolve to empty or "<no value>" and get baked into the
+    # kubernetes-services-endpoint ConfigMap, crash-looping the tigera-operator
+    # with "KUBERNETES_SERVICE_HOST ... must be defined". Omitting the block lets
+    # the operator use in-cluster config.
+    {{- if and .Cluster.spec.controlPlaneEndpoint.host .Cluster.spec.controlPlaneEndpoint.port }}
     kubernetesServiceEndpoint:
       host: "{{ .Cluster.spec.controlPlaneEndpoint.host }}"
       port: "{{ .Cluster.spec.controlPlaneEndpoint.port }}"
+    {{- end }}
     # By default, tigera tolerates all NoSchedule taints. This breaks upgrades
     # when it continuously gets scheduled onto an out-of-date Node that is being
     # deleted. Tolerate only the NoSchedule taints that are expected.


### PR DESCRIPTION

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation

/kind flake
-->
/kind failing-test

**What this PR does / why we need it**:

Only set kubernetesServiceEndpoint when Cluster has already controlPlaneEndpoint populated.

Current template is confirmed to be causing issues by debugging info from #6494, which has produced the following log for me eventually:

 envFrom ConfigMap tigera-operator/kubernetes-services-endpoint keys:
    KUBERNETES_SERVICE_HOST: empty
    KUBERNETES_SERVICE_PORT: empty


**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [x] includes documentation
- [x] adds unit tests
- [x] cherry-pick candidate

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
