### PR TITLE
[release-1.25] Bump Go toolchain to v1.25.14

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module sigs.k8s.io/cluster-api-provider-azure
 
 go 1.25.0
 
-toolchain go1.25.12
+toolchain go1.25.14
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.23.0

--- a/hack/ensure-go.sh
+++ b/hack/ensure-go.sh
@@ -31,7 +31,7 @@ EOF
   local go_version
   IFS=" " read -ra go_version <<< "$(go version)"
   local minimum_go_version
-  minimum_go_version=go1.25.12
+  minimum_go_version=go1.25.14
   if [[ "${minimum_go_version}" != $(echo -e "${minimum_go_version}\n${go_version[2]}" | sort -s -t. -k 1,1 -k 2,2n -k 3,3n | head -n1) && "${go_version[2]}" != "devel" ]]; then
     cat <<EOF
 Detected go version: ${go_version[*]}.

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -2,7 +2,7 @@ module sigs.k8s.io/cluster-api-provider-azure/hack/tools
 
 go 1.25.0
 
-toolchain go1.25.12
+toolchain go1.25.14
 
 require sigs.k8s.io/cluster-api/hack/tools v0.0.0-20260714113117-27f464418c19
 


### PR DESCRIPTION
/kind cleanup

Updates the Go compiler and tools to v1.25.14 on `release-1.25`.

> go1.25.14 (released 2026-08-19) includes fixes to the `net/http` package. See the [Go 1.25.14 milestone](https://github.com/golang/go/issues?q=milestone%3AGo1.25.14+label%3ACherryPickApproved) on our issue tracker for details.

This also picks up go1.25.13 (released 2026-08-13), which includes security fixes to the `go` command, and the `crypto/tls`, `encoding/asn1`, `encoding/xml`, `html/template`, `net/http`, and `net/url` packages, fixing several CVEs reported against the previous version of the toolchain.

This is the `release-1.25`-line equivalent of #6603, which bumps `main` to v1.26.7. It is not an automated cherry-pick because `main` has since moved to the Go 1.26 line.

See #6461 for prior art.

```release-note
NONE
```