### PR TITLE
Add opt-in depth-based deletion ordering for ASO resources

### DIFF
--- a/controllers/resource_reconciler.go
+++ b/controllers/resource_reconciler.go
@@ -30,6 +30,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -51,9 +52,10 @@ const (
 // ResourceReconciler reconciles a set of arbitrary ASO resources.
 type ResourceReconciler struct {
 	client.Client
-	resources []*unstructured.Unstructured
-	owner     resourceStatusObject
-	watcher   watcher
+	resources     []*unstructured.Unstructured
+	owner         resourceStatusObject
+	watcher       watcher
+	childrenFirst bool
 }
 
 type watcher interface {
@@ -172,7 +174,24 @@ func (r *ResourceReconciler) reconcile(ctx context.Context) error {
 		})
 	}
 
+	var deferred sets.Set[types.UID]
+	if r.childrenFirst {
+		deferred = deferShallowerResources(toBeDeletedResources)
+	}
 	for _, obj := range toBeDeletedResources {
+		if deferred.Has(obj.UID) {
+			gvk := obj.GroupVersionKind()
+			newResourceStatuses = append(newResourceStatuses, infrav1.ResourceStatus{
+				Resource: infrav1.StatusResource{
+					Group:   gvk.Group,
+					Version: gvk.Version,
+					Kind:    gvk.Kind,
+					Name:    obj.Name,
+				},
+				Ready: false,
+			})
+			continue
+		}
 		newStatus, err := r.deleteResource(ctx, obj)
 		if err != nil {
 			return fmt.Errorf("failed to delete %s %s/%s", obj.GroupVersionKind(), obj.Namespace, obj.Name)
@@ -350,6 +369,57 @@ func statusResource(resource *unstructured.Unstructured) infrav1.StatusResource 
 		Kind:    gvk.Kind,
 		Name:    resource.GetName(),
 	}
+}
+
+// deferShallowerResources returns the set of UIDs that should NOT be deleted
+// this cycle. It computes the depth of each resource (hops to root via
+// non-controller owner references) and only allows the deepest level to
+// proceed. This ensures leaf resources (e.g. Subnet) are deleted before
+// shallower ones (e.g. NSG), respecting implicit Azure-level dependencies.
+func deferShallowerResources(resources []*metav1.PartialObjectMetadata) sets.Set[types.UID] {
+	pending := make(map[types.UID]*metav1.PartialObjectMetadata, len(resources))
+	for _, obj := range resources {
+		pending[obj.UID] = obj
+	}
+
+	depth := make(map[types.UID]int, len(resources))
+	var computeDepth func(types.UID) int
+	computeDepth = func(uid types.UID) int {
+		if d, ok := depth[uid]; ok {
+			return d
+		}
+		depth[uid] = 0 // guard against cycles
+		obj := pending[uid]
+		maxParentDepth := -1
+		for i := range obj.OwnerReferences {
+			ref := &obj.OwnerReferences[i]
+			if ref.Controller != nil && *ref.Controller {
+				continue
+			}
+			if _, inSet := pending[ref.UID]; inSet {
+				if pd := computeDepth(ref.UID); pd > maxParentDepth {
+					maxParentDepth = pd
+				}
+			}
+		}
+		depth[uid] = maxParentDepth + 1
+		return depth[uid]
+	}
+
+	maxDepth := 0
+	for uid := range pending {
+		if d := computeDepth(uid); d > maxDepth {
+			maxDepth = d
+		}
+	}
+
+	deferred := sets.New[types.UID]()
+	for uid, d := range depth {
+		if d < maxDepth {
+			deferred.Insert(uid)
+		}
+	}
+	return deferred
 }
 
 func metadataRefersToResource(metadata *metav1.PartialObjectMetadata) func(*unstructured.Unstructured) bool {

--- a/controllers/resource_reconciler_test.go
+++ b/controllers/resource_reconciler_test.go
@@ -717,6 +717,94 @@ func controlledBy(g *GomegaWithT, s *runtime.Scheme, owner client.Object) []meta
 	}
 }
 
+func TestDeferShallowerResources(t *testing.T) {
+	boolPtr := func(b bool) *bool { return &b }
+
+	rg := &metav1.PartialObjectMetadata{
+		ObjectMeta: metav1.ObjectMeta{UID: "rg-uid", Name: "rg"},
+	}
+	vnet := &metav1.PartialObjectMetadata{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:  "vnet-uid",
+			Name: "vnet",
+			OwnerReferences: []metav1.OwnerReference{
+				{UID: "controller-uid", Controller: boolPtr(true)},
+				{UID: "rg-uid"},
+			},
+		},
+	}
+	nsg := &metav1.PartialObjectMetadata{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:  "nsg-uid",
+			Name: "nsg",
+			OwnerReferences: []metav1.OwnerReference{
+				{UID: "controller-uid", Controller: boolPtr(true)},
+				{UID: "rg-uid"},
+			},
+		},
+	}
+	subnet := &metav1.PartialObjectMetadata{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:  "subnet-uid",
+			Name: "subnet",
+			OwnerReferences: []metav1.OwnerReference{
+				{UID: "controller-uid", Controller: boolPtr(true)},
+				{UID: "vnet-uid"},
+			},
+		},
+	}
+
+	tests := []struct {
+		name             string
+		resources        []*metav1.PartialObjectMetadata
+		expectedDeferred []string
+	}{
+		{
+			name:             "all levels present: only deepest (subnet) proceeds",
+			resources:        []*metav1.PartialObjectMetadata{rg, vnet, nsg, subnet},
+			expectedDeferred: []string{"rg", "vnet", "nsg"},
+		},
+		{
+			name:             "without subnet: nsg and vnet are deepest, rg deferred",
+			resources:        []*metav1.PartialObjectMetadata{rg, vnet, nsg},
+			expectedDeferred: []string{"rg"},
+		},
+		{
+			name:             "only roots: nothing deferred",
+			resources:        []*metav1.PartialObjectMetadata{rg},
+			expectedDeferred: []string{},
+		},
+		{
+			name:             "siblings only (no hierarchy): nothing deferred",
+			resources:        []*metav1.PartialObjectMetadata{vnet, nsg},
+			expectedDeferred: []string{},
+		},
+		{
+			name:             "empty input: nothing deferred",
+			resources:        nil,
+			expectedDeferred: []string{},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			deferred := deferShallowerResources(tc.resources)
+			var deferredNames []string
+			for _, r := range tc.resources {
+				if deferred.Has(r.UID) {
+					deferredNames = append(deferredNames, r.Name)
+				}
+			}
+			if len(tc.expectedDeferred) == 0 {
+				g.Expect(deferredNames).To(BeEmpty())
+			} else {
+				g.Expect(deferredNames).To(ConsistOf(tc.expectedDeferred))
+			}
+		})
+	}
+}
+
 var rgTypeMeta = metav1.TypeMeta{
 	APIVersion: asoresourcesv1.GroupVersion.Identifier(),
 	Kind:       "ResourceGroup",


### PR DESCRIPTION
/kind feature

## What problem does this PR solve?

When a controller manages a set of ASO resources that have implicit Azure-level
dependencies (e.g. a Subnet references a NetworkSecurityGroup), the current parallel
deletion strategy can cause long stalls during cluster teardown.

**The failure sequence:**
1. `ResourceReconciler` issues `kubectl delete` on all ASO resources in parallel
2. Azure rejects the NSG deletion with `InUseNetworkSecurityGroupCannotBeDeleted`
   because the Subnet still references it
3. ASO enters `RetryVerySlow` backoff (~48 minutes)
4. The Subnet is deleted successfully seconds later, but ASO won't retry the NSG
   for ~48 minutes
5. Meanwhile, the ResourceGroup deletion in Azure cascade-deletes everything, but
   the NSG CR in Kubernetes keeps its ASO finalizer until the backoff expires

This causes cluster deletion to take ~48 extra minutes, which exceeds typical CI
timeouts and leaves clusters stuck in a `Deleting` state.

## How does this PR solve it?

Adds an opt-in `childrenFirst` field to `ResourceReconciler` that uses ASO
non-controller owner references to compute each resource's depth (hops to root
in the ownership tree) and deletes only the deepest level per reconcile cycle.

For example, with ASO resources organized as:
```
Depth 0: ResourceGroup
Depth 1: VirtualNetwork, NetworkSecurityGroup
Depth 2: Subnet, RoleAssignment
```

The reconciler deletes depth 2 first (Subnet), then depth 1 (NSG — now safe
because Subnet is gone), then depth 0 (ResourceGroup). Each level is handled
in a separate reconcile cycle, naturally respecting Azure ordering constraints
without hardcoding resource-specific knowledge.

**Key properties:**
- **Opt-in**: Existing controllers are completely unaffected — `childrenFirst`
  defaults to `false`
- **Generic**: Uses ASO's own owner reference hierarchy, no Azure-specific
  resource type knowledge
- **Graceful fallback**: If resources have no owner reference hierarchy (all at
  the same depth), everything is deleted in parallel — same as today

## Are there any special considerations for review?

- The depth computation uses a recursive function with cycle detection
  (`depth[uid] = 0` guard)
- `sets.Set[types.UID].Has()` is nil-safe — returns false when `childrenFirst`
  is disabled and `deferred` is nil, so the non-opt-in path has zero overhead
- Test coverage for `deferShallowerResources` included with 5 cases:
  multi-level hierarchy, partial hierarchy, single root, siblings-only, and
  empty input

## Test plan
- [x] Unit test `TestDeferShallowerResources` — 5 cases covering all depth scenarios
- [x] Existing `TestResourceReconciler{Reconcile,Pause,Delete}` tests pass unchanged
- [ ] E2E validation in downstream with 48 ASO resources and complex dependencies

**Release note**:
```release-note
Add an opt-in `childrenFirst` option to order deletion of ASO resources from deepest to shallowest, preventing dependency-related deletion stalls.
```