### PR TITLE
Bump Go toolchain to v1.26.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@
 ARG ARCH
 
 # Build the manager binary
-FROM golang:1.26.5 AS builder
+FROM golang:1.26.7 AS builder
 WORKDIR /workspace
 
 # Run this with docker build --build_arg $(go env GOPROXY) to override the goproxy

--- a/Tiltfile
+++ b/Tiltfile
@@ -173,7 +173,7 @@ def validate_auth():
 
 tilt_helper_dockerfile_header = """
 # Tilt image
-FROM golang:1.26.5 AS tilt-helper
+FROM golang:1.26.7 AS tilt-helper
 # Support live reloading with Tilt
 RUN wget --output-document /restart.sh --quiet https://raw.githubusercontent.com/windmilleng/rerun-process-wrapper/master/restart.sh  && \
     wget --output-document /start.sh --quiet https://raw.githubusercontent.com/windmilleng/rerun-process-wrapper/master/start.sh && \

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module sigs.k8s.io/cluster-api-provider-azure
 
 go 1.26.0
 
-toolchain go1.26.5
+toolchain go1.26.7
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.23.0

--- a/hack/ensure-go.sh
+++ b/hack/ensure-go.sh
@@ -31,7 +31,7 @@ EOF
   local go_version
   IFS=" " read -ra go_version <<< "$(go version)"
   local minimum_go_version
-  minimum_go_version=go1.26.5
+  minimum_go_version=go1.26.7
   if [[ "${minimum_go_version}" != $(echo -e "${minimum_go_version}\n${go_version[2]}" | sort -s -t. -k 1,1 -k 2,2n -k 3,3n | head -n1) && "${go_version[2]}" != "devel" ]]; then
     cat <<EOF
 Detected go version: ${go_version[*]}.

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -2,7 +2,7 @@ module sigs.k8s.io/cluster-api-provider-azure/hack/tools
 
 go 1.26.0
 
-toolchain go1.26.5
+toolchain go1.26.7
 
 require sigs.k8s.io/cluster-api/hack/tools v0.0.0-20260730162741-560d4acf507b
 


### PR DESCRIPTION
/kind cleanup

Updates the Go compiler and tools to v1.26.7.

> go1.26.7 (released 2026-08-19) includes fixes to the `net/http` package. See the [Go 1.26.7 milestone](https://github.com/golang/go/issues?q=milestone%3AGo1.26.7+label%3ACherryPickApproved) on our issue tracker for details.

This also picks up the security fixes from go1.26.6 (released 2026-08-13) to the `go` command, and the `crypto/tls`, `encoding/asn1`, `encoding/xml`, `html/template`, `net`, `net/http`, and `net/url` packages, fixing several CVEs reported against the previous version of the toolchain.

See #6455 for prior art.

```release-note
NONE
```