### PR TITLE
test: fallback AKS version to community gallery version

### DIFF
--- a/test/e2e/aks_versions.go
+++ b/test/e2e/aks_versions.go
@@ -30,7 +30,63 @@ import (
 	"golang.org/x/mod/semver"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
+
+	"sigs.k8s.io/cluster-api-provider-azure/azure"
+	"sigs.k8s.io/cluster-api-provider-azure/test/e2e/internal/kubeversion"
 )
+
+// GetAKSKubernetesVersionWithCommunityGalleryImage gets a Kubernetes version supported by both AKS and a community gallery image in the configured region.
+func GetAKSKubernetesVersionWithCommunityGalleryImage(ctx context.Context, e2eConfig *clusterctl.E2EConfig, versionVar, image string) (string, error) {
+	requestedVersion := e2eConfig.MustGetVariable(versionVar)
+	location := e2eConfig.MustGetVariable(AzureLocation)
+	subscriptionID := getSubscriptionID(Default)
+
+	aksVersions, err := getStableAKSKubernetesVersions(ctx, subscriptionID, location)
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to list stable AKS Kubernetes versions in location %q", location)
+	}
+	galleryVersionMap, err := listVersionsInCommunityGallery(ctx, location, azure.DefaultPublicGalleryName, image)
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to list community gallery image %q versions in location %q", image, location)
+	}
+	galleryVersions := make([]string, 0, len(galleryVersionMap))
+	for version := range galleryVersionMap {
+		galleryVersions = append(galleryVersions, version)
+	}
+
+	version, err := kubeversion.Select(requestedVersion, kubeversion.Common(aksVersions, galleryVersions))
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to resolve Kubernetes version %q for AKS and community gallery image %q in location %q", requestedVersion, image, location)
+	}
+	Byf("Resolved %s (set to %s) to %s using AKS and community gallery image %q in location %q", versionVar, requestedVersion, version, image, location)
+	return version, nil
+}
+
+func getStableAKSKubernetesVersions(ctx context.Context, subscriptionID, location string) ([]string, error) {
+	cred, err := azidentity.NewDefaultAzureCredential(nil)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create a default credential")
+	}
+	managedClustersClient, err := armcontainerservice.NewManagedClustersClient(subscriptionID, cred, nil)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create a ContainerServices client")
+	}
+	result, err := managedClustersClient.ListKubernetesVersions(ctx, location, nil)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to list Orchestrators")
+	}
+
+	var versions []string
+	for _, minor := range result.KubernetesVersionListResult.Values {
+		if minor == nil || ptr.Deref(minor.IsPreview, false) {
+			continue
+		}
+		for patch := range minor.PatchVersions {
+			versions = append(versions, patch)
+		}
+	}
+	return versions, nil
+}
 
 // GetAKSKubernetesVersion gets the kubernetes version for AKS clusters as specified by the environment variable defined by versionVar.
 func GetAKSKubernetesVersion(ctx context.Context, e2eConfig *clusterctl.E2EConfig, versionVar string) (string, error) {
@@ -76,7 +132,7 @@ func GetWorkingAKSKubernetesVersion(ctx context.Context, subscriptionID, locatio
 	var latestStableVersionDesired bool
 	// We're not doing much input validation here,
 	// we assume that if the prefix is 'stable-' that the remainder of the string is in the format <Major>.<Minor>
-	if isStableVersion, _ := validateStableReleaseString(version); isStableVersion {
+	if isStableVersion, _ := kubeversion.ValidateStableReleaseString(version); isStableVersion {
 		latestStableVersionDesired = true
 		// Form a fully valid semver version @ the initial patch release (".0")
 		version = fmt.Sprintf("%s.0", version[7:])
@@ -133,40 +189,13 @@ func GetNextLatestStableAKSKubernetesVersion(ctx context.Context, subscriptionID
 }
 
 func getLatestStableAKSKubernetesVersionOffset(ctx context.Context, subscriptionID, location string, offset int) (string, error) {
-	cred, err := azidentity.NewDefaultAzureCredential(nil)
+	versions, err := getStableAKSKubernetesVersions(ctx, subscriptionID, location)
 	if err != nil {
-		return "", errors.Wrap(err, "failed to create a default credential")
+		return "", err
 	}
-	managedClustersClient, err := armcontainerservice.NewManagedClustersClient(subscriptionID, cred, nil)
+	version, err := kubeversion.LatestStable(versions, offset)
 	if err != nil {
-		return "", errors.Wrap(err, "failed to create a ContainerServices client")
+		return "", errors.Wrapf(err, "failed to find a stable AKS Kubernetes version in location %q", location)
 	}
-	result, err := managedClustersClient.ListKubernetesVersions(ctx, location, nil)
-	if err != nil {
-		return "", errors.Wrap(err, "failed to list Orchestrators")
-	}
-
-	var orchestratorversions []string
-	var foundWorkingVersion bool
-	var version string
-	var maxVersion string
-
-	for _, minor := range result.KubernetesVersionListResult.Values {
-		for patch := range minor.PatchVersions {
-			// semver comparisons require a "v" prefix
-			if patch[:1] != "v" && !ptr.Deref(minor.IsPreview, false) {
-				version = "v" + patch
-			}
-			orchestratorversions = append(orchestratorversions, version)
-		}
-	}
-	semver.Sort(orchestratorversions)
-	maxVersion = orchestratorversions[len(orchestratorversions)-1-offset]
-	if semver.IsValid(maxVersion) {
-		foundWorkingVersion = true
-	}
-	if !foundWorkingVersion {
-		return "", errors.New("latest stable AKS version not found")
-	}
-	return maxVersion, nil
+	return version, nil
 }

--- a/test/e2e/azure_test.go
+++ b/test/e2e/azure_test.go
@@ -42,6 +42,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
+	"sigs.k8s.io/cluster-api-provider-azure/azure"
 )
 
 var _ = Describe("Workload cluster creation", func() {
@@ -731,7 +732,7 @@ var _ = Describe("Workload cluster creation", func() {
 	Context("Creating an AKS cluster for node pool tests [Managed Kubernetes]", func() {
 		It("with a single control plane node and 1 node", func() {
 			clusterName = getClusterName(clusterNamePrefix, "pool")
-			kubernetesVersion, err := GetAKSKubernetesVersion(ctx, e2eConfig, AKSKubernetesVersion)
+			kubernetesVersion, err := GetAKSKubernetesVersionWithCommunityGalleryImage(ctx, e2eConfig, AKSKubernetesVersion, azure.DefaultLinuxGalleryImageName)
 			Expect(err).NotTo(HaveOccurred())
 
 			clusterctl.ApplyClusterTemplateAndWait(ctx, createApplyClusterTemplateInput(

--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -84,7 +84,6 @@ const (
 	capiImagePublisher                = "cncf-upstream"
 	capiOfferName                     = "capi"
 	capiWindowsOfferName              = "capi-windows"
-	capiCommunityGallery              = "ClusterAPI-f72ceb4f-5159-4c26-a0fe-2ea738f0d019"
 	aksClusterNameSuffix              = "aks"
 	defaultNamespace                  = "default"
 	AzureCNIv1Manifest                = "AZURE_CNI_V1_MANIFEST_PATH"

--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -29,7 +29,6 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strconv"
 	"strings"
 	"text/tabwriter"
@@ -59,6 +58,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
+	"sigs.k8s.io/cluster-api-provider-azure/test/e2e/internal/kubeversion"
 )
 
 const (
@@ -743,14 +743,6 @@ func publicKeyFile(file string) (ssh.AuthMethod, error) {
 	return ssh.PublicKeys(signer), nil
 }
 
-// validateStableReleaseString validates the string format that declares "get be the latest stable release for this <Major>.<Minor>"
-// it should be called wherever we process a stable version string expression like "stable-1.22"
-func validateStableReleaseString(stableVersion string) (isStable bool, matches []string) {
-	stableReleaseFormat := regexp.MustCompile(`^stable-(0|[1-9]\d*)\.(0|[1-9]\d*)$`)
-	matches = stableReleaseFormat.FindStringSubmatch(stableVersion)
-	return len(matches) > 0, matches
-}
-
 // resolveCIVersion resolves kubernetes version labels (e.g. latest, latest-1.xx) to the corresponding CI version numbers.
 // Go implementation of https://github.com/kubernetes-sigs/cluster-api/blob/d1dc87d5df3ab12a15ae5b63e50541a191b7fec4/scripts/ci-e2e-lib.sh#L75-L95.
 func resolveCIVersion(label string) (string, error) {
@@ -831,7 +823,7 @@ func resolveKubetestRepoListPath(version string, path string) (string, error) {
 // that has an existing capi offer image available. For example, if the version is "stable-1.22", the function will set it to the latest 1.22 version that has a published reference image.
 func resolveKubernetesVersions(config *clusterctl.E2EConfig) {
 	ctx := context.TODO()
-	linuxVersions := getVersionsInCommunityGallery(ctx, os.Getenv(AzureLocation), capiCommunityGallery, "capi-ubun2-2404")
+	linuxVersions := getVersionsInCommunityGallery(ctx, os.Getenv(AzureLocation), azure.DefaultPublicGalleryName, azure.DefaultLinuxGalleryImageName)
 
 	var versions semver.Versions
 
@@ -840,7 +832,7 @@ func resolveKubernetesVersions(config *clusterctl.E2EConfig) {
 	windowsRequired := testWindows == "true"
 
 	if windowsRequired {
-		windowsVersions := getVersionsInCommunityGallery(ctx, os.Getenv(AzureLocation), capiCommunityGallery, "capi-win-2022-containerd")
+		windowsVersions := getVersionsInCommunityGallery(ctx, os.Getenv(AzureLocation), azure.DefaultPublicGalleryName, azure.DefaultWindowsGalleryImageName)
 		for k, v := range linuxVersions {
 			if _, ok := windowsVersions[k]; ok {
 				versions = append(versions, v)
@@ -885,35 +877,50 @@ func resolveVariable(config *clusterctl.E2EConfig, varName, v string) {
 	Logf("Resolved %s (set to %s) to %s", varName, oldVersion, v)
 }
 
-func newCommunityGalleryImageVersionsClient() *armcompute.CommunityGalleryImageVersionsClient {
-	cred, err := azidentity.NewDefaultAzureCredential(nil)
+func getVersionsInCommunityGallery(ctx context.Context, location, galleryName, image string) map[string]semver.Version {
+	versions, err := listVersionsInCommunityGallery(ctx, location, galleryName, image)
 	Expect(err).NotTo(HaveOccurred())
-	communityGalleryImageVersionsClient, err := armcompute.NewCommunityGalleryImageVersionsClient(getSubscriptionID(Default), cred, nil)
-	Expect(err).NotTo(HaveOccurred())
-
-	return communityGalleryImageVersionsClient
+	return versions
 }
 
-func getVersionsInCommunityGallery(ctx context.Context, location, galleryName, image string) map[string]semver.Version {
+func listVersionsInCommunityGallery(ctx context.Context, location, galleryName, image string) (map[string]semver.Version, error) {
 	Logf("Getting versions for image %q in community gallery %q in location %q", image, galleryName, location)
 	versions := make(map[string]semver.Version)
 
-	client := newCommunityGalleryImageVersionsClient()
-	pager := client.NewListPager(location, galleryName, image, nil)
+	cred, err := azidentity.NewDefaultAzureCredential(nil)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create a default credential")
+	}
+	communityGalleryImageVersionsClient, err := armcompute.NewCommunityGalleryImageVersionsClient(getSubscriptionID(Default), cred, nil)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create a community gallery image versions client")
+	}
+
+	pager := communityGalleryImageVersionsClient.NewListPager(location, galleryName, image, nil)
 	for pager.More() {
 		resp, err := pager.NextPage(ctx)
-		Expect(err).NotTo(HaveOccurred())
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to list versions for image %q in community gallery %q in location %q", image, galleryName, location)
+		}
 		for _, version := range resp.Value {
-			versions[*version.Name] = semver.MustParse(*version.Name)
+			if version == nil || version.Name == nil {
+				continue
+			}
+			parsedVersion, err := semver.Parse(*version.Name)
+			if err != nil {
+				Logf("Ignoring version %q for image %q in community gallery %q in location %q: %v", *version.Name, image, galleryName, location, err)
+				continue
+			}
+			versions[*version.Name] = parsedVersion
 		}
 	}
 
-	return versions
+	return versions, nil
 }
 
 // getLatestVersionForMinor gets the latest available patch version in the provided list of sku versions that corresponds to the provided k8s version.
 func getLatestVersionForMinor(version string, versions semver.Versions, imagesSource string) string {
-	isStable, match := validateStableReleaseString(version)
+	isStable, match := kubeversion.ValidateStableReleaseString(version)
 	if isStable {
 		// if the version is in the format "stable-1.21", we find the latest 1.21.x version.
 		major, err := strconv.ParseUint(match[1], 10, 64)

--- a/test/e2e/internal/kubeversion/kubeversion.go
+++ b/test/e2e/internal/kubeversion/kubeversion.go
@@ -1,0 +1,136 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package kubeversion resolves the Kubernetes version expressions used by the e2e tests
+// ("latest", "latest-1", "stable-<Major>.<Minor>", or an explicit version) against the
+// versions an environment actually offers. It holds no build tag so that these pure
+// helpers are exercised by the default `go test ./...` run.
+package kubeversion
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/pkg/errors"
+	"golang.org/x/mod/semver"
+)
+
+var stableReleaseFormat = regexp.MustCompile(`^stable-(0|[1-9]\d*)\.(0|[1-9]\d*)$`)
+
+// ValidateStableReleaseString validates the string format that declares "get the latest stable release for this <Major>.<Minor>"
+// it should be called wherever we process a stable version string expression like "stable-1.22".
+func ValidateStableReleaseString(stableVersion string) (isStable bool, matches []string) {
+	matches = stableReleaseFormat.FindStringSubmatch(stableVersion)
+	return len(matches) > 0, matches
+}
+
+// Common returns the versions found in both a and b, canonicalized and sorted in ascending
+// semver order. Prerelease, duplicate, and unparsable versions are dropped.
+func Common(a, b []string) []string {
+	inA := make(map[string]struct{}, len(a))
+	for _, version := range normalize(a) {
+		inA[version] = struct{}{}
+	}
+
+	common := make([]string, 0, len(inA))
+	for _, version := range normalize(b) {
+		if _, ok := inA[version]; ok {
+			common = append(common, version)
+		}
+	}
+	return common
+}
+
+// Select resolves requestedVersion against versions, which must be canonical, stable, and sorted
+// in ascending semver order as returned by Common. An explicit version that versions doesn't offer
+// falls back to the newest version sharing its major.minor.
+func Select(requestedVersion string, versions []string) (string, error) {
+	switch requestedVersion {
+	case "latest":
+		return atOffset(versions, 0)
+	case "latest-1":
+		return atOffset(versions, 1)
+	}
+
+	if isStableVersion, match := ValidateStableReleaseString(requestedVersion); isStableVersion {
+		return latestForMajorMinor(versions, fmt.Sprintf("v%s.%s", match[1], match[2]))
+	}
+
+	canonicalRequestedVersion := canonical(requestedVersion)
+	if canonicalRequestedVersion == "" {
+		return "", errors.Errorf("invalid Kubernetes version %q", requestedVersion)
+	}
+	for _, version := range versions {
+		if version == canonicalRequestedVersion {
+			return version, nil
+		}
+	}
+
+	return latestForMajorMinor(versions, semver.MajorMinor(canonicalRequestedVersion))
+}
+
+// LatestStable returns the stable version at offset positions before the newest in versions.
+// versions need not be canonical, sorted, or free of prereleases.
+func LatestStable(versions []string, offset int) (string, error) {
+	return atOffset(normalize(versions), offset)
+}
+
+// atOffset returns the version at offset positions before the end of an ascending-sorted versions.
+func atOffset(versions []string, offset int) (string, error) {
+	if len(versions) <= offset {
+		if offset == 0 {
+			return "", errors.New("no stable Kubernetes versions available")
+		}
+		return "", errors.Errorf("fewer than %d stable Kubernetes versions available", offset+1)
+	}
+	return versions[len(versions)-1-offset], nil
+}
+
+// latestForMajorMinor returns the newest version in an ascending-sorted versions matching majorMinor.
+func latestForMajorMinor(versions []string, majorMinor string) (string, error) {
+	for i := len(versions) - 1; i >= 0; i-- {
+		if semver.MajorMinor(versions[i]) == majorMinor {
+			return versions[i], nil
+		}
+	}
+	return "", errors.Errorf("no Kubernetes version available for %s", majorMinor)
+}
+
+// normalize returns the canonical, stable versions in versions, sorted in ascending semver order.
+func normalize(versions []string) []string {
+	set := make(map[string]struct{}, len(versions))
+	for _, version := range versions {
+		if version = canonical(version); version != "" && semver.Prerelease(version) == "" {
+			set[version] = struct{}{}
+		}
+	}
+
+	normalized := make([]string, 0, len(set))
+	for version := range set {
+		normalized = append(normalized, version)
+	}
+	semver.Sort(normalized)
+	return normalized
+}
+
+// canonical returns the canonical "v"-prefixed semver form of version, or "" if it isn't valid semver.
+func canonical(version string) string {
+	if !strings.HasPrefix(version, "v") {
+		version = "v" + version
+	}
+	return semver.Canonical(version)
+}

--- a/test/e2e/internal/kubeversion/kubeversion_test.go
+++ b/test/e2e/internal/kubeversion/kubeversion_test.go
@@ -1,0 +1,195 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubeversion
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestSelect(t *testing.T) {
+	tests := []struct {
+		name          string
+		requested     string
+		aksVersions   []string
+		imageVersions []string
+		expected      string
+		expectedError string
+	}{
+		{
+			name:          "latest falls back to newest image available in AKS",
+			requested:     "latest",
+			aksVersions:   []string{"1.35.10", "1.36.2", "1.36.3"},
+			imageVersions: []string{"1.35.10", "1.36.2"},
+			expected:      "v1.36.2",
+		},
+		{
+			name:          "latest ignores images unavailable in AKS",
+			requested:     "latest",
+			aksVersions:   []string{"v1.35.10", "v1.36.2"},
+			imageVersions: []string{"1.36.2", "1.37.0"},
+			expected:      "v1.36.2",
+		},
+		{
+			name:          "stable release selects latest common patch",
+			requested:     "stable-1.35",
+			aksVersions:   []string{"1.35.9", "1.35.10", "1.36.2"},
+			imageVersions: []string{"1.35.9", "1.35.10", "1.36.1"},
+			expected:      "v1.35.10",
+		},
+		{
+			name:          "unavailable patch falls back within requested minor",
+			requested:     "v1.35.11",
+			aksVersions:   []string{"1.35.9", "1.35.10", "1.36.2"},
+			imageVersions: []string{"1.35.9", "1.35.10", "1.36.2"},
+			expected:      "v1.35.10",
+		},
+		{
+			name:          "latest minus one selects preceding common version",
+			requested:     "latest-1",
+			aksVersions:   []string{"1.35.10", "1.36.1", "1.36.2"},
+			imageVersions: []string{"1.35.10", "1.36.1", "1.36.2"},
+			expected:      "v1.36.1",
+		},
+		{
+			name:          "no intersection fails",
+			requested:     "latest",
+			aksVersions:   []string{"1.36.3"},
+			imageVersions: []string{"1.36.2"},
+			expectedError: "no stable Kubernetes versions available",
+		},
+		{
+			name:          "stable release without a common minor fails",
+			requested:     "stable-1.34",
+			aksVersions:   []string{"1.35.10", "1.36.2"},
+			imageVersions: []string{"1.35.10", "1.36.2"},
+			expectedError: "no Kubernetes version available for v1.34",
+		},
+		{
+			name:          "unparsable requested version fails",
+			requested:     "not-a-version",
+			aksVersions:   []string{"1.36.2"},
+			imageVersions: []string{"1.36.2"},
+			expectedError: `invalid Kubernetes version "not-a-version"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			version, err := Select(tt.requested, Common(tt.aksVersions, tt.imageVersions))
+			if tt.expectedError != "" {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err.Error()).To(ContainSubstring(tt.expectedError))
+				return
+			}
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(version).To(Equal(tt.expected))
+		})
+	}
+}
+
+func TestCommon(t *testing.T) {
+	tests := []struct {
+		name     string
+		a        []string
+		b        []string
+		expected []string
+	}{
+		{
+			name:     "canonicalizes, sorts, and dedupes the intersection",
+			a:        []string{"1.36.2", "v1.36.2", "1.35.10", "1.36.10"},
+			b:        []string{"v1.36.10", "1.35.10", "1.36.2"},
+			expected: []string{"v1.35.10", "v1.36.2", "v1.36.10"},
+		},
+		{
+			name:     "drops prereleases and unparsable versions",
+			a:        []string{"1.36.2", "1.37.0-alpha.1", "not-a-version", ""},
+			b:        []string{"1.36.2", "1.37.0-alpha.1", "not-a-version", ""},
+			expected: []string{"v1.36.2"},
+		},
+		{
+			name:     "returns empty when nothing is shared",
+			a:        []string{"1.36.3"},
+			b:        []string{"1.36.2"},
+			expected: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			g.Expect(Common(tt.a, tt.b)).To(Equal(tt.expected))
+		})
+	}
+}
+
+func TestLatestStable(t *testing.T) {
+	tests := []struct {
+		name          string
+		versions      []string
+		offset        int
+		expected      string
+		expectedError string
+	}{
+		{
+			name:     "unsorted and unprefixed input",
+			versions: []string{"1.36.2", "1.35.10", "v1.36.10", "1.36.9"},
+			expected: "v1.36.10",
+		},
+		{
+			name:     "offset selects the preceding version",
+			versions: []string{"1.36.2", "1.35.10", "v1.36.10", "1.36.9"},
+			offset:   1,
+			expected: "v1.36.9",
+		},
+		{
+			name:     "prereleases and unparsable entries are dropped",
+			versions: []string{"1.36.2", "1.37.0-alpha.1", "not-a-version", ""},
+			expected: "v1.36.2",
+		},
+		{
+			name:          "offset beyond available versions fails",
+			versions:      []string{"1.36.2"},
+			offset:        1,
+			expectedError: "fewer than 2 stable Kubernetes versions available",
+		},
+		{
+			name:          "no parseable versions fails",
+			versions:      []string{"not-a-version"},
+			expectedError: "no stable Kubernetes versions available",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			version, err := LatestStable(tt.versions, tt.offset)
+			if tt.expectedError != "" {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err.Error()).To(ContainSubstring(tt.expectedError))
+				return
+			}
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(version).To(Equal(tt.expected))
+		})
+	}
+}


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

/kind flake
/kind failing-test

**What this PR does / why we need it**:

Problem statement: the AKS node-pool E2E reused AKS’s regional latest Kubernetes version for a self-managed BYO MachinePool, even when the corresponding capi-ubun2-2404 image was not yet available in that region’s community gallery.

This PR changes the version selection logic to select the newest stable version available from both regional AKS and community-gallery inventories before creating the cluster, and fails early if no common version exists. If AKS has a greater version than any published community gallery image, we fall back to the community gallery image.

The new resolver is called only by the managed AKS node-pool scenario and does not modify shared E2E configuration or environment variables, so non-AKS E2E version selection remains unchanged.

Evidence of failures before this fix:

[PR #6566: pull-cluster-api-provider-azure-e2e-aks-v1beta1 build 2089742298970591232](https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/kubernetes-sigs_cluster-api-provider-azure/6566/pull-cluster-api-provider-azure-e2e-aks-v1beta1/2089742298970591232)
[Build log showing GalleryImageNotFound for capi-ubun2-2404/1.36.3 in uksouth](https://storage.googleapis.com/kubernetes-ci-logs/pr-logs/pull/kubernetes-sigs_cluster-api-provider-azure/6566/pull-cluster-api-provider-azure-e2e-aks-v1beta1/2089742298970591232/build-log.txt)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->


**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] cherry-pick candidate

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
