### PR TITLE
fix: make SecurityRule description optional in APIs

### DIFF
--- a/api/v1beta1/types.go
+++ b/api/v1beta1/types.go
@@ -314,7 +314,9 @@ type SecurityRule struct {
 	// Name is a unique name within the network security group.
 	Name string `json:"name"`
 	// A description for this rule. Restricted to 140 chars.
-	Description string `json:"description"`
+	// +kubebuilder:validation:MaxLength=140
+	// +optional
+	Description string `json:"description,omitempty"`
 	// Protocol specifies the protocol type. "Tcp", "Udp", "Icmp", or "*".
 	// +kubebuilder:validation:Enum=Tcp;Udp;Icmp;*
 	Protocol SecurityGroupProtocol `json:"protocol"`

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azureclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azureclusters.yaml
@@ -356,6 +356,7 @@ spec:
                                     description:
                                       description: A description for this rule. Restricted
                                         to 140 chars.
+                                      maxLength: 140
                                       type: string
                                     destination:
                                       description: Destination is the destination
@@ -423,7 +424,6 @@ spec:
                                         type: string
                                       type: array
                                   required:
-                                  - description
                                   - direction
                                   - name
                                   - protocol
@@ -1378,6 +1378,7 @@ spec:
                                   description:
                                     description: A description for this rule. Restricted
                                       to 140 chars.
+                                    maxLength: 140
                                     type: string
                                   destination:
                                     description: Destination is the destination address
@@ -1442,7 +1443,6 @@ spec:
                                       type: string
                                     type: array
                                 required:
-                                - description
                                 - direction
                                 - name
                                 - protocol

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_azureclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_azureclustertemplates.yaml
@@ -228,6 +228,7 @@ spec:
                                             description:
                                               description: A description for this
                                                 rule. Restricted to 140 chars.
+                                              maxLength: 140
                                               type: string
                                             destination:
                                               description: Destination is the destination
@@ -299,7 +300,6 @@ spec:
                                                 type: string
                                               type: array
                                           required:
-                                          - description
                                           - direction
                                           - name
                                           - protocol
@@ -747,6 +747,7 @@ spec:
                                           description:
                                             description: A description for this rule.
                                               Restricted to 140 chars.
+                                            maxLength: 140
                                             type: string
                                           destination:
                                             description: Destination is the destination
@@ -816,7 +817,6 @@ spec:
                                               type: string
                                             type: array
                                         required:
-                                        - description
                                         - direction
                                         - name
                                         - protocol


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

/kind bug

**What this PR does / why we need it**:

This solves an issue discovered when introducing static manifest validation using https://github.com/fluxcd/flux-schema in one of our repos containing CAPZ manifests. For our only AzureCluster manifest, flux-schema outputs these validation errors:

````
stdin - AzureCluster/stas/talos-poc is invalid: schema violation
  - /spec/networkSpec/subnets/0/securityGroup/securityRules/0: missing property 'description'
  - /spec/networkSpec/subnets/0/securityGroup/securityRules/1: missing property 'description'
````

This happens because the SecurityRule description field is marked as required in the CRD OpenAPI schema, but we haven't specified a value for the field. I cannot imagine this was intentional, mainly because a "description" is seldom required, but the strongest evidence is that the validation is ineffective.  When a resource that doesn't specify this currently required field reaches the API server, the value is the empty string (`""`), probably because of webhooks in the admission pipeline.

In addition to making the field optional in the API specification, I've added an actual validation of the max length restriction documented in the field docs. Happy to remove this from the PR if requested to.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

I can create an issue if that's required for even a minor PR like this one.

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->


**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [x] cherry-pick candidate

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
